### PR TITLE
Add AMD GPU architecture support (arch/amd crate)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallaios-arch-amd"
+version = "0.1.0"
+dependencies = [
+ "smallaios-kernel",
+]
+
+[[package]]
 name = "smallaios-arch-intel-gpu"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "arch/riscv64",
     "arch/nvidia",
     "arch/intel_gpu",
+    "arch/amd",
     "onnx-rt",
     "ipc",
     "net",

--- a/arch/amd/Cargo.toml
+++ b/arch/amd/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "smallaios-arch-amd"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "SmallAIOS AMD GPU HAL: PCIe, GPU init, memory, compute, DMA"
+
+[features]
+default = []
+gfx900 = []   # Vega 10 (MI25, Vega 56/64)
+gfx906 = []   # Vega 20 (MI50/MI60)
+gfx908 = []   # CDNA 1 (MI100)
+gfx90a = []   # CDNA 2 (MI200)
+gfx942 = []   # CDNA 3 (MI300X)
+gfx1010 = []  # RDNA 1 (RX 5600/5700)
+gfx1030 = []  # RDNA 2 (RX 6700/6800/6900)
+gfx1100 = []  # RDNA 3 (RX 7800/7900)
+
+[dependencies]
+smallaios-kernel = { path = "../../kernel" }

--- a/arch/amd/src/compute.rs
+++ b/arch/amd/src/compute.rs
@@ -1,0 +1,491 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Wavefront-based compute engine -- kernel launch, grid/block config, synchronization.
+//!
+//! AMD GPUs use wavefronts (analogous to NVIDIA warps):
+//! - CDNA: 64-wide wavefronts exclusively
+//! - RDNA: 32-wide wavefronts (wave32) with wave64 compatibility mode
+//!
+//! Kernels follow the state machine:
+//! `Queued -> Running -> Completed | Failed`.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use crate::GpuError;
+
+/// Three-dimensional size used for grid and workgroup dimensions.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Dim3 {
+    pub x: u32,
+    pub y: u32,
+    pub z: u32,
+}
+
+impl Dim3 {
+    /// Create a new `Dim3` with explicit x/y/z components.
+    pub fn new(x: u32, y: u32, z: u32) -> Self {
+        Self { x, y, z }
+    }
+
+    /// Convenience for one-dimensional launches: `(n, 1, 1)`.
+    pub fn linear(n: u32) -> Self {
+        Self { x: n, y: 1, z: 1 }
+    }
+
+    /// Total number of threads/workgroups represented by this `Dim3`.
+    pub fn total(&self) -> u64 {
+        self.x as u64 * self.y as u64 * self.z as u64
+    }
+}
+
+/// Wavefront mode for kernel dispatch.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum WavefrontMode {
+    /// 32-thread wavefronts (RDNA native, wave32).
+    Wave32,
+    /// 64-thread wavefronts (CDNA native, GCN compatible).
+    Wave64,
+}
+
+/// Configuration for a kernel launch.
+#[derive(Clone, Debug, PartialEq)]
+pub struct LaunchConfig {
+    /// Number of workgroups in the grid.
+    pub grid: Dim3,
+    /// Number of work-items per workgroup.
+    pub workgroup: Dim3,
+    /// Bytes of LDS (local data share) per workgroup.
+    pub lds_size: u32,
+    /// Queue/stream ordinal.
+    pub queue: u32,
+    /// Wavefront mode for this dispatch.
+    pub wavefront_mode: WavefrontMode,
+}
+
+/// Maximum work-items per workgroup (hardware limit).
+const MAX_WORKITEMS_PER_WORKGROUP: u64 = 1024;
+
+/// Maximum LDS per workgroup (128 KiB).
+const MAX_LDS_PER_WORKGROUP: u32 = 131072;
+
+impl LaunchConfig {
+    /// Validate that this configuration is within hardware limits.
+    pub fn validate(&self) -> Result<(), GpuError> {
+        if self.workgroup.total() > MAX_WORKITEMS_PER_WORKGROUP {
+            return Err(GpuError::InvalidConfig);
+        }
+        if self.grid.x == 0 || self.grid.y == 0 || self.grid.z == 0 {
+            return Err(GpuError::InvalidConfig);
+        }
+        if self.workgroup.x == 0 || self.workgroup.y == 0 || self.workgroup.z == 0 {
+            return Err(GpuError::InvalidConfig);
+        }
+        if self.lds_size > MAX_LDS_PER_WORKGROUP {
+            return Err(GpuError::InvalidConfig);
+        }
+        Ok(())
+    }
+}
+
+/// Unique identifier for a submitted kernel.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct KernelId(pub u64);
+
+/// Lifecycle state of a kernel.
+#[derive(Clone, Debug, PartialEq)]
+pub enum KernelStatus {
+    /// Submitted and waiting in the queue.
+    Queued,
+    /// Currently executing on the GPU.
+    Running,
+    /// Finished successfully.
+    Completed,
+    /// Terminated with an error.
+    Failed,
+}
+
+/// A single kernel tracked by the compute engine.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Kernel {
+    /// Unique kernel identifier.
+    pub id: KernelId,
+    /// Human-readable kernel name (e.g. ONNX op name).
+    pub name: String,
+    /// Launch configuration.
+    pub config: LaunchConfig,
+    /// Current status.
+    pub status: KernelStatus,
+}
+
+/// Maximum number of kernels that may be queued at once.
+pub const MAX_QUEUED_KERNELS: usize = 512;
+
+/// Wavefront-based GPU compute engine.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ComputeEngine {
+    /// All tracked kernels.
+    pub(crate) kernels: Vec<Kernel>,
+    /// Monotonically increasing id generator.
+    next_id: u64,
+    /// Running count of successfully completed kernels.
+    completed_count: u64,
+    /// Running count of failed kernels.
+    failed_count: u64,
+}
+
+impl Default for ComputeEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ComputeEngine {
+    /// Create a new, empty compute engine.
+    pub fn new() -> Self {
+        Self {
+            kernels: Vec::new(),
+            next_id: 1,
+            completed_count: 0,
+            failed_count: 0,
+        }
+    }
+
+    /// Submit a kernel for execution.
+    pub fn launch(&mut self, name: &str, config: LaunchConfig) -> Result<KernelId, GpuError> {
+        config.validate()?;
+
+        if self.kernels.len() >= MAX_QUEUED_KERNELS {
+            return Err(GpuError::QueueFull);
+        }
+
+        let id = KernelId(self.next_id);
+        self.next_id += 1;
+
+        self.kernels.push(Kernel {
+            id,
+            name: String::from(name),
+            config,
+            status: KernelStatus::Queued,
+        });
+
+        Ok(id)
+    }
+
+    /// Dispatch a queued kernel to the GPU (Queued -> Running).
+    pub fn dispatch(&mut self, id: KernelId) -> Result<(), GpuError> {
+        let kernel = self.find_mut(id)?;
+        if kernel.status != KernelStatus::Queued {
+            return Err(GpuError::InvalidState);
+        }
+        kernel.status = KernelStatus::Running;
+        Ok(())
+    }
+
+    /// Mark a running kernel as completed (Running -> Completed).
+    pub fn complete(&mut self, id: KernelId) -> Result<(), GpuError> {
+        let kernel = self.find_mut(id)?;
+        if kernel.status != KernelStatus::Running {
+            return Err(GpuError::InvalidState);
+        }
+        kernel.status = KernelStatus::Completed;
+        self.completed_count += 1;
+        Ok(())
+    }
+
+    /// Mark a running kernel as failed (Running -> Failed).
+    pub fn fail(&mut self, id: KernelId) -> Result<(), GpuError> {
+        let kernel = self.find_mut(id)?;
+        if kernel.status != KernelStatus::Running {
+            return Err(GpuError::InvalidState);
+        }
+        kernel.status = KernelStatus::Failed;
+        self.failed_count += 1;
+        Ok(())
+    }
+
+    /// Query the current status of a kernel.
+    pub fn status(&self, id: KernelId) -> Result<&KernelStatus, GpuError> {
+        let kernel = self
+            .kernels
+            .iter()
+            .find(|k| k.id == id)
+            .ok_or(GpuError::NotFound)?;
+        Ok(&kernel.status)
+    }
+
+    /// Device-wide synchronization barrier.
+    ///
+    /// All `Running` kernels are moved to `Completed`.
+    pub fn synchronize(&mut self) {
+        for kernel in &mut self.kernels {
+            if kernel.status == KernelStatus::Running {
+                kernel.status = KernelStatus::Completed;
+                self.completed_count += 1;
+            }
+        }
+    }
+
+    /// Total number of kernels that have completed successfully.
+    pub fn completed_count(&self) -> u64 {
+        self.completed_count
+    }
+
+    /// Number of kernels currently in [`KernelStatus::Queued`] state.
+    pub fn queued_count(&self) -> usize {
+        self.kernels
+            .iter()
+            .filter(|k| k.status == KernelStatus::Queued)
+            .count()
+    }
+
+    // -- internal helpers ---------------------------------------------------
+
+    fn find_mut(&mut self, id: KernelId) -> Result<&mut Kernel, GpuError> {
+        self.kernels
+            .iter_mut()
+            .find(|k| k.id == id)
+            .ok_or(GpuError::NotFound)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_config() -> LaunchConfig {
+        LaunchConfig {
+            grid: Dim3::linear(128),
+            workgroup: Dim3::linear(256),
+            lds_size: 0,
+            queue: 0,
+            wavefront_mode: WavefrontMode::Wave64,
+        }
+    }
+
+    fn valid_wave32_config() -> LaunchConfig {
+        LaunchConfig {
+            grid: Dim3::linear(128),
+            workgroup: Dim3::linear(256),
+            lds_size: 0,
+            queue: 0,
+            wavefront_mode: WavefrontMode::Wave32,
+        }
+    }
+
+    #[test]
+    fn test_dim3_creation_and_total() {
+        let d = Dim3::new(4, 8, 2);
+        assert_eq!(d.x, 4);
+        assert_eq!(d.y, 8);
+        assert_eq!(d.z, 2);
+        assert_eq!(d.total(), 64);
+    }
+
+    #[test]
+    fn test_dim3_linear() {
+        let d = Dim3::linear(512);
+        assert_eq!(d.x, 512);
+        assert_eq!(d.y, 1);
+        assert_eq!(d.z, 1);
+        assert_eq!(d.total(), 512);
+    }
+
+    #[test]
+    fn test_launch_config_valid() {
+        assert!(valid_config().validate().is_ok());
+    }
+
+    #[test]
+    fn test_launch_config_workgroup_too_large() {
+        let cfg = LaunchConfig {
+            grid: Dim3::linear(1),
+            workgroup: Dim3::new(32, 32, 2), // 2048 > 1024
+            lds_size: 0,
+            queue: 0,
+            wavefront_mode: WavefrontMode::Wave64,
+        };
+        assert_eq!(cfg.validate(), Err(GpuError::InvalidConfig));
+    }
+
+    #[test]
+    fn test_launch_config_zero_grid() {
+        let cfg = LaunchConfig {
+            grid: Dim3::new(0, 1, 1),
+            workgroup: Dim3::linear(256),
+            lds_size: 0,
+            queue: 0,
+            wavefront_mode: WavefrontMode::Wave64,
+        };
+        assert_eq!(cfg.validate(), Err(GpuError::InvalidConfig));
+    }
+
+    #[test]
+    fn test_launch_config_lds_limit() {
+        let cfg = LaunchConfig {
+            grid: Dim3::linear(1),
+            workgroup: Dim3::linear(256),
+            lds_size: MAX_LDS_PER_WORKGROUP + 1,
+            queue: 0,
+            wavefront_mode: WavefrontMode::Wave64,
+        };
+        assert_eq!(cfg.validate(), Err(GpuError::InvalidConfig));
+    }
+
+    #[test]
+    fn test_launch_creates_queued() {
+        let mut eng = ComputeEngine::new();
+        let id = eng.launch("matmul", valid_config()).unwrap();
+        assert_eq!(eng.status(id), Ok(&KernelStatus::Queued));
+    }
+
+    #[test]
+    fn test_dispatch_queued() {
+        let mut eng = ComputeEngine::new();
+        let id = eng.launch("relu", valid_config()).unwrap();
+        eng.dispatch(id).unwrap();
+        assert_eq!(eng.status(id), Ok(&KernelStatus::Running));
+    }
+
+    #[test]
+    fn test_complete_running() {
+        let mut eng = ComputeEngine::new();
+        let id = eng.launch("conv2d", valid_config()).unwrap();
+        eng.dispatch(id).unwrap();
+        eng.complete(id).unwrap();
+        assert_eq!(eng.status(id), Ok(&KernelStatus::Completed));
+    }
+
+    #[test]
+    fn test_fail_running() {
+        let mut eng = ComputeEngine::new();
+        let id = eng.launch("softmax", valid_config()).unwrap();
+        eng.dispatch(id).unwrap();
+        eng.fail(id).unwrap();
+        assert_eq!(eng.status(id), Ok(&KernelStatus::Failed));
+    }
+
+    #[test]
+    fn test_cannot_dispatch_completed() {
+        let mut eng = ComputeEngine::new();
+        let id = eng.launch("add", valid_config()).unwrap();
+        eng.dispatch(id).unwrap();
+        eng.complete(id).unwrap();
+        assert_eq!(eng.dispatch(id), Err(GpuError::InvalidState));
+    }
+
+    #[test]
+    fn test_synchronize() {
+        let mut eng = ComputeEngine::new();
+        let id1 = eng.launch("k1", valid_config()).unwrap();
+        let id2 = eng.launch("k2", valid_config()).unwrap();
+        let id3 = eng.launch("k3", valid_config()).unwrap();
+        eng.dispatch(id1).unwrap();
+        eng.dispatch(id2).unwrap();
+        eng.synchronize();
+        assert_eq!(eng.status(id1), Ok(&KernelStatus::Completed));
+        assert_eq!(eng.status(id2), Ok(&KernelStatus::Completed));
+        assert_eq!(eng.status(id3), Ok(&KernelStatus::Queued));
+        assert_eq!(eng.completed_count(), 2);
+    }
+
+    #[test]
+    fn test_status_not_found() {
+        let eng = ComputeEngine::new();
+        assert_eq!(eng.status(KernelId(999)), Err(GpuError::NotFound));
+    }
+
+    #[test]
+    fn test_completed_queued_counts() {
+        let mut eng = ComputeEngine::new();
+        let id1 = eng.launch("a", valid_config()).unwrap();
+        let _id2 = eng.launch("b", valid_config()).unwrap();
+        assert_eq!(eng.queued_count(), 2);
+        eng.dispatch(id1).unwrap();
+        eng.complete(id1).unwrap();
+        assert_eq!(eng.completed_count(), 1);
+        assert_eq!(eng.queued_count(), 1);
+    }
+
+    #[test]
+    fn test_queue_full() {
+        let mut eng = ComputeEngine::new();
+        for i in 0..MAX_QUEUED_KERNELS {
+            eng.launch(&alloc::format!("k{}", i), valid_config())
+                .unwrap();
+        }
+        assert_eq!(
+            eng.launch("overflow", valid_config()),
+            Err(GpuError::QueueFull)
+        );
+    }
+
+    #[test]
+    fn test_zero_workgroup_dimension() {
+        let cfg = LaunchConfig {
+            grid: Dim3::linear(1),
+            workgroup: Dim3::new(256, 0, 1),
+            lds_size: 0,
+            queue: 0,
+            wavefront_mode: WavefrontMode::Wave64,
+        };
+        assert_eq!(cfg.validate(), Err(GpuError::InvalidConfig));
+    }
+
+    #[test]
+    fn test_exact_max_workitems() {
+        let cfg = LaunchConfig {
+            grid: Dim3::linear(1),
+            workgroup: Dim3::new(32, 32, 1), // 1024 == MAX
+            lds_size: 0,
+            queue: 0,
+            wavefront_mode: WavefrontMode::Wave64,
+        };
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn test_exact_max_lds() {
+        let cfg = LaunchConfig {
+            grid: Dim3::linear(1),
+            workgroup: Dim3::linear(64),
+            lds_size: MAX_LDS_PER_WORKGROUP,
+            queue: 0,
+            wavefront_mode: WavefrontMode::Wave64,
+        };
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn test_failed_count() {
+        let mut eng = ComputeEngine::new();
+        let id = eng.launch("bad_kernel", valid_config()).unwrap();
+        eng.dispatch(id).unwrap();
+        eng.fail(id).unwrap();
+        assert_eq!(eng.failed_count, 1);
+        assert_eq!(eng.completed_count(), 0);
+    }
+
+    #[test]
+    fn test_cannot_complete_queued() {
+        let mut eng = ComputeEngine::new();
+        let id = eng.launch("skip", valid_config()).unwrap();
+        assert_eq!(eng.complete(id), Err(GpuError::InvalidState));
+    }
+
+    #[test]
+    fn test_wavefront_modes() {
+        let mut eng = ComputeEngine::new();
+        let id1 = eng.launch("wave64_kernel", valid_config()).unwrap();
+        let id2 = eng.launch("wave32_kernel", valid_wave32_config()).unwrap();
+        let k1 = eng.kernels.iter().find(|k| k.id == id1).unwrap();
+        let k2 = eng.kernels.iter().find(|k| k.id == id2).unwrap();
+        assert_eq!(k1.config.wavefront_mode, WavefrontMode::Wave64);
+        assert_eq!(k2.config.wavefront_mode, WavefrontMode::Wave32);
+    }
+}

--- a/arch/amd/src/dma.rs
+++ b/arch/amd/src/dma.rs
@@ -1,0 +1,420 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! SDMA (System DMA) engine for host<->device transfers.
+//!
+//! Manages asynchronous memory transfers between host RAM and device VRAM
+//! (and device-to-device copies). AMD GPUs use SDMA engines (typically 2
+//! per GPU) for async data movement. Each transfer goes through a strict
+//! state machine: `Pending -> InProgress -> Completed | Failed`.
+
+use alloc::vec::Vec;
+
+use crate::GpuError;
+
+/// Direction of a DMA transfer.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum DmaDirection {
+    /// Host RAM -> Device VRAM.
+    HostToDevice,
+    /// Device VRAM -> Host RAM.
+    DeviceToHost,
+    /// Device VRAM -> Device VRAM (peer or same GPU).
+    DeviceToDevice,
+}
+
+/// State of a DMA transfer.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum DmaStatus {
+    /// Submitted but not yet started by the SDMA engine.
+    Pending,
+    /// Currently being executed by the SDMA engine.
+    InProgress,
+    /// Successfully finished.
+    Completed,
+    /// Terminated with an error.
+    Failed,
+}
+
+/// Unique identifier for a DMA transfer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct TransferId(pub u64);
+
+/// A single DMA transfer descriptor.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DmaTransfer {
+    /// Unique transfer identifier.
+    pub id: TransferId,
+    /// Direction of the transfer.
+    pub direction: DmaDirection,
+    /// Source address (host-physical or GPU-virtual, depending on direction).
+    pub src_addr: u64,
+    /// Destination address.
+    pub dst_addr: u64,
+    /// Transfer size in bytes.
+    pub size: u64,
+    /// Current status.
+    pub status: DmaStatus,
+}
+
+/// Maximum number of tracked transfers.
+pub const MAX_TRANSFERS: usize = 256;
+
+/// Maximum size of a single DMA transfer (256 MiB).
+pub const MAX_TRANSFER_SIZE: u64 = 256 * 1024 * 1024;
+
+/// SDMA engine controller.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SdmaEngine {
+    /// All tracked transfer descriptors.
+    transfers: Vec<DmaTransfer>,
+    /// Monotonically increasing id generator.
+    next_id: u64,
+    /// Running total of successfully transferred bytes.
+    bytes_transferred: u64,
+    /// Whether the engine is active (ready to accept work).
+    active: bool,
+    /// SDMA engine index (AMD GPUs typically have 2 SDMA engines).
+    engine_index: u32,
+}
+
+impl SdmaEngine {
+    /// Create a new, active SDMA engine with no pending work.
+    pub fn new(engine_index: u32) -> Self {
+        Self {
+            transfers: Vec::new(),
+            next_id: 1,
+            bytes_transferred: 0,
+            active: true,
+            engine_index,
+        }
+    }
+
+    /// Submit a new transfer request.
+    ///
+    /// The transfer is created in [`DmaStatus::Pending`] state.
+    pub fn submit(
+        &mut self,
+        direction: DmaDirection,
+        src: u64,
+        dst: u64,
+        size: u64,
+    ) -> Result<TransferId, GpuError> {
+        if size == 0 {
+            return Err(GpuError::DmaError);
+        }
+        if size > MAX_TRANSFER_SIZE {
+            return Err(GpuError::TransferTooLarge);
+        }
+        if self.transfers.len() >= MAX_TRANSFERS {
+            return Err(GpuError::QueueFull);
+        }
+
+        let id = TransferId(self.next_id);
+        self.next_id += 1;
+
+        self.transfers.push(DmaTransfer {
+            id,
+            direction,
+            src_addr: src,
+            dst_addr: dst,
+            size,
+            status: DmaStatus::Pending,
+        });
+
+        Ok(id)
+    }
+
+    /// Start a pending transfer (Pending -> InProgress).
+    pub fn start(&mut self, id: TransferId) -> Result<(), GpuError> {
+        let xfer = self.find_mut(id)?;
+        if xfer.status != DmaStatus::Pending {
+            return Err(GpuError::InvalidState);
+        }
+        xfer.status = DmaStatus::InProgress;
+        Ok(())
+    }
+
+    /// Mark an in-progress transfer as completed (InProgress -> Completed).
+    pub fn complete(&mut self, id: TransferId) -> Result<(), GpuError> {
+        let xfer = self.find_mut(id)?;
+        if xfer.status != DmaStatus::InProgress {
+            return Err(GpuError::InvalidState);
+        }
+        xfer.status = DmaStatus::Completed;
+        self.bytes_transferred += xfer.size;
+        Ok(())
+    }
+
+    /// Mark an in-progress transfer as failed (InProgress -> Failed).
+    pub fn fail(&mut self, id: TransferId) -> Result<(), GpuError> {
+        let xfer = self.find_mut(id)?;
+        if xfer.status != DmaStatus::InProgress {
+            return Err(GpuError::InvalidState);
+        }
+        xfer.status = DmaStatus::Failed;
+        Ok(())
+    }
+
+    /// Query the current status of a transfer.
+    pub fn status(&self, id: TransferId) -> Result<&DmaStatus, GpuError> {
+        let xfer = self
+            .transfers
+            .iter()
+            .find(|t| t.id == id)
+            .ok_or(GpuError::NotFound)?;
+        Ok(&xfer.status)
+    }
+
+    /// Cancel a pending transfer.
+    pub fn cancel(&mut self, id: TransferId) -> Result<(), GpuError> {
+        let idx = self
+            .transfers
+            .iter()
+            .position(|t| t.id == id)
+            .ok_or(GpuError::NotFound)?;
+
+        if self.transfers[idx].status != DmaStatus::Pending {
+            return Err(GpuError::InvalidState);
+        }
+
+        self.transfers.remove(idx);
+        Ok(())
+    }
+
+    /// Total bytes successfully transferred since engine creation.
+    pub fn total_bytes_transferred(&self) -> u64 {
+        self.bytes_transferred
+    }
+
+    /// Number of transfers currently in [`DmaStatus::Pending`] state.
+    pub fn pending_count(&self) -> usize {
+        self.transfers
+            .iter()
+            .filter(|t| t.status == DmaStatus::Pending)
+            .count()
+    }
+
+    /// Number of transfers currently in [`DmaStatus::InProgress`] state.
+    pub fn active_count(&self) -> usize {
+        self.transfers
+            .iter()
+            .filter(|t| t.status == DmaStatus::InProgress)
+            .count()
+    }
+
+    /// SDMA engine index.
+    pub fn engine_index(&self) -> u32 {
+        self.engine_index
+    }
+
+    // -- internal helpers ---------------------------------------------------
+
+    fn find_mut(&mut self, id: TransferId) -> Result<&mut DmaTransfer, GpuError> {
+        self.transfers
+            .iter_mut()
+            .find(|t| t.id == id)
+            .ok_or(GpuError::NotFound)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_submit_unique_ids() {
+        let mut eng = SdmaEngine::new(0);
+        let id1 = eng
+            .submit(DmaDirection::HostToDevice, 0x1000, 0x2000, 4096)
+            .unwrap();
+        let id2 = eng
+            .submit(DmaDirection::DeviceToHost, 0x3000, 0x4000, 8192)
+            .unwrap();
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn test_start_pending() {
+        let mut eng = SdmaEngine::new(0);
+        let id = eng.submit(DmaDirection::HostToDevice, 0, 0, 4096).unwrap();
+        assert_eq!(eng.status(id), Ok(&DmaStatus::Pending));
+        eng.start(id).unwrap();
+        assert_eq!(eng.status(id), Ok(&DmaStatus::InProgress));
+    }
+
+    #[test]
+    fn test_complete_in_progress() {
+        let mut eng = SdmaEngine::new(0);
+        let id = eng.submit(DmaDirection::HostToDevice, 0, 0, 4096).unwrap();
+        eng.start(id).unwrap();
+        eng.complete(id).unwrap();
+        assert_eq!(eng.status(id), Ok(&DmaStatus::Completed));
+    }
+
+    #[test]
+    fn test_fail_in_progress() {
+        let mut eng = SdmaEngine::new(0);
+        let id = eng.submit(DmaDirection::DeviceToHost, 0, 0, 4096).unwrap();
+        eng.start(id).unwrap();
+        eng.fail(id).unwrap();
+        assert_eq!(eng.status(id), Ok(&DmaStatus::Failed));
+    }
+
+    #[test]
+    fn test_cancel_pending() {
+        let mut eng = SdmaEngine::new(0);
+        let id = eng.submit(DmaDirection::HostToDevice, 0, 0, 4096).unwrap();
+        eng.cancel(id).unwrap();
+        assert_eq!(eng.status(id), Err(GpuError::NotFound));
+    }
+
+    #[test]
+    fn test_cannot_start_completed() {
+        let mut eng = SdmaEngine::new(0);
+        let id = eng.submit(DmaDirection::HostToDevice, 0, 0, 4096).unwrap();
+        eng.start(id).unwrap();
+        eng.complete(id).unwrap();
+        assert_eq!(eng.start(id), Err(GpuError::InvalidState));
+    }
+
+    #[test]
+    fn test_cannot_complete_pending() {
+        let mut eng = SdmaEngine::new(0);
+        let id = eng.submit(DmaDirection::HostToDevice, 0, 0, 4096).unwrap();
+        assert_eq!(eng.complete(id), Err(GpuError::InvalidState));
+    }
+
+    #[test]
+    fn test_zero_size_rejected() {
+        let mut eng = SdmaEngine::new(0);
+        assert_eq!(
+            eng.submit(DmaDirection::HostToDevice, 0, 0, 0),
+            Err(GpuError::DmaError)
+        );
+    }
+
+    #[test]
+    fn test_transfer_too_large() {
+        let mut eng = SdmaEngine::new(0);
+        assert_eq!(
+            eng.submit(DmaDirection::HostToDevice, 0, 0, MAX_TRANSFER_SIZE + 1),
+            Err(GpuError::TransferTooLarge)
+        );
+    }
+
+    #[test]
+    fn test_bytes_transferred() {
+        let mut eng = SdmaEngine::new(0);
+        let id1 = eng.submit(DmaDirection::HostToDevice, 0, 0, 1000).unwrap();
+        eng.start(id1).unwrap();
+        eng.complete(id1).unwrap();
+
+        let id2 = eng.submit(DmaDirection::DeviceToHost, 0, 0, 2000).unwrap();
+        eng.start(id2).unwrap();
+        eng.complete(id2).unwrap();
+
+        assert_eq!(eng.total_bytes_transferred(), 3000);
+    }
+
+    #[test]
+    fn test_pending_active_counts() {
+        let mut eng = SdmaEngine::new(0);
+        let id1 = eng.submit(DmaDirection::HostToDevice, 0, 0, 4096).unwrap();
+        let _id2 = eng.submit(DmaDirection::DeviceToHost, 0, 0, 4096).unwrap();
+        assert_eq!(eng.pending_count(), 2);
+        assert_eq!(eng.active_count(), 0);
+
+        eng.start(id1).unwrap();
+        assert_eq!(eng.pending_count(), 1);
+        assert_eq!(eng.active_count(), 1);
+    }
+
+    #[test]
+    fn test_status_lookup() {
+        let mut eng = SdmaEngine::new(0);
+        assert_eq!(eng.status(TransferId(999)), Err(GpuError::NotFound));
+        let id = eng.submit(DmaDirection::HostToDevice, 0, 0, 4096).unwrap();
+        assert_eq!(eng.status(id), Ok(&DmaStatus::Pending));
+    }
+
+    #[test]
+    fn test_direction_types() {
+        let mut eng = SdmaEngine::new(0);
+        let id_h2d = eng.submit(DmaDirection::HostToDevice, 0, 0, 4096).unwrap();
+        let id_d2h = eng.submit(DmaDirection::DeviceToHost, 0, 0, 4096).unwrap();
+        let id_d2d = eng
+            .submit(DmaDirection::DeviceToDevice, 0, 0, 4096)
+            .unwrap();
+        let t1 = eng.transfers.iter().find(|t| t.id == id_h2d).unwrap();
+        let t2 = eng.transfers.iter().find(|t| t.id == id_d2h).unwrap();
+        let t3 = eng.transfers.iter().find(|t| t.id == id_d2d).unwrap();
+        assert_eq!(t1.direction, DmaDirection::HostToDevice);
+        assert_eq!(t2.direction, DmaDirection::DeviceToHost);
+        assert_eq!(t3.direction, DmaDirection::DeviceToDevice);
+    }
+
+    #[test]
+    fn test_full_lifecycle() {
+        let mut eng = SdmaEngine::new(0);
+        let id = eng
+            .submit(DmaDirection::HostToDevice, 0xA000, 0xB000, 65536)
+            .unwrap();
+        assert_eq!(eng.status(id), Ok(&DmaStatus::Pending));
+        eng.start(id).unwrap();
+        assert_eq!(eng.status(id), Ok(&DmaStatus::InProgress));
+        eng.complete(id).unwrap();
+        assert_eq!(eng.status(id), Ok(&DmaStatus::Completed));
+        assert_eq!(eng.total_bytes_transferred(), 65536);
+    }
+
+    #[test]
+    fn test_cannot_cancel_in_progress() {
+        let mut eng = SdmaEngine::new(0);
+        let id = eng.submit(DmaDirection::HostToDevice, 0, 0, 4096).unwrap();
+        eng.start(id).unwrap();
+        assert_eq!(eng.cancel(id), Err(GpuError::InvalidState));
+    }
+
+    #[test]
+    fn test_queue_full() {
+        let mut eng = SdmaEngine::new(0);
+        for _ in 0..MAX_TRANSFERS {
+            eng.submit(DmaDirection::HostToDevice, 0, 0, 4096).unwrap();
+        }
+        assert_eq!(
+            eng.submit(DmaDirection::HostToDevice, 0, 0, 4096),
+            Err(GpuError::QueueFull)
+        );
+    }
+
+    #[test]
+    fn test_failed_no_bytes() {
+        let mut eng = SdmaEngine::new(0);
+        let id = eng.submit(DmaDirection::HostToDevice, 0, 0, 4096).unwrap();
+        eng.start(id).unwrap();
+        eng.fail(id).unwrap();
+        assert_eq!(eng.total_bytes_transferred(), 0);
+    }
+
+    #[test]
+    fn test_max_transfer_size_boundary() {
+        let mut eng = SdmaEngine::new(0);
+        let id = eng
+            .submit(DmaDirection::HostToDevice, 0, 0, MAX_TRANSFER_SIZE)
+            .unwrap();
+        assert_eq!(eng.status(id), Ok(&DmaStatus::Pending));
+    }
+
+    #[test]
+    fn test_engine_index() {
+        let eng0 = SdmaEngine::new(0);
+        let eng1 = SdmaEngine::new(1);
+        assert_eq!(eng0.engine_index(), 0);
+        assert_eq!(eng1.engine_index(), 1);
+    }
+}

--- a/arch/amd/src/gpu_id.rs
+++ b/arch/amd/src/gpu_id.rs
@@ -1,0 +1,487 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! GPU identification -- architecture, GFX version, resources.
+//!
+//! Given a PCI device ID this module returns a [`GpuInfo`] that describes the
+//! GPU architecture, compute unit count, VRAM size, wavefront geometry, and
+//! other parameters required by the compute-launch and memory-management layers.
+
+use crate::GpuError;
+
+// ---------------------------------------------------------------------------
+// GpuArchitecture
+// ---------------------------------------------------------------------------
+
+/// AMD GPU micro-architecture family.
+#[derive(Clone, Debug, PartialEq)]
+pub enum GpuArchitecture {
+    /// RDNA 1 (Navi 10/14) -- RX 5600/5700 series.
+    Rdna1,
+    /// RDNA 2 (Navi 21/22/23) -- RX 6700/6800/6900 series.
+    Rdna2,
+    /// RDNA 3 (Navi 31/32/33) -- RX 7800/7900 series.
+    Rdna3,
+    /// CDNA 1 (Arcturus) -- Instinct MI100.
+    Cdna1,
+    /// CDNA 2 (Aldebaran) -- Instinct MI200 series.
+    Cdna2,
+    /// CDNA 3 -- Instinct MI300 series.
+    Cdna3,
+    /// Architecture could not be determined.
+    Unknown,
+}
+
+impl GpuArchitecture {
+    /// Returns `true` for CDNA architectures (datacenter compute).
+    pub fn is_cdna(&self) -> bool {
+        matches!(self, Self::Cdna1 | Self::Cdna2 | Self::Cdna3)
+    }
+
+    /// Returns `true` for RDNA architectures (consumer/gaming).
+    pub fn is_rdna(&self) -> bool {
+        matches!(self, Self::Rdna1 | Self::Rdna2 | Self::Rdna3)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GfxVersion
+// ---------------------------------------------------------------------------
+
+/// AMD GFX ISA version (e.g., gfx908, gfx942, gfx1100).
+#[derive(Clone, Debug, PartialEq)]
+pub struct GfxVersion {
+    pub major: u16,
+    pub minor: u16,
+    pub stepping: u16,
+}
+
+impl GfxVersion {
+    /// Create a new GFX version.
+    pub fn new(major: u16, minor: u16, stepping: u16) -> Self {
+        Self {
+            major,
+            minor,
+            stepping,
+        }
+    }
+
+    /// Encode as the `gfxNNN` version used by ROCm toolchains.
+    ///
+    /// Example: GFX 9.0.8 -> `gfx908` -> returns `908`.
+    pub fn as_gfx_id(&self) -> u32 {
+        self.major as u32 * 100 + self.minor as u32 * 10 + self.stepping as u32
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GpuInfo
+// ---------------------------------------------------------------------------
+
+/// Static description of a particular AMD GPU.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GpuInfo {
+    /// PCI device ID used to identify the GPU.
+    pub device_id: u16,
+    /// Micro-architecture family.
+    pub architecture: GpuArchitecture,
+    /// GFX ISA version.
+    pub gfx_version: GfxVersion,
+    /// Number of Compute Units (CU).
+    pub cu_count: u32,
+    /// Video RAM in megabytes.
+    pub vram_size_mb: u32,
+    /// Maximum wavefronts per CU.
+    pub max_wavefronts_per_cu: u32,
+    /// Threads per wavefront (64 for CDNA, 32 for RDNA wave32).
+    pub wavefront_size: u32,
+    /// Shared memory (LDS) per CU in bytes.
+    pub lds_per_cu: u32,
+    /// Vector GPRs per CU.
+    pub vgprs_per_cu: u32,
+    /// Human-readable product name.
+    pub name: &'static str,
+}
+
+impl GpuInfo {
+    /// Total stream processors on the GPU.
+    ///
+    /// The number of stream processors per CU varies by architecture:
+    /// - RDNA: 64 stream processors per CU (2 WGPs of 32 each)
+    /// - CDNA: 64 stream processors per CU
+    pub fn total_stream_processors(&self) -> u32 {
+        self.cu_count * 64
+    }
+
+    /// Maximum number of threads that can be resident across all CUs.
+    pub fn max_concurrent_threads(&self) -> u32 {
+        self.cu_count * self.max_wavefronts_per_cu * self.wavefront_size
+    }
+
+    /// Whether this GPU supports wave32 mode (RDNA only).
+    pub fn supports_wave32(&self) -> bool {
+        self.architecture.is_rdna()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// identify_gpu
+// ---------------------------------------------------------------------------
+
+/// Identify a GPU from its PCI device ID.
+///
+/// Returns a fully-populated [`GpuInfo`] for known AMD device IDs or
+/// [`GpuError::UnsupportedDevice`] otherwise.
+pub fn identify_gpu(device_id: u16) -> Result<GpuInfo, GpuError> {
+    match device_id {
+        // ----- RDNA 1 (gfx1010) -- RX 5000 series -----------------------
+        0x7310..=0x737F => {
+            let (name, cu, vram) = match device_id {
+                0x7310 => ("AMD Radeon RX 5600 XT", 36, 6144),
+                0x7312 => ("AMD Radeon RX 5700", 36, 8192),
+                0x7318 => ("AMD Radeon RX 5700 XT", 40, 8192),
+                _ => ("AMD RDNA 1 GPU", 36, 8192),
+            };
+            Ok(GpuInfo {
+                device_id,
+                architecture: GpuArchitecture::Rdna1,
+                gfx_version: GfxVersion::new(10, 1, 0),
+                cu_count: cu,
+                vram_size_mb: vram,
+                max_wavefronts_per_cu: 20,
+                wavefront_size: 32,
+                lds_per_cu: 128 * 1024,
+                vgprs_per_cu: 1024,
+                name,
+            })
+        }
+
+        // ----- CDNA 1 (gfx908) -- MI100 ---------------------------------
+        0x7380..=0x739F => {
+            let (name, cu, vram) = match device_id {
+                0x7388 => ("AMD Instinct MI100", 120, 32768),
+                _ => ("AMD CDNA 1 GPU", 120, 32768),
+            };
+            Ok(GpuInfo {
+                device_id,
+                architecture: GpuArchitecture::Cdna1,
+                gfx_version: GfxVersion::new(9, 0, 8),
+                cu_count: cu,
+                vram_size_mb: vram,
+                max_wavefronts_per_cu: 40,
+                wavefront_size: 64,
+                lds_per_cu: 64 * 1024,
+                vgprs_per_cu: 1024,
+                name,
+            })
+        }
+
+        // ----- RDNA 2 (gfx1030) -- RX 6000 series -----------------------
+        0x73A0..=0x73EF => {
+            let (name, cu, vram) = match device_id {
+                0x73A2 => ("AMD Radeon RX 6700 XT", 40, 12288),
+                0x73BF => ("AMD Radeon RX 6900 XT", 80, 16384),
+                0x73C0 => ("AMD Radeon RX 6800 XT", 72, 16384),
+                _ => ("AMD RDNA 2 GPU", 60, 16384),
+            };
+            Ok(GpuInfo {
+                device_id,
+                architecture: GpuArchitecture::Rdna2,
+                gfx_version: GfxVersion::new(10, 3, 0),
+                cu_count: cu,
+                vram_size_mb: vram,
+                max_wavefronts_per_cu: 20,
+                wavefront_size: 32,
+                lds_per_cu: 128 * 1024,
+                vgprs_per_cu: 1024,
+                name,
+            })
+        }
+
+        // ----- CDNA 2 (gfx90a) -- MI200 series --------------------------
+        0x7400..=0x743F => {
+            let (name, cu, vram) = match device_id {
+                0x7400 => ("AMD Instinct MI250X", 220, 131072),
+                0x7402 => ("AMD Instinct MI250", 208, 131072),
+                0x7408 => ("AMD Instinct MI210", 104, 65536),
+                _ => ("AMD CDNA 2 GPU", 220, 131072),
+            };
+            Ok(GpuInfo {
+                device_id,
+                architecture: GpuArchitecture::Cdna2,
+                gfx_version: GfxVersion::new(9, 0, 10),
+                cu_count: cu,
+                vram_size_mb: vram,
+                max_wavefronts_per_cu: 40,
+                wavefront_size: 64,
+                lds_per_cu: 64 * 1024,
+                vgprs_per_cu: 1024,
+                name,
+            })
+        }
+
+        // ----- RDNA 3 (gfx1100) -- RX 7000 series -----------------------
+        0x7440..=0x74FF => {
+            let (name, cu, vram) = match device_id {
+                0x7440 => ("AMD Radeon RX 7900 XTX", 96, 24576),
+                0x7448 => ("AMD Radeon RX 7900 XT", 84, 20480),
+                0x7480 => ("AMD Radeon RX 7800 XT", 60, 16384),
+                _ => ("AMD RDNA 3 GPU", 60, 16384),
+            };
+            Ok(GpuInfo {
+                device_id,
+                architecture: GpuArchitecture::Rdna3,
+                gfx_version: GfxVersion::new(11, 0, 0),
+                cu_count: cu,
+                vram_size_mb: vram,
+                max_wavefronts_per_cu: 20,
+                wavefront_size: 32,
+                lds_per_cu: 128 * 1024,
+                vgprs_per_cu: 1536,
+                name,
+            })
+        }
+
+        // ----- CDNA 3 (gfx942) -- MI300 series --------------------------
+        0x7500..=0x75FF => {
+            let (name, cu, vram) = match device_id {
+                0x7500 => ("AMD Instinct MI300X", 304, 196608),
+                0x7502 => ("AMD Instinct MI300A", 228, 131072),
+                0x7508 => ("AMD Instinct MI325X", 304, 262144),
+                _ => ("AMD CDNA 3 GPU", 304, 196608),
+            };
+            Ok(GpuInfo {
+                device_id,
+                architecture: GpuArchitecture::Cdna3,
+                gfx_version: GfxVersion::new(9, 4, 2),
+                cu_count: cu,
+                vram_size_mb: vram,
+                max_wavefronts_per_cu: 40,
+                wavefront_size: 64,
+                lds_per_cu: 64 * 1024,
+                vgprs_per_cu: 1024,
+                name,
+            })
+        }
+
+        // ----- Unknown / unsupported -------------------------------------
+        _ => Err(GpuError::UnsupportedDevice),
+    }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- Individual GPU identification ------------------------------------
+
+    #[test]
+    fn identify_mi300x_cdna3() {
+        let info = identify_gpu(0x7500).unwrap();
+        assert_eq!(info.architecture, GpuArchitecture::Cdna3);
+        assert_eq!(info.gfx_version, GfxVersion::new(9, 4, 2));
+        assert_eq!(info.cu_count, 304);
+        assert_eq!(info.vram_size_mb, 196608);
+        assert_eq!(info.name, "AMD Instinct MI300X");
+    }
+
+    #[test]
+    fn identify_mi250x_cdna2() {
+        let info = identify_gpu(0x7400).unwrap();
+        assert_eq!(info.architecture, GpuArchitecture::Cdna2);
+        assert_eq!(info.gfx_version, GfxVersion::new(9, 0, 10));
+        assert_eq!(info.cu_count, 220);
+        assert_eq!(info.vram_size_mb, 131072);
+        assert_eq!(info.name, "AMD Instinct MI250X");
+    }
+
+    #[test]
+    fn identify_mi100_cdna1() {
+        let info = identify_gpu(0x7388).unwrap();
+        assert_eq!(info.architecture, GpuArchitecture::Cdna1);
+        assert_eq!(info.gfx_version, GfxVersion::new(9, 0, 8));
+        assert_eq!(info.cu_count, 120);
+        assert_eq!(info.vram_size_mb, 32768);
+        assert_eq!(info.name, "AMD Instinct MI100");
+    }
+
+    #[test]
+    fn identify_rx7900xtx_rdna3() {
+        let info = identify_gpu(0x7440).unwrap();
+        assert_eq!(info.architecture, GpuArchitecture::Rdna3);
+        assert_eq!(info.gfx_version, GfxVersion::new(11, 0, 0));
+        assert_eq!(info.cu_count, 96);
+        assert_eq!(info.vram_size_mb, 24576);
+        assert_eq!(info.name, "AMD Radeon RX 7900 XTX");
+    }
+
+    #[test]
+    fn identify_rx6900xt_rdna2() {
+        let info = identify_gpu(0x73BF).unwrap();
+        assert_eq!(info.architecture, GpuArchitecture::Rdna2);
+        assert_eq!(info.gfx_version, GfxVersion::new(10, 3, 0));
+        assert_eq!(info.cu_count, 80);
+        assert_eq!(info.vram_size_mb, 16384);
+        assert_eq!(info.name, "AMD Radeon RX 6900 XT");
+    }
+
+    #[test]
+    fn identify_rx5700xt_rdna1() {
+        let info = identify_gpu(0x7318).unwrap();
+        assert_eq!(info.architecture, GpuArchitecture::Rdna1);
+        assert_eq!(info.gfx_version, GfxVersion::new(10, 1, 0));
+        assert_eq!(info.cu_count, 40);
+        assert_eq!(info.vram_size_mb, 8192);
+        assert_eq!(info.name, "AMD Radeon RX 5700 XT");
+    }
+
+    #[test]
+    fn identify_mi325x_cdna3() {
+        let info = identify_gpu(0x7508).unwrap();
+        assert_eq!(info.architecture, GpuArchitecture::Cdna3);
+        assert_eq!(info.cu_count, 304);
+        assert_eq!(info.vram_size_mb, 262144);
+        assert_eq!(info.name, "AMD Instinct MI325X");
+    }
+
+    #[test]
+    fn unknown_device_returns_error() {
+        let result = identify_gpu(0xFFFF);
+        assert_eq!(result, Err(GpuError::UnsupportedDevice));
+    }
+
+    #[test]
+    fn unknown_device_in_gap_returns_error() {
+        let result = identify_gpu(0x0001);
+        assert_eq!(result, Err(GpuError::UnsupportedDevice));
+    }
+
+    // -- GfxVersion -------------------------------------------------------
+
+    #[test]
+    fn gfx_version_id_908() {
+        let gfx = GfxVersion::new(9, 0, 8);
+        assert_eq!(gfx.as_gfx_id(), 908);
+    }
+
+    #[test]
+    fn gfx_version_id_942() {
+        let gfx = GfxVersion::new(9, 4, 2);
+        assert_eq!(gfx.as_gfx_id(), 942);
+    }
+
+    #[test]
+    fn gfx_version_id_1100() {
+        let gfx = GfxVersion::new(11, 0, 0);
+        assert_eq!(gfx.as_gfx_id(), 1100);
+    }
+
+    #[test]
+    fn gfx_version_id_1030() {
+        let gfx = GfxVersion::new(10, 3, 0);
+        assert_eq!(gfx.as_gfx_id(), 1030);
+    }
+
+    // -- GpuInfo derived values -------------------------------------------
+
+    #[test]
+    fn total_stream_processors_cdna3() {
+        let info = identify_gpu(0x7500).unwrap();
+        // 304 CU * 64 SP = 19456
+        assert_eq!(info.total_stream_processors(), 304 * 64);
+    }
+
+    #[test]
+    fn total_stream_processors_rdna3() {
+        let info = identify_gpu(0x7440).unwrap();
+        // 96 CU * 64 SP = 6144
+        assert_eq!(info.total_stream_processors(), 96 * 64);
+    }
+
+    #[test]
+    fn max_concurrent_threads_mi300x() {
+        let info = identify_gpu(0x7500).unwrap();
+        // 304 CU * 40 wavefronts * 64 threads = 778240
+        assert_eq!(info.max_concurrent_threads(), 304 * 40 * 64);
+    }
+
+    #[test]
+    fn max_concurrent_threads_rdna3() {
+        let info = identify_gpu(0x7440).unwrap();
+        // 96 CU * 20 wavefronts * 32 threads = 61440
+        assert_eq!(info.max_concurrent_threads(), 96 * 20 * 32);
+    }
+
+    #[test]
+    fn wavefront_size_cdna_is_64() {
+        for &dev_id in &[0x7388, 0x7400, 0x7500] {
+            let info = identify_gpu(dev_id).unwrap();
+            assert_eq!(
+                info.wavefront_size, 64,
+                "CDNA wavefront must be 64 for device 0x{:04X}",
+                dev_id
+            );
+        }
+    }
+
+    #[test]
+    fn wavefront_size_rdna_is_32() {
+        for &dev_id in &[0x7318, 0x73BF, 0x7440] {
+            let info = identify_gpu(dev_id).unwrap();
+            assert_eq!(
+                info.wavefront_size, 32,
+                "RDNA wavefront must be 32 for device 0x{:04X}",
+                dev_id
+            );
+        }
+    }
+
+    #[test]
+    fn supports_wave32_rdna_only() {
+        let rdna = identify_gpu(0x7440).unwrap();
+        assert!(rdna.supports_wave32());
+        let cdna = identify_gpu(0x7500).unwrap();
+        assert!(!cdna.supports_wave32());
+    }
+
+    // -- Architecture classification --------------------------------------
+
+    #[test]
+    fn architecture_is_cdna() {
+        assert!(GpuArchitecture::Cdna1.is_cdna());
+        assert!(GpuArchitecture::Cdna2.is_cdna());
+        assert!(GpuArchitecture::Cdna3.is_cdna());
+        assert!(!GpuArchitecture::Rdna1.is_cdna());
+        assert!(!GpuArchitecture::Rdna3.is_cdna());
+        assert!(!GpuArchitecture::Unknown.is_cdna());
+    }
+
+    #[test]
+    fn architecture_is_rdna() {
+        assert!(GpuArchitecture::Rdna1.is_rdna());
+        assert!(GpuArchitecture::Rdna2.is_rdna());
+        assert!(GpuArchitecture::Rdna3.is_rdna());
+        assert!(!GpuArchitecture::Cdna1.is_rdna());
+        assert!(!GpuArchitecture::Cdna3.is_rdna());
+        assert!(!GpuArchitecture::Unknown.is_rdna());
+    }
+
+    #[test]
+    fn architecture_enum_clone_debug() {
+        let arch = GpuArchitecture::Cdna3;
+        let cloned = arch.clone();
+        assert_eq!(arch, cloned);
+        let dbg = alloc::format!("{:?}", arch);
+        assert!(dbg.contains("Cdna3"));
+    }
+
+    #[test]
+    fn architecture_unknown_variant() {
+        let arch = GpuArchitecture::Unknown;
+        assert_eq!(arch, GpuArchitecture::Unknown);
+    }
+}

--- a/arch/amd/src/gpu_init.rs
+++ b/arch/amd/src/gpu_init.rs
@@ -1,0 +1,501 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! GPU initialization sequence.
+//!
+//! Orchestrates the bring-up of an AMD GPU after PCIe enumeration:
+//! BAR mapping, engine initialisation, power-state management, and
+//! suspend/resume lifecycle.
+
+use crate::gpu_id::GpuInfo;
+use crate::pcie::{BarType, BaseAddressRegister};
+use crate::GpuError;
+
+// ---------------------------------------------------------------------------
+// GpuState
+// ---------------------------------------------------------------------------
+
+/// Lifecycle state of a GPU context.
+#[derive(Clone, Debug, PartialEq)]
+pub enum GpuState {
+    /// GPU discovered but no BARs mapped yet.
+    Uninitialized,
+    /// BAR0 / BAR1 mapped into the address space.
+    BarsMapped,
+    /// Compute and SDMA engines initialised.
+    EnginesReady,
+    /// GPU is actively running workloads.
+    Running,
+    /// An unrecoverable error was encountered.
+    Error,
+    /// GPU power-gated; can be resumed.
+    Suspended,
+}
+
+// ---------------------------------------------------------------------------
+// PowerState
+// ---------------------------------------------------------------------------
+
+/// Requested power level for the GPU.
+#[derive(Clone, Debug, PartialEq)]
+pub enum PowerState {
+    /// Maximum performance, all clocks ungated.
+    FullPower,
+    /// Reduced clocks / partial power gating.
+    LowPower,
+    /// Deep sleep -- minimal leakage, state saved to system RAM.
+    Suspended,
+}
+
+// ---------------------------------------------------------------------------
+// GpuRegisters
+// ---------------------------------------------------------------------------
+
+/// Represents the MMIO register apertures obtained from BAR mapping.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GpuRegisters {
+    /// BAR0 base: GPU control/status registers (MMIO).
+    pub bar0_base: u64,
+    /// BAR1 base: VRAM aperture (framebuffer / device memory).
+    pub bar1_base: u64,
+    /// Size of BAR0 in bytes.
+    pub bar0_size: u64,
+    /// Size of BAR1 in bytes.
+    pub bar1_size: u64,
+}
+
+// ---------------------------------------------------------------------------
+// InitConfig
+// ---------------------------------------------------------------------------
+
+/// Configuration knobs for the GPU initialisation sequence.
+#[derive(Clone, Debug, PartialEq)]
+pub struct InitConfig {
+    /// Enable the compute engine during init.
+    pub enable_compute: bool,
+    /// Enable the SDMA (copy) engine during init.
+    pub enable_sdma: bool,
+    /// Enable MSI-X / interrupt-based completion notification.
+    pub enable_interrupts: bool,
+    /// Requested power state after init.
+    pub power_state: PowerState,
+}
+
+impl Default for InitConfig {
+    fn default() -> Self {
+        Self {
+            enable_compute: true,
+            enable_sdma: true,
+            enable_interrupts: true,
+            power_state: PowerState::FullPower,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GpuContext
+// ---------------------------------------------------------------------------
+
+/// Top-level handle that tracks the complete state of a single AMD GPU.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GpuContext {
+    /// Static information about the GPU (architecture, CU count, etc.).
+    info: GpuInfo,
+    /// Current lifecycle state.
+    state: GpuState,
+    /// Mapped register apertures (populated after `map_bars`).
+    registers: Option<GpuRegisters>,
+    /// Initialisation configuration.
+    config: InitConfig,
+}
+
+impl GpuContext {
+    /// Create a new context in the [`GpuState::Uninitialized`] state.
+    pub fn new(info: GpuInfo) -> Self {
+        Self {
+            info,
+            state: GpuState::Uninitialized,
+            registers: None,
+            config: InitConfig::default(),
+        }
+    }
+
+    // -- lifecycle transitions --------------------------------------------
+
+    /// Map BAR0 (registers) and BAR1 (VRAM aperture) from the PCI device's
+    /// Base Address Registers.
+    ///
+    /// Transitions: `Uninitialized` -> `BarsMapped`.
+    pub fn map_bars(&mut self, bars: &[BaseAddressRegister]) -> Result<(), GpuError> {
+        if self.state != GpuState::Uninitialized {
+            return Err(GpuError::InvalidState);
+        }
+
+        let memory_bars: alloc::vec::Vec<&BaseAddressRegister> = bars
+            .iter()
+            .filter(|b| matches!(b.bar_type, BarType::Memory32 | BarType::Memory64))
+            .collect();
+
+        if memory_bars.len() < 2 {
+            return Err(GpuError::BarNotFound);
+        }
+
+        self.registers = Some(GpuRegisters {
+            bar0_base: memory_bars[0].address,
+            bar1_base: memory_bars[1].address,
+            bar0_size: memory_bars[0].size,
+            bar1_size: memory_bars[1].size,
+        });
+
+        self.state = GpuState::BarsMapped;
+        Ok(())
+    }
+
+    /// Initialize compute and SDMA engines.
+    ///
+    /// Transitions: `BarsMapped` -> `EnginesReady`.
+    pub fn initialize_engines(&mut self) -> Result<(), GpuError> {
+        if self.state != GpuState::BarsMapped {
+            return Err(GpuError::InvalidState);
+        }
+
+        // Stub: real implementation would:
+        // 1. Program GFX ring buffer (compute engine)
+        // 2. Initialize SDMA engines (typically 2 per GPU)
+        // 3. Set up IH (interrupt handler) ring
+        // 4. Configure MQD (memory queue descriptor) for dispatch
+
+        self.state = GpuState::EnginesReady;
+        Ok(())
+    }
+
+    /// Transition the GPU to the running state.
+    ///
+    /// Transitions: `EnginesReady` -> `Running`.
+    pub fn start(&mut self) -> Result<(), GpuError> {
+        if self.state != GpuState::EnginesReady {
+            return Err(GpuError::InvalidState);
+        }
+        self.state = GpuState::Running;
+        Ok(())
+    }
+
+    /// Suspend the GPU (power gate, save state).
+    ///
+    /// Transitions: `Running` -> `Suspended`.
+    pub fn suspend(&mut self) -> Result<(), GpuError> {
+        if self.state != GpuState::Running {
+            return Err(GpuError::InvalidState);
+        }
+        self.state = GpuState::Suspended;
+        Ok(())
+    }
+
+    /// Resume a previously suspended GPU.
+    ///
+    /// Transitions: `Suspended` -> `Running`.
+    pub fn resume(&mut self) -> Result<(), GpuError> {
+        if self.state != GpuState::Suspended {
+            return Err(GpuError::InvalidState);
+        }
+        self.state = GpuState::Running;
+        Ok(())
+    }
+
+    /// Hard reset -- tear everything down and return to uninitialized.
+    ///
+    /// Transitions: `*` -> `Uninitialized`.
+    pub fn reset(&mut self) {
+        self.state = GpuState::Uninitialized;
+        self.registers = None;
+    }
+
+    // -- accessors --------------------------------------------------------
+
+    /// Current lifecycle state.
+    pub fn state(&self) -> &GpuState {
+        &self.state
+    }
+
+    /// Static GPU information.
+    pub fn info(&self) -> &GpuInfo {
+        &self.info
+    }
+
+    /// Mapped register apertures (if any).
+    pub fn registers(&self) -> Option<&GpuRegisters> {
+        self.registers.as_ref()
+    }
+
+    /// Current init configuration.
+    pub fn config(&self) -> &InitConfig {
+        &self.config
+    }
+
+    /// Replace the init configuration.
+    pub fn set_config(&mut self, config: InitConfig) {
+        self.config = config;
+    }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gpu_id::{GfxVersion, GpuArchitecture, GpuInfo};
+    use crate::pcie::{BarType, BaseAddressRegister};
+
+    fn test_gpu_info() -> GpuInfo {
+        GpuInfo {
+            device_id: 0x7500,
+            architecture: GpuArchitecture::Cdna3,
+            gfx_version: GfxVersion::new(9, 4, 2),
+            cu_count: 304,
+            vram_size_mb: 196608,
+            max_wavefronts_per_cu: 40,
+            wavefront_size: 64,
+            lds_per_cu: 64 * 1024,
+            vgprs_per_cu: 1024,
+            name: "AMD Instinct MI300X",
+        }
+    }
+
+    fn test_bars() -> alloc::vec::Vec<BaseAddressRegister> {
+        alloc::vec![
+            BaseAddressRegister {
+                bar_type: BarType::Memory64,
+                address: 0xFB00_0000,
+                size: 32 * 1024 * 1024,
+                prefetchable: false,
+            },
+            BaseAddressRegister {
+                bar_type: BarType::Memory64,
+                address: 0x3800_0000_0000,
+                size: 512 * 1024 * 1024,
+                prefetchable: true,
+            },
+        ]
+    }
+
+    #[test]
+    fn new_context_is_uninitialized() {
+        let ctx = GpuContext::new(test_gpu_info());
+        assert_eq!(*ctx.state(), GpuState::Uninitialized);
+        assert!(ctx.registers().is_none());
+    }
+
+    #[test]
+    fn new_context_preserves_info() {
+        let info = test_gpu_info();
+        let ctx = GpuContext::new(info.clone());
+        assert_eq!(*ctx.info(), info);
+    }
+
+    #[test]
+    fn map_bars_transitions_to_bars_mapped() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        ctx.map_bars(&test_bars()).unwrap();
+        assert_eq!(*ctx.state(), GpuState::BarsMapped);
+        let regs = ctx.registers().unwrap();
+        assert_eq!(regs.bar0_base, 0xFB00_0000);
+        assert_eq!(regs.bar1_base, 0x3800_0000_0000);
+    }
+
+    #[test]
+    fn map_bars_no_memory_bars_returns_error() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        let io_bars = alloc::vec![BaseAddressRegister {
+            bar_type: BarType::Io,
+            address: 0x1000,
+            size: 256,
+            prefetchable: false,
+        }];
+        assert_eq!(ctx.map_bars(&io_bars), Err(GpuError::BarNotFound));
+        assert_eq!(*ctx.state(), GpuState::Uninitialized);
+    }
+
+    #[test]
+    fn map_bars_only_one_memory_bar_returns_error() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        let single = alloc::vec![BaseAddressRegister {
+            bar_type: BarType::Memory32,
+            address: 0xF000_0000,
+            size: 1024,
+            prefetchable: false,
+        }];
+        assert_eq!(ctx.map_bars(&single), Err(GpuError::BarNotFound));
+    }
+
+    #[test]
+    fn map_bars_requires_uninitialized_state() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        ctx.map_bars(&test_bars()).unwrap();
+        assert_eq!(ctx.map_bars(&test_bars()), Err(GpuError::InvalidState));
+    }
+
+    #[test]
+    fn initialize_engines_requires_bars_mapped() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        assert_eq!(ctx.initialize_engines(), Err(GpuError::InvalidState));
+    }
+
+    #[test]
+    fn initialize_engines_transitions_to_engines_ready() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        ctx.map_bars(&test_bars()).unwrap();
+        ctx.initialize_engines().unwrap();
+        assert_eq!(*ctx.state(), GpuState::EnginesReady);
+    }
+
+    #[test]
+    fn start_requires_engines_ready() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        assert_eq!(ctx.start(), Err(GpuError::InvalidState));
+    }
+
+    #[test]
+    fn start_transitions_to_running() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        ctx.map_bars(&test_bars()).unwrap();
+        ctx.initialize_engines().unwrap();
+        ctx.start().unwrap();
+        assert_eq!(*ctx.state(), GpuState::Running);
+    }
+
+    #[test]
+    fn suspend_requires_running() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        assert_eq!(ctx.suspend(), Err(GpuError::InvalidState));
+    }
+
+    #[test]
+    fn suspend_transitions_to_suspended() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        ctx.map_bars(&test_bars()).unwrap();
+        ctx.initialize_engines().unwrap();
+        ctx.start().unwrap();
+        ctx.suspend().unwrap();
+        assert_eq!(*ctx.state(), GpuState::Suspended);
+    }
+
+    #[test]
+    fn resume_requires_suspended() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        assert_eq!(ctx.resume(), Err(GpuError::InvalidState));
+    }
+
+    #[test]
+    fn resume_transitions_to_running() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        ctx.map_bars(&test_bars()).unwrap();
+        ctx.initialize_engines().unwrap();
+        ctx.start().unwrap();
+        ctx.suspend().unwrap();
+        ctx.resume().unwrap();
+        assert_eq!(*ctx.state(), GpuState::Running);
+    }
+
+    #[test]
+    fn full_lifecycle() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        assert_eq!(*ctx.state(), GpuState::Uninitialized);
+
+        ctx.map_bars(&test_bars()).unwrap();
+        assert_eq!(*ctx.state(), GpuState::BarsMapped);
+
+        ctx.initialize_engines().unwrap();
+        assert_eq!(*ctx.state(), GpuState::EnginesReady);
+
+        ctx.start().unwrap();
+        assert_eq!(*ctx.state(), GpuState::Running);
+
+        ctx.suspend().unwrap();
+        assert_eq!(*ctx.state(), GpuState::Suspended);
+
+        ctx.resume().unwrap();
+        assert_eq!(*ctx.state(), GpuState::Running);
+
+        ctx.reset();
+        assert_eq!(*ctx.state(), GpuState::Uninitialized);
+        assert!(ctx.registers().is_none());
+    }
+
+    #[test]
+    fn reset_from_bars_mapped() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        ctx.map_bars(&test_bars()).unwrap();
+        ctx.reset();
+        assert_eq!(*ctx.state(), GpuState::Uninitialized);
+        assert!(ctx.registers().is_none());
+    }
+
+    #[test]
+    fn reset_from_running() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        ctx.map_bars(&test_bars()).unwrap();
+        ctx.initialize_engines().unwrap();
+        ctx.start().unwrap();
+        ctx.reset();
+        assert_eq!(*ctx.state(), GpuState::Uninitialized);
+    }
+
+    #[test]
+    fn reset_from_uninitialized_is_noop() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        ctx.reset();
+        assert_eq!(*ctx.state(), GpuState::Uninitialized);
+    }
+
+    #[test]
+    fn config_defaults() {
+        let cfg = InitConfig::default();
+        assert!(cfg.enable_compute);
+        assert!(cfg.enable_sdma);
+        assert!(cfg.enable_interrupts);
+        assert_eq!(cfg.power_state, PowerState::FullPower);
+    }
+
+    #[test]
+    fn config_custom() {
+        let cfg = InitConfig {
+            enable_compute: true,
+            enable_sdma: false,
+            enable_interrupts: false,
+            power_state: PowerState::LowPower,
+        };
+        assert!(!cfg.enable_sdma);
+        assert_eq!(cfg.power_state, PowerState::LowPower);
+    }
+
+    #[test]
+    fn power_state_variants() {
+        assert_eq!(PowerState::FullPower, PowerState::FullPower);
+        assert_eq!(PowerState::LowPower, PowerState::LowPower);
+        assert_eq!(PowerState::Suspended, PowerState::Suspended);
+        assert_ne!(PowerState::FullPower, PowerState::Suspended);
+    }
+
+    #[test]
+    fn gpu_state_variants() {
+        let states = [
+            GpuState::Uninitialized,
+            GpuState::BarsMapped,
+            GpuState::EnginesReady,
+            GpuState::Running,
+            GpuState::Error,
+            GpuState::Suspended,
+        ];
+        for (i, a) in states.iter().enumerate() {
+            for (j, b) in states.iter().enumerate() {
+                if i == j {
+                    assert_eq!(a, b);
+                } else {
+                    assert_ne!(a, b);
+                }
+            }
+        }
+    }
+}

--- a/arch/amd/src/hip_kernels.rs
+++ b/arch/amd/src/hip_kernels.rs
@@ -1,0 +1,637 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! HIP kernel definitions and registry.
+//!
+//! Maintains a registry of HIP/GCN kernels that implement ONNX operators on
+//! AMD GPUs. Each [`HipKernel`] records its required GFX version, LDS
+//! footprint, and workgroup geometry. The [`HipRegistry`] provides lookup by
+//! operator type, precision, and hardware compatibility.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use crate::gpu_id::GfxVersion;
+use crate::GpuError;
+
+// ---------------------------------------------------------------------------
+// DataPrecision
+// ---------------------------------------------------------------------------
+
+/// Numeric precision for a HIP kernel.
+#[derive(Clone, Debug, PartialEq)]
+pub enum DataPrecision {
+    /// 32-bit IEEE 754 single-precision float.
+    F32,
+    /// 16-bit IEEE 754 half-precision float.
+    F16,
+    /// 16-bit brain floating-point.
+    Bf16,
+    /// 8-bit signed integer (quantised inference).
+    Int8,
+    /// 32-bit signed integer.
+    Int32,
+}
+
+// ---------------------------------------------------------------------------
+// HipKernelType
+// ---------------------------------------------------------------------------
+
+/// Category of GPU kernel, mapping 1-to-1 with ONNX operator families.
+#[derive(Clone, Debug, PartialEq)]
+pub enum HipKernelType {
+    /// General matrix-matrix multiply (MatMul / Gemm).
+    Gemm,
+    /// 2-D convolution (Conv).
+    Conv2d,
+    /// Softmax normalisation.
+    Softmax,
+    /// Layer normalisation.
+    LayerNorm,
+    /// Point-wise element-wise ops (Relu, Sigmoid, Tanh, Add, Mul, Sub).
+    Elementwise,
+    /// Reduction along one or more axes (ReduceSum, ReduceMean, ReduceMax).
+    Reduce,
+    /// Transpose / permute dimensions.
+    Transpose,
+    /// Tensor concatenation along an axis.
+    Concat,
+    /// Pooling (MaxPool, AveragePool, GlobalAveragePool).
+    Pool,
+}
+
+// ---------------------------------------------------------------------------
+// HipKernel
+// ---------------------------------------------------------------------------
+
+/// A single HIP kernel that can be launched on an AMD GPU.
+#[derive(Clone, Debug, PartialEq)]
+pub struct HipKernel {
+    /// Human-readable kernel identifier (e.g. `"gemm_f32"`).
+    pub name: String,
+    /// Operator family this kernel implements.
+    pub kernel_type: HipKernelType,
+    /// Numeric precision.
+    pub precision: DataPrecision,
+    /// Minimum GFX ISA version required (e.g. 908 for MI100).
+    pub min_gfx: u32,
+    /// LDS (local data share) requirement in bytes.
+    pub lds_size: u32,
+    /// Maximum work-items per workgroup this kernel supports.
+    pub max_workitems_per_workgroup: u32,
+    /// VGPRs consumed per work-item.
+    pub vgprs_per_workitem: u32,
+}
+
+impl HipKernel {
+    /// Returns `true` when the given GFX version meets or exceeds the
+    /// kernel's minimum GFX requirement.
+    pub fn is_compatible(&self, gfx: &GfxVersion) -> bool {
+        gfx.as_gfx_id() >= self.min_gfx
+    }
+
+    /// Theoretical occupancy ratio for the given `workitems_per_workgroup`.
+    pub fn occupancy(&self, workitems_per_workgroup: u32) -> f64 {
+        workitems_per_workgroup as f64 / self.max_workitems_per_workgroup as f64
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HipRegistry
+// ---------------------------------------------------------------------------
+
+/// Maximum number of kernels the registry can hold.
+pub const MAX_KERNELS: usize = 128;
+
+/// Registry of HIP kernels available for dispatch.
+#[derive(Clone, Debug, PartialEq)]
+pub struct HipRegistry {
+    /// Registered kernels.
+    kernels: Vec<HipKernel>,
+    /// Monotonically increasing id generator.
+    next_id: u64,
+}
+
+impl Default for HipRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HipRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self {
+            kernels: Vec::new(),
+            next_id: 1,
+        }
+    }
+
+    /// Register a new HIP kernel and return its unique id.
+    pub fn register(&mut self, kernel: HipKernel) -> Result<u64, GpuError> {
+        if self.kernels.len() >= MAX_KERNELS {
+            return Err(GpuError::QueueFull);
+        }
+        let id = self.next_id;
+        self.next_id += 1;
+        self.kernels.push(kernel);
+        Ok(id)
+    }
+
+    /// Find a registered kernel matching the requested type, precision, and
+    /// hardware capability.
+    pub fn find_kernel(
+        &self,
+        kernel_type: HipKernelType,
+        precision: DataPrecision,
+        gfx: &GfxVersion,
+    ) -> Option<&HipKernel> {
+        self.kernels.iter().find(|k| {
+            k.kernel_type == kernel_type && k.precision == precision && k.is_compatible(gfx)
+        })
+    }
+
+    /// Populate the registry with standard kernels covering the core ONNX
+    /// operator set.
+    ///
+    /// Registers 11 default kernels:
+    /// - `gemm_f32` (gfx900), `gemm_f16` (gfx900)
+    /// - `conv2d_f32` (gfx900), `conv2d_f16` (gfx908)
+    /// - `softmax_f32` (gfx900), `layernorm_f32` (gfx900)
+    /// - `elementwise_f32` (gfx900), `reduce_f32` (gfx900)
+    /// - `transpose_f32` (gfx900), `concat_f32` (gfx900)
+    /// - `pool_f32` (gfx900)
+    pub fn register_defaults(&mut self) -> Result<(), GpuError> {
+        let defaults = alloc::vec![
+            HipKernel {
+                name: String::from("gemm_f32"),
+                kernel_type: HipKernelType::Gemm,
+                precision: DataPrecision::F32,
+                min_gfx: 900,
+                lds_size: 49152,
+                max_workitems_per_workgroup: 256,
+                vgprs_per_workitem: 32,
+            },
+            HipKernel {
+                name: String::from("gemm_f16"),
+                kernel_type: HipKernelType::Gemm,
+                precision: DataPrecision::F16,
+                min_gfx: 900,
+                lds_size: 32768,
+                max_workitems_per_workgroup: 256,
+                vgprs_per_workitem: 24,
+            },
+            HipKernel {
+                name: String::from("conv2d_f32"),
+                kernel_type: HipKernelType::Conv2d,
+                precision: DataPrecision::F32,
+                min_gfx: 900,
+                lds_size: 49152,
+                max_workitems_per_workgroup: 256,
+                vgprs_per_workitem: 32,
+            },
+            HipKernel {
+                name: String::from("conv2d_f16"),
+                kernel_type: HipKernelType::Conv2d,
+                precision: DataPrecision::F16,
+                min_gfx: 908,
+                lds_size: 32768,
+                max_workitems_per_workgroup: 256,
+                vgprs_per_workitem: 24,
+            },
+            HipKernel {
+                name: String::from("softmax_f32"),
+                kernel_type: HipKernelType::Softmax,
+                precision: DataPrecision::F32,
+                min_gfx: 900,
+                lds_size: 16384,
+                max_workitems_per_workgroup: 256,
+                vgprs_per_workitem: 16,
+            },
+            HipKernel {
+                name: String::from("layernorm_f32"),
+                kernel_type: HipKernelType::LayerNorm,
+                precision: DataPrecision::F32,
+                min_gfx: 900,
+                lds_size: 16384,
+                max_workitems_per_workgroup: 256,
+                vgprs_per_workitem: 16,
+            },
+            HipKernel {
+                name: String::from("elementwise_f32"),
+                kernel_type: HipKernelType::Elementwise,
+                precision: DataPrecision::F32,
+                min_gfx: 900,
+                lds_size: 0,
+                max_workitems_per_workgroup: 1024,
+                vgprs_per_workitem: 8,
+            },
+            HipKernel {
+                name: String::from("reduce_f32"),
+                kernel_type: HipKernelType::Reduce,
+                precision: DataPrecision::F32,
+                min_gfx: 900,
+                lds_size: 32768,
+                max_workitems_per_workgroup: 256,
+                vgprs_per_workitem: 16,
+            },
+            HipKernel {
+                name: String::from("transpose_f32"),
+                kernel_type: HipKernelType::Transpose,
+                precision: DataPrecision::F32,
+                min_gfx: 900,
+                lds_size: 32768,
+                max_workitems_per_workgroup: 256,
+                vgprs_per_workitem: 16,
+            },
+            HipKernel {
+                name: String::from("concat_f32"),
+                kernel_type: HipKernelType::Concat,
+                precision: DataPrecision::F32,
+                min_gfx: 900,
+                lds_size: 0,
+                max_workitems_per_workgroup: 1024,
+                vgprs_per_workitem: 8,
+            },
+            HipKernel {
+                name: String::from("pool_f32"),
+                kernel_type: HipKernelType::Pool,
+                precision: DataPrecision::F32,
+                min_gfx: 900,
+                lds_size: 16384,
+                max_workitems_per_workgroup: 256,
+                vgprs_per_workitem: 16,
+            },
+        ];
+
+        for kernel in defaults {
+            self.register(kernel)?;
+        }
+
+        Ok(())
+    }
+
+    /// Number of kernels currently registered.
+    pub fn kernel_count(&self) -> usize {
+        self.kernels.len()
+    }
+
+    /// Return references to all kernels compatible with the given GFX version.
+    pub fn compatible_kernels(&self, gfx: &GfxVersion) -> Vec<&HipKernel> {
+        self.kernels
+            .iter()
+            .filter(|k| k.is_compatible(gfx))
+            .collect()
+    }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gpu_id::identify_gpu;
+
+    fn test_gfx_cdna3() -> GfxVersion {
+        GfxVersion::new(9, 4, 2) // gfx942
+    }
+
+    fn test_gfx_cdna1() -> GfxVersion {
+        GfxVersion::new(9, 0, 8) // gfx908
+    }
+
+    fn test_gfx_vega() -> GfxVersion {
+        GfxVersion::new(9, 0, 0) // gfx900
+    }
+
+    fn test_gfx_too_old() -> GfxVersion {
+        GfxVersion::new(8, 0, 0) // gfx800, below any supported
+    }
+
+    fn make_kernel(name: &str, kt: HipKernelType, prec: DataPrecision, gfx: u32) -> HipKernel {
+        HipKernel {
+            name: String::from(name),
+            kernel_type: kt,
+            precision: prec,
+            min_gfx: gfx,
+            lds_size: 4096,
+            max_workitems_per_workgroup: 256,
+            vgprs_per_workitem: 16,
+        }
+    }
+
+    #[test]
+    fn test_register_kernel() {
+        let mut reg = HipRegistry::new();
+        let kernel = make_kernel("test_gemm", HipKernelType::Gemm, DataPrecision::F32, 900);
+        let id = reg.register(kernel).unwrap();
+        assert_eq!(id, 1);
+        assert_eq!(reg.kernel_count(), 1);
+    }
+
+    #[test]
+    fn test_find_kernel_by_type_and_precision() {
+        let mut reg = HipRegistry::new();
+        reg.register(make_kernel(
+            "gemm_f32",
+            HipKernelType::Gemm,
+            DataPrecision::F32,
+            900,
+        ))
+        .unwrap();
+        reg.register(make_kernel(
+            "gemm_f16",
+            HipKernelType::Gemm,
+            DataPrecision::F16,
+            900,
+        ))
+        .unwrap();
+
+        let gfx = test_gfx_cdna3();
+        let found = reg.find_kernel(HipKernelType::Gemm, DataPrecision::F16, &gfx);
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().name, "gemm_f16");
+    }
+
+    #[test]
+    fn test_compatibility_check() {
+        let kernel = make_kernel("conv2d_f16", HipKernelType::Conv2d, DataPrecision::F16, 908);
+        assert!(kernel.is_compatible(&test_gfx_cdna1())); // gfx908 >= 908
+        assert!(!kernel.is_compatible(&test_gfx_vega())); // gfx900 < 908
+    }
+
+    #[test]
+    fn test_register_defaults_creates_11_kernels() {
+        let mut reg = HipRegistry::new();
+        reg.register_defaults().unwrap();
+        assert_eq!(reg.kernel_count(), 11);
+    }
+
+    #[test]
+    fn test_incompatible_gfx_returns_none() {
+        let mut reg = HipRegistry::new();
+        reg.register_defaults().unwrap();
+        let gfx = test_gfx_too_old();
+        let found = reg.find_kernel(HipKernelType::Gemm, DataPrecision::F32, &gfx);
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn test_compatible_kernels_filtering() {
+        let mut reg = HipRegistry::new();
+        reg.register_defaults().unwrap();
+
+        // gfx900: everything except conv2d_f16 (gfx908)
+        let compat = reg.compatible_kernels(&test_gfx_vega());
+        assert_eq!(compat.len(), 10);
+
+        // gfx942: all 11 kernels
+        let compat = reg.compatible_kernels(&test_gfx_cdna3());
+        assert_eq!(compat.len(), 11);
+    }
+
+    #[test]
+    fn test_kernel_count() {
+        let mut reg = HipRegistry::new();
+        assert_eq!(reg.kernel_count(), 0);
+        reg.register(make_kernel(
+            "a",
+            HipKernelType::Pool,
+            DataPrecision::F32,
+            900,
+        ))
+        .unwrap();
+        assert_eq!(reg.kernel_count(), 1);
+        reg.register(make_kernel(
+            "b",
+            HipKernelType::Pool,
+            DataPrecision::F16,
+            900,
+        ))
+        .unwrap();
+        assert_eq!(reg.kernel_count(), 2);
+    }
+
+    #[test]
+    fn test_occupancy_calculation() {
+        let kernel = HipKernel {
+            name: String::from("occ_test"),
+            kernel_type: HipKernelType::Elementwise,
+            precision: DataPrecision::F32,
+            min_gfx: 900,
+            lds_size: 0,
+            max_workitems_per_workgroup: 1024,
+            vgprs_per_workitem: 8,
+        };
+        let occ = kernel.occupancy(512);
+        assert!((occ - 0.5).abs() < 1e-9);
+        let occ_full = kernel.occupancy(1024);
+        assert!((occ_full - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_registry_full_error() {
+        let mut reg = HipRegistry::new();
+        for i in 0..MAX_KERNELS {
+            let name = alloc::format!("k{}", i);
+            reg.register(make_kernel(
+                &name,
+                HipKernelType::Gemm,
+                DataPrecision::F32,
+                900,
+            ))
+            .unwrap();
+        }
+        assert_eq!(reg.kernel_count(), MAX_KERNELS);
+        let result = reg.register(make_kernel(
+            "overflow",
+            HipKernelType::Gemm,
+            DataPrecision::F32,
+            900,
+        ));
+        assert_eq!(result, Err(GpuError::QueueFull));
+    }
+
+    #[test]
+    fn test_all_kernel_types_in_defaults() {
+        let mut reg = HipRegistry::new();
+        reg.register_defaults().unwrap();
+        let gfx = test_gfx_cdna3();
+
+        let types = [
+            HipKernelType::Gemm,
+            HipKernelType::Conv2d,
+            HipKernelType::Softmax,
+            HipKernelType::LayerNorm,
+            HipKernelType::Elementwise,
+            HipKernelType::Reduce,
+            HipKernelType::Transpose,
+            HipKernelType::Concat,
+            HipKernelType::Pool,
+        ];
+        for kt in &types {
+            let found = reg.find_kernel(kt.clone(), DataPrecision::F32, &gfx);
+            assert!(found.is_some(), "Expected default F32 kernel for {:?}", kt);
+        }
+    }
+
+    #[test]
+    fn test_f16_kernels_require_higher_gfx() {
+        let mut reg = HipRegistry::new();
+        reg.register_defaults().unwrap();
+
+        // conv2d_f16 requires gfx908. gfx900 should fail.
+        let found = reg.find_kernel(HipKernelType::Conv2d, DataPrecision::F16, &test_gfx_vega());
+        assert!(
+            found.is_none(),
+            "conv2d_f16 should not be compatible with gfx900"
+        );
+
+        // gfx942 should succeed.
+        let found = reg.find_kernel(HipKernelType::Conv2d, DataPrecision::F16, &test_gfx_cdna3());
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().name, "conv2d_f16");
+    }
+
+    #[test]
+    fn test_default_kernel_lds_values() {
+        let mut reg = HipRegistry::new();
+        reg.register_defaults().unwrap();
+        let gfx = test_gfx_cdna3();
+
+        let gemm = reg
+            .find_kernel(HipKernelType::Gemm, DataPrecision::F32, &gfx)
+            .unwrap();
+        assert_eq!(gemm.lds_size, 49152);
+
+        let eltwise = reg
+            .find_kernel(HipKernelType::Elementwise, DataPrecision::F32, &gfx)
+            .unwrap();
+        assert_eq!(eltwise.lds_size, 0);
+
+        let softmax = reg
+            .find_kernel(HipKernelType::Softmax, DataPrecision::F32, &gfx)
+            .unwrap();
+        assert_eq!(softmax.lds_size, 16384);
+    }
+
+    #[test]
+    fn test_hip_kernel_type_variants() {
+        let variants = [
+            HipKernelType::Gemm,
+            HipKernelType::Conv2d,
+            HipKernelType::Softmax,
+            HipKernelType::LayerNorm,
+            HipKernelType::Elementwise,
+            HipKernelType::Reduce,
+            HipKernelType::Transpose,
+            HipKernelType::Concat,
+            HipKernelType::Pool,
+        ];
+        assert_eq!(variants.len(), 9);
+        for (i, a) in variants.iter().enumerate() {
+            for (j, b) in variants.iter().enumerate() {
+                if i == j {
+                    assert_eq!(a, b);
+                } else {
+                    assert_ne!(a, b);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_data_precision_variants() {
+        let variants = [
+            DataPrecision::F32,
+            DataPrecision::F16,
+            DataPrecision::Bf16,
+            DataPrecision::Int8,
+            DataPrecision::Int32,
+        ];
+        assert_eq!(variants.len(), 5);
+        for (i, a) in variants.iter().enumerate() {
+            for (j, b) in variants.iter().enumerate() {
+                if i == j {
+                    assert_eq!(a, b);
+                } else {
+                    assert_ne!(a, b);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_kernel_clone_debug() {
+        let kernel = make_kernel(
+            "clone_test",
+            HipKernelType::Softmax,
+            DataPrecision::F32,
+            900,
+        );
+        let cloned = kernel.clone();
+        assert_eq!(kernel, cloned);
+        let dbg = alloc::format!("{:?}", kernel);
+        assert!(dbg.contains("clone_test"));
+        assert!(dbg.contains("Softmax"));
+    }
+
+    #[test]
+    fn test_find_nonexistent_precision_returns_none() {
+        let mut reg = HipRegistry::new();
+        reg.register_defaults().unwrap();
+        let gfx = test_gfx_cdna3();
+        let found = reg.find_kernel(HipKernelType::Gemm, DataPrecision::Bf16, &gfx);
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn test_identify_gpu_gfx_works_with_registry() {
+        let gpu = identify_gpu(0x7500).unwrap();
+        let mut reg = HipRegistry::new();
+        reg.register_defaults().unwrap();
+        let compat = reg.compatible_kernels(&gpu.gfx_version);
+        assert_eq!(compat.len(), 11);
+    }
+
+    #[test]
+    fn test_registry_initial_state() {
+        let reg = HipRegistry::new();
+        assert_eq!(reg.kernel_count(), 0);
+        assert_eq!(reg.next_id, 1);
+    }
+
+    #[test]
+    fn test_register_ids_increase() {
+        let mut reg = HipRegistry::new();
+        let id1 = reg
+            .register(make_kernel(
+                "k1",
+                HipKernelType::Pool,
+                DataPrecision::F32,
+                900,
+            ))
+            .unwrap();
+        let id2 = reg
+            .register(make_kernel(
+                "k2",
+                HipKernelType::Pool,
+                DataPrecision::F16,
+                900,
+            ))
+            .unwrap();
+        let id3 = reg
+            .register(make_kernel(
+                "k3",
+                HipKernelType::Pool,
+                DataPrecision::Int8,
+                900,
+            ))
+            .unwrap();
+        assert_eq!(id1, 1);
+        assert_eq!(id2, 2);
+        assert_eq!(id3, 3);
+    }
+}

--- a/arch/amd/src/lib.rs
+++ b/arch/amd/src/lib.rs
@@ -1,0 +1,56 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! AMD GPU Hardware Abstraction Layer
+//!
+//! Minimal GPU driver for compute workloads:
+//! - PCIe enumeration and BAR mapping
+//! - GPU identification and initialization
+//! - VRAM memory management (allocator, GPU page tables)
+//! - SDMA engine for host<->device transfers
+//! - Wavefront-based compute engine kernel launch
+//! - ROCm/HIP execution provider for ONNX inference
+//!
+//! Supports: RDNA 1/2/3 (RX 5000/6000/7000),
+//!           CDNA 1/2/3 (MI100/MI200/MI300)
+
+#![no_std]
+#![allow(dead_code)]
+
+extern crate alloc;
+
+pub mod compute;
+pub mod dma;
+pub mod gpu_id;
+pub mod gpu_init;
+pub mod hip_kernels;
+pub mod memory;
+pub mod pcie;
+pub mod rocm_provider;
+
+/// GPU error type used throughout the AMD crate.
+#[derive(Clone, Debug, PartialEq)]
+pub enum GpuError {
+    /// Device not supported or not recognized.
+    UnsupportedDevice,
+    /// Operation invalid for the current state.
+    InvalidState,
+    /// PCI BAR not found or not mapped.
+    BarNotFound,
+    /// GPU initialization failure.
+    InitFailed,
+    /// VRAM allocation or addressing error.
+    MemoryError,
+    /// DMA/SDMA engine error.
+    DmaError,
+    /// Kernel launch error.
+    LaunchError,
+    /// Resource not found by ID.
+    NotFound,
+    /// Queue is full.
+    QueueFull,
+    /// Invalid configuration parameter.
+    InvalidConfig,
+    /// Transfer exceeds maximum allowed size.
+    TransferTooLarge,
+}

--- a/arch/amd/src/memory.rs
+++ b/arch/amd/src/memory.rs
@@ -1,0 +1,365 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! GPU VRAM memory allocator.
+//!
+//! Manages two regions of video memory:
+//! - **Static** -- long-lived allocations for model weights, rarely freed.
+//! - **Dynamic** -- short-lived workspace buffers for intermediate tensors.
+//!
+//! All allocations are aligned to [`GPU_PAGE_SIZE`] (64 KiB).
+
+use alloc::vec::Vec;
+
+use crate::GpuError;
+
+/// GPU page size -- 64 KiB, matching AMD's GPU page granularity.
+pub const GPU_PAGE_SIZE: usize = 65536;
+
+/// Maximum number of live allocations tracked by the allocator.
+pub const MAX_ALLOCATIONS: usize = 4096;
+
+/// Describes which VRAM region an allocation belongs to.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum MemoryRegion {
+    /// Static region -- model weights and other long-lived data.
+    Static,
+    /// Dynamic region -- workspace buffers and temporaries.
+    Dynamic,
+}
+
+/// A single VRAM allocation record.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GpuAllocation {
+    /// Unique allocation identifier.
+    pub id: u64,
+    /// Byte offset within the VRAM region.
+    pub offset: u64,
+    /// Aligned size in bytes.
+    pub size: u64,
+    /// Which region this allocation lives in.
+    pub region: MemoryRegion,
+    /// Whether this allocation is currently in use.
+    pub in_use: bool,
+}
+
+/// Bump-style VRAM allocator with static and dynamic regions.
+#[derive(Clone, Debug, PartialEq)]
+pub struct VramAllocator {
+    /// Total VRAM managed by this allocator.
+    total_size: u64,
+
+    /// Base address of the static region.
+    static_base: u64,
+    /// Total capacity of the static region.
+    static_size: u64,
+    /// Bytes currently consumed in the static region.
+    static_used: u64,
+
+    /// Base address of the dynamic region.
+    dynamic_base: u64,
+    /// Total capacity of the dynamic region.
+    dynamic_size: u64,
+    /// Bytes currently consumed in the dynamic region.
+    dynamic_used: u64,
+
+    /// All tracked allocations (both live and freed).
+    allocations: Vec<GpuAllocation>,
+
+    /// Monotonically increasing allocation-id generator.
+    next_id: u64,
+}
+
+/// Align `size` up to the nearest multiple of [`GPU_PAGE_SIZE`].
+fn align_up(size: u64) -> u64 {
+    let page = GPU_PAGE_SIZE as u64;
+    (size + page - 1) & !(page - 1)
+}
+
+impl VramAllocator {
+    /// Create a new VRAM allocator.
+    ///
+    /// `total_size` -- total VRAM in bytes.
+    /// `static_fraction` -- fraction of VRAM reserved for the static region
+    /// (0.0..=1.0; typically 0.7 for 70% weights / 30% workspace).
+    pub fn new(total_size: u64, static_fraction: f64) -> Self {
+        let raw_static = (total_size as f64 * static_fraction) as u64;
+        let static_size = align_up(raw_static);
+        let static_size = if static_size > total_size {
+            total_size
+        } else {
+            static_size
+        };
+        let dynamic_size = total_size - static_size;
+
+        Self {
+            total_size,
+            static_base: 0,
+            static_size,
+            static_used: 0,
+            dynamic_base: static_size,
+            dynamic_size,
+            dynamic_used: 0,
+            allocations: Vec::new(),
+            next_id: 1,
+        }
+    }
+
+    /// Allocate `size` bytes from the requested `region`.
+    ///
+    /// Returns the unique allocation id on success.
+    pub fn alloc(&mut self, size: u64, region: MemoryRegion) -> Result<u64, GpuError> {
+        if size == 0 {
+            return Err(GpuError::MemoryError);
+        }
+
+        if self.allocation_count() >= MAX_ALLOCATIONS {
+            return Err(GpuError::MemoryError);
+        }
+
+        let aligned = align_up(size);
+
+        let (base, region_size, used) = match region {
+            MemoryRegion::Static => (self.static_base, self.static_size, &mut self.static_used),
+            MemoryRegion::Dynamic => (self.dynamic_base, self.dynamic_size, &mut self.dynamic_used),
+        };
+
+        if *used + aligned > region_size {
+            return Err(GpuError::MemoryError);
+        }
+
+        let offset = base + *used;
+        *used += aligned;
+
+        let id = self.next_id;
+        self.next_id += 1;
+
+        self.allocations.push(GpuAllocation {
+            id,
+            offset,
+            size: aligned,
+            region,
+            in_use: true,
+        });
+
+        Ok(id)
+    }
+
+    /// Free a previous allocation by id.
+    pub fn free(&mut self, id: u64) -> Result<(), GpuError> {
+        let alloc = self
+            .allocations
+            .iter_mut()
+            .find(|a| a.id == id)
+            .ok_or(GpuError::NotFound)?;
+
+        if !alloc.in_use {
+            return Err(GpuError::InvalidState);
+        }
+
+        alloc.in_use = false;
+
+        match alloc.region {
+            MemoryRegion::Static => self.static_used -= alloc.size,
+            MemoryRegion::Dynamic => self.dynamic_used -= alloc.size,
+        }
+
+        Ok(())
+    }
+
+    /// Bytes currently used in `region`.
+    pub fn used_bytes(&self, region: MemoryRegion) -> u64 {
+        match region {
+            MemoryRegion::Static => self.static_used,
+            MemoryRegion::Dynamic => self.dynamic_used,
+        }
+    }
+
+    /// Bytes still available in `region`.
+    pub fn free_bytes(&self, region: MemoryRegion) -> u64 {
+        match region {
+            MemoryRegion::Static => self.static_size - self.static_used,
+            MemoryRegion::Dynamic => self.dynamic_size - self.dynamic_used,
+        }
+    }
+
+    /// Total bytes used across both regions.
+    pub fn total_used(&self) -> u64 {
+        self.static_used + self.dynamic_used
+    }
+
+    /// Total bytes free across both regions.
+    pub fn total_free(&self) -> u64 {
+        self.total_size - self.total_used()
+    }
+
+    /// Number of currently active (in-use) allocations.
+    pub fn allocation_count(&self) -> usize {
+        self.allocations.iter().filter(|a| a.in_use).count()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ONE_GIB: u64 = 1024 * 1024 * 1024;
+    const PAGE: u64 = GPU_PAGE_SIZE as u64;
+
+    #[test]
+    fn test_new_allocator_splits_correctly() {
+        let alloc = VramAllocator::new(ONE_GIB, 0.7);
+        let expected_static = align_up((ONE_GIB as f64 * 0.7) as u64);
+        assert_eq!(alloc.static_size, expected_static);
+        assert_eq!(alloc.dynamic_size, ONE_GIB - expected_static);
+        assert_eq!(alloc.static_base, 0);
+        assert_eq!(alloc.dynamic_base, expected_static);
+        assert_eq!(alloc.total_size, ONE_GIB);
+    }
+
+    #[test]
+    fn test_alloc_static() {
+        let mut alloc = VramAllocator::new(ONE_GIB, 0.7);
+        let id = alloc.alloc(1024, MemoryRegion::Static).unwrap();
+        assert_eq!(id, 1);
+        assert_eq!(alloc.used_bytes(MemoryRegion::Static), PAGE);
+    }
+
+    #[test]
+    fn test_alloc_dynamic() {
+        let mut alloc = VramAllocator::new(ONE_GIB, 0.7);
+        let id = alloc.alloc(1024, MemoryRegion::Dynamic).unwrap();
+        assert_eq!(id, 1);
+        assert_eq!(alloc.used_bytes(MemoryRegion::Dynamic), PAGE);
+    }
+
+    #[test]
+    fn test_free_allocation() {
+        let mut alloc = VramAllocator::new(ONE_GIB, 0.7);
+        let id = alloc.alloc(PAGE, MemoryRegion::Static).unwrap();
+        assert_eq!(alloc.used_bytes(MemoryRegion::Static), PAGE);
+        alloc.free(id).unwrap();
+        assert_eq!(alloc.used_bytes(MemoryRegion::Static), 0);
+    }
+
+    #[test]
+    fn test_double_free_error() {
+        let mut alloc = VramAllocator::new(ONE_GIB, 0.7);
+        let id = alloc.alloc(PAGE, MemoryRegion::Static).unwrap();
+        alloc.free(id).unwrap();
+        assert_eq!(alloc.free(id), Err(GpuError::InvalidState));
+    }
+
+    #[test]
+    fn test_out_of_memory() {
+        let mut alloc = VramAllocator::new(PAGE * 2, 0.5);
+        alloc.alloc(PAGE, MemoryRegion::Static).unwrap();
+        assert_eq!(
+            alloc.alloc(PAGE, MemoryRegion::Static),
+            Err(GpuError::MemoryError)
+        );
+    }
+
+    #[test]
+    fn test_alignment() {
+        let mut alloc = VramAllocator::new(ONE_GIB, 0.7);
+        alloc.alloc(1, MemoryRegion::Static).unwrap();
+        assert_eq!(alloc.used_bytes(MemoryRegion::Static), PAGE);
+    }
+
+    #[test]
+    fn test_used_free_tracking() {
+        let mut alloc = VramAllocator::new(ONE_GIB, 0.5);
+        let half = align_up((ONE_GIB as f64 * 0.5) as u64);
+        assert_eq!(alloc.free_bytes(MemoryRegion::Static), half);
+        alloc.alloc(PAGE * 3, MemoryRegion::Static).unwrap();
+        assert_eq!(alloc.used_bytes(MemoryRegion::Static), PAGE * 3);
+        assert_eq!(alloc.free_bytes(MemoryRegion::Static), half - PAGE * 3);
+    }
+
+    #[test]
+    fn test_total_used_free() {
+        let mut alloc = VramAllocator::new(ONE_GIB, 0.5);
+        alloc.alloc(PAGE, MemoryRegion::Static).unwrap();
+        alloc.alloc(PAGE * 2, MemoryRegion::Dynamic).unwrap();
+        assert_eq!(alloc.total_used(), PAGE * 3);
+        assert_eq!(alloc.total_free(), ONE_GIB - PAGE * 3);
+    }
+
+    #[test]
+    fn test_allocation_count() {
+        let mut alloc = VramAllocator::new(ONE_GIB, 0.5);
+        assert_eq!(alloc.allocation_count(), 0);
+        let id1 = alloc.alloc(PAGE, MemoryRegion::Static).unwrap();
+        let _id2 = alloc.alloc(PAGE, MemoryRegion::Dynamic).unwrap();
+        assert_eq!(alloc.allocation_count(), 2);
+        alloc.free(id1).unwrap();
+        assert_eq!(alloc.allocation_count(), 1);
+    }
+
+    #[test]
+    fn test_max_allocations() {
+        let big = PAGE * (MAX_ALLOCATIONS as u64 + 10);
+        let mut alloc = VramAllocator::new(big, 1.0);
+        for _ in 0..MAX_ALLOCATIONS {
+            alloc.alloc(PAGE, MemoryRegion::Static).unwrap();
+        }
+        assert_eq!(
+            alloc.alloc(PAGE, MemoryRegion::Static),
+            Err(GpuError::MemoryError)
+        );
+    }
+
+    #[test]
+    fn test_zero_size_alloc() {
+        let mut alloc = VramAllocator::new(ONE_GIB, 0.5);
+        assert_eq!(
+            alloc.alloc(0, MemoryRegion::Static),
+            Err(GpuError::MemoryError)
+        );
+    }
+
+    #[test]
+    fn test_large_allocation() {
+        let mut alloc = VramAllocator::new(ONE_GIB, 0.7);
+        let static_cap = alloc.free_bytes(MemoryRegion::Static);
+        let id = alloc.alloc(static_cap, MemoryRegion::Static).unwrap();
+        assert_eq!(alloc.free_bytes(MemoryRegion::Static), 0);
+        alloc.free(id).unwrap();
+        assert_eq!(alloc.free_bytes(MemoryRegion::Static), static_cap);
+    }
+
+    #[test]
+    fn test_free_nonexistent() {
+        let mut alloc = VramAllocator::new(ONE_GIB, 0.5);
+        assert_eq!(alloc.free(999), Err(GpuError::NotFound));
+    }
+
+    #[test]
+    fn test_sequential_offsets() {
+        let mut alloc = VramAllocator::new(ONE_GIB, 0.5);
+        let id1 = alloc.alloc(PAGE, MemoryRegion::Static).unwrap();
+        let id2 = alloc.alloc(PAGE, MemoryRegion::Static).unwrap();
+        let a1 = alloc.allocations.iter().find(|a| a.id == id1).unwrap();
+        let a2 = alloc.allocations.iter().find(|a| a.id == id2).unwrap();
+        assert_eq!(a2.offset, a1.offset + PAGE);
+    }
+
+    #[test]
+    fn test_full_static_fraction() {
+        let alloc = VramAllocator::new(ONE_GIB, 1.0);
+        assert_eq!(alloc.static_size, ONE_GIB);
+        assert_eq!(alloc.dynamic_size, 0);
+    }
+
+    #[test]
+    fn test_zero_static_fraction() {
+        let alloc = VramAllocator::new(ONE_GIB, 0.0);
+        assert_eq!(alloc.static_size, 0);
+        assert_eq!(alloc.dynamic_size, ONE_GIB);
+    }
+}

--- a/arch/amd/src/pcie.rs
+++ b/arch/amd/src/pcie.rs
@@ -1,0 +1,646 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! PCIe enumeration and BAR mapping for AMD GPUs.
+//!
+//! Scans the PCI configuration space for AMD display/3D controllers,
+//! decodes Base Address Registers, and provides device filtering. On real
+//! hardware the scan reads I/O ports 0x0CF8/0x0CFC; under `#[cfg(test)]`
+//! the scanner pushes mock devices instead.
+
+use alloc::vec::Vec;
+
+use crate::GpuError;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// AMD PCI vendor ID.
+const AMD_VENDOR_ID: u16 = 0x1002;
+
+/// Number of PCI buses to scan (first 8 covers most single-segment systems).
+const MAX_BUSES: u8 = 8;
+
+/// Maximum devices per bus (PCI spec).
+const MAX_DEVICES: u8 = 32;
+
+/// Maximum functions per device (PCI spec, multi-function).
+const MAX_FUNCTIONS: u8 = 8;
+
+/// Hard cap on the number of PCI devices we store.
+const MAX_PCI_DEVICES: usize = 32;
+
+// ---------------------------------------------------------------------------
+// PciAddress
+// ---------------------------------------------------------------------------
+
+/// Bus/device/function triplet that identifies a PCI function.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PciAddress {
+    pub bus: u8,
+    pub device: u8,
+    pub function: u8,
+}
+
+impl PciAddress {
+    /// Encode this address + a register offset into the 32-bit value written
+    /// to the PCI configuration address port.
+    ///
+    /// Layout (bit 31 = enable):
+    /// ```text
+    /// 31   | 30..24 | 23..16 | 15..11   | 10..8      | 7..2 | 1..0
+    /// 1    | 0      | bus    | device   | function   | reg  | 00
+    /// ```
+    pub fn config_address(&self, reg: u8) -> u32 {
+        (1u32 << 31)
+            | ((self.bus as u32) << 16)
+            | (((self.device & 0x1F) as u32) << 11)
+            | (((self.function & 0x07) as u32) << 8)
+            | ((reg & 0xFC) as u32)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// BarType / BaseAddressRegister
+// ---------------------------------------------------------------------------
+
+/// PCI Base Address Register type.
+#[derive(Clone, Debug, PartialEq)]
+pub enum BarType {
+    /// 32-bit memory-mapped region.
+    Memory32,
+    /// 64-bit memory-mapped region (consumes two BAR slots).
+    Memory64,
+    /// I/O port region.
+    Io,
+}
+
+/// Decoded information about a single PCI BAR.
+#[derive(Clone, Debug, PartialEq)]
+pub struct BaseAddressRegister {
+    pub bar_type: BarType,
+    pub address: u64,
+    pub size: u64,
+    pub prefetchable: bool,
+}
+
+// ---------------------------------------------------------------------------
+// PciDevice
+// ---------------------------------------------------------------------------
+
+/// A single PCI device (function) discovered during enumeration.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PciDevice {
+    pub address: PciAddress,
+    pub vendor_id: u16,
+    pub device_id: u16,
+    pub class_code: u8,
+    pub subclass: u8,
+    pub revision: u8,
+    pub bars: Vec<BaseAddressRegister>,
+    pub irq_line: u8,
+}
+
+impl PciDevice {
+    /// Returns `true` when the vendor is AMD (0x1002).
+    pub fn is_amd(&self) -> bool {
+        self.vendor_id == AMD_VENDOR_ID
+    }
+
+    /// Returns `true` when the device belongs to PCI display-controller class
+    /// (class code 0x03).
+    pub fn is_display_controller(&self) -> bool {
+        self.class_code == 0x03
+    }
+
+    /// Returns `true` for a PCI 3D controller (class 0x03, subclass 0x02).
+    pub fn is_3d_controller(&self) -> bool {
+        self.class_code == 0x03 && self.subclass == 0x02
+    }
+
+    /// Returns `true` for a PCI VGA-compatible controller (class 0x03, subclass 0x00).
+    pub fn is_vga_controller(&self) -> bool {
+        self.class_code == 0x03 && self.subclass == 0x00
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PciScanner
+// ---------------------------------------------------------------------------
+
+/// Enumerates PCI buses and stores discovered devices.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PciScanner {
+    devices: Vec<PciDevice>,
+}
+
+impl Default for PciScanner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PciScanner {
+    /// Create a new, empty scanner.
+    pub fn new() -> Self {
+        Self {
+            devices: Vec::new(),
+        }
+    }
+
+    /// Scan the PCI configuration space for AMD display/3D controllers.
+    ///
+    /// On real hardware this reads I/O ports; in test builds it pushes a set
+    /// of mock devices so the rest of the stack can be exercised without
+    /// actual hardware.
+    pub fn scan(&mut self) -> Result<(), GpuError> {
+        #[cfg(test)]
+        {
+            self.scan_mock()
+        }
+        #[cfg(not(test))]
+        {
+            self.scan_hardware()
+        }
+    }
+
+    /// Hardware scan (placeholder -- real implementation reads I/O ports).
+    #[cfg(not(test))]
+    fn scan_hardware(&mut self) -> Result<(), GpuError> {
+        for _bus in 0..MAX_BUSES {
+            for _device in 0..MAX_DEVICES {
+                for _function in 0..MAX_FUNCTIONS {
+                    // Stub: no-op on real hardware until port I/O ready.
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Mock scan used in unit tests -- pushes representative AMD devices.
+    #[cfg(test)]
+    fn scan_mock(&mut self) -> Result<(), GpuError> {
+        // AMD Instinct MI300X (CDNA 3)
+        self.push_device(PciDevice {
+            address: PciAddress {
+                bus: 0,
+                device: 3,
+                function: 0,
+            },
+            vendor_id: AMD_VENDOR_ID,
+            device_id: 0x7500,
+            class_code: 0x03,
+            subclass: 0x02,
+            revision: 0xC1,
+            bars: alloc::vec![
+                BaseAddressRegister {
+                    bar_type: BarType::Memory64,
+                    address: 0xFB00_0000,
+                    size: 32 * 1024 * 1024,
+                    prefetchable: false,
+                },
+                BaseAddressRegister {
+                    bar_type: BarType::Memory64,
+                    address: 0x3800_0000_0000,
+                    size: 512 * 1024 * 1024,
+                    prefetchable: true,
+                },
+            ],
+            irq_line: 11,
+        });
+
+        // AMD Instinct MI200 (CDNA 2)
+        self.push_device(PciDevice {
+            address: PciAddress {
+                bus: 0,
+                device: 4,
+                function: 0,
+            },
+            vendor_id: AMD_VENDOR_ID,
+            device_id: 0x7400,
+            class_code: 0x03,
+            subclass: 0x02,
+            revision: 0xC1,
+            bars: alloc::vec![
+                BaseAddressRegister {
+                    bar_type: BarType::Memory64,
+                    address: 0xFC00_0000,
+                    size: 32 * 1024 * 1024,
+                    prefetchable: false,
+                },
+                BaseAddressRegister {
+                    bar_type: BarType::Memory64,
+                    address: 0x3900_0000_0000,
+                    size: 256 * 1024 * 1024,
+                    prefetchable: true,
+                },
+            ],
+            irq_line: 12,
+        });
+
+        // AMD Radeon RX 7900 XTX (RDNA 3)
+        self.push_device(PciDevice {
+            address: PciAddress {
+                bus: 0,
+                device: 5,
+                function: 0,
+            },
+            vendor_id: AMD_VENDOR_ID,
+            device_id: 0x7440,
+            class_code: 0x03,
+            subclass: 0x00,
+            revision: 0xC1,
+            bars: alloc::vec![
+                BaseAddressRegister {
+                    bar_type: BarType::Memory64,
+                    address: 0xFD00_0000,
+                    size: 16 * 1024 * 1024,
+                    prefetchable: false,
+                },
+                BaseAddressRegister {
+                    bar_type: BarType::Memory64,
+                    address: 0x3A00_0000_0000,
+                    size: 256 * 1024 * 1024,
+                    prefetchable: true,
+                },
+            ],
+            irq_line: 13,
+        });
+
+        // Non-AMD device (NVIDIA, for filter testing)
+        self.push_device(PciDevice {
+            address: PciAddress {
+                bus: 0,
+                device: 2,
+                function: 0,
+            },
+            vendor_id: 0x10DE,
+            device_id: 0x1B80,
+            class_code: 0x03,
+            subclass: 0x02,
+            revision: 0xA1,
+            bars: alloc::vec![BaseAddressRegister {
+                bar_type: BarType::Memory64,
+                address: 0xDE00_0000,
+                size: 16 * 1024 * 1024,
+                prefetchable: false,
+            }],
+            irq_line: 10,
+        });
+
+        Ok(())
+    }
+
+    /// Add a device to the internal list (capped at `MAX_PCI_DEVICES`).
+    fn push_device(&mut self, device: PciDevice) {
+        if self.devices.len() < MAX_PCI_DEVICES {
+            self.devices.push(device);
+        }
+    }
+
+    /// Return references to only the AMD-vendor devices.
+    pub fn amd_devices(&self) -> Vec<&PciDevice> {
+        self.devices.iter().filter(|d| d.is_amd()).collect()
+    }
+
+    /// Total number of discovered PCI devices (all vendors).
+    pub fn device_count(&self) -> usize {
+        self.devices.len()
+    }
+
+    /// Return a reference to the full device list.
+    pub fn devices(&self) -> &[PciDevice] {
+        &self.devices
+    }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- PciAddress --------------------------------------------------------
+
+    #[test]
+    fn config_address_enable_bit_set() {
+        let addr = PciAddress {
+            bus: 0,
+            device: 0,
+            function: 0,
+        };
+        let cfg = addr.config_address(0);
+        assert!(cfg & (1 << 31) != 0, "enable bit must be set");
+    }
+
+    #[test]
+    fn config_address_bus_encoding() {
+        let addr = PciAddress {
+            bus: 5,
+            device: 0,
+            function: 0,
+        };
+        let cfg = addr.config_address(0);
+        let bus_field = (cfg >> 16) & 0xFF;
+        assert_eq!(bus_field, 5);
+    }
+
+    #[test]
+    fn config_address_device_encoding() {
+        let addr = PciAddress {
+            bus: 0,
+            device: 18,
+            function: 0,
+        };
+        let cfg = addr.config_address(0);
+        let dev_field = (cfg >> 11) & 0x1F;
+        assert_eq!(dev_field, 18);
+    }
+
+    #[test]
+    fn config_address_function_encoding() {
+        let addr = PciAddress {
+            bus: 0,
+            device: 0,
+            function: 7,
+        };
+        let cfg = addr.config_address(0);
+        let fn_field = (cfg >> 8) & 0x07;
+        assert_eq!(fn_field, 7);
+    }
+
+    #[test]
+    fn config_address_register_encoding() {
+        let addr = PciAddress {
+            bus: 0,
+            device: 0,
+            function: 0,
+        };
+        let cfg = addr.config_address(0x3C);
+        let reg_field = cfg & 0xFC;
+        assert_eq!(reg_field, 0x3C);
+    }
+
+    #[test]
+    fn config_address_full_encoding() {
+        let addr = PciAddress {
+            bus: 1,
+            device: 3,
+            function: 2,
+        };
+        let cfg = addr.config_address(0x10);
+        let expected = (1u32 << 31) | (1u32 << 16) | (3u32 << 11) | (2u32 << 8) | 0x10u32;
+        assert_eq!(cfg, expected);
+    }
+
+    // -- BarType -----------------------------------------------------------
+
+    #[test]
+    fn bar_type_memory32() {
+        let bar = BaseAddressRegister {
+            bar_type: BarType::Memory32,
+            address: 0xF000_0000,
+            size: 1024,
+            prefetchable: false,
+        };
+        assert_eq!(bar.bar_type, BarType::Memory32);
+        assert!(!bar.prefetchable);
+    }
+
+    #[test]
+    fn bar_type_memory64_prefetchable() {
+        let bar = BaseAddressRegister {
+            bar_type: BarType::Memory64,
+            address: 0x3800_0000_0000,
+            size: 256 * 1024 * 1024,
+            prefetchable: true,
+        };
+        assert_eq!(bar.bar_type, BarType::Memory64);
+        assert!(bar.prefetchable);
+    }
+
+    #[test]
+    fn bar_type_io() {
+        let bar = BaseAddressRegister {
+            bar_type: BarType::Io,
+            address: 0x1000,
+            size: 256,
+            prefetchable: false,
+        };
+        assert_eq!(bar.bar_type, BarType::Io);
+    }
+
+    // -- PciDevice classification ------------------------------------------
+
+    #[test]
+    fn device_is_amd() {
+        let dev = PciDevice {
+            address: PciAddress {
+                bus: 0,
+                device: 0,
+                function: 0,
+            },
+            vendor_id: AMD_VENDOR_ID,
+            device_id: 0x7500,
+            class_code: 0x03,
+            subclass: 0x02,
+            revision: 0xC1,
+            bars: alloc::vec![],
+            irq_line: 11,
+        };
+        assert!(dev.is_amd());
+    }
+
+    #[test]
+    fn device_is_not_amd() {
+        let dev = PciDevice {
+            address: PciAddress {
+                bus: 0,
+                device: 0,
+                function: 0,
+            },
+            vendor_id: 0x10DE,
+            device_id: 0x1B80,
+            class_code: 0x03,
+            subclass: 0x02,
+            revision: 0xA1,
+            bars: alloc::vec![],
+            irq_line: 10,
+        };
+        assert!(!dev.is_amd());
+    }
+
+    #[test]
+    fn device_is_display_controller() {
+        let dev = PciDevice {
+            address: PciAddress {
+                bus: 0,
+                device: 0,
+                function: 0,
+            },
+            vendor_id: AMD_VENDOR_ID,
+            device_id: 0x7500,
+            class_code: 0x03,
+            subclass: 0x00,
+            revision: 0,
+            bars: alloc::vec![],
+            irq_line: 0,
+        };
+        assert!(dev.is_display_controller());
+    }
+
+    #[test]
+    fn device_is_3d_controller() {
+        let dev = PciDevice {
+            address: PciAddress {
+                bus: 0,
+                device: 0,
+                function: 0,
+            },
+            vendor_id: AMD_VENDOR_ID,
+            device_id: 0x7500,
+            class_code: 0x03,
+            subclass: 0x02,
+            revision: 0,
+            bars: alloc::vec![],
+            irq_line: 0,
+        };
+        assert!(dev.is_3d_controller());
+    }
+
+    #[test]
+    fn device_not_3d_if_wrong_subclass() {
+        let dev = PciDevice {
+            address: PciAddress {
+                bus: 0,
+                device: 0,
+                function: 0,
+            },
+            vendor_id: AMD_VENDOR_ID,
+            device_id: 0x7500,
+            class_code: 0x03,
+            subclass: 0x00,
+            revision: 0,
+            bars: alloc::vec![],
+            irq_line: 0,
+        };
+        assert!(!dev.is_3d_controller());
+    }
+
+    #[test]
+    fn device_is_vga_controller() {
+        let dev = PciDevice {
+            address: PciAddress {
+                bus: 0,
+                device: 0,
+                function: 0,
+            },
+            vendor_id: AMD_VENDOR_ID,
+            device_id: 0x7440,
+            class_code: 0x03,
+            subclass: 0x00,
+            revision: 0,
+            bars: alloc::vec![],
+            irq_line: 0,
+        };
+        assert!(dev.is_vga_controller());
+    }
+
+    // -- PciScanner --------------------------------------------------------
+
+    #[test]
+    fn scanner_new_is_empty() {
+        let scanner = PciScanner::new();
+        assert_eq!(scanner.device_count(), 0);
+    }
+
+    #[test]
+    fn scanner_mock_scan_finds_devices() {
+        let mut scanner = PciScanner::new();
+        scanner.scan().expect("mock scan should succeed");
+        assert_eq!(scanner.device_count(), 4);
+    }
+
+    #[test]
+    fn scanner_amd_filter() {
+        let mut scanner = PciScanner::new();
+        scanner.scan().unwrap();
+        let amd = scanner.amd_devices();
+        assert_eq!(amd.len(), 3, "mock scan has exactly 3 AMD devices");
+        for dev in &amd {
+            assert!(dev.is_amd());
+        }
+    }
+
+    #[test]
+    fn scanner_non_amd_present() {
+        let mut scanner = PciScanner::new();
+        scanner.scan().unwrap();
+        let non_amd: Vec<_> = scanner.devices().iter().filter(|d| !d.is_amd()).collect();
+        assert_eq!(non_amd.len(), 1, "mock scan has 1 non-AMD device");
+        assert_eq!(non_amd[0].vendor_id, 0x10DE);
+    }
+
+    #[test]
+    fn scanner_device_ids_for_known_families() {
+        let mut scanner = PciScanner::new();
+        scanner.scan().unwrap();
+        let amd = scanner.amd_devices();
+        let ids: Vec<u16> = amd.iter().map(|d| d.device_id).collect();
+        assert!(ids.contains(&0x7500), "should contain MI300X (CDNA 3)");
+        assert!(ids.contains(&0x7400), "should contain MI200 (CDNA 2)");
+        assert!(ids.contains(&0x7440), "should contain RX 7900 XTX (RDNA 3)");
+    }
+
+    #[test]
+    fn scanner_max_capacity() {
+        let mut scanner = PciScanner::new();
+        for i in 0..MAX_PCI_DEVICES + 10 {
+            scanner.push_device(PciDevice {
+                address: PciAddress {
+                    bus: 0,
+                    device: (i % 32) as u8,
+                    function: 0,
+                },
+                vendor_id: AMD_VENDOR_ID,
+                device_id: 0x7500,
+                class_code: 0x03,
+                subclass: 0x02,
+                revision: 0,
+                bars: alloc::vec![],
+                irq_line: 0,
+            });
+        }
+        assert_eq!(scanner.device_count(), MAX_PCI_DEVICES);
+    }
+
+    #[test]
+    fn pci_address_ranges_valid() {
+        let addr = PciAddress {
+            bus: 255,
+            device: 31,
+            function: 7,
+        };
+        let cfg = addr.config_address(0xFC);
+        assert_eq!((cfg >> 16) & 0xFF, 255);
+        assert_eq!((cfg >> 11) & 0x1F, 31);
+        assert_eq!((cfg >> 8) & 0x07, 7);
+        assert_eq!(cfg & 0xFC, 0xFC);
+    }
+
+    #[test]
+    fn mock_devices_have_bars() {
+        let mut scanner = PciScanner::new();
+        scanner.scan().unwrap();
+        let amd = scanner.amd_devices();
+        for dev in &amd {
+            assert!(
+                !dev.bars.is_empty(),
+                "AMD mock devices should have at least one BAR"
+            );
+        }
+    }
+}

--- a/arch/amd/src/rocm_provider.rs
+++ b/arch/amd/src/rocm_provider.rs
@@ -1,0 +1,555 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! ROCm execution provider for ONNX inference.
+//!
+//! [`RocmProvider`] is the top-level entry point that wires together the
+//! VRAM allocator, SDMA engine, compute engine, and HIP kernel registry to
+//! execute ONNX operators on an AMD GPU. It translates high-level ONNX
+//! operator names into HIP kernel launches with appropriate grid/workgroup sizing.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use crate::compute::{ComputeEngine, Dim3, LaunchConfig, WavefrontMode};
+use crate::dma::{DmaDirection, SdmaEngine};
+use crate::gpu_id::GpuInfo;
+use crate::hip_kernels::{DataPrecision, HipKernelType, HipRegistry};
+use crate::memory::{MemoryRegion, VramAllocator};
+use crate::GpuError;
+
+// ---------------------------------------------------------------------------
+// OperatorMapping
+// ---------------------------------------------------------------------------
+
+/// Maps an ONNX operator name to a GPU kernel type and precision.
+#[derive(Clone, Debug, PartialEq)]
+pub struct OperatorMapping {
+    /// ONNX operator name (e.g. `"MatMul"`, `"Conv"`).
+    pub op_name: String,
+    /// HIP kernel family to use.
+    pub kernel_type: HipKernelType,
+    /// Numeric precision for the kernel.
+    pub precision: DataPrecision,
+}
+
+// ---------------------------------------------------------------------------
+// ExecutionStep / ExecutionPlan
+// ---------------------------------------------------------------------------
+
+/// A single step in an execution plan.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExecutionStep {
+    /// ONNX operator name.
+    pub op_name: String,
+    /// HIP kernel type to dispatch.
+    pub kernel_type: HipKernelType,
+    /// VRAM allocation ids for input tensors.
+    pub input_allocs: Vec<u64>,
+    /// VRAM allocation id for the output tensor.
+    pub output_alloc: u64,
+    /// Launch configuration for this step.
+    pub config: LaunchConfig,
+}
+
+/// A complete execution plan for a model inference pass.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExecutionPlan {
+    /// Ordered sequence of execution steps.
+    pub steps: Vec<ExecutionStep>,
+    /// Total workspace memory required in bytes.
+    pub total_workspace: u64,
+}
+
+// ---------------------------------------------------------------------------
+// ProviderStatus
+// ---------------------------------------------------------------------------
+
+/// Lifecycle state of the ROCm execution provider.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ProviderStatus {
+    /// Provider has not been initialised.
+    Uninitialized,
+    /// Ready to accept work.
+    Ready,
+    /// Currently executing a kernel or model.
+    Executing,
+    /// An unrecoverable error has occurred.
+    Error,
+}
+
+// ---------------------------------------------------------------------------
+// RocmProvider
+// ---------------------------------------------------------------------------
+
+/// ROCm execution provider that dispatches ONNX operators to AMD GPU kernels.
+///
+/// Owns all GPU-side resources: memory allocator, compute and SDMA engines,
+/// and the HIP kernel registry.
+pub struct RocmProvider {
+    /// Static description of the GPU.
+    gpu_info: GpuInfo,
+    /// VRAM allocator (70% static / 30% dynamic).
+    allocator: VramAllocator,
+    /// Kernel launch engine.
+    compute: ComputeEngine,
+    /// Host<->device SDMA engine.
+    sdma: SdmaEngine,
+    /// Registered HIP kernels.
+    registry: HipRegistry,
+    /// Current provider state.
+    status: ProviderStatus,
+    /// Number of models whose weights have been loaded.
+    models_loaded: u32,
+}
+
+impl RocmProvider {
+    /// Create a new ROCm provider for the given GPU.
+    ///
+    /// `vram_size` is the total usable VRAM in bytes. The allocator is
+    /// configured with 70% static (weights) / 30% dynamic (workspace).
+    /// Default HIP kernels are registered and the provider moves to
+    /// [`ProviderStatus::Ready`].
+    pub fn new(gpu_info: GpuInfo, vram_size: u64) -> Self {
+        let allocator = VramAllocator::new(vram_size, 0.7);
+        let compute = ComputeEngine::new();
+        let sdma = SdmaEngine::new(0);
+        let mut registry = HipRegistry::new();
+        let _ = registry.register_defaults();
+
+        Self {
+            gpu_info,
+            allocator,
+            compute,
+            sdma,
+            registry,
+            status: ProviderStatus::Ready,
+            models_loaded: 0,
+        }
+    }
+
+    /// Current provider status.
+    pub fn status(&self) -> &ProviderStatus {
+        &self.status
+    }
+
+    /// Static GPU information.
+    pub fn gpu_info(&self) -> &GpuInfo {
+        &self.gpu_info
+    }
+
+    /// Load model weights into VRAM (static region).
+    pub fn load_weights(&mut self, size: u64) -> Result<u64, GpuError> {
+        let id = self.allocator.alloc(size, MemoryRegion::Static)?;
+        self.models_loaded += 1;
+        Ok(id)
+    }
+
+    /// Allocate workspace memory (dynamic region) for intermediate tensors.
+    pub fn allocate_workspace(&mut self, size: u64) -> Result<u64, GpuError> {
+        self.allocator.alloc(size, MemoryRegion::Dynamic)
+    }
+
+    /// Free a previous VRAM allocation (static or dynamic).
+    pub fn free_allocation(&mut self, id: u64) -> Result<(), GpuError> {
+        self.allocator.free(id)
+    }
+
+    /// Submit a host-to-device DMA transfer.
+    pub fn transfer_to_device(&mut self, src: u64, dst: u64, size: u64) -> Result<u64, GpuError> {
+        let tid = self
+            .sdma
+            .submit(DmaDirection::HostToDevice, src, dst, size)?;
+        Ok(tid.0)
+    }
+
+    /// Submit a device-to-host DMA transfer.
+    pub fn transfer_from_device(&mut self, src: u64, dst: u64, size: u64) -> Result<u64, GpuError> {
+        let tid = self
+            .sdma
+            .submit(DmaDirection::DeviceToHost, src, dst, size)?;
+        Ok(tid.0)
+    }
+
+    /// Map an ONNX operator name to a GPU kernel type and precision.
+    pub fn map_operator(op_name: &str) -> Option<OperatorMapping> {
+        let kernel_type = match op_name {
+            "MatMul" | "Gemm" => HipKernelType::Gemm,
+            "Conv" => HipKernelType::Conv2d,
+            "Relu" | "Sigmoid" | "Tanh" | "Add" | "Mul" | "Sub" => HipKernelType::Elementwise,
+            "Softmax" => HipKernelType::Softmax,
+            "LayerNormalization" => HipKernelType::LayerNorm,
+            "ReduceSum" | "ReduceMean" | "ReduceMax" => HipKernelType::Reduce,
+            "Transpose" => HipKernelType::Transpose,
+            "Concat" => HipKernelType::Concat,
+            "MaxPool" | "AveragePool" | "GlobalAveragePool" => HipKernelType::Pool,
+            "Reshape" | "Flatten" | "Squeeze" | "Unsqueeze" => return None,
+            _ => return None,
+        };
+
+        Some(OperatorMapping {
+            op_name: String::from(op_name),
+            kernel_type,
+            precision: DataPrecision::F32,
+        })
+    }
+
+    /// Determine wavefront mode based on GPU architecture.
+    fn wavefront_mode(&self) -> WavefrontMode {
+        if self.gpu_info.architecture.is_rdna() {
+            WavefrontMode::Wave32
+        } else {
+            WavefrontMode::Wave64
+        }
+    }
+
+    /// Launch a GPU kernel for the named ONNX operator.
+    pub fn launch_kernel(&mut self, op_name: &str, elements: u32) -> Result<u64, GpuError> {
+        let mapping = Self::map_operator(op_name).ok_or(GpuError::NotFound)?;
+
+        let hip_kernel = self
+            .registry
+            .find_kernel(
+                mapping.kernel_type,
+                mapping.precision,
+                &self.gpu_info.gfx_version,
+            )
+            .ok_or(GpuError::LaunchError)?;
+
+        let workgroup_size: u32 = 256;
+        let grid_size = elements.div_ceil(workgroup_size);
+
+        let config = LaunchConfig {
+            grid: Dim3::linear(grid_size),
+            workgroup: Dim3::linear(workgroup_size),
+            lds_size: hip_kernel.lds_size,
+            queue: 0,
+            wavefront_mode: self.wavefront_mode(),
+        };
+
+        let kid = self.compute.launch(op_name, config)?;
+        self.compute.dispatch(kid)?;
+        Ok(kid.0)
+    }
+
+    /// Synchronise the compute engine.
+    pub fn synchronize(&mut self) {
+        self.compute.synchronize();
+    }
+
+    /// Total VRAM currently in use (bytes).
+    pub fn vram_used(&self) -> u64 {
+        self.allocator.total_used()
+    }
+
+    /// Total VRAM available for new allocations (bytes).
+    pub fn vram_free(&self) -> u64 {
+        self.allocator.total_free()
+    }
+
+    /// Number of models whose weights have been loaded.
+    pub fn models_loaded(&self) -> u32 {
+        self.models_loaded
+    }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compute::KernelStatus;
+    use crate::gpu_id::identify_gpu;
+    use crate::memory::GPU_PAGE_SIZE;
+
+    fn test_gpu_info() -> GpuInfo {
+        identify_gpu(0x7500).unwrap() // MI300X (CDNA 3, gfx942)
+    }
+
+    fn test_rdna_gpu_info() -> GpuInfo {
+        identify_gpu(0x7440).unwrap() // RX 7900 XTX (RDNA 3, gfx1100)
+    }
+
+    fn test_provider() -> RocmProvider {
+        let gpu = test_gpu_info();
+        RocmProvider::new(gpu, 1024 * 1024 * 1024) // 1 GiB
+    }
+
+    fn test_rdna_provider() -> RocmProvider {
+        let gpu = test_rdna_gpu_info();
+        RocmProvider::new(gpu, 1024 * 1024 * 1024)
+    }
+
+    const PAGE: u64 = GPU_PAGE_SIZE as u64;
+
+    #[test]
+    fn test_new_provider_is_ready() {
+        let prov = test_provider();
+        assert_eq!(*prov.status(), ProviderStatus::Ready);
+    }
+
+    #[test]
+    fn test_load_weights_static_region() {
+        let mut prov = test_provider();
+        let initial_used = prov.allocator.used_bytes(MemoryRegion::Static);
+        let id = prov.load_weights(PAGE).unwrap();
+        assert!(id >= 1);
+        assert_eq!(
+            prov.allocator.used_bytes(MemoryRegion::Static),
+            initial_used + PAGE
+        );
+    }
+
+    #[test]
+    fn test_allocate_workspace_dynamic_region() {
+        let mut prov = test_provider();
+        let initial_used = prov.allocator.used_bytes(MemoryRegion::Dynamic);
+        let id = prov.allocate_workspace(PAGE * 2).unwrap();
+        assert!(id >= 1);
+        assert_eq!(
+            prov.allocator.used_bytes(MemoryRegion::Dynamic),
+            initial_used + PAGE * 2
+        );
+    }
+
+    #[test]
+    fn test_free_allocation() {
+        let mut prov = test_provider();
+        let id = prov.load_weights(PAGE).unwrap();
+        let used_before_free = prov.vram_used();
+        prov.free_allocation(id).unwrap();
+        assert_eq!(prov.vram_used(), used_before_free - PAGE);
+    }
+
+    #[test]
+    fn test_transfer_to_device() {
+        let mut prov = test_provider();
+        let tid = prov.transfer_to_device(0x1000, 0x2000, 4096).unwrap();
+        assert!(tid >= 1);
+    }
+
+    #[test]
+    fn test_transfer_from_device() {
+        let mut prov = test_provider();
+        let tid = prov.transfer_from_device(0x2000, 0x1000, 8192).unwrap();
+        assert!(tid >= 1);
+    }
+
+    #[test]
+    fn test_map_known_operators() {
+        let cases = [
+            ("MatMul", HipKernelType::Gemm),
+            ("Gemm", HipKernelType::Gemm),
+            ("Conv", HipKernelType::Conv2d),
+            ("Relu", HipKernelType::Elementwise),
+            ("Sigmoid", HipKernelType::Elementwise),
+            ("Tanh", HipKernelType::Elementwise),
+            ("Add", HipKernelType::Elementwise),
+            ("Mul", HipKernelType::Elementwise),
+            ("Sub", HipKernelType::Elementwise),
+            ("Softmax", HipKernelType::Softmax),
+            ("LayerNormalization", HipKernelType::LayerNorm),
+            ("ReduceSum", HipKernelType::Reduce),
+            ("ReduceMean", HipKernelType::Reduce),
+            ("ReduceMax", HipKernelType::Reduce),
+            ("Transpose", HipKernelType::Transpose),
+            ("Concat", HipKernelType::Concat),
+            ("MaxPool", HipKernelType::Pool),
+            ("AveragePool", HipKernelType::Pool),
+            ("GlobalAveragePool", HipKernelType::Pool),
+        ];
+        for (op, expected_type) in &cases {
+            let mapping = RocmProvider::map_operator(op);
+            assert!(mapping.is_some(), "Expected mapping for {}", op);
+            let m = mapping.unwrap();
+            assert_eq!(m.kernel_type, *expected_type, "Wrong type for {}", op);
+            assert_eq!(m.precision, DataPrecision::F32);
+            assert_eq!(m.op_name, *op);
+        }
+    }
+
+    #[test]
+    fn test_map_unknown_operator_returns_none() {
+        assert!(RocmProvider::map_operator("UnknownOp").is_none());
+        assert!(RocmProvider::map_operator("").is_none());
+    }
+
+    #[test]
+    fn test_map_reshape_returns_none() {
+        assert!(RocmProvider::map_operator("Reshape").is_none());
+        assert!(RocmProvider::map_operator("Flatten").is_none());
+        assert!(RocmProvider::map_operator("Squeeze").is_none());
+        assert!(RocmProvider::map_operator("Unsqueeze").is_none());
+    }
+
+    #[test]
+    fn test_launch_matmul_kernel() {
+        let mut prov = test_provider();
+        let launch_id = prov.launch_kernel("MatMul", 1024).unwrap();
+        assert!(launch_id >= 1);
+    }
+
+    #[test]
+    fn test_launch_elementwise_kernel() {
+        let mut prov = test_provider();
+        let launch_id = prov.launch_kernel("Relu", 512).unwrap();
+        assert!(launch_id >= 1);
+    }
+
+    #[test]
+    fn test_synchronize() {
+        let mut prov = test_provider();
+        let kid_raw = prov.launch_kernel("Add", 256).unwrap();
+        let kid = crate::compute::KernelId(kid_raw);
+        assert_eq!(prov.compute.status(kid), Ok(&KernelStatus::Running));
+        prov.synchronize();
+        assert_eq!(prov.compute.status(kid), Ok(&KernelStatus::Completed));
+    }
+
+    #[test]
+    fn test_vram_tracking() {
+        let mut prov = test_provider();
+        let total = prov.vram_used() + prov.vram_free();
+        assert_eq!(total, 1024 * 1024 * 1024);
+
+        let initial_used = prov.vram_used();
+        prov.load_weights(PAGE).unwrap();
+        assert_eq!(prov.vram_used(), initial_used + PAGE);
+        assert_eq!(prov.vram_free(), total - prov.vram_used());
+    }
+
+    #[test]
+    fn test_provider_gpu_info_access() {
+        let prov = test_provider();
+        let info = prov.gpu_info();
+        assert_eq!(info.device_id, 0x7500);
+        assert_eq!(info.name, "AMD Instinct MI300X");
+        assert_eq!(info.gfx_version.as_gfx_id(), 942);
+    }
+
+    #[test]
+    fn test_launch_config_grid_workgroup_sizing() {
+        let mut prov = test_provider();
+
+        let kid_raw = prov.launch_kernel("MatMul", 1000).unwrap();
+        let kid = crate::compute::KernelId(kid_raw);
+        let kernel = prov.compute.kernels.iter().find(|k| k.id == kid).unwrap();
+        assert_eq!(kernel.config.grid.x, 4);
+        assert_eq!(kernel.config.workgroup.x, 256);
+
+        let kid_raw2 = prov.launch_kernel("Relu", 256).unwrap();
+        let kid2 = crate::compute::KernelId(kid_raw2);
+        let kernel2 = prov.compute.kernels.iter().find(|k| k.id == kid2).unwrap();
+        assert_eq!(kernel2.config.grid.x, 1);
+        assert_eq!(kernel2.config.workgroup.x, 256);
+    }
+
+    #[test]
+    fn test_provider_status_enum() {
+        assert_ne!(ProviderStatus::Uninitialized, ProviderStatus::Ready);
+        assert_ne!(ProviderStatus::Ready, ProviderStatus::Executing);
+        assert_ne!(ProviderStatus::Executing, ProviderStatus::Error);
+        let cloned = ProviderStatus::Ready.clone();
+        assert_eq!(cloned, ProviderStatus::Ready);
+        let dbg = alloc::format!("{:?}", ProviderStatus::Executing);
+        assert!(dbg.contains("Executing"));
+    }
+
+    #[test]
+    fn test_models_loaded_counter() {
+        let mut prov = test_provider();
+        assert_eq!(prov.models_loaded(), 0);
+        prov.load_weights(PAGE).unwrap();
+        assert_eq!(prov.models_loaded(), 1);
+        prov.load_weights(PAGE).unwrap();
+        assert_eq!(prov.models_loaded(), 2);
+    }
+
+    #[test]
+    fn test_launch_unknown_op_returns_not_found() {
+        let mut prov = test_provider();
+        let result = prov.launch_kernel("UnknownOp", 100);
+        assert_eq!(result, Err(GpuError::NotFound));
+    }
+
+    #[test]
+    fn test_launch_cpu_only_op_returns_not_found() {
+        let mut prov = test_provider();
+        let result = prov.launch_kernel("Reshape", 100);
+        assert_eq!(result, Err(GpuError::NotFound));
+    }
+
+    #[test]
+    fn test_execution_plan_derives() {
+        let step = ExecutionStep {
+            op_name: String::from("MatMul"),
+            kernel_type: HipKernelType::Gemm,
+            input_allocs: alloc::vec![1, 2],
+            output_alloc: 3,
+            config: LaunchConfig {
+                grid: Dim3::linear(4),
+                workgroup: Dim3::linear(256),
+                lds_size: 49152,
+                queue: 0,
+                wavefront_mode: WavefrontMode::Wave64,
+            },
+        };
+        let plan = ExecutionPlan {
+            steps: alloc::vec![step.clone()],
+            total_workspace: 1024 * 1024,
+        };
+        let plan2 = plan.clone();
+        assert_eq!(plan, plan2);
+        let dbg = alloc::format!("{:?}", plan);
+        assert!(dbg.contains("MatMul"));
+    }
+
+    #[test]
+    fn test_multiple_launches_and_sync() {
+        let mut prov = test_provider();
+        let id1 = prov.launch_kernel("MatMul", 1024).unwrap();
+        let id2 = prov.launch_kernel("Relu", 2048).unwrap();
+        let id3 = prov.launch_kernel("Softmax", 512).unwrap();
+        assert!(id1 < id2);
+        assert!(id2 < id3);
+        prov.synchronize();
+        for kid_raw in [id1, id2, id3] {
+            let kid = crate::compute::KernelId(kid_raw);
+            assert_eq!(prov.compute.status(kid), Ok(&KernelStatus::Completed));
+        }
+    }
+
+    #[test]
+    fn test_lds_passed_through() {
+        let mut prov = test_provider();
+        let kid_raw = prov.launch_kernel("MatMul", 256).unwrap();
+        let kid = crate::compute::KernelId(kid_raw);
+        let kernel = prov.compute.kernels.iter().find(|k| k.id == kid).unwrap();
+        assert_eq!(kernel.config.lds_size, 49152);
+
+        let kid_raw2 = prov.launch_kernel("Relu", 256).unwrap();
+        let kid2 = crate::compute::KernelId(kid_raw2);
+        let kernel2 = prov.compute.kernels.iter().find(|k| k.id == kid2).unwrap();
+        assert_eq!(kernel2.config.lds_size, 0);
+    }
+
+    #[test]
+    fn test_cdna_uses_wave64() {
+        let mut prov = test_provider();
+        let kid_raw = prov.launch_kernel("MatMul", 256).unwrap();
+        let kid = crate::compute::KernelId(kid_raw);
+        let kernel = prov.compute.kernels.iter().find(|k| k.id == kid).unwrap();
+        assert_eq!(kernel.config.wavefront_mode, WavefrontMode::Wave64);
+    }
+
+    #[test]
+    fn test_rdna_uses_wave32() {
+        let mut prov = test_rdna_provider();
+        let kid_raw = prov.launch_kernel("MatMul", 256).unwrap();
+        let kid = crate::compute::KernelId(kid_raw);
+        let kernel = prov.compute.kernels.iter().find(|k| k.id == kid).unwrap();
+        assert_eq!(kernel.config.wavefront_mode, WavefrontMode::Wave32);
+    }
+}

--- a/openspec/changes/amd-gpu-support-v4/design.md
+++ b/openspec/changes/amd-gpu-support-v4/design.md
@@ -1,0 +1,52 @@
+# AMD GPU Support - Design Document
+
+## Architecture Overview
+
+The `arch/amd` crate follows the same modular design as `arch/nvidia`:
+
+```
+arch/amd/
+  src/
+    lib.rs          -- Crate root, GpuError enum, module declarations
+    pcie.rs         -- PCIe enumeration (vendor 0x1002)
+    gpu_id.rs       -- GPU identification (RDNA/CDNA families)
+    memory.rs       -- VRAM allocator (static/dynamic regions)
+    dma.rs          -- DMA/SDMA engine for host<->device transfers
+    compute.rs      -- Wavefront-based compute engine
+    hip_kernels.rs  -- HIP kernel definitions and registry
+    rocm_provider.rs -- ROCm execution provider (ONNX operator dispatch)
+    gpu_init.rs     -- GPU initialization and lifecycle management
+```
+
+## Key Design Decisions
+
+### Wavefront Size
+AMD GPUs use wavefronts instead of NVIDIA warps:
+- CDNA (MI100/MI200/MI300): 64-wide wavefronts
+- RDNA (RX 5000/6000/7000): 32-wide wavefronts (wave32) with wave64 compatibility
+
+The compute engine adapts launch configurations based on detected architecture.
+
+### Architecture Detection
+GPU family detection uses PCI device ID ranges:
+- RDNA 1 (Navi 10/14): 0x7310-0x73FF
+- RDNA 2 (Navi 21/22/23): 0x73A0-0x73EF
+- RDNA 3 (Navi 31/32/33): 0x7440-0x74FF
+- CDNA 1 (MI100): 0x7380-0x739F
+- CDNA 2 (MI200): 0x7400-0x743F
+- CDNA 3 (MI300): 0x7500-0x75FF
+
+### Memory Model
+Same dual-region approach as NVIDIA: 70% static (weights), 30% dynamic (workspace).
+Page size is 64 KiB (matching AMD's GPU page granularity).
+
+### HIP Kernel Registry
+Mirrors the PTX kernel registry but uses HIP/GCN ISA terminology.
+Kernels specify minimum GFX version (e.g., gfx908 for MI100, gfx942 for MI300X).
+
+### Execution Provider
+`RocmProvider` is the AMD equivalent of `CudaProvider`, wiring together:
+- VRAM allocator
+- DMA engine
+- Compute engine
+- HIP kernel registry

--- a/openspec/changes/amd-gpu-support-v4/proposal.md
+++ b/openspec/changes/amd-gpu-support-v4/proposal.md
@@ -1,0 +1,40 @@
+# AMD GPU Support Proposal
+
+## Summary
+
+Add AMD GPU hardware abstraction layer (arch/amd crate) to SmallAIOS, enabling AI inference workloads on AMD Radeon and Instinct GPUs via ROCm/HIP-compatible abstractions.
+
+## Motivation
+
+SmallAIOS currently supports NVIDIA GPUs exclusively. AMD GPUs (RDNA for consumer/edge, CDNA for datacenter) represent a significant and growing share of the AI accelerator market. Adding AMD support enables:
+
+- Datacenter deployment on AMD Instinct MI200/MI300 series
+- Edge inference on RDNA-based APUs and discrete GPUs
+- Multi-vendor GPU strategy reducing vendor lock-in
+- Cost-competitive inference alternatives
+
+## Scope
+
+- PCIe enumeration for AMD GPUs (vendor ID 0x1002)
+- GPU identification: RDNA 1/2/3, CDNA 1/2/3 architectures
+- VRAM memory allocator with static/dynamic regions
+- DMA engine for host-device transfers
+- Wavefront-based compute engine (64-wide wavefronts for CDNA, 32-wide for RDNA)
+- ROCm/HIP execution provider mapping ONNX operators to GPU kernels
+- Comprehensive test suite
+
+## Non-Goals
+
+- Actual hardware register programming (stub implementation like NVIDIA crate)
+- Display/graphics pipeline support
+- Multi-GPU peer-to-peer (future work)
+- ROCm userspace runtime integration (bare-metal only)
+
+## Dependencies
+
+- `smallaios-kernel` crate (same as NVIDIA crate)
+- No external C dependencies (pure `#![no_std]` Rust)
+
+## Timeline
+
+Single implementation phase covering all modules.

--- a/openspec/changes/amd-gpu-support-v4/tasks.md
+++ b/openspec/changes/amd-gpu-support-v4/tasks.md
@@ -1,0 +1,18 @@
+# AMD GPU Support - Tasks
+
+## Implementation Tasks
+
+- [x] T1: Create arch/amd/Cargo.toml with workspace integration
+- [x] T2: Implement lib.rs with GpuError enum and module declarations
+- [x] T3: Implement pcie.rs - PCIe enumeration for AMD GPUs (vendor 0x1002)
+- [x] T4: Implement gpu_id.rs - GPU identification for RDNA 1/2/3 and CDNA 1/2/3
+- [x] T5: Implement memory.rs - VRAM allocator with static/dynamic regions
+- [x] T6: Implement dma.rs - DMA/SDMA engine for host<->device transfers
+- [x] T7: Implement compute.rs - Wavefront-based compute engine
+- [x] T8: Implement hip_kernels.rs - HIP kernel definitions and registry
+- [x] T9: Implement rocm_provider.rs - ROCm execution provider
+- [x] T10: Implement gpu_init.rs - GPU initialization and lifecycle management
+- [x] T11: Add arch/amd to workspace Cargo.toml members
+- [x] T12: Write comprehensive tests for all modules
+- [x] T13: Verify cargo check/test passes
+- [x] T14: Commit and push to branch


### PR DESCRIPTION
## Summary
- Add `arch/amd` crate with full AMD GPU hardware abstraction layer
- PCIe enumeration (vendor 0x1002), GPU identification (RDNA 1/2/3, CDNA 1/2/3)
- VRAM allocator, SDMA engine, wavefront-based compute engine
- HIP kernel registry and ROCm execution provider for ONNX inference
- OpenSpec proposal, design, and task artifacts
- **169 tests passing**, zero clippy warnings

## Test plan
- [x] `cargo test -p smallaios-arch-amd` passes (169 tests)
- [x] `cargo clippy -p smallaios-arch-amd -- -D warnings` clean
- [x] `cargo fmt -p smallaios-arch-amd -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)