### PR TITLE
Add Intel GPU architecture support (arch/intel_gpu crate)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallaios-arch-intel-gpu"
+version = "0.1.0"
+dependencies = [
+ "smallaios-kernel",
+]
+
+[[package]]
 name = "smallaios-arch-nvidia"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "arch/aarch64",
     "arch/riscv64",
     "arch/nvidia",
+    "arch/intel_gpu",
     "onnx-rt",
     "ipc",
     "net",

--- a/arch/intel_gpu/Cargo.toml
+++ b/arch/intel_gpu/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "smallaios-arch-intel-gpu"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "SmallAIOS Intel GPU HAL: PCIe, GPU init, memory, compute, DMA"
+
+[features]
+default = []
+xe_lp  = []    # Xe-LP (Arc integrated, DG1)
+xe_hpg = []    # Xe-HPG (Arc A770/A750/A580/A380)
+xe_hpc = []    # Xe-HPC (Data Center GPU Max / Ponte Vecchio)
+xe_lpg = []    # Xe-LPG (Meteor Lake integrated)
+xe2    = []    # Xe2 (Battlemage)
+
+[dependencies]
+smallaios-kernel = { path = "../../kernel" }

--- a/arch/intel_gpu/src/compute.rs
+++ b/arch/intel_gpu/src/compute.rs
@@ -1,0 +1,509 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! EU-based compute engine -- kernel launch, workgroup config, synchronization.
+//!
+//! Intel GPUs use Execution Units (EUs) with SIMD execution. Each EU supports
+//! 8 hardware threads, and each thread processes data using SIMD8, SIMD16, or
+//! SIMD32 widths. This module manages kernel lifecycle:
+//! `Queued -> Running -> Completed | Failed`.
+//!
+//! [`ComputeEngine::synchronize`] is a convenience that marks every `Running`
+//! kernel as `Completed` (simulating a device-wide barrier).
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use crate::GpuError;
+
+/// SIMD execution width for Intel EU threads.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SimdWidth {
+    /// 8-wide SIMD execution.
+    Simd8,
+    /// 16-wide SIMD execution.
+    Simd16,
+    /// 32-wide SIMD execution.
+    Simd32,
+}
+
+impl SimdWidth {
+    /// Return the numeric width.
+    pub fn width(&self) -> u32 {
+        match self {
+            SimdWidth::Simd8 => 8,
+            SimdWidth::Simd16 => 16,
+            SimdWidth::Simd32 => 32,
+        }
+    }
+}
+
+/// Three-dimensional size used for grid (workgroup count) and workgroup
+/// (threads per workgroup) dimensions.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Dim3 {
+    pub x: u32,
+    pub y: u32,
+    pub z: u32,
+}
+
+impl Dim3 {
+    /// Create a new `Dim3` with explicit x/y/z components.
+    pub fn new(x: u32, y: u32, z: u32) -> Self {
+        Self { x, y, z }
+    }
+
+    /// Convenience for one-dimensional launches: `(n, 1, 1)`.
+    pub fn linear(n: u32) -> Self {
+        Self { x: n, y: 1, z: 1 }
+    }
+
+    /// Total number of threads/workgroups represented by this `Dim3`.
+    pub fn total(&self) -> u64 {
+        self.x as u64 * self.y as u64 * self.z as u64
+    }
+}
+
+/// Configuration for a kernel launch.
+#[derive(Clone, Debug, PartialEq)]
+pub struct LaunchConfig {
+    /// Number of workgroups in the grid.
+    pub grid: Dim3,
+    /// Number of threads per workgroup.
+    pub workgroup: Dim3,
+    /// Bytes of shared local memory (SLM) per workgroup.
+    pub shared_local_memory: u32,
+    /// Queue ordinal.
+    pub queue: u32,
+}
+
+/// Maximum threads per workgroup (Intel GPU hardware limit).
+const MAX_THREADS_PER_WORKGROUP: u64 = 1024;
+
+/// Maximum shared local memory per workgroup (64 KiB).
+const MAX_SHARED_LOCAL_MEMORY: u32 = 65536;
+
+impl LaunchConfig {
+    /// Validate that this configuration is within hardware limits.
+    pub fn validate(&self) -> Result<(), GpuError> {
+        if self.workgroup.total() > MAX_THREADS_PER_WORKGROUP {
+            return Err(GpuError::InvalidConfig);
+        }
+        if self.grid.x == 0 || self.grid.y == 0 || self.grid.z == 0 {
+            return Err(GpuError::InvalidConfig);
+        }
+        if self.workgroup.x == 0 || self.workgroup.y == 0 || self.workgroup.z == 0 {
+            return Err(GpuError::InvalidConfig);
+        }
+        if self.shared_local_memory > MAX_SHARED_LOCAL_MEMORY {
+            return Err(GpuError::InvalidConfig);
+        }
+        Ok(())
+    }
+}
+
+/// Unique identifier for a submitted kernel.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct KernelId(pub u64);
+
+/// Lifecycle state of a kernel.
+#[derive(Clone, Debug, PartialEq)]
+pub enum KernelStatus {
+    /// Submitted and waiting in the queue.
+    Queued,
+    /// Currently executing on the GPU.
+    Running,
+    /// Finished successfully.
+    Completed,
+    /// Terminated with an error.
+    Failed,
+}
+
+/// A single kernel tracked by the compute engine.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Kernel {
+    /// Unique kernel identifier.
+    pub id: KernelId,
+    /// Human-readable kernel name (e.g. ONNX op name).
+    pub name: String,
+    /// Launch configuration.
+    pub config: LaunchConfig,
+    /// Current status.
+    pub status: KernelStatus,
+}
+
+/// Maximum number of kernels that may be queued at once.
+pub const MAX_QUEUED_KERNELS: usize = 512;
+
+/// Stub Intel GPU compute engine.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ComputeEngine {
+    /// All tracked kernels.
+    pub(crate) kernels: Vec<Kernel>,
+    /// Monotonically increasing id generator.
+    next_id: u64,
+    /// Running count of successfully completed kernels.
+    completed_count: u64,
+    /// Running count of failed kernels.
+    failed_count: u64,
+}
+
+impl Default for ComputeEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ComputeEngine {
+    /// Create a new, empty compute engine.
+    pub fn new() -> Self {
+        Self {
+            kernels: Vec::new(),
+            next_id: 1,
+            completed_count: 0,
+            failed_count: 0,
+        }
+    }
+
+    /// Submit a kernel for execution.
+    ///
+    /// The launch configuration is validated first. On success, the kernel is
+    /// placed in [`KernelStatus::Queued`] and its [`KernelId`] is returned.
+    pub fn launch(&mut self, name: &str, config: LaunchConfig) -> Result<KernelId, GpuError> {
+        config.validate()?;
+
+        if self.kernels.len() >= MAX_QUEUED_KERNELS {
+            return Err(GpuError::QueueFull);
+        }
+
+        let id = KernelId(self.next_id);
+        self.next_id += 1;
+
+        self.kernels.push(Kernel {
+            id,
+            name: String::from(name),
+            config,
+            status: KernelStatus::Queued,
+        });
+
+        Ok(id)
+    }
+
+    /// Dispatch a queued kernel to the GPU (Queued -> Running).
+    pub fn dispatch(&mut self, id: KernelId) -> Result<(), GpuError> {
+        let kernel = self.find_mut(id)?;
+        if kernel.status != KernelStatus::Queued {
+            return Err(GpuError::InvalidState);
+        }
+        kernel.status = KernelStatus::Running;
+        Ok(())
+    }
+
+    /// Mark a running kernel as completed (Running -> Completed).
+    pub fn complete(&mut self, id: KernelId) -> Result<(), GpuError> {
+        let kernel = self.find_mut(id)?;
+        if kernel.status != KernelStatus::Running {
+            return Err(GpuError::InvalidState);
+        }
+        kernel.status = KernelStatus::Completed;
+        self.completed_count += 1;
+        Ok(())
+    }
+
+    /// Mark a running kernel as failed (Running -> Failed).
+    pub fn fail(&mut self, id: KernelId) -> Result<(), GpuError> {
+        let kernel = self.find_mut(id)?;
+        if kernel.status != KernelStatus::Running {
+            return Err(GpuError::InvalidState);
+        }
+        kernel.status = KernelStatus::Failed;
+        self.failed_count += 1;
+        Ok(())
+    }
+
+    /// Query the current status of a kernel.
+    pub fn status(&self, id: KernelId) -> Result<&KernelStatus, GpuError> {
+        let kernel = self
+            .kernels
+            .iter()
+            .find(|k| k.id == id)
+            .ok_or(GpuError::NotFound)?;
+        Ok(&kernel.status)
+    }
+
+    /// Device-wide synchronization barrier.
+    ///
+    /// In this stub, all `Running` kernels are moved to `Completed`.
+    pub fn synchronize(&mut self) {
+        for kernel in &mut self.kernels {
+            if kernel.status == KernelStatus::Running {
+                kernel.status = KernelStatus::Completed;
+                self.completed_count += 1;
+            }
+        }
+    }
+
+    /// Total number of kernels that have completed successfully.
+    pub fn completed_count(&self) -> u64 {
+        self.completed_count
+    }
+
+    /// Number of kernels currently in [`KernelStatus::Queued`] state.
+    pub fn queued_count(&self) -> usize {
+        self.kernels
+            .iter()
+            .filter(|k| k.status == KernelStatus::Queued)
+            .count()
+    }
+
+    // -- internal helpers ---------------------------------------------------
+
+    fn find_mut(&mut self, id: KernelId) -> Result<&mut Kernel, GpuError> {
+        self.kernels
+            .iter_mut()
+            .find(|k| k.id == id)
+            .ok_or(GpuError::NotFound)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: build a valid 1-D launch config.
+    fn valid_config() -> LaunchConfig {
+        LaunchConfig {
+            grid: Dim3::linear(128),
+            workgroup: Dim3::linear(256),
+            shared_local_memory: 0,
+            queue: 0,
+        }
+    }
+
+    // 1. Dim3 creation and total.
+    #[test]
+    fn test_dim3_creation_and_total() {
+        let d = Dim3::new(4, 8, 2);
+        assert_eq!(d.x, 4);
+        assert_eq!(d.y, 8);
+        assert_eq!(d.z, 2);
+        assert_eq!(d.total(), 64);
+    }
+
+    // 2. Linear dim3.
+    #[test]
+    fn test_dim3_linear() {
+        let d = Dim3::linear(512);
+        assert_eq!(d.x, 512);
+        assert_eq!(d.y, 1);
+        assert_eq!(d.z, 1);
+        assert_eq!(d.total(), 512);
+    }
+
+    // 3. Launch config validation (valid).
+    #[test]
+    fn test_launch_config_valid() {
+        assert!(valid_config().validate().is_ok());
+    }
+
+    // 4. Launch config validation (workgroup too large).
+    #[test]
+    fn test_launch_config_workgroup_too_large() {
+        let cfg = LaunchConfig {
+            grid: Dim3::linear(1),
+            workgroup: Dim3::new(32, 32, 2), // 2048 > 1024
+            shared_local_memory: 0,
+            queue: 0,
+        };
+        assert_eq!(cfg.validate(), Err(GpuError::InvalidConfig));
+    }
+
+    // 5. Launch config validation (zero dimensions).
+    #[test]
+    fn test_launch_config_zero_grid() {
+        let cfg = LaunchConfig {
+            grid: Dim3::new(0, 1, 1),
+            workgroup: Dim3::linear(256),
+            shared_local_memory: 0,
+            queue: 0,
+        };
+        assert_eq!(cfg.validate(), Err(GpuError::InvalidConfig));
+    }
+
+    // 6. Launch config shared local memory limit.
+    #[test]
+    fn test_launch_config_slm_limit() {
+        let cfg = LaunchConfig {
+            grid: Dim3::linear(1),
+            workgroup: Dim3::linear(256),
+            shared_local_memory: MAX_SHARED_LOCAL_MEMORY + 1,
+            queue: 0,
+        };
+        assert_eq!(cfg.validate(), Err(GpuError::InvalidConfig));
+    }
+
+    // 7. Launch kernel creates Queued.
+    #[test]
+    fn test_launch_creates_queued() {
+        let mut eng = ComputeEngine::new();
+        let id = eng.launch("matmul", valid_config()).unwrap();
+        assert_eq!(eng.status(id), Ok(&KernelStatus::Queued));
+    }
+
+    // 8. Dispatch queued kernel.
+    #[test]
+    fn test_dispatch_queued() {
+        let mut eng = ComputeEngine::new();
+        let id = eng.launch("relu", valid_config()).unwrap();
+        eng.dispatch(id).unwrap();
+        assert_eq!(eng.status(id), Ok(&KernelStatus::Running));
+    }
+
+    // 9. Complete running kernel.
+    #[test]
+    fn test_complete_running() {
+        let mut eng = ComputeEngine::new();
+        let id = eng.launch("conv2d", valid_config()).unwrap();
+        eng.dispatch(id).unwrap();
+        eng.complete(id).unwrap();
+        assert_eq!(eng.status(id), Ok(&KernelStatus::Completed));
+    }
+
+    // 10. Fail running kernel.
+    #[test]
+    fn test_fail_running() {
+        let mut eng = ComputeEngine::new();
+        let id = eng.launch("softmax", valid_config()).unwrap();
+        eng.dispatch(id).unwrap();
+        eng.fail(id).unwrap();
+        assert_eq!(eng.status(id), Ok(&KernelStatus::Failed));
+    }
+
+    // 11. Cannot dispatch completed kernel.
+    #[test]
+    fn test_cannot_dispatch_completed() {
+        let mut eng = ComputeEngine::new();
+        let id = eng.launch("add", valid_config()).unwrap();
+        eng.dispatch(id).unwrap();
+        eng.complete(id).unwrap();
+        assert_eq!(eng.dispatch(id), Err(GpuError::InvalidState));
+    }
+
+    // 12. Synchronize completes all running.
+    #[test]
+    fn test_synchronize() {
+        let mut eng = ComputeEngine::new();
+        let id1 = eng.launch("k1", valid_config()).unwrap();
+        let id2 = eng.launch("k2", valid_config()).unwrap();
+        let id3 = eng.launch("k3", valid_config()).unwrap();
+        eng.dispatch(id1).unwrap();
+        eng.dispatch(id2).unwrap();
+        // id3 stays Queued.
+        eng.synchronize();
+        assert_eq!(eng.status(id1), Ok(&KernelStatus::Completed));
+        assert_eq!(eng.status(id2), Ok(&KernelStatus::Completed));
+        assert_eq!(eng.status(id3), Ok(&KernelStatus::Queued));
+        assert_eq!(eng.completed_count(), 2);
+    }
+
+    // 13. Status lookup (not found).
+    #[test]
+    fn test_status_not_found() {
+        let eng = ComputeEngine::new();
+        assert_eq!(eng.status(KernelId(999)), Err(GpuError::NotFound));
+    }
+
+    // 14. Completed / queued counts.
+    #[test]
+    fn test_completed_queued_counts() {
+        let mut eng = ComputeEngine::new();
+        let id1 = eng.launch("a", valid_config()).unwrap();
+        let _id2 = eng.launch("b", valid_config()).unwrap();
+        assert_eq!(eng.queued_count(), 2);
+        eng.dispatch(id1).unwrap();
+        eng.complete(id1).unwrap();
+        assert_eq!(eng.completed_count(), 1);
+        assert_eq!(eng.queued_count(), 1);
+    }
+
+    // 15. Queue full at MAX_QUEUED_KERNELS.
+    #[test]
+    fn test_queue_full() {
+        let mut eng = ComputeEngine::new();
+        for i in 0..MAX_QUEUED_KERNELS {
+            eng.launch(&alloc::format!("k{}", i), valid_config())
+                .unwrap();
+        }
+        assert_eq!(
+            eng.launch("overflow", valid_config()),
+            Err(GpuError::QueueFull)
+        );
+    }
+
+    // 16. Zero workgroup dimension rejected.
+    #[test]
+    fn test_zero_workgroup_dimension() {
+        let cfg = LaunchConfig {
+            grid: Dim3::linear(1),
+            workgroup: Dim3::new(256, 0, 1),
+            shared_local_memory: 0,
+            queue: 0,
+        };
+        assert_eq!(cfg.validate(), Err(GpuError::InvalidConfig));
+    }
+
+    // 17. Exactly MAX_THREADS_PER_WORKGROUP is allowed.
+    #[test]
+    fn test_exact_max_threads() {
+        let cfg = LaunchConfig {
+            grid: Dim3::linear(1),
+            workgroup: Dim3::new(32, 32, 1), // 1024 == MAX_THREADS_PER_WORKGROUP
+            shared_local_memory: 0,
+            queue: 0,
+        };
+        assert!(cfg.validate().is_ok());
+    }
+
+    // 18. Exactly MAX_SHARED_LOCAL_MEMORY is allowed.
+    #[test]
+    fn test_exact_max_slm() {
+        let cfg = LaunchConfig {
+            grid: Dim3::linear(1),
+            workgroup: Dim3::linear(64),
+            shared_local_memory: MAX_SHARED_LOCAL_MEMORY,
+            queue: 0,
+        };
+        assert!(cfg.validate().is_ok());
+    }
+
+    // 19. Failed count tracked.
+    #[test]
+    fn test_failed_count() {
+        let mut eng = ComputeEngine::new();
+        let id = eng.launch("bad_kernel", valid_config()).unwrap();
+        eng.dispatch(id).unwrap();
+        eng.fail(id).unwrap();
+        assert_eq!(eng.failed_count, 1);
+        assert_eq!(eng.completed_count(), 0);
+    }
+
+    // 20. Cannot complete a Queued kernel directly.
+    #[test]
+    fn test_cannot_complete_queued() {
+        let mut eng = ComputeEngine::new();
+        let id = eng.launch("skip", valid_config()).unwrap();
+        assert_eq!(eng.complete(id), Err(GpuError::InvalidState));
+    }
+
+    // 21. SimdWidth values.
+    #[test]
+    fn test_simd_width_values() {
+        assert_eq!(SimdWidth::Simd8.width(), 8);
+        assert_eq!(SimdWidth::Simd16.width(), 16);
+        assert_eq!(SimdWidth::Simd32.width(), 32);
+    }
+}

--- a/arch/intel_gpu/src/dma.rs
+++ b/arch/intel_gpu/src/dma.rs
@@ -1,0 +1,431 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! DMA/Blitter engine for host<->device transfers.
+//!
+//! Manages asynchronous memory transfers between host RAM and device VRAM
+//! (and device-to-device copies) via the Intel Blitter Command Streamer (BCS).
+//! Each transfer goes through a strict state machine:
+//! `Pending -> InProgress -> Completed | Failed`. Pending transfers may also
+//! be cancelled.
+
+use alloc::vec::Vec;
+
+use crate::GpuError;
+
+/// Direction of a DMA transfer.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum DmaDirection {
+    /// Host RAM -> Device VRAM.
+    HostToDevice,
+    /// Device VRAM -> Host RAM.
+    DeviceToHost,
+    /// Device VRAM -> Device VRAM (peer or same GPU).
+    DeviceToDevice,
+}
+
+/// State of a DMA transfer.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum DmaStatus {
+    /// Submitted but not yet started by the blitter engine.
+    Pending,
+    /// Currently being executed by the blitter copy engine.
+    InProgress,
+    /// Successfully finished.
+    Completed,
+    /// Terminated with an error.
+    Failed,
+}
+
+/// Unique identifier for a DMA transfer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct TransferId(pub u64);
+
+/// A single DMA transfer descriptor.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DmaTransfer {
+    /// Unique transfer identifier.
+    pub id: TransferId,
+    /// Direction of the transfer.
+    pub direction: DmaDirection,
+    /// Source address (host-physical or GPU-virtual, depending on direction).
+    pub src_addr: u64,
+    /// Destination address.
+    pub dst_addr: u64,
+    /// Transfer size in bytes.
+    pub size: u64,
+    /// Current status.
+    pub status: DmaStatus,
+}
+
+/// Maximum number of tracked transfers.
+pub const MAX_TRANSFERS: usize = 256;
+
+/// Maximum size of a single DMA transfer (256 MiB).
+pub const MAX_TRANSFER_SIZE: u64 = 256 * 1024 * 1024;
+
+/// DMA / blitter-engine controller.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DmaEngine {
+    /// All tracked transfer descriptors.
+    transfers: Vec<DmaTransfer>,
+    /// Monotonically increasing id generator.
+    next_id: u64,
+    /// Running total of successfully transferred bytes.
+    bytes_transferred: u64,
+    /// Whether the engine is active (ready to accept work).
+    active: bool,
+}
+
+impl Default for DmaEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DmaEngine {
+    /// Create a new, active DMA engine with no pending work.
+    pub fn new() -> Self {
+        Self {
+            transfers: Vec::new(),
+            next_id: 1,
+            bytes_transferred: 0,
+            active: true,
+        }
+    }
+
+    /// Submit a new transfer request.
+    ///
+    /// The transfer is created in [`DmaStatus::Pending`] state.
+    /// Returns the unique [`TransferId`] on success.
+    pub fn submit(
+        &mut self,
+        direction: DmaDirection,
+        src: u64,
+        dst: u64,
+        size: u64,
+    ) -> Result<TransferId, GpuError> {
+        if size == 0 {
+            return Err(GpuError::DmaError);
+        }
+        if size > MAX_TRANSFER_SIZE {
+            return Err(GpuError::TransferTooLarge);
+        }
+        if self.transfers.len() >= MAX_TRANSFERS {
+            return Err(GpuError::QueueFull);
+        }
+
+        let id = TransferId(self.next_id);
+        self.next_id += 1;
+
+        self.transfers.push(DmaTransfer {
+            id,
+            direction,
+            src_addr: src,
+            dst_addr: dst,
+            size,
+            status: DmaStatus::Pending,
+        });
+
+        Ok(id)
+    }
+
+    /// Start a pending transfer (Pending -> InProgress).
+    pub fn start(&mut self, id: TransferId) -> Result<(), GpuError> {
+        let xfer = self.find_mut(id)?;
+        if xfer.status != DmaStatus::Pending {
+            return Err(GpuError::InvalidState);
+        }
+        xfer.status = DmaStatus::InProgress;
+        Ok(())
+    }
+
+    /// Mark an in-progress transfer as completed (InProgress -> Completed).
+    pub fn complete(&mut self, id: TransferId) -> Result<(), GpuError> {
+        let xfer = self.find_mut(id)?;
+        if xfer.status != DmaStatus::InProgress {
+            return Err(GpuError::InvalidState);
+        }
+        xfer.status = DmaStatus::Completed;
+        self.bytes_transferred += xfer.size;
+        Ok(())
+    }
+
+    /// Mark an in-progress transfer as failed (InProgress -> Failed).
+    pub fn fail(&mut self, id: TransferId) -> Result<(), GpuError> {
+        let xfer = self.find_mut(id)?;
+        if xfer.status != DmaStatus::InProgress {
+            return Err(GpuError::InvalidState);
+        }
+        xfer.status = DmaStatus::Failed;
+        Ok(())
+    }
+
+    /// Query the current status of a transfer.
+    pub fn status(&self, id: TransferId) -> Result<&DmaStatus, GpuError> {
+        let xfer = self
+            .transfers
+            .iter()
+            .find(|t| t.id == id)
+            .ok_or(GpuError::NotFound)?;
+        Ok(&xfer.status)
+    }
+
+    /// Cancel a pending transfer. Only [`DmaStatus::Pending`] transfers may
+    /// be cancelled.
+    pub fn cancel(&mut self, id: TransferId) -> Result<(), GpuError> {
+        let idx = self
+            .transfers
+            .iter()
+            .position(|t| t.id == id)
+            .ok_or(GpuError::NotFound)?;
+
+        if self.transfers[idx].status != DmaStatus::Pending {
+            return Err(GpuError::InvalidState);
+        }
+
+        self.transfers.remove(idx);
+        Ok(())
+    }
+
+    /// Total bytes successfully transferred since engine creation.
+    pub fn total_bytes_transferred(&self) -> u64 {
+        self.bytes_transferred
+    }
+
+    /// Number of transfers currently in [`DmaStatus::Pending`] state.
+    pub fn pending_count(&self) -> usize {
+        self.transfers
+            .iter()
+            .filter(|t| t.status == DmaStatus::Pending)
+            .count()
+    }
+
+    /// Number of transfers currently in [`DmaStatus::InProgress`] state.
+    pub fn active_count(&self) -> usize {
+        self.transfers
+            .iter()
+            .filter(|t| t.status == DmaStatus::InProgress)
+            .count()
+    }
+
+    // -- internal helpers ---------------------------------------------------
+
+    fn find_mut(&mut self, id: TransferId) -> Result<&mut DmaTransfer, GpuError> {
+        self.transfers
+            .iter_mut()
+            .find(|t| t.id == id)
+            .ok_or(GpuError::NotFound)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // 1. Submit transfer returns unique ID.
+    #[test]
+    fn test_submit_unique_ids() {
+        let mut eng = DmaEngine::new();
+        let id1 = eng
+            .submit(DmaDirection::HostToDevice, 0x1000, 0x2000, 4096)
+            .unwrap();
+        let id2 = eng
+            .submit(DmaDirection::DeviceToHost, 0x3000, 0x4000, 8192)
+            .unwrap();
+        assert_ne!(id1, id2);
+    }
+
+    // 2. Start pending transfer.
+    #[test]
+    fn test_start_pending() {
+        let mut eng = DmaEngine::new();
+        let id = eng.submit(DmaDirection::HostToDevice, 0, 0, 4096).unwrap();
+        assert_eq!(eng.status(id), Ok(&DmaStatus::Pending));
+        eng.start(id).unwrap();
+        assert_eq!(eng.status(id), Ok(&DmaStatus::InProgress));
+    }
+
+    // 3. Complete in-progress transfer.
+    #[test]
+    fn test_complete_in_progress() {
+        let mut eng = DmaEngine::new();
+        let id = eng.submit(DmaDirection::HostToDevice, 0, 0, 4096).unwrap();
+        eng.start(id).unwrap();
+        eng.complete(id).unwrap();
+        assert_eq!(eng.status(id), Ok(&DmaStatus::Completed));
+    }
+
+    // 4. Fail in-progress transfer.
+    #[test]
+    fn test_fail_in_progress() {
+        let mut eng = DmaEngine::new();
+        let id = eng.submit(DmaDirection::DeviceToHost, 0, 0, 4096).unwrap();
+        eng.start(id).unwrap();
+        eng.fail(id).unwrap();
+        assert_eq!(eng.status(id), Ok(&DmaStatus::Failed));
+    }
+
+    // 5. Cancel pending transfer.
+    #[test]
+    fn test_cancel_pending() {
+        let mut eng = DmaEngine::new();
+        let id = eng.submit(DmaDirection::HostToDevice, 0, 0, 4096).unwrap();
+        eng.cancel(id).unwrap();
+        assert_eq!(eng.status(id), Err(GpuError::NotFound));
+    }
+
+    // 6. Cannot start completed transfer.
+    #[test]
+    fn test_cannot_start_completed() {
+        let mut eng = DmaEngine::new();
+        let id = eng.submit(DmaDirection::HostToDevice, 0, 0, 4096).unwrap();
+        eng.start(id).unwrap();
+        eng.complete(id).unwrap();
+        assert_eq!(eng.start(id), Err(GpuError::InvalidState));
+    }
+
+    // 7. Cannot complete pending transfer.
+    #[test]
+    fn test_cannot_complete_pending() {
+        let mut eng = DmaEngine::new();
+        let id = eng.submit(DmaDirection::HostToDevice, 0, 0, 4096).unwrap();
+        assert_eq!(eng.complete(id), Err(GpuError::InvalidState));
+    }
+
+    // 8. Zero-size transfer rejected.
+    #[test]
+    fn test_zero_size_rejected() {
+        let mut eng = DmaEngine::new();
+        assert_eq!(
+            eng.submit(DmaDirection::HostToDevice, 0, 0, 0),
+            Err(GpuError::DmaError)
+        );
+    }
+
+    // 9. Transfer too large rejected.
+    #[test]
+    fn test_transfer_too_large() {
+        let mut eng = DmaEngine::new();
+        assert_eq!(
+            eng.submit(DmaDirection::HostToDevice, 0, 0, MAX_TRANSFER_SIZE + 1),
+            Err(GpuError::TransferTooLarge)
+        );
+    }
+
+    // 10. Bytes transferred tracking.
+    #[test]
+    fn test_bytes_transferred() {
+        let mut eng = DmaEngine::new();
+        let id1 = eng.submit(DmaDirection::HostToDevice, 0, 0, 1000).unwrap();
+        eng.start(id1).unwrap();
+        eng.complete(id1).unwrap();
+
+        let id2 = eng.submit(DmaDirection::DeviceToHost, 0, 0, 2000).unwrap();
+        eng.start(id2).unwrap();
+        eng.complete(id2).unwrap();
+
+        assert_eq!(eng.total_bytes_transferred(), 3000);
+    }
+
+    // 11. Pending and active counts.
+    #[test]
+    fn test_pending_active_counts() {
+        let mut eng = DmaEngine::new();
+        let id1 = eng.submit(DmaDirection::HostToDevice, 0, 0, 4096).unwrap();
+        let _id2 = eng.submit(DmaDirection::DeviceToHost, 0, 0, 4096).unwrap();
+        assert_eq!(eng.pending_count(), 2);
+        assert_eq!(eng.active_count(), 0);
+
+        eng.start(id1).unwrap();
+        assert_eq!(eng.pending_count(), 1);
+        assert_eq!(eng.active_count(), 1);
+    }
+
+    // 12. Status lookup.
+    #[test]
+    fn test_status_lookup() {
+        let mut eng = DmaEngine::new();
+        assert_eq!(eng.status(TransferId(999)), Err(GpuError::NotFound));
+        let id = eng.submit(DmaDirection::HostToDevice, 0, 0, 4096).unwrap();
+        assert_eq!(eng.status(id), Ok(&DmaStatus::Pending));
+    }
+
+    // 13. Direction types.
+    #[test]
+    fn test_direction_types() {
+        let mut eng = DmaEngine::new();
+        let id_h2d = eng.submit(DmaDirection::HostToDevice, 0, 0, 4096).unwrap();
+        let id_d2h = eng.submit(DmaDirection::DeviceToHost, 0, 0, 4096).unwrap();
+        let id_d2d = eng
+            .submit(DmaDirection::DeviceToDevice, 0, 0, 4096)
+            .unwrap();
+        let t1 = eng.transfers.iter().find(|t| t.id == id_h2d).unwrap();
+        let t2 = eng.transfers.iter().find(|t| t.id == id_d2h).unwrap();
+        let t3 = eng.transfers.iter().find(|t| t.id == id_d2d).unwrap();
+        assert_eq!(t1.direction, DmaDirection::HostToDevice);
+        assert_eq!(t2.direction, DmaDirection::DeviceToHost);
+        assert_eq!(t3.direction, DmaDirection::DeviceToDevice);
+    }
+
+    // 14. Full lifecycle (Pending -> InProgress -> Completed).
+    #[test]
+    fn test_full_lifecycle() {
+        let mut eng = DmaEngine::new();
+        let id = eng
+            .submit(DmaDirection::HostToDevice, 0xA000, 0xB000, 65536)
+            .unwrap();
+        assert_eq!(eng.status(id), Ok(&DmaStatus::Pending));
+        eng.start(id).unwrap();
+        assert_eq!(eng.status(id), Ok(&DmaStatus::InProgress));
+        eng.complete(id).unwrap();
+        assert_eq!(eng.status(id), Ok(&DmaStatus::Completed));
+        assert_eq!(eng.total_bytes_transferred(), 65536);
+    }
+
+    // 15. Cannot cancel in-progress transfer.
+    #[test]
+    fn test_cannot_cancel_in_progress() {
+        let mut eng = DmaEngine::new();
+        let id = eng.submit(DmaDirection::HostToDevice, 0, 0, 4096).unwrap();
+        eng.start(id).unwrap();
+        assert_eq!(eng.cancel(id), Err(GpuError::InvalidState));
+    }
+
+    // 16. Queue full at MAX_TRANSFERS.
+    #[test]
+    fn test_queue_full() {
+        let mut eng = DmaEngine::new();
+        for _ in 0..MAX_TRANSFERS {
+            eng.submit(DmaDirection::HostToDevice, 0, 0, 4096).unwrap();
+        }
+        assert_eq!(
+            eng.submit(DmaDirection::HostToDevice, 0, 0, 4096),
+            Err(GpuError::QueueFull)
+        );
+    }
+
+    // 17. Failed transfer does not count bytes.
+    #[test]
+    fn test_failed_no_bytes() {
+        let mut eng = DmaEngine::new();
+        let id = eng.submit(DmaDirection::HostToDevice, 0, 0, 4096).unwrap();
+        eng.start(id).unwrap();
+        eng.fail(id).unwrap();
+        assert_eq!(eng.total_bytes_transferred(), 0);
+    }
+
+    // 18. Max transfer size boundary (exactly MAX_TRANSFER_SIZE is allowed).
+    #[test]
+    fn test_max_transfer_size_boundary() {
+        let mut eng = DmaEngine::new();
+        let id = eng
+            .submit(DmaDirection::HostToDevice, 0, 0, MAX_TRANSFER_SIZE)
+            .unwrap();
+        assert_eq!(eng.status(id), Ok(&DmaStatus::Pending));
+    }
+}

--- a/arch/intel_gpu/src/gpu_id.rs
+++ b/arch/intel_gpu/src/gpu_id.rs
@@ -1,0 +1,455 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! GPU identification -- architecture, execution units, resources.
+//!
+//! Given a PCI device ID this module returns a [`GpuInfo`] that describes the
+//! GPU architecture, EU count, slice/subslice topology, VRAM size, and other
+//! parameters required by the compute-launch and memory-management layers.
+
+use crate::GpuError;
+
+// ---------------------------------------------------------------------------
+// GpuArchitecture
+// ---------------------------------------------------------------------------
+
+/// Intel GPU micro-architecture family.
+#[derive(Clone, Debug, PartialEq)]
+pub enum GpuArchitecture {
+    /// Xe-LP -- integrated GPUs (DG1, Tiger Lake, Rocket Lake).
+    XeLP,
+    /// Xe-HPG -- Arc A-series discrete GPUs (Alchemist).
+    XeHPG,
+    /// Xe-HPC -- Data Center GPU Max (Ponte Vecchio).
+    XeHPC,
+    /// Xe-LPG -- Meteor Lake integrated GPU.
+    XeLPG,
+    /// Xe2 -- Battlemage (next-generation discrete).
+    Xe2,
+    /// Architecture could not be determined.
+    Unknown,
+}
+
+// ---------------------------------------------------------------------------
+// XeVersion
+// ---------------------------------------------------------------------------
+
+/// Numeric Xe generation version for compatibility comparison.
+///
+/// Higher values represent newer architectures with more features.
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct XeVersion(pub u8);
+
+impl XeVersion {
+    /// Xe-LP generation.
+    pub const XE_LP: XeVersion = XeVersion(1);
+    /// Xe-HPG generation.
+    pub const XE_HPG: XeVersion = XeVersion(2);
+    /// Xe-HPC generation.
+    pub const XE_HPC: XeVersion = XeVersion(3);
+    /// Xe-LPG generation.
+    pub const XE_LPG: XeVersion = XeVersion(4);
+    /// Xe2 generation.
+    pub const XE2: XeVersion = XeVersion(5);
+
+    /// Create a new Xe version.
+    pub fn new(version: u8) -> Self {
+        Self(version)
+    }
+
+    /// Return the raw version number.
+    pub fn as_version(&self) -> u8 {
+        self.0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GpuInfo
+// ---------------------------------------------------------------------------
+
+/// Static description of a particular Intel GPU.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GpuInfo {
+    /// PCI device ID used to identify the GPU.
+    pub device_id: u16,
+    /// Micro-architecture family.
+    pub architecture: GpuArchitecture,
+    /// Xe generation version for compatibility checks.
+    pub xe_version: XeVersion,
+    /// Number of Execution Units (EUs).
+    pub eu_count: u32,
+    /// Number of slices.
+    pub slices: u32,
+    /// Number of subslices (dual subslices on Xe-HPG+).
+    pub subslices: u32,
+    /// Video RAM in megabytes (0 for integrated GPUs using system memory).
+    pub vram_size_mb: u32,
+    /// Maximum hardware threads per EU (always 8 on current Intel GPUs).
+    pub max_threads_per_eu: u32,
+    /// Human-readable product name.
+    pub name: &'static str,
+}
+
+impl GpuInfo {
+    /// Total hardware threads across all EUs.
+    ///
+    /// Each Intel EU supports 8 concurrent hardware threads.
+    pub fn total_threads(&self) -> u32 {
+        self.eu_count * self.max_threads_per_eu
+    }
+
+    /// Total EUs per subslice (derived).
+    pub fn eus_per_subslice(&self) -> u32 {
+        if self.subslices == 0 {
+            return 0;
+        }
+        self.eu_count / self.subslices
+    }
+
+    /// Whether this GPU has dedicated VRAM (discrete GPU).
+    pub fn has_dedicated_vram(&self) -> bool {
+        self.vram_size_mb > 0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// identify_gpu
+// ---------------------------------------------------------------------------
+
+/// Identify a GPU from its PCI device ID.
+///
+/// Returns a fully-populated [`GpuInfo`] for known Intel device IDs or
+/// [`GpuError::UnsupportedDevice`] otherwise.
+pub fn identify_gpu(device_id: u16) -> Result<GpuInfo, GpuError> {
+    match device_id {
+        // ----- Xe-LP (integrated / DG1) ----------------------------------
+        0x4905..=0x4908 => {
+            let (name, eus, slices, subslices, vram) = match device_id {
+                0x4905 => ("Intel DG1 (Xe-LP)", 96, 1, 6, 4096),
+                0x4906 => ("Intel Iris Xe (Tiger Lake)", 96, 1, 6, 0),
+                0x4907 => ("Intel Iris Xe (Rocket Lake)", 32, 1, 2, 0),
+                _ => ("Intel Xe-LP GPU", 96, 1, 6, 0),
+            };
+            Ok(GpuInfo {
+                device_id,
+                architecture: GpuArchitecture::XeLP,
+                xe_version: XeVersion::XE_LP,
+                eu_count: eus,
+                slices,
+                subslices,
+                vram_size_mb: vram,
+                max_threads_per_eu: 8,
+                name,
+            })
+        }
+
+        // ----- Xe-HPG (Arc A-series, Alchemist) --------------------------
+        // ACM-G10: Arc A770 (0x56A0), A750 (0x56A1), A580 (0x56A2)
+        // ACM-G11: Arc A380 (0x56A5)
+        0x56A0..=0x56AF => {
+            let (name, eus, slices, subslices, vram) = match device_id {
+                0x56A0 => ("Intel Arc A770", 512, 8, 32, 16384),
+                0x56A1 => ("Intel Arc A750", 448, 7, 28, 8192),
+                0x56A2 => ("Intel Arc A580", 384, 6, 24, 8192),
+                0x56A5 => ("Intel Arc A380", 128, 2, 8, 6144),
+                _ => ("Intel Arc GPU (Xe-HPG)", 512, 8, 32, 16384),
+            };
+            Ok(GpuInfo {
+                device_id,
+                architecture: GpuArchitecture::XeHPG,
+                xe_version: XeVersion::XE_HPG,
+                eu_count: eus,
+                slices,
+                subslices,
+                vram_size_mb: vram,
+                max_threads_per_eu: 8,
+                name,
+            })
+        }
+
+        // ----- Xe-HPG (Flex series) --------------------------------------
+        0x56C0..=0x56CF => {
+            let (name, eus, slices, subslices, vram) = match device_id {
+                0x56C0 => ("Intel Data Center GPU Flex 170", 512, 8, 32, 16384),
+                0x56C1 => ("Intel Data Center GPU Flex 140", 256, 4, 16, 12288),
+                _ => ("Intel Flex GPU (Xe-HPG)", 512, 8, 32, 16384),
+            };
+            Ok(GpuInfo {
+                device_id,
+                architecture: GpuArchitecture::XeHPG,
+                xe_version: XeVersion::XE_HPG,
+                eu_count: eus,
+                slices,
+                subslices,
+                vram_size_mb: vram,
+                max_threads_per_eu: 8,
+                name,
+            })
+        }
+
+        // ----- Xe-HPC (Data Center GPU Max / Ponte Vecchio) --------------
+        0x0BD0..=0x0BDF => {
+            let (name, eus, slices, subslices, vram) = match device_id {
+                0x0BD5 => ("Intel Data Center GPU Max 1550", 1024, 8, 64, 131072),
+                0x0BD6 => ("Intel Data Center GPU Max 1100", 896, 7, 56, 49152),
+                0x0BD9 => ("Intel Data Center GPU Max 1350", 1024, 8, 64, 98304),
+                _ => ("Intel Data Center GPU Max", 1024, 8, 64, 131072),
+            };
+            Ok(GpuInfo {
+                device_id,
+                architecture: GpuArchitecture::XeHPC,
+                xe_version: XeVersion::XE_HPC,
+                eu_count: eus,
+                slices,
+                subslices,
+                vram_size_mb: vram,
+                max_threads_per_eu: 8,
+                name,
+            })
+        }
+
+        // ----- Xe-LPG (Meteor Lake integrated) ---------------------------
+        0x7D40..=0x7D6F => {
+            let (name, eus, slices, subslices) = match device_id {
+                0x7D45 => ("Intel Meteor Lake Iris Xe (GT2)", 128, 2, 8),
+                0x7D55 => ("Intel Meteor Lake Iris Xe (GT1)", 64, 1, 4),
+                _ => ("Intel Meteor Lake GPU (Xe-LPG)", 128, 2, 8),
+            };
+            Ok(GpuInfo {
+                device_id,
+                architecture: GpuArchitecture::XeLPG,
+                xe_version: XeVersion::XE_LPG,
+                eu_count: eus,
+                slices,
+                subslices,
+                vram_size_mb: 0, // Integrated, uses system memory.
+                max_threads_per_eu: 8,
+                name,
+            })
+        }
+
+        // ----- Xe2 (Battlemage) ------------------------------------------
+        0xE202..=0xE20F => {
+            let (name, eus, slices, subslices, vram) = match device_id {
+                0xE202 => ("Intel Battlemage B580", 320, 5, 20, 12288),
+                0xE20B => ("Intel Battlemage B570", 288, 4, 18, 10240),
+                _ => ("Intel Xe2 GPU (Battlemage)", 320, 5, 20, 12288),
+            };
+            Ok(GpuInfo {
+                device_id,
+                architecture: GpuArchitecture::Xe2,
+                xe_version: XeVersion::XE2,
+                eu_count: eus,
+                slices,
+                subslices,
+                vram_size_mb: vram,
+                max_threads_per_eu: 8,
+                name,
+            })
+        }
+
+        // ----- Unknown / unsupported -------------------------------------
+        _ => Err(GpuError::UnsupportedDevice),
+    }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- Individual GPU identification ------------------------------------
+
+    #[test]
+    fn identify_arc_a770() {
+        let info = identify_gpu(0x56A0).unwrap();
+        assert_eq!(info.architecture, GpuArchitecture::XeHPG);
+        assert_eq!(info.xe_version, XeVersion::XE_HPG);
+        assert_eq!(info.eu_count, 512);
+        assert_eq!(info.slices, 8);
+        assert_eq!(info.subslices, 32);
+        assert_eq!(info.vram_size_mb, 16384);
+        assert_eq!(info.name, "Intel Arc A770");
+    }
+
+    #[test]
+    fn identify_arc_a750() {
+        let info = identify_gpu(0x56A1).unwrap();
+        assert_eq!(info.architecture, GpuArchitecture::XeHPG);
+        assert_eq!(info.eu_count, 448);
+        assert_eq!(info.vram_size_mb, 8192);
+        assert_eq!(info.name, "Intel Arc A750");
+    }
+
+    #[test]
+    fn identify_arc_a580() {
+        let info = identify_gpu(0x56A2).unwrap();
+        assert_eq!(info.architecture, GpuArchitecture::XeHPG);
+        assert_eq!(info.eu_count, 384);
+        assert_eq!(info.vram_size_mb, 8192);
+        assert_eq!(info.name, "Intel Arc A580");
+    }
+
+    #[test]
+    fn identify_arc_a380() {
+        let info = identify_gpu(0x56A5).unwrap();
+        assert_eq!(info.architecture, GpuArchitecture::XeHPG);
+        assert_eq!(info.eu_count, 128);
+        assert_eq!(info.vram_size_mb, 6144);
+        assert_eq!(info.name, "Intel Arc A380");
+    }
+
+    #[test]
+    fn identify_dc_max_1550() {
+        let info = identify_gpu(0x0BD5).unwrap();
+        assert_eq!(info.architecture, GpuArchitecture::XeHPC);
+        assert_eq!(info.xe_version, XeVersion::XE_HPC);
+        assert_eq!(info.eu_count, 1024);
+        assert_eq!(info.vram_size_mb, 131072);
+        assert_eq!(info.name, "Intel Data Center GPU Max 1550");
+    }
+
+    #[test]
+    fn identify_dc_max_1100() {
+        let info = identify_gpu(0x0BD6).unwrap();
+        assert_eq!(info.architecture, GpuArchitecture::XeHPC);
+        assert_eq!(info.eu_count, 896);
+        assert_eq!(info.vram_size_mb, 49152);
+        assert_eq!(info.name, "Intel Data Center GPU Max 1100");
+    }
+
+    #[test]
+    fn identify_flex_170() {
+        let info = identify_gpu(0x56C0).unwrap();
+        assert_eq!(info.architecture, GpuArchitecture::XeHPG);
+        assert_eq!(info.eu_count, 512);
+        assert_eq!(info.vram_size_mb, 16384);
+        assert_eq!(info.name, "Intel Data Center GPU Flex 170");
+    }
+
+    #[test]
+    fn identify_dg1_xe_lp() {
+        let info = identify_gpu(0x4905).unwrap();
+        assert_eq!(info.architecture, GpuArchitecture::XeLP);
+        assert_eq!(info.xe_version, XeVersion::XE_LP);
+        assert_eq!(info.eu_count, 96);
+        assert_eq!(info.vram_size_mb, 4096);
+        assert_eq!(info.name, "Intel DG1 (Xe-LP)");
+    }
+
+    #[test]
+    fn identify_iris_xe_tiger_lake() {
+        let info = identify_gpu(0x4906).unwrap();
+        assert_eq!(info.architecture, GpuArchitecture::XeLP);
+        assert_eq!(info.vram_size_mb, 0); // Integrated
+        assert!(!info.has_dedicated_vram());
+    }
+
+    #[test]
+    fn identify_meteor_lake_gt2() {
+        let info = identify_gpu(0x7D45).unwrap();
+        assert_eq!(info.architecture, GpuArchitecture::XeLPG);
+        assert_eq!(info.xe_version, XeVersion::XE_LPG);
+        assert_eq!(info.eu_count, 128);
+        assert_eq!(info.vram_size_mb, 0); // Integrated
+    }
+
+    #[test]
+    fn identify_battlemage_b580() {
+        let info = identify_gpu(0xE202).unwrap();
+        assert_eq!(info.architecture, GpuArchitecture::Xe2);
+        assert_eq!(info.xe_version, XeVersion::XE2);
+        assert_eq!(info.eu_count, 320);
+        assert_eq!(info.vram_size_mb, 12288);
+        assert_eq!(info.name, "Intel Battlemage B580");
+    }
+
+    #[test]
+    fn unknown_device_returns_error() {
+        let result = identify_gpu(0xFFFF);
+        assert_eq!(result, Err(GpuError::UnsupportedDevice));
+    }
+
+    #[test]
+    fn unknown_device_in_gap_returns_error() {
+        let result = identify_gpu(0x0001);
+        assert_eq!(result, Err(GpuError::UnsupportedDevice));
+    }
+
+    // -- XeVersion --------------------------------------------------------
+
+    #[test]
+    fn xe_version_ordering() {
+        assert!(XeVersion::XE_LP < XeVersion::XE_HPG);
+        assert!(XeVersion::XE_HPG < XeVersion::XE_HPC);
+        assert!(XeVersion::XE_HPC < XeVersion::XE_LPG);
+        assert!(XeVersion::XE_LPG < XeVersion::XE2);
+    }
+
+    #[test]
+    fn xe_version_as_version() {
+        assert_eq!(XeVersion::XE_LP.as_version(), 1);
+        assert_eq!(XeVersion::XE2.as_version(), 5);
+    }
+
+    // -- GpuInfo derived values -------------------------------------------
+
+    #[test]
+    fn total_threads_arc_a770() {
+        let info = identify_gpu(0x56A0).unwrap();
+        // 512 EUs * 8 threads/EU = 4096
+        assert_eq!(info.total_threads(), 512 * 8);
+    }
+
+    #[test]
+    fn total_threads_dc_max_1550() {
+        let info = identify_gpu(0x0BD5).unwrap();
+        // 1024 EUs * 8 threads/EU = 8192
+        assert_eq!(info.total_threads(), 1024 * 8);
+    }
+
+    #[test]
+    fn eus_per_subslice_arc_a770() {
+        let info = identify_gpu(0x56A0).unwrap();
+        // 512 EUs / 32 subslices = 16 EUs per subslice
+        assert_eq!(info.eus_per_subslice(), 16);
+    }
+
+    #[test]
+    fn has_dedicated_vram_discrete() {
+        let info = identify_gpu(0x56A0).unwrap();
+        assert!(info.has_dedicated_vram());
+    }
+
+    #[test]
+    fn threads_per_eu_always_8() {
+        for &dev_id in &[0x4905, 0x56A0, 0x0BD5, 0x7D45, 0xE202] {
+            let info = identify_gpu(dev_id).unwrap();
+            assert_eq!(
+                info.max_threads_per_eu, 8,
+                "threads per EU must be 8 for device 0x{:04X}",
+                dev_id
+            );
+        }
+    }
+
+    // -- Architecture enum ------------------------------------------------
+
+    #[test]
+    fn architecture_enum_clone_debug() {
+        let arch = GpuArchitecture::XeHPC;
+        let cloned = arch.clone();
+        assert_eq!(arch, cloned);
+        let dbg = alloc::format!("{:?}", arch);
+        assert!(dbg.contains("XeHPC"));
+    }
+
+    #[test]
+    fn architecture_unknown_variant() {
+        let arch = GpuArchitecture::Unknown;
+        assert_eq!(arch, GpuArchitecture::Unknown);
+    }
+}

--- a/arch/intel_gpu/src/gpu_init.rs
+++ b/arch/intel_gpu/src/gpu_init.rs
@@ -1,0 +1,543 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! GPU initialization sequence.
+//!
+//! Orchestrates the bring-up of an Intel GPU after PCIe enumeration:
+//! BAR mapping, engine initialisation, power-state management, and
+//! suspend/resume lifecycle.
+//!
+//! Intel GPUs use GuC (Graphics micro Controller) for scheduling and HuC
+//! (HEVC/media micro Controller) for media acceleration. This module
+//! references firmware loading in comments but currently operates as a
+//! state-machine stub.
+
+use crate::gpu_id::GpuInfo;
+use crate::pcie::{BarType, BaseAddressRegister};
+use crate::GpuError;
+
+// ---------------------------------------------------------------------------
+// GpuState
+// ---------------------------------------------------------------------------
+
+/// Lifecycle state of a GPU context.
+#[derive(Clone, Debug, PartialEq)]
+pub enum GpuState {
+    /// GPU discovered but no BARs mapped yet.
+    Uninitialized,
+    /// MMIO BAR / Aperture BAR mapped into the address space.
+    BarsMapped,
+    /// Compute and blitter engines initialised.
+    EnginesReady,
+    /// GPU is actively running workloads.
+    Running,
+    /// An unrecoverable error was encountered.
+    Error,
+    /// GPU power-gated; can be resumed.
+    Suspended,
+}
+
+// ---------------------------------------------------------------------------
+// PowerState
+// ---------------------------------------------------------------------------
+
+/// Requested power level for the GPU.
+#[derive(Clone, Debug, PartialEq)]
+pub enum PowerState {
+    /// Maximum performance, all clocks ungated (RC0).
+    FullPower,
+    /// Reduced clocks / partial power gating (RC6).
+    LowPower,
+    /// Deep sleep -- minimal leakage, state saved to system RAM (D3).
+    Suspended,
+}
+
+// ---------------------------------------------------------------------------
+// GpuRegisters
+// ---------------------------------------------------------------------------
+
+/// Represents the MMIO register apertures obtained from BAR mapping.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GpuRegisters {
+    /// MMIO BAR base: GPU control/status registers.
+    pub mmio_base: u64,
+    /// Aperture BAR base: VRAM/GTT aperture (device memory window).
+    pub aperture_base: u64,
+    /// Size of MMIO BAR in bytes.
+    pub mmio_size: u64,
+    /// Size of Aperture BAR in bytes.
+    pub aperture_size: u64,
+}
+
+// ---------------------------------------------------------------------------
+// InitConfig
+// ---------------------------------------------------------------------------
+
+/// Configuration knobs for the GPU initialisation sequence.
+#[derive(Clone, Debug, PartialEq)]
+pub struct InitConfig {
+    /// Enable the compute (render/CCS) engine during init.
+    pub enable_compute: bool,
+    /// Enable the blitter (BCS) copy engine during init.
+    pub enable_blitter: bool,
+    /// Enable MSI-X / interrupt-based completion notification.
+    pub enable_interrupts: bool,
+    /// Requested power state after init.
+    pub power_state: PowerState,
+}
+
+impl Default for InitConfig {
+    fn default() -> Self {
+        Self {
+            enable_compute: true,
+            enable_blitter: true,
+            enable_interrupts: true,
+            power_state: PowerState::FullPower,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GpuContext
+// ---------------------------------------------------------------------------
+
+/// Top-level handle that tracks the complete state of a single Intel GPU.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GpuContext {
+    /// Static information about the GPU (architecture, EU count, etc.).
+    info: GpuInfo,
+    /// Current lifecycle state.
+    state: GpuState,
+    /// Mapped register apertures (populated after `map_bars`).
+    registers: Option<GpuRegisters>,
+    /// Initialisation configuration.
+    config: InitConfig,
+}
+
+impl GpuContext {
+    /// Create a new context in the [`GpuState::Uninitialized`] state.
+    pub fn new(info: GpuInfo) -> Self {
+        Self {
+            info,
+            state: GpuState::Uninitialized,
+            registers: None,
+            config: InitConfig::default(),
+        }
+    }
+
+    // -- lifecycle transitions --------------------------------------------
+
+    /// Map MMIO BAR (registers) and Aperture BAR (VRAM/GTT) from the PCI
+    /// device's Base Address Registers.
+    ///
+    /// Expects at least two memory-type BARs. The first memory BAR becomes
+    /// the MMIO BAR and the second becomes the Aperture BAR.
+    ///
+    /// Transitions: `Uninitialized` -> `BarsMapped`.
+    pub fn map_bars(&mut self, bars: &[BaseAddressRegister]) -> Result<(), GpuError> {
+        if self.state != GpuState::Uninitialized {
+            return Err(GpuError::InvalidState);
+        }
+
+        let memory_bars: alloc::vec::Vec<&BaseAddressRegister> = bars
+            .iter()
+            .filter(|b| matches!(b.bar_type, BarType::Memory32 | BarType::Memory64))
+            .collect();
+
+        if memory_bars.len() < 2 {
+            return Err(GpuError::BarNotFound);
+        }
+
+        self.registers = Some(GpuRegisters {
+            mmio_base: memory_bars[0].address,
+            aperture_base: memory_bars[1].address,
+            mmio_size: memory_bars[0].size,
+            aperture_size: memory_bars[1].size,
+        });
+
+        self.state = GpuState::BarsMapped;
+        Ok(())
+    }
+
+    /// Initialize compute and blitter engines.
+    ///
+    /// On real hardware this programs the Render Command Streamer (RCS),
+    /// Compute Command Streamer (CCS), and Blitter Command Streamer (BCS).
+    /// Currently a state-machine stub.
+    ///
+    /// Transitions: `BarsMapped` -> `EnginesReady`.
+    pub fn initialize_engines(&mut self) -> Result<(), GpuError> {
+        if self.state != GpuState::BarsMapped {
+            return Err(GpuError::InvalidState);
+        }
+
+        // Stub: real implementation would:
+        // 1. Load GuC firmware (graphics microcontroller) for EU scheduling
+        // 2. Load HuC firmware (HEVC microcontroller) for media
+        // 3. Initialize RCS (Render Command Streamer) for compute
+        // 4. Initialize CCS (Compute Command Streamer) for GPGPU
+        // 5. Initialize BCS (Blitter Command Streamer) for DMA
+        // 6. Set up GGTT (Global Graphics Translation Table)
+        // 7. Configure EU thread dispatch
+
+        self.state = GpuState::EnginesReady;
+        Ok(())
+    }
+
+    /// Transition the GPU to the running state.
+    ///
+    /// Transitions: `EnginesReady` -> `Running`.
+    pub fn start(&mut self) -> Result<(), GpuError> {
+        if self.state != GpuState::EnginesReady {
+            return Err(GpuError::InvalidState);
+        }
+        self.state = GpuState::Running;
+        Ok(())
+    }
+
+    /// Suspend the GPU (power gate, save state).
+    ///
+    /// Transitions: `Running` -> `Suspended`.
+    pub fn suspend(&mut self) -> Result<(), GpuError> {
+        if self.state != GpuState::Running {
+            return Err(GpuError::InvalidState);
+        }
+        self.state = GpuState::Suspended;
+        Ok(())
+    }
+
+    /// Resume a previously suspended GPU.
+    ///
+    /// Transitions: `Suspended` -> `Running`.
+    pub fn resume(&mut self) -> Result<(), GpuError> {
+        if self.state != GpuState::Suspended {
+            return Err(GpuError::InvalidState);
+        }
+        self.state = GpuState::Running;
+        Ok(())
+    }
+
+    /// Hard reset -- tear everything down and return to uninitialized.
+    ///
+    /// Transitions: `*` -> `Uninitialized`.
+    pub fn reset(&mut self) {
+        self.state = GpuState::Uninitialized;
+        self.registers = None;
+    }
+
+    // -- accessors --------------------------------------------------------
+
+    /// Current lifecycle state.
+    pub fn state(&self) -> &GpuState {
+        &self.state
+    }
+
+    /// Static GPU information.
+    pub fn info(&self) -> &GpuInfo {
+        &self.info
+    }
+
+    /// Mapped register apertures (if any).
+    pub fn registers(&self) -> Option<&GpuRegisters> {
+        self.registers.as_ref()
+    }
+
+    /// Current init configuration.
+    pub fn config(&self) -> &InitConfig {
+        &self.config
+    }
+
+    /// Replace the init configuration.
+    pub fn set_config(&mut self, config: InitConfig) {
+        self.config = config;
+    }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gpu_id::{GpuArchitecture, GpuInfo, XeVersion};
+    use crate::pcie::{BarType, BaseAddressRegister};
+
+    /// Helper: create a representative `GpuInfo` for test use (Arc A770).
+    fn test_gpu_info() -> GpuInfo {
+        GpuInfo {
+            device_id: 0x56A0,
+            architecture: GpuArchitecture::XeHPG,
+            xe_version: XeVersion::XE_HPG,
+            eu_count: 512,
+            slices: 8,
+            subslices: 32,
+            vram_size_mb: 16384,
+            max_threads_per_eu: 8,
+            name: "Intel Arc A770",
+        }
+    }
+
+    /// Helper: return two memory-type BARs (MMIO + Aperture).
+    fn test_bars() -> alloc::vec::Vec<BaseAddressRegister> {
+        alloc::vec![
+            BaseAddressRegister {
+                bar_type: BarType::Memory64,
+                address: 0xFB00_0000,
+                size: 16 * 1024 * 1024,
+                prefetchable: false,
+            },
+            BaseAddressRegister {
+                bar_type: BarType::Memory64,
+                address: 0x6000_0000_0000,
+                size: 256 * 1024 * 1024,
+                prefetchable: true,
+            },
+        ]
+    }
+
+    // -- construction & initial state -------------------------------------
+
+    #[test]
+    fn new_context_is_uninitialized() {
+        let ctx = GpuContext::new(test_gpu_info());
+        assert_eq!(*ctx.state(), GpuState::Uninitialized);
+        assert!(ctx.registers().is_none());
+    }
+
+    #[test]
+    fn new_context_preserves_info() {
+        let info = test_gpu_info();
+        let ctx = GpuContext::new(info.clone());
+        assert_eq!(*ctx.info(), info);
+    }
+
+    // -- map_bars ---------------------------------------------------------
+
+    #[test]
+    fn map_bars_transitions_to_bars_mapped() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        ctx.map_bars(&test_bars()).unwrap();
+        assert_eq!(*ctx.state(), GpuState::BarsMapped);
+        let regs = ctx.registers().unwrap();
+        assert_eq!(regs.mmio_base, 0xFB00_0000);
+        assert_eq!(regs.aperture_base, 0x6000_0000_0000);
+    }
+
+    #[test]
+    fn map_bars_no_memory_bars_returns_error() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        let io_bars = alloc::vec![BaseAddressRegister {
+            bar_type: BarType::Io,
+            address: 0x1000,
+            size: 256,
+            prefetchable: false,
+        }];
+        assert_eq!(ctx.map_bars(&io_bars), Err(GpuError::BarNotFound));
+        assert_eq!(*ctx.state(), GpuState::Uninitialized);
+    }
+
+    #[test]
+    fn map_bars_only_one_memory_bar_returns_error() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        let single = alloc::vec![BaseAddressRegister {
+            bar_type: BarType::Memory32,
+            address: 0xF000_0000,
+            size: 1024,
+            prefetchable: false,
+        }];
+        assert_eq!(ctx.map_bars(&single), Err(GpuError::BarNotFound));
+    }
+
+    #[test]
+    fn map_bars_requires_uninitialized_state() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        ctx.map_bars(&test_bars()).unwrap();
+        assert_eq!(ctx.map_bars(&test_bars()), Err(GpuError::InvalidState));
+    }
+
+    // -- initialize_engines -----------------------------------------------
+
+    #[test]
+    fn initialize_engines_requires_bars_mapped() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        assert_eq!(ctx.initialize_engines(), Err(GpuError::InvalidState));
+    }
+
+    #[test]
+    fn initialize_engines_transitions_to_engines_ready() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        ctx.map_bars(&test_bars()).unwrap();
+        ctx.initialize_engines().unwrap();
+        assert_eq!(*ctx.state(), GpuState::EnginesReady);
+    }
+
+    // -- start ------------------------------------------------------------
+
+    #[test]
+    fn start_requires_engines_ready() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        assert_eq!(ctx.start(), Err(GpuError::InvalidState));
+    }
+
+    #[test]
+    fn start_transitions_to_running() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        ctx.map_bars(&test_bars()).unwrap();
+        ctx.initialize_engines().unwrap();
+        ctx.start().unwrap();
+        assert_eq!(*ctx.state(), GpuState::Running);
+    }
+
+    #[test]
+    fn cannot_start_from_uninitialized() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        assert_eq!(ctx.start(), Err(GpuError::InvalidState));
+    }
+
+    // -- suspend / resume -------------------------------------------------
+
+    #[test]
+    fn suspend_requires_running() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        assert_eq!(ctx.suspend(), Err(GpuError::InvalidState));
+    }
+
+    #[test]
+    fn suspend_transitions_to_suspended() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        ctx.map_bars(&test_bars()).unwrap();
+        ctx.initialize_engines().unwrap();
+        ctx.start().unwrap();
+        ctx.suspend().unwrap();
+        assert_eq!(*ctx.state(), GpuState::Suspended);
+    }
+
+    #[test]
+    fn resume_requires_suspended() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        assert_eq!(ctx.resume(), Err(GpuError::InvalidState));
+    }
+
+    #[test]
+    fn resume_transitions_to_running() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        ctx.map_bars(&test_bars()).unwrap();
+        ctx.initialize_engines().unwrap();
+        ctx.start().unwrap();
+        ctx.suspend().unwrap();
+        ctx.resume().unwrap();
+        assert_eq!(*ctx.state(), GpuState::Running);
+    }
+
+    // -- full lifecycle ---------------------------------------------------
+
+    #[test]
+    fn full_lifecycle() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        assert_eq!(*ctx.state(), GpuState::Uninitialized);
+
+        ctx.map_bars(&test_bars()).unwrap();
+        assert_eq!(*ctx.state(), GpuState::BarsMapped);
+
+        ctx.initialize_engines().unwrap();
+        assert_eq!(*ctx.state(), GpuState::EnginesReady);
+
+        ctx.start().unwrap();
+        assert_eq!(*ctx.state(), GpuState::Running);
+
+        ctx.suspend().unwrap();
+        assert_eq!(*ctx.state(), GpuState::Suspended);
+
+        ctx.resume().unwrap();
+        assert_eq!(*ctx.state(), GpuState::Running);
+
+        ctx.reset();
+        assert_eq!(*ctx.state(), GpuState::Uninitialized);
+        assert!(ctx.registers().is_none());
+    }
+
+    // -- reset ------------------------------------------------------------
+
+    #[test]
+    fn reset_from_bars_mapped() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        ctx.map_bars(&test_bars()).unwrap();
+        ctx.reset();
+        assert_eq!(*ctx.state(), GpuState::Uninitialized);
+        assert!(ctx.registers().is_none());
+    }
+
+    #[test]
+    fn reset_from_running() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        ctx.map_bars(&test_bars()).unwrap();
+        ctx.initialize_engines().unwrap();
+        ctx.start().unwrap();
+        ctx.reset();
+        assert_eq!(*ctx.state(), GpuState::Uninitialized);
+    }
+
+    #[test]
+    fn reset_from_uninitialized_is_noop() {
+        let mut ctx = GpuContext::new(test_gpu_info());
+        ctx.reset();
+        assert_eq!(*ctx.state(), GpuState::Uninitialized);
+    }
+
+    // -- InitConfig -------------------------------------------------------
+
+    #[test]
+    fn config_defaults() {
+        let cfg = InitConfig::default();
+        assert!(cfg.enable_compute);
+        assert!(cfg.enable_blitter);
+        assert!(cfg.enable_interrupts);
+        assert_eq!(cfg.power_state, PowerState::FullPower);
+    }
+
+    #[test]
+    fn config_custom() {
+        let cfg = InitConfig {
+            enable_compute: true,
+            enable_blitter: false,
+            enable_interrupts: false,
+            power_state: PowerState::LowPower,
+        };
+        assert!(!cfg.enable_blitter);
+        assert_eq!(cfg.power_state, PowerState::LowPower);
+    }
+
+    // -- PowerState -------------------------------------------------------
+
+    #[test]
+    fn power_state_variants() {
+        assert_eq!(PowerState::FullPower, PowerState::FullPower);
+        assert_eq!(PowerState::LowPower, PowerState::LowPower);
+        assert_eq!(PowerState::Suspended, PowerState::Suspended);
+        assert_ne!(PowerState::FullPower, PowerState::Suspended);
+    }
+
+    // -- GpuState ---------------------------------------------------------
+
+    #[test]
+    fn gpu_state_variants() {
+        let states = [
+            GpuState::Uninitialized,
+            GpuState::BarsMapped,
+            GpuState::EnginesReady,
+            GpuState::Running,
+            GpuState::Error,
+            GpuState::Suspended,
+        ];
+        for (i, a) in states.iter().enumerate() {
+            for (j, b) in states.iter().enumerate() {
+                if i == j {
+                    assert_eq!(a, b);
+                } else {
+                    assert_ne!(a, b);
+                }
+            }
+        }
+    }
+}

--- a/arch/intel_gpu/src/level_zero_provider.rs
+++ b/arch/intel_gpu/src/level_zero_provider.rs
@@ -1,0 +1,603 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Level Zero execution provider for ONNX inference.
+//!
+//! [`LevelZeroProvider`] is the top-level entry point that wires together the
+//! VRAM allocator, DMA engine, compute engine, and SPIR-V kernel registry to
+//! execute ONNX operators on an Intel GPU. It translates high-level ONNX
+//! operator names into SPIR-V kernel launches with appropriate grid/workgroup
+//! sizing.
+//!
+//! Level Zero is Intel's low-level GPU programming API (part of oneAPI),
+//! analogous to NVIDIA's CUDA Driver API.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use crate::compute::{ComputeEngine, Dim3, LaunchConfig};
+use crate::dma::{DmaDirection, DmaEngine};
+use crate::gpu_id::GpuInfo;
+use crate::memory::{MemoryRegion, VramAllocator};
+use crate::spirv_kernels::{DataPrecision, SpirvKernelType, SpirvRegistry};
+use crate::GpuError;
+
+// ---------------------------------------------------------------------------
+// OperatorMapping
+// ---------------------------------------------------------------------------
+
+/// Maps an ONNX operator name to a GPU kernel type and precision.
+#[derive(Clone, Debug, PartialEq)]
+pub struct OperatorMapping {
+    /// ONNX operator name (e.g. `"MatMul"`, `"Conv"`).
+    pub op_name: String,
+    /// SPIR-V kernel family to use.
+    pub kernel_type: SpirvKernelType,
+    /// Numeric precision for the kernel.
+    pub precision: DataPrecision,
+}
+
+// ---------------------------------------------------------------------------
+// ExecutionStep / ExecutionPlan
+// ---------------------------------------------------------------------------
+
+/// A single step in an execution plan.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExecutionStep {
+    /// ONNX operator name.
+    pub op_name: String,
+    /// SPIR-V kernel type to dispatch.
+    pub kernel_type: SpirvKernelType,
+    /// VRAM allocation ids for input tensors.
+    pub input_allocs: Vec<u64>,
+    /// VRAM allocation id for the output tensor.
+    pub output_alloc: u64,
+    /// Launch configuration for this step.
+    pub config: LaunchConfig,
+}
+
+/// A complete execution plan for a model inference pass.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExecutionPlan {
+    /// Ordered sequence of execution steps.
+    pub steps: Vec<ExecutionStep>,
+    /// Total workspace memory required in bytes.
+    pub total_workspace: u64,
+}
+
+// ---------------------------------------------------------------------------
+// ProviderStatus
+// ---------------------------------------------------------------------------
+
+/// Lifecycle state of the Level Zero execution provider.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ProviderStatus {
+    /// Provider has not been initialised.
+    Uninitialized,
+    /// Ready to accept work.
+    Ready,
+    /// Currently executing a kernel or model.
+    Executing,
+    /// An unrecoverable error has occurred.
+    Error,
+}
+
+// ---------------------------------------------------------------------------
+// LevelZeroProvider
+// ---------------------------------------------------------------------------
+
+/// Level Zero execution provider that dispatches ONNX operators to Intel GPU
+/// kernels.
+///
+/// Owns all GPU-side resources: memory allocator, compute and DMA engines,
+/// and the SPIR-V kernel registry.
+pub struct LevelZeroProvider {
+    /// Static description of the GPU.
+    gpu_info: GpuInfo,
+    /// VRAM allocator (70% static / 30% dynamic).
+    allocator: VramAllocator,
+    /// Kernel launch engine.
+    compute: ComputeEngine,
+    /// Host<->device DMA / blitter engine.
+    dma: DmaEngine,
+    /// Registered SPIR-V kernels.
+    registry: SpirvRegistry,
+    /// Current provider state.
+    status: ProviderStatus,
+    /// Number of models whose weights have been loaded.
+    models_loaded: u32,
+}
+
+impl LevelZeroProvider {
+    /// Create a new Level Zero provider for the given GPU.
+    ///
+    /// `vram_size` is the total usable VRAM in bytes. The allocator is
+    /// configured with 70% static (weights) / 30% dynamic (workspace).
+    /// Default SPIR-V kernels are registered and the provider moves to
+    /// [`ProviderStatus::Ready`].
+    pub fn new(gpu_info: GpuInfo, vram_size: u64) -> Self {
+        let allocator = VramAllocator::new(vram_size, 0.7);
+        let compute = ComputeEngine::new();
+        let dma = DmaEngine::new();
+        let mut registry = SpirvRegistry::new();
+        // Registering defaults should not fail on a fresh registry.
+        let _ = registry.register_defaults();
+
+        Self {
+            gpu_info,
+            allocator,
+            compute,
+            dma,
+            registry,
+            status: ProviderStatus::Ready,
+            models_loaded: 0,
+        }
+    }
+
+    /// Current provider status.
+    pub fn status(&self) -> &ProviderStatus {
+        &self.status
+    }
+
+    /// Static GPU information.
+    pub fn gpu_info(&self) -> &GpuInfo {
+        &self.gpu_info
+    }
+
+    /// Load model weights into VRAM (static region).
+    ///
+    /// Returns the VRAM allocation id on success and increments the loaded
+    /// model counter.
+    pub fn load_weights(&mut self, size: u64) -> Result<u64, GpuError> {
+        let id = self.allocator.alloc(size, MemoryRegion::Static)?;
+        self.models_loaded += 1;
+        Ok(id)
+    }
+
+    /// Allocate workspace memory (dynamic region) for intermediate tensors.
+    ///
+    /// Returns the VRAM allocation id.
+    pub fn allocate_workspace(&mut self, size: u64) -> Result<u64, GpuError> {
+        self.allocator.alloc(size, MemoryRegion::Dynamic)
+    }
+
+    /// Free a previous VRAM allocation (static or dynamic).
+    pub fn free_allocation(&mut self, id: u64) -> Result<(), GpuError> {
+        self.allocator.free(id)
+    }
+
+    /// Submit a host-to-device DMA transfer.
+    ///
+    /// Returns the DMA transfer id.
+    pub fn transfer_to_device(&mut self, src: u64, dst: u64, size: u64) -> Result<u64, GpuError> {
+        let tid = self
+            .dma
+            .submit(DmaDirection::HostToDevice, src, dst, size)?;
+        Ok(tid.0)
+    }
+
+    /// Submit a device-to-host DMA transfer.
+    ///
+    /// Returns the DMA transfer id.
+    pub fn transfer_from_device(&mut self, src: u64, dst: u64, size: u64) -> Result<u64, GpuError> {
+        let tid = self
+            .dma
+            .submit(DmaDirection::DeviceToHost, src, dst, size)?;
+        Ok(tid.0)
+    }
+
+    /// Map an ONNX operator name to a GPU kernel type and precision.
+    ///
+    /// Returns `None` for operators that are handled on the CPU (reshape-like
+    /// ops) or that are not recognised.
+    pub fn map_operator(op_name: &str) -> Option<OperatorMapping> {
+        let kernel_type = match op_name {
+            "MatMul" | "Gemm" => SpirvKernelType::Gemm,
+            "Conv" => SpirvKernelType::Conv2d,
+            "Relu" | "Sigmoid" | "Tanh" | "Add" | "Mul" | "Sub" => SpirvKernelType::Elementwise,
+            "Softmax" => SpirvKernelType::Softmax,
+            "LayerNormalization" => SpirvKernelType::LayerNorm,
+            "ReduceSum" | "ReduceMean" | "ReduceMax" => SpirvKernelType::Reduce,
+            "Transpose" => SpirvKernelType::Transpose,
+            "Concat" => SpirvKernelType::Concat,
+            "MaxPool" | "AveragePool" | "GlobalAveragePool" => SpirvKernelType::Pool,
+            // CPU-only shape manipulation -- no GPU kernel needed.
+            "Reshape" | "Flatten" | "Squeeze" | "Unsqueeze" => return None,
+            // Unknown operator.
+            _ => return None,
+        };
+
+        Some(OperatorMapping {
+            op_name: String::from(op_name),
+            kernel_type,
+            precision: DataPrecision::F32,
+        })
+    }
+
+    /// Launch a GPU kernel for the named ONNX operator.
+    ///
+    /// Looks up the operator mapping, finds the matching SPIR-V kernel, builds
+    /// a launch configuration with workgroup size 256, and dispatches to the
+    /// compute engine. Returns the kernel launch id.
+    pub fn launch_kernel(&mut self, op_name: &str, elements: u32) -> Result<u64, GpuError> {
+        // 1. Map ONNX op to kernel type.
+        let mapping = Self::map_operator(op_name).ok_or(GpuError::NotFound)?;
+
+        // 2. Find a compatible SPIR-V kernel.
+        let spirv_kernel = self
+            .registry
+            .find_kernel(
+                mapping.kernel_type,
+                mapping.precision,
+                &self.gpu_info.xe_version,
+            )
+            .ok_or(GpuError::LaunchError)?;
+
+        // 3. Build launch config: workgroup = 256, grid = ceil(elements / 256).
+        let workgroup_size: u32 = 256;
+        let grid_size = elements.div_ceil(workgroup_size);
+
+        let config = LaunchConfig {
+            grid: Dim3::linear(grid_size),
+            workgroup: Dim3::linear(workgroup_size),
+            shared_local_memory: spirv_kernel.shared_local_memory,
+            queue: 0,
+        };
+
+        // 4. Submit to compute engine and dispatch immediately.
+        let kid = self.compute.launch(op_name, config)?;
+        self.compute.dispatch(kid)?;
+        Ok(kid.0)
+    }
+
+    /// Synchronise the compute engine -- wait for all running kernels to
+    /// complete.
+    pub fn synchronize(&mut self) {
+        self.compute.synchronize();
+    }
+
+    /// Total VRAM currently in use (bytes, across both regions).
+    pub fn vram_used(&self) -> u64 {
+        self.allocator.total_used()
+    }
+
+    /// Total VRAM available for new allocations (bytes).
+    pub fn vram_free(&self) -> u64 {
+        self.allocator.total_free()
+    }
+
+    /// Number of models whose weights have been loaded.
+    pub fn models_loaded(&self) -> u32 {
+        self.models_loaded
+    }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compute::KernelStatus;
+    use crate::gpu_id::identify_gpu;
+    use crate::memory::GPU_PAGE_SIZE;
+
+    // -- helpers ------------------------------------------------------------
+
+    /// Construct a GpuInfo for Arc A770 (Xe-HPG).
+    fn test_gpu_info() -> GpuInfo {
+        identify_gpu(0x56A0).unwrap()
+    }
+
+    /// Build a LevelZeroProvider backed by 1 GiB of VRAM.
+    fn test_provider() -> LevelZeroProvider {
+        let gpu = test_gpu_info();
+        LevelZeroProvider::new(gpu, 1024 * 1024 * 1024) // 1 GiB
+    }
+
+    const PAGE: u64 = GPU_PAGE_SIZE as u64;
+
+    // -- 1. New provider is Ready -------------------------------------------
+
+    #[test]
+    fn test_new_provider_is_ready() {
+        let prov = test_provider();
+        assert_eq!(*prov.status(), ProviderStatus::Ready);
+    }
+
+    // -- 2. Load weights allocates in static region -------------------------
+
+    #[test]
+    fn test_load_weights_static_region() {
+        let mut prov = test_provider();
+        let initial_used = prov.allocator.used_bytes(MemoryRegion::Static);
+        let id = prov.load_weights(PAGE).unwrap();
+        assert!(id >= 1);
+        assert_eq!(
+            prov.allocator.used_bytes(MemoryRegion::Static),
+            initial_used + PAGE
+        );
+    }
+
+    // -- 3. Allocate workspace in dynamic region ----------------------------
+
+    #[test]
+    fn test_allocate_workspace_dynamic_region() {
+        let mut prov = test_provider();
+        let initial_used = prov.allocator.used_bytes(MemoryRegion::Dynamic);
+        let id = prov.allocate_workspace(PAGE * 2).unwrap();
+        assert!(id >= 1);
+        assert_eq!(
+            prov.allocator.used_bytes(MemoryRegion::Dynamic),
+            initial_used + PAGE * 2
+        );
+    }
+
+    // -- 4. Free allocation -------------------------------------------------
+
+    #[test]
+    fn test_free_allocation() {
+        let mut prov = test_provider();
+        let id = prov.load_weights(PAGE).unwrap();
+        let used_before_free = prov.vram_used();
+        prov.free_allocation(id).unwrap();
+        assert_eq!(prov.vram_used(), used_before_free - PAGE);
+    }
+
+    // -- 5. Transfer to device ----------------------------------------------
+
+    #[test]
+    fn test_transfer_to_device() {
+        let mut prov = test_provider();
+        let tid = prov.transfer_to_device(0x1000, 0x2000, 4096).unwrap();
+        assert!(tid >= 1);
+    }
+
+    // -- 6. Transfer from device --------------------------------------------
+
+    #[test]
+    fn test_transfer_from_device() {
+        let mut prov = test_provider();
+        let tid = prov.transfer_from_device(0x2000, 0x1000, 8192).unwrap();
+        assert!(tid >= 1);
+    }
+
+    // -- 7. Map known operators: MatMul, Conv, Relu, Softmax ----------------
+
+    #[test]
+    fn test_map_known_operators() {
+        let cases = [
+            ("MatMul", SpirvKernelType::Gemm),
+            ("Gemm", SpirvKernelType::Gemm),
+            ("Conv", SpirvKernelType::Conv2d),
+            ("Relu", SpirvKernelType::Elementwise),
+            ("Sigmoid", SpirvKernelType::Elementwise),
+            ("Tanh", SpirvKernelType::Elementwise),
+            ("Add", SpirvKernelType::Elementwise),
+            ("Mul", SpirvKernelType::Elementwise),
+            ("Sub", SpirvKernelType::Elementwise),
+            ("Softmax", SpirvKernelType::Softmax),
+            ("LayerNormalization", SpirvKernelType::LayerNorm),
+            ("ReduceSum", SpirvKernelType::Reduce),
+            ("ReduceMean", SpirvKernelType::Reduce),
+            ("ReduceMax", SpirvKernelType::Reduce),
+            ("Transpose", SpirvKernelType::Transpose),
+            ("Concat", SpirvKernelType::Concat),
+            ("MaxPool", SpirvKernelType::Pool),
+            ("AveragePool", SpirvKernelType::Pool),
+            ("GlobalAveragePool", SpirvKernelType::Pool),
+        ];
+        for (op, expected_type) in &cases {
+            let mapping = LevelZeroProvider::map_operator(op);
+            assert!(mapping.is_some(), "Expected mapping for {}", op);
+            let m = mapping.unwrap();
+            assert_eq!(m.kernel_type, *expected_type, "Wrong type for {}", op);
+            assert_eq!(
+                m.precision,
+                DataPrecision::F32,
+                "Default precision should be F32"
+            );
+            assert_eq!(m.op_name, *op);
+        }
+    }
+
+    // -- 8. Map unknown operator returns None -------------------------------
+
+    #[test]
+    fn test_map_unknown_operator_returns_none() {
+        assert!(LevelZeroProvider::map_operator("UnknownOp").is_none());
+        assert!(LevelZeroProvider::map_operator("").is_none());
+        assert!(LevelZeroProvider::map_operator("CustomAttention").is_none());
+    }
+
+    // -- 9. Map reshape returns None (CPU-only) -----------------------------
+
+    #[test]
+    fn test_map_reshape_returns_none() {
+        assert!(LevelZeroProvider::map_operator("Reshape").is_none());
+        assert!(LevelZeroProvider::map_operator("Flatten").is_none());
+        assert!(LevelZeroProvider::map_operator("Squeeze").is_none());
+        assert!(LevelZeroProvider::map_operator("Unsqueeze").is_none());
+    }
+
+    // -- 10. Launch MatMul kernel -------------------------------------------
+
+    #[test]
+    fn test_launch_matmul_kernel() {
+        let mut prov = test_provider();
+        let launch_id = prov.launch_kernel("MatMul", 1024).unwrap();
+        assert!(launch_id >= 1);
+    }
+
+    // -- 11. Launch Elementwise kernel --------------------------------------
+
+    #[test]
+    fn test_launch_elementwise_kernel() {
+        let mut prov = test_provider();
+        let launch_id = prov.launch_kernel("Relu", 512).unwrap();
+        assert!(launch_id >= 1);
+    }
+
+    // -- 12. Synchronize ----------------------------------------------------
+
+    #[test]
+    fn test_synchronize() {
+        let mut prov = test_provider();
+        let kid_raw = prov.launch_kernel("Add", 256).unwrap();
+        let kid = crate::compute::KernelId(kid_raw);
+        assert_eq!(prov.compute.status(kid), Ok(&KernelStatus::Running));
+        prov.synchronize();
+        assert_eq!(prov.compute.status(kid), Ok(&KernelStatus::Completed));
+    }
+
+    // -- 13. VRAM tracking --------------------------------------------------
+
+    #[test]
+    fn test_vram_tracking() {
+        let mut prov = test_provider();
+        let total = prov.vram_used() + prov.vram_free();
+        assert_eq!(total, 1024 * 1024 * 1024);
+
+        let initial_used = prov.vram_used();
+        prov.load_weights(PAGE).unwrap();
+        assert_eq!(prov.vram_used(), initial_used + PAGE);
+        assert_eq!(prov.vram_free(), total - prov.vram_used());
+    }
+
+    // -- 14. Provider GPU info access ---------------------------------------
+
+    #[test]
+    fn test_provider_gpu_info_access() {
+        let prov = test_provider();
+        let info = prov.gpu_info();
+        assert_eq!(info.device_id, 0x56A0);
+        assert_eq!(info.name, "Intel Arc A770");
+        assert_eq!(info.eu_count, 512);
+    }
+
+    // -- 15. Launch config calculation (grid/workgroup sizing) ---------------
+
+    #[test]
+    fn test_launch_config_grid_workgroup_sizing() {
+        let mut prov = test_provider();
+
+        // 1000 elements => grid should be ceil(1000/256) = 4.
+        let kid_raw = prov.launch_kernel("MatMul", 1000).unwrap();
+        let kid = crate::compute::KernelId(kid_raw);
+        let kernel = prov.compute.kernels.iter().find(|k| k.id == kid).unwrap();
+        assert_eq!(kernel.config.grid.x, 4);
+        assert_eq!(kernel.config.workgroup.x, 256);
+
+        // 256 elements => grid should be 1.
+        let kid_raw2 = prov.launch_kernel("Relu", 256).unwrap();
+        let kid2 = crate::compute::KernelId(kid_raw2);
+        let kernel2 = prov.compute.kernels.iter().find(|k| k.id == kid2).unwrap();
+        assert_eq!(kernel2.config.grid.x, 1);
+        assert_eq!(kernel2.config.workgroup.x, 256);
+    }
+
+    // -- 16. Provider status enum -------------------------------------------
+
+    #[test]
+    fn test_provider_status_enum() {
+        assert_ne!(ProviderStatus::Uninitialized, ProviderStatus::Ready);
+        assert_ne!(ProviderStatus::Ready, ProviderStatus::Executing);
+        assert_ne!(ProviderStatus::Executing, ProviderStatus::Error);
+        let cloned = ProviderStatus::Ready.clone();
+        assert_eq!(cloned, ProviderStatus::Ready);
+        let dbg = alloc::format!("{:?}", ProviderStatus::Executing);
+        assert!(dbg.contains("Executing"));
+    }
+
+    // -- 17. Models loaded counter ------------------------------------------
+
+    #[test]
+    fn test_models_loaded_counter() {
+        let mut prov = test_provider();
+        assert_eq!(prov.models_loaded(), 0);
+        prov.load_weights(PAGE).unwrap();
+        assert_eq!(prov.models_loaded(), 1);
+        prov.load_weights(PAGE).unwrap();
+        assert_eq!(prov.models_loaded(), 2);
+    }
+
+    // -- 18. Launch unknown op returns NotFound -----------------------------
+
+    #[test]
+    fn test_launch_unknown_op_returns_not_found() {
+        let mut prov = test_provider();
+        let result = prov.launch_kernel("UnknownOp", 100);
+        assert_eq!(result, Err(GpuError::NotFound));
+    }
+
+    // -- 19. Launch CPU-only op returns NotFound ----------------------------
+
+    #[test]
+    fn test_launch_cpu_only_op_returns_not_found() {
+        let mut prov = test_provider();
+        let result = prov.launch_kernel("Reshape", 100);
+        assert_eq!(result, Err(GpuError::NotFound));
+    }
+
+    // -- 20. ExecutionPlan and ExecutionStep derive traits -------------------
+
+    #[test]
+    fn test_execution_plan_derives() {
+        let step = ExecutionStep {
+            op_name: String::from("MatMul"),
+            kernel_type: SpirvKernelType::Gemm,
+            input_allocs: alloc::vec![1, 2],
+            output_alloc: 3,
+            config: LaunchConfig {
+                grid: Dim3::linear(4),
+                workgroup: Dim3::linear(256),
+                shared_local_memory: 49152,
+                queue: 0,
+            },
+        };
+        let plan = ExecutionPlan {
+            steps: alloc::vec![step.clone()],
+            total_workspace: 1024 * 1024,
+        };
+        let plan2 = plan.clone();
+        assert_eq!(plan, plan2);
+        let dbg = alloc::format!("{:?}", plan);
+        assert!(dbg.contains("MatMul"));
+    }
+
+    // -- 21. Multiple launches and sync -------------------------------------
+
+    #[test]
+    fn test_multiple_launches_and_sync() {
+        let mut prov = test_provider();
+        let id1 = prov.launch_kernel("MatMul", 1024).unwrap();
+        let id2 = prov.launch_kernel("Relu", 2048).unwrap();
+        let id3 = prov.launch_kernel("Softmax", 512).unwrap();
+        assert!(id1 < id2);
+        assert!(id2 < id3);
+        prov.synchronize();
+        for kid_raw in [id1, id2, id3] {
+            let kid = crate::compute::KernelId(kid_raw);
+            assert_eq!(prov.compute.status(kid), Ok(&KernelStatus::Completed));
+        }
+    }
+
+    // -- 22. Shared memory passed through from SPIR-V kernel ----------------
+
+    #[test]
+    fn test_shared_memory_passed_through() {
+        let mut prov = test_provider();
+        // Launch a GEMM kernel -- should use gemm_f32 with 49152 bytes SLM.
+        let kid_raw = prov.launch_kernel("MatMul", 256).unwrap();
+        let kid = crate::compute::KernelId(kid_raw);
+        let kernel = prov.compute.kernels.iter().find(|k| k.id == kid).unwrap();
+        assert_eq!(kernel.config.shared_local_memory, 49152);
+
+        // Launch an Elementwise -- should use 0 bytes SLM.
+        let kid_raw2 = prov.launch_kernel("Relu", 256).unwrap();
+        let kid2 = crate::compute::KernelId(kid_raw2);
+        let kernel2 = prov.compute.kernels.iter().find(|k| k.id == kid2).unwrap();
+        assert_eq!(kernel2.config.shared_local_memory, 0);
+    }
+}

--- a/arch/intel_gpu/src/lib.rs
+++ b/arch/intel_gpu/src/lib.rs
@@ -1,0 +1,59 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Intel GPU Hardware Abstraction Layer
+//!
+//! Minimal GPU driver for compute workloads on Intel discrete and integrated
+//! GPUs:
+//! - PCIe enumeration and BAR mapping
+//! - GPU identification and initialization
+//! - VRAM/GTT memory management (allocator, GPU page tables)
+//! - Blitter command streamer (DMA/copy engine)
+//! - EU-based compute engine with SIMD8/16/32 dispatch
+//! - SPIR-V kernel registry
+//! - Level Zero execution provider for ONNX inference
+//!
+//! Supports: Xe-LP (integrated), Xe-HPG (Arc A-series),
+//!           Xe-HPC (Data Center GPU Max), Xe-LPG (Meteor Lake),
+//!           Xe2 (Battlemage)
+
+#![no_std]
+#![allow(dead_code)]
+
+extern crate alloc;
+
+pub mod compute;
+pub mod dma;
+pub mod gpu_id;
+pub mod gpu_init;
+pub mod level_zero_provider;
+pub mod memory;
+pub mod pcie;
+pub mod spirv_kernels;
+
+/// GPU error type used throughout the Intel GPU crate.
+#[derive(Clone, Debug, PartialEq)]
+pub enum GpuError {
+    /// Device not supported or not recognized.
+    UnsupportedDevice,
+    /// Operation invalid for the current state.
+    InvalidState,
+    /// PCI BAR not found or not mapped.
+    BarNotFound,
+    /// GPU initialization failure.
+    InitFailed,
+    /// VRAM allocation or addressing error.
+    MemoryError,
+    /// DMA/blitter-engine error.
+    DmaError,
+    /// Kernel launch error.
+    LaunchError,
+    /// Resource not found by ID.
+    NotFound,
+    /// Queue is full.
+    QueueFull,
+    /// Invalid configuration parameter.
+    InvalidConfig,
+    /// Transfer exceeds maximum allowed size.
+    TransferTooLarge,
+}

--- a/arch/intel_gpu/src/memory.rs
+++ b/arch/intel_gpu/src/memory.rs
@@ -1,0 +1,387 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! GPU VRAM/GTT memory allocator.
+//!
+//! Manages two regions of video memory:
+//! - **Static** -- long-lived allocations for model weights, rarely freed.
+//! - **Dynamic** -- short-lived workspace buffers for intermediate tensors.
+//!
+//! All allocations are aligned to [`GPU_PAGE_SIZE`] (4 KiB).
+//! Intel GPUs use 4 KiB pages (vs NVIDIA's 64 KiB).
+
+use alloc::vec::Vec;
+
+use crate::GpuError;
+
+/// GPU page size -- 4 KiB, the native page granularity for Intel GPUs.
+pub const GPU_PAGE_SIZE: usize = 4096;
+
+/// Maximum number of live allocations tracked by the allocator.
+pub const MAX_ALLOCATIONS: usize = 4096;
+
+/// Describes which VRAM region an allocation belongs to.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum MemoryRegion {
+    /// Static region -- model weights and other long-lived data.
+    Static,
+    /// Dynamic region -- workspace buffers and temporaries.
+    Dynamic,
+}
+
+/// A single VRAM allocation record.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GpuAllocation {
+    /// Unique allocation identifier.
+    pub id: u64,
+    /// Byte offset within the VRAM region.
+    pub offset: u64,
+    /// Aligned size in bytes.
+    pub size: u64,
+    /// Which region this allocation lives in.
+    pub region: MemoryRegion,
+    /// Whether this allocation is currently in use.
+    pub in_use: bool,
+}
+
+/// Bump-style VRAM allocator with static and dynamic regions.
+#[derive(Clone, Debug, PartialEq)]
+pub struct VramAllocator {
+    /// Total VRAM managed by this allocator.
+    total_size: u64,
+
+    /// Base address of the static region.
+    static_base: u64,
+    /// Total capacity of the static region.
+    static_size: u64,
+    /// Bytes currently consumed in the static region.
+    static_used: u64,
+
+    /// Base address of the dynamic region.
+    dynamic_base: u64,
+    /// Total capacity of the dynamic region.
+    dynamic_size: u64,
+    /// Bytes currently consumed in the dynamic region.
+    dynamic_used: u64,
+
+    /// All tracked allocations (both live and freed).
+    allocations: Vec<GpuAllocation>,
+
+    /// Monotonically increasing allocation-id generator.
+    next_id: u64,
+}
+
+/// Align `size` up to the nearest multiple of [`GPU_PAGE_SIZE`].
+fn align_up(size: u64) -> u64 {
+    let page = GPU_PAGE_SIZE as u64;
+    (size + page - 1) & !(page - 1)
+}
+
+impl VramAllocator {
+    /// Create a new VRAM allocator.
+    ///
+    /// `total_size` -- total VRAM in bytes.
+    /// `static_fraction` -- fraction of VRAM reserved for the static region
+    /// (0.0..=1.0; typically 0.7 for 70% weights / 30% workspace).
+    pub fn new(total_size: u64, static_fraction: f64) -> Self {
+        let raw_static = (total_size as f64 * static_fraction) as u64;
+        let static_size = align_up(raw_static);
+        // Clamp so static never exceeds total.
+        let static_size = if static_size > total_size {
+            total_size
+        } else {
+            static_size
+        };
+        let dynamic_size = total_size - static_size;
+
+        Self {
+            total_size,
+            static_base: 0,
+            static_size,
+            static_used: 0,
+            dynamic_base: static_size,
+            dynamic_size,
+            dynamic_used: 0,
+            allocations: Vec::new(),
+            next_id: 1,
+        }
+    }
+
+    /// Allocate `size` bytes from the requested `region`.
+    ///
+    /// Returns the unique allocation id on success.
+    pub fn alloc(&mut self, size: u64, region: MemoryRegion) -> Result<u64, GpuError> {
+        if size == 0 {
+            return Err(GpuError::MemoryError);
+        }
+
+        if self.allocation_count() >= MAX_ALLOCATIONS {
+            return Err(GpuError::MemoryError);
+        }
+
+        let aligned = align_up(size);
+
+        let (base, region_size, used) = match region {
+            MemoryRegion::Static => (self.static_base, self.static_size, &mut self.static_used),
+            MemoryRegion::Dynamic => (self.dynamic_base, self.dynamic_size, &mut self.dynamic_used),
+        };
+
+        if *used + aligned > region_size {
+            return Err(GpuError::MemoryError);
+        }
+
+        let offset = base + *used;
+        *used += aligned;
+
+        let id = self.next_id;
+        self.next_id += 1;
+
+        self.allocations.push(GpuAllocation {
+            id,
+            offset,
+            size: aligned,
+            region,
+            in_use: true,
+        });
+
+        Ok(id)
+    }
+
+    /// Free a previous allocation by id.
+    ///
+    /// The freed bytes are returned to the region's used counter so they can be
+    /// reclaimed. Double-free is an error.
+    pub fn free(&mut self, id: u64) -> Result<(), GpuError> {
+        let alloc = self
+            .allocations
+            .iter_mut()
+            .find(|a| a.id == id)
+            .ok_or(GpuError::NotFound)?;
+
+        if !alloc.in_use {
+            return Err(GpuError::InvalidState);
+        }
+
+        alloc.in_use = false;
+
+        match alloc.region {
+            MemoryRegion::Static => self.static_used -= alloc.size,
+            MemoryRegion::Dynamic => self.dynamic_used -= alloc.size,
+        }
+
+        Ok(())
+    }
+
+    /// Bytes currently used in `region`.
+    pub fn used_bytes(&self, region: MemoryRegion) -> u64 {
+        match region {
+            MemoryRegion::Static => self.static_used,
+            MemoryRegion::Dynamic => self.dynamic_used,
+        }
+    }
+
+    /// Bytes still available in `region`.
+    pub fn free_bytes(&self, region: MemoryRegion) -> u64 {
+        match region {
+            MemoryRegion::Static => self.static_size - self.static_used,
+            MemoryRegion::Dynamic => self.dynamic_size - self.dynamic_used,
+        }
+    }
+
+    /// Total bytes used across both regions.
+    pub fn total_used(&self) -> u64 {
+        self.static_used + self.dynamic_used
+    }
+
+    /// Total bytes free across both regions.
+    pub fn total_free(&self) -> u64 {
+        self.total_size - self.total_used()
+    }
+
+    /// Number of currently active (in-use) allocations.
+    pub fn allocation_count(&self) -> usize {
+        self.allocations.iter().filter(|a| a.in_use).count()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ONE_GIB: u64 = 1024 * 1024 * 1024;
+    const PAGE: u64 = GPU_PAGE_SIZE as u64;
+
+    // 1. New allocator splits correctly.
+    #[test]
+    fn test_new_allocator_splits_correctly() {
+        let alloc = VramAllocator::new(ONE_GIB, 0.7);
+        let expected_static = align_up((ONE_GIB as f64 * 0.7) as u64);
+        assert_eq!(alloc.static_size, expected_static);
+        assert_eq!(alloc.dynamic_size, ONE_GIB - expected_static);
+        assert_eq!(alloc.static_base, 0);
+        assert_eq!(alloc.dynamic_base, expected_static);
+        assert_eq!(alloc.total_size, ONE_GIB);
+    }
+
+    // 2. Alloc in static region.
+    #[test]
+    fn test_alloc_static() {
+        let mut alloc = VramAllocator::new(ONE_GIB, 0.7);
+        let id = alloc.alloc(1024, MemoryRegion::Static).unwrap();
+        assert_eq!(id, 1);
+        assert_eq!(alloc.used_bytes(MemoryRegion::Static), PAGE);
+    }
+
+    // 3. Alloc in dynamic region.
+    #[test]
+    fn test_alloc_dynamic() {
+        let mut alloc = VramAllocator::new(ONE_GIB, 0.7);
+        let id = alloc.alloc(1024, MemoryRegion::Dynamic).unwrap();
+        assert_eq!(id, 1);
+        assert_eq!(alloc.used_bytes(MemoryRegion::Dynamic), PAGE);
+    }
+
+    // 4. Free allocation.
+    #[test]
+    fn test_free_allocation() {
+        let mut alloc = VramAllocator::new(ONE_GIB, 0.7);
+        let id = alloc.alloc(PAGE, MemoryRegion::Static).unwrap();
+        assert_eq!(alloc.used_bytes(MemoryRegion::Static), PAGE);
+        alloc.free(id).unwrap();
+        assert_eq!(alloc.used_bytes(MemoryRegion::Static), 0);
+    }
+
+    // 5. Double free returns error.
+    #[test]
+    fn test_double_free_error() {
+        let mut alloc = VramAllocator::new(ONE_GIB, 0.7);
+        let id = alloc.alloc(PAGE, MemoryRegion::Static).unwrap();
+        alloc.free(id).unwrap();
+        assert_eq!(alloc.free(id), Err(GpuError::InvalidState));
+    }
+
+    // 6. Out of memory in region.
+    #[test]
+    fn test_out_of_memory() {
+        let mut alloc = VramAllocator::new(PAGE * 2, 0.5);
+        alloc.alloc(PAGE, MemoryRegion::Static).unwrap();
+        assert_eq!(
+            alloc.alloc(PAGE, MemoryRegion::Static),
+            Err(GpuError::MemoryError)
+        );
+    }
+
+    // 7. Alignment to GPU_PAGE_SIZE.
+    #[test]
+    fn test_alignment() {
+        let mut alloc = VramAllocator::new(ONE_GIB, 0.7);
+        alloc.alloc(1, MemoryRegion::Static).unwrap();
+        assert_eq!(alloc.used_bytes(MemoryRegion::Static), PAGE);
+    }
+
+    // 8. Used / free byte tracking.
+    #[test]
+    fn test_used_free_tracking() {
+        let mut alloc = VramAllocator::new(ONE_GIB, 0.5);
+        let half = align_up((ONE_GIB as f64 * 0.5) as u64);
+        assert_eq!(alloc.free_bytes(MemoryRegion::Static), half);
+        alloc.alloc(PAGE * 3, MemoryRegion::Static).unwrap();
+        assert_eq!(alloc.used_bytes(MemoryRegion::Static), PAGE * 3);
+        assert_eq!(alloc.free_bytes(MemoryRegion::Static), half - PAGE * 3);
+    }
+
+    // 9. Total used / free.
+    #[test]
+    fn test_total_used_free() {
+        let mut alloc = VramAllocator::new(ONE_GIB, 0.5);
+        alloc.alloc(PAGE, MemoryRegion::Static).unwrap();
+        alloc.alloc(PAGE * 2, MemoryRegion::Dynamic).unwrap();
+        assert_eq!(alloc.total_used(), PAGE * 3);
+        assert_eq!(alloc.total_free(), ONE_GIB - PAGE * 3);
+    }
+
+    // 10. Allocation count.
+    #[test]
+    fn test_allocation_count() {
+        let mut alloc = VramAllocator::new(ONE_GIB, 0.5);
+        assert_eq!(alloc.allocation_count(), 0);
+        let id1 = alloc.alloc(PAGE, MemoryRegion::Static).unwrap();
+        let _id2 = alloc.alloc(PAGE, MemoryRegion::Dynamic).unwrap();
+        assert_eq!(alloc.allocation_count(), 2);
+        alloc.free(id1).unwrap();
+        assert_eq!(alloc.allocation_count(), 1);
+    }
+
+    // 11. Max allocations limit.
+    #[test]
+    fn test_max_allocations() {
+        let big = PAGE * (MAX_ALLOCATIONS as u64 + 10);
+        let mut alloc = VramAllocator::new(big, 1.0);
+        for _ in 0..MAX_ALLOCATIONS {
+            alloc.alloc(PAGE, MemoryRegion::Static).unwrap();
+        }
+        assert_eq!(
+            alloc.alloc(PAGE, MemoryRegion::Static),
+            Err(GpuError::MemoryError)
+        );
+    }
+
+    // 12. Zero-size allocation handling.
+    #[test]
+    fn test_zero_size_alloc() {
+        let mut alloc = VramAllocator::new(ONE_GIB, 0.5);
+        assert_eq!(
+            alloc.alloc(0, MemoryRegion::Static),
+            Err(GpuError::MemoryError)
+        );
+    }
+
+    // 13. Large allocation.
+    #[test]
+    fn test_large_allocation() {
+        let mut alloc = VramAllocator::new(ONE_GIB, 0.7);
+        let static_cap = alloc.free_bytes(MemoryRegion::Static);
+        let id = alloc.alloc(static_cap, MemoryRegion::Static).unwrap();
+        assert_eq!(alloc.free_bytes(MemoryRegion::Static), 0);
+        alloc.free(id).unwrap();
+        assert_eq!(alloc.free_bytes(MemoryRegion::Static), static_cap);
+    }
+
+    // 14. Free non-existent allocation returns NotFound.
+    #[test]
+    fn test_free_nonexistent() {
+        let mut alloc = VramAllocator::new(ONE_GIB, 0.5);
+        assert_eq!(alloc.free(999), Err(GpuError::NotFound));
+    }
+
+    // 15. Multiple sequential allocations have increasing offsets.
+    #[test]
+    fn test_sequential_offsets() {
+        let mut alloc = VramAllocator::new(ONE_GIB, 0.5);
+        let id1 = alloc.alloc(PAGE, MemoryRegion::Static).unwrap();
+        let id2 = alloc.alloc(PAGE, MemoryRegion::Static).unwrap();
+        let a1 = alloc.allocations.iter().find(|a| a.id == id1).unwrap();
+        let a2 = alloc.allocations.iter().find(|a| a.id == id2).unwrap();
+        assert_eq!(a2.offset, a1.offset + PAGE);
+    }
+
+    // 16. 100% static fraction leaves zero dynamic.
+    #[test]
+    fn test_full_static_fraction() {
+        let alloc = VramAllocator::new(ONE_GIB, 1.0);
+        assert_eq!(alloc.static_size, ONE_GIB);
+        assert_eq!(alloc.dynamic_size, 0);
+    }
+
+    // 17. 0% static fraction leaves zero static.
+    #[test]
+    fn test_zero_static_fraction() {
+        let alloc = VramAllocator::new(ONE_GIB, 0.0);
+        assert_eq!(alloc.static_size, 0);
+        assert_eq!(alloc.dynamic_size, ONE_GIB);
+    }
+}

--- a/arch/intel_gpu/src/pcie.rs
+++ b/arch/intel_gpu/src/pcie.rs
@@ -1,0 +1,685 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! PCIe enumeration and BAR mapping for Intel GPUs.
+//!
+//! Scans the PCI configuration space for Intel display/3D controllers,
+//! decodes Base Address Registers, and provides device filtering. On real
+//! hardware the scan reads I/O ports 0x0CF8/0x0CFC; under `#[cfg(test)]`
+//! the scanner pushes mock devices instead.
+
+use alloc::vec::Vec;
+
+use crate::GpuError;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Intel PCI vendor ID.
+const INTEL_VENDOR_ID: u16 = 0x8086;
+
+/// x86 PCI configuration address port.
+const PCI_CONFIG_ADDR: u32 = 0x0CF8;
+
+/// x86 PCI configuration data port.
+const PCI_CONFIG_DATA: u32 = 0x0CFC;
+
+/// Number of PCI buses to scan (first 8 covers most single-segment systems).
+const MAX_BUSES: u8 = 8;
+
+/// Maximum devices per bus (PCI spec).
+const MAX_DEVICES: u8 = 32;
+
+/// Maximum functions per device (PCI spec, multi-function).
+const MAX_FUNCTIONS: u8 = 8;
+
+/// Hard cap on the number of PCI devices we store.
+const MAX_PCI_DEVICES: usize = 32;
+
+// ---------------------------------------------------------------------------
+// Known Intel GPU device IDs
+// ---------------------------------------------------------------------------
+
+/// Intel Arc A770 (Xe-HPG, ACM-G10).
+pub const ARC_A770_DEVICE_ID: u16 = 0x56A0;
+
+/// Intel Arc A750 (Xe-HPG, ACM-G10).
+pub const ARC_A750_DEVICE_ID: u16 = 0x56A1;
+
+/// Intel Arc A580 (Xe-HPG, ACM-G10).
+pub const ARC_A580_DEVICE_ID: u16 = 0x56A2;
+
+/// Intel Arc A380 (Xe-HPG, ACM-G11).
+pub const ARC_A380_DEVICE_ID: u16 = 0x56A5;
+
+/// Intel Data Center GPU Max 1550 (Xe-HPC, Ponte Vecchio).
+pub const DC_MAX_1550_DEVICE_ID: u16 = 0x0BD5;
+
+/// Intel Data Center GPU Flex 170 (Xe-HPG derivative).
+pub const FLEX_170_DEVICE_ID: u16 = 0x56C0;
+
+// ---------------------------------------------------------------------------
+// PciAddress
+// ---------------------------------------------------------------------------
+
+/// Bus/device/function triplet that identifies a PCI function.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PciAddress {
+    pub bus: u8,
+    pub device: u8,
+    pub function: u8,
+}
+
+impl PciAddress {
+    /// Encode this address + a register offset into the 32-bit value written
+    /// to `PCI_CONFIG_ADDR`.
+    ///
+    /// Layout (bit 31 = enable):
+    /// ```text
+    /// 31   | 30..24 | 23..16 | 15..11   | 10..8      | 7..2 | 1..0
+    /// 1    | 0      | bus    | device   | function   | reg  | 00
+    /// ```
+    pub fn config_address(&self, reg: u8) -> u32 {
+        (1u32 << 31)
+            | ((self.bus as u32) << 16)
+            | (((self.device & 0x1F) as u32) << 11)
+            | (((self.function & 0x07) as u32) << 8)
+            | ((reg & 0xFC) as u32)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// BarType / BaseAddressRegister
+// ---------------------------------------------------------------------------
+
+/// PCI Base Address Register type.
+#[derive(Clone, Debug, PartialEq)]
+pub enum BarType {
+    /// 32-bit memory-mapped region.
+    Memory32,
+    /// 64-bit memory-mapped region (consumes two BAR slots).
+    Memory64,
+    /// I/O port region.
+    Io,
+}
+
+/// Decoded information about a single PCI BAR.
+#[derive(Clone, Debug, PartialEq)]
+pub struct BaseAddressRegister {
+    pub bar_type: BarType,
+    pub address: u64,
+    pub size: u64,
+    pub prefetchable: bool,
+}
+
+// ---------------------------------------------------------------------------
+// PciDevice
+// ---------------------------------------------------------------------------
+
+/// A single PCI device (function) discovered during enumeration.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PciDevice {
+    pub address: PciAddress,
+    pub vendor_id: u16,
+    pub device_id: u16,
+    pub class_code: u8,
+    pub subclass: u8,
+    pub revision: u8,
+    pub bars: Vec<BaseAddressRegister>,
+    pub irq_line: u8,
+}
+
+impl PciDevice {
+    /// Returns `true` when the vendor is Intel (0x8086).
+    pub fn is_intel(&self) -> bool {
+        self.vendor_id == INTEL_VENDOR_ID
+    }
+
+    /// Returns `true` when the device belongs to PCI display-controller class
+    /// (class code 0x03).
+    pub fn is_display_controller(&self) -> bool {
+        self.class_code == 0x03
+    }
+
+    /// Returns `true` for a PCI 3D controller (class 0x03, subclass 0x02).
+    pub fn is_3d_controller(&self) -> bool {
+        self.class_code == 0x03 && self.subclass == 0x02
+    }
+
+    /// Returns `true` for a PCI VGA-compatible controller (class 0x03, subclass 0x00).
+    pub fn is_vga_controller(&self) -> bool {
+        self.class_code == 0x03 && self.subclass == 0x00
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PciScanner
+// ---------------------------------------------------------------------------
+
+/// Enumerates PCI buses and stores discovered devices.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PciScanner {
+    devices: Vec<PciDevice>,
+}
+
+impl Default for PciScanner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PciScanner {
+    /// Create a new, empty scanner.
+    pub fn new() -> Self {
+        Self {
+            devices: Vec::new(),
+        }
+    }
+
+    /// Scan the PCI configuration space for Intel display/3D controllers.
+    ///
+    /// On real hardware this reads I/O ports; in test builds it pushes a set
+    /// of mock devices so the rest of the stack can be exercised without
+    /// actual hardware.
+    pub fn scan(&mut self) -> Result<(), GpuError> {
+        #[cfg(test)]
+        {
+            self.scan_mock()
+        }
+        #[cfg(not(test))]
+        {
+            self.scan_hardware()
+        }
+    }
+
+    /// Hardware scan (placeholder -- real implementation reads I/O ports).
+    #[cfg(not(test))]
+    fn scan_hardware(&mut self) -> Result<(), GpuError> {
+        // Iterate over buses / devices / functions.
+        // For each function, read vendor_id; skip 0xFFFF.
+        // If vendor == INTEL_VENDOR_ID and class == 0x03, record device.
+        //
+        // Actual I/O port access will be implemented once we have the
+        // port-I/O abstraction from the x86-64 arch crate.
+        for _bus in 0..MAX_BUSES {
+            for _device in 0..MAX_DEVICES {
+                for _function in 0..MAX_FUNCTIONS {
+                    // Stub: no-op on real hardware until port I/O ready.
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Mock scan used in unit tests -- pushes representative Intel devices.
+    #[cfg(test)]
+    fn scan_mock(&mut self) -> Result<(), GpuError> {
+        // Intel Arc A770 (Xe-HPG)
+        self.push_device(PciDevice {
+            address: PciAddress {
+                bus: 0,
+                device: 3,
+                function: 0,
+            },
+            vendor_id: INTEL_VENDOR_ID,
+            device_id: ARC_A770_DEVICE_ID,
+            class_code: 0x03,
+            subclass: 0x00,
+            revision: 0x08,
+            bars: alloc::vec![
+                BaseAddressRegister {
+                    bar_type: BarType::Memory64,
+                    address: 0xFB00_0000,
+                    size: 16 * 1024 * 1024,
+                    prefetchable: false,
+                },
+                BaseAddressRegister {
+                    bar_type: BarType::Memory64,
+                    address: 0x6000_0000_0000,
+                    size: 256 * 1024 * 1024,
+                    prefetchable: true,
+                },
+            ],
+            irq_line: 11,
+        });
+
+        // Intel Arc A750 (Xe-HPG)
+        self.push_device(PciDevice {
+            address: PciAddress {
+                bus: 0,
+                device: 4,
+                function: 0,
+            },
+            vendor_id: INTEL_VENDOR_ID,
+            device_id: ARC_A750_DEVICE_ID,
+            class_code: 0x03,
+            subclass: 0x00,
+            revision: 0x08,
+            bars: alloc::vec![
+                BaseAddressRegister {
+                    bar_type: BarType::Memory64,
+                    address: 0xFC00_0000,
+                    size: 16 * 1024 * 1024,
+                    prefetchable: false,
+                },
+                BaseAddressRegister {
+                    bar_type: BarType::Memory64,
+                    address: 0x6100_0000_0000,
+                    size: 256 * 1024 * 1024,
+                    prefetchable: true,
+                },
+            ],
+            irq_line: 12,
+        });
+
+        // Intel Data Center GPU Max 1550 (Xe-HPC)
+        self.push_device(PciDevice {
+            address: PciAddress {
+                bus: 0,
+                device: 5,
+                function: 0,
+            },
+            vendor_id: INTEL_VENDOR_ID,
+            device_id: DC_MAX_1550_DEVICE_ID,
+            class_code: 0x03,
+            subclass: 0x02,
+            revision: 0x01,
+            bars: alloc::vec![
+                BaseAddressRegister {
+                    bar_type: BarType::Memory64,
+                    address: 0xFD00_0000,
+                    size: 64 * 1024 * 1024,
+                    prefetchable: false,
+                },
+                BaseAddressRegister {
+                    bar_type: BarType::Memory64,
+                    address: 0x6200_0000_0000,
+                    size: 4096 * 1024 * 1024,
+                    prefetchable: true,
+                },
+            ],
+            irq_line: 13,
+        });
+
+        // Non-Intel device (NVIDIA, for filter testing)
+        self.push_device(PciDevice {
+            address: PciAddress {
+                bus: 0,
+                device: 2,
+                function: 0,
+            },
+            vendor_id: 0x10DE,
+            device_id: 0x1B80,
+            class_code: 0x03,
+            subclass: 0x02,
+            revision: 0xA1,
+            bars: alloc::vec![BaseAddressRegister {
+                bar_type: BarType::Memory64,
+                address: 0xDE00_0000,
+                size: 16 * 1024 * 1024,
+                prefetchable: false,
+            }],
+            irq_line: 10,
+        });
+
+        Ok(())
+    }
+
+    /// Add a device to the internal list (capped at `MAX_PCI_DEVICES`).
+    fn push_device(&mut self, device: PciDevice) {
+        if self.devices.len() < MAX_PCI_DEVICES {
+            self.devices.push(device);
+        }
+    }
+
+    /// Return references to only the Intel-vendor devices.
+    pub fn intel_devices(&self) -> Vec<&PciDevice> {
+        self.devices.iter().filter(|d| d.is_intel()).collect()
+    }
+
+    /// Total number of discovered PCI devices (all vendors).
+    pub fn device_count(&self) -> usize {
+        self.devices.len()
+    }
+
+    /// Return a reference to the full device list.
+    pub fn devices(&self) -> &[PciDevice] {
+        &self.devices
+    }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- PciAddress --------------------------------------------------------
+
+    #[test]
+    fn config_address_enable_bit_set() {
+        let addr = PciAddress {
+            bus: 0,
+            device: 0,
+            function: 0,
+        };
+        let cfg = addr.config_address(0);
+        assert!(cfg & (1 << 31) != 0, "enable bit must be set");
+    }
+
+    #[test]
+    fn config_address_bus_encoding() {
+        let addr = PciAddress {
+            bus: 5,
+            device: 0,
+            function: 0,
+        };
+        let cfg = addr.config_address(0);
+        let bus_field = (cfg >> 16) & 0xFF;
+        assert_eq!(bus_field, 5);
+    }
+
+    #[test]
+    fn config_address_device_encoding() {
+        let addr = PciAddress {
+            bus: 0,
+            device: 18,
+            function: 0,
+        };
+        let cfg = addr.config_address(0);
+        let dev_field = (cfg >> 11) & 0x1F;
+        assert_eq!(dev_field, 18);
+    }
+
+    #[test]
+    fn config_address_function_encoding() {
+        let addr = PciAddress {
+            bus: 0,
+            device: 0,
+            function: 7,
+        };
+        let cfg = addr.config_address(0);
+        let fn_field = (cfg >> 8) & 0x07;
+        assert_eq!(fn_field, 7);
+    }
+
+    #[test]
+    fn config_address_register_encoding() {
+        let addr = PciAddress {
+            bus: 0,
+            device: 0,
+            function: 0,
+        };
+        let cfg = addr.config_address(0x3C);
+        let reg_field = cfg & 0xFC;
+        assert_eq!(reg_field, 0x3C);
+    }
+
+    #[test]
+    fn config_address_full_encoding() {
+        // bus=1, device=3, function=2, register=0x10
+        let addr = PciAddress {
+            bus: 1,
+            device: 3,
+            function: 2,
+        };
+        let cfg = addr.config_address(0x10);
+        let expected = (1u32 << 31) | (1u32 << 16) | (3u32 << 11) | (2u32 << 8) | 0x10u32;
+        assert_eq!(cfg, expected);
+    }
+
+    // -- BarType -----------------------------------------------------------
+
+    #[test]
+    fn bar_type_memory32() {
+        let bar = BaseAddressRegister {
+            bar_type: BarType::Memory32,
+            address: 0xF000_0000,
+            size: 1024,
+            prefetchable: false,
+        };
+        assert_eq!(bar.bar_type, BarType::Memory32);
+        assert!(!bar.prefetchable);
+    }
+
+    #[test]
+    fn bar_type_memory64_prefetchable() {
+        let bar = BaseAddressRegister {
+            bar_type: BarType::Memory64,
+            address: 0x6000_0000_0000,
+            size: 256 * 1024 * 1024,
+            prefetchable: true,
+        };
+        assert_eq!(bar.bar_type, BarType::Memory64);
+        assert!(bar.prefetchable);
+    }
+
+    #[test]
+    fn bar_type_io() {
+        let bar = BaseAddressRegister {
+            bar_type: BarType::Io,
+            address: 0x1000,
+            size: 256,
+            prefetchable: false,
+        };
+        assert_eq!(bar.bar_type, BarType::Io);
+    }
+
+    // -- PciDevice classification ------------------------------------------
+
+    #[test]
+    fn device_is_intel() {
+        let dev = PciDevice {
+            address: PciAddress {
+                bus: 0,
+                device: 0,
+                function: 0,
+            },
+            vendor_id: INTEL_VENDOR_ID,
+            device_id: ARC_A770_DEVICE_ID,
+            class_code: 0x03,
+            subclass: 0x00,
+            revision: 0x08,
+            bars: alloc::vec![],
+            irq_line: 11,
+        };
+        assert!(dev.is_intel());
+    }
+
+    #[test]
+    fn device_is_not_intel() {
+        let dev = PciDevice {
+            address: PciAddress {
+                bus: 0,
+                device: 0,
+                function: 0,
+            },
+            vendor_id: 0x10DE,
+            device_id: 0x1B80,
+            class_code: 0x03,
+            subclass: 0x02,
+            revision: 0xA1,
+            bars: alloc::vec![],
+            irq_line: 10,
+        };
+        assert!(!dev.is_intel());
+    }
+
+    #[test]
+    fn device_is_display_controller() {
+        let dev = PciDevice {
+            address: PciAddress {
+                bus: 0,
+                device: 0,
+                function: 0,
+            },
+            vendor_id: INTEL_VENDOR_ID,
+            device_id: ARC_A770_DEVICE_ID,
+            class_code: 0x03,
+            subclass: 0x00,
+            revision: 0,
+            bars: alloc::vec![],
+            irq_line: 0,
+        };
+        assert!(dev.is_display_controller());
+    }
+
+    #[test]
+    fn device_is_3d_controller() {
+        let dev = PciDevice {
+            address: PciAddress {
+                bus: 0,
+                device: 0,
+                function: 0,
+            },
+            vendor_id: INTEL_VENDOR_ID,
+            device_id: DC_MAX_1550_DEVICE_ID,
+            class_code: 0x03,
+            subclass: 0x02,
+            revision: 0,
+            bars: alloc::vec![],
+            irq_line: 0,
+        };
+        assert!(dev.is_3d_controller());
+    }
+
+    #[test]
+    fn device_not_3d_if_wrong_subclass() {
+        let dev = PciDevice {
+            address: PciAddress {
+                bus: 0,
+                device: 0,
+                function: 0,
+            },
+            vendor_id: INTEL_VENDOR_ID,
+            device_id: ARC_A770_DEVICE_ID,
+            class_code: 0x03,
+            subclass: 0x00,
+            revision: 0,
+            bars: alloc::vec![],
+            irq_line: 0,
+        };
+        assert!(!dev.is_3d_controller());
+    }
+
+    #[test]
+    fn device_is_vga_controller() {
+        let dev = PciDevice {
+            address: PciAddress {
+                bus: 0,
+                device: 0,
+                function: 0,
+            },
+            vendor_id: INTEL_VENDOR_ID,
+            device_id: ARC_A770_DEVICE_ID,
+            class_code: 0x03,
+            subclass: 0x00,
+            revision: 0,
+            bars: alloc::vec![],
+            irq_line: 0,
+        };
+        assert!(dev.is_vga_controller());
+    }
+
+    // -- PciScanner --------------------------------------------------------
+
+    #[test]
+    fn scanner_new_is_empty() {
+        let scanner = PciScanner::new();
+        assert_eq!(scanner.device_count(), 0);
+    }
+
+    #[test]
+    fn scanner_mock_scan_finds_devices() {
+        let mut scanner = PciScanner::new();
+        scanner.scan().expect("mock scan should succeed");
+        assert_eq!(scanner.device_count(), 4);
+    }
+
+    #[test]
+    fn scanner_intel_filter() {
+        let mut scanner = PciScanner::new();
+        scanner.scan().unwrap();
+        let intel = scanner.intel_devices();
+        assert_eq!(intel.len(), 3, "mock scan has exactly 3 Intel devices");
+        for dev in &intel {
+            assert!(dev.is_intel());
+        }
+    }
+
+    #[test]
+    fn scanner_non_intel_present() {
+        let mut scanner = PciScanner::new();
+        scanner.scan().unwrap();
+        let non_intel: Vec<_> = scanner.devices().iter().filter(|d| !d.is_intel()).collect();
+        assert_eq!(non_intel.len(), 1, "mock scan has 1 non-Intel device");
+        assert_eq!(non_intel[0].vendor_id, 0x10DE);
+    }
+
+    #[test]
+    fn scanner_device_ids_for_known_families() {
+        let mut scanner = PciScanner::new();
+        scanner.scan().unwrap();
+        let intel = scanner.intel_devices();
+        let ids: Vec<u16> = intel.iter().map(|d| d.device_id).collect();
+        assert!(ids.contains(&ARC_A770_DEVICE_ID), "should contain Arc A770");
+        assert!(ids.contains(&ARC_A750_DEVICE_ID), "should contain Arc A750");
+        assert!(
+            ids.contains(&DC_MAX_1550_DEVICE_ID),
+            "should contain DC Max 1550"
+        );
+    }
+
+    #[test]
+    fn scanner_max_capacity() {
+        let mut scanner = PciScanner::new();
+        for i in 0..MAX_PCI_DEVICES + 10 {
+            scanner.push_device(PciDevice {
+                address: PciAddress {
+                    bus: 0,
+                    device: (i % 32) as u8,
+                    function: 0,
+                },
+                vendor_id: INTEL_VENDOR_ID,
+                device_id: ARC_A770_DEVICE_ID,
+                class_code: 0x03,
+                subclass: 0x00,
+                revision: 0,
+                bars: alloc::vec![],
+                irq_line: 0,
+            });
+        }
+        assert_eq!(scanner.device_count(), MAX_PCI_DEVICES);
+    }
+
+    #[test]
+    fn pci_address_ranges_valid() {
+        // Verify that device and function fields are masked properly.
+        let addr = PciAddress {
+            bus: 255,
+            device: 31,
+            function: 7,
+        };
+        let cfg = addr.config_address(0xFC);
+        assert_eq!((cfg >> 16) & 0xFF, 255);
+        assert_eq!((cfg >> 11) & 0x1F, 31);
+        assert_eq!((cfg >> 8) & 0x07, 7);
+        assert_eq!(cfg & 0xFC, 0xFC);
+    }
+
+    #[test]
+    fn mock_devices_have_bars() {
+        let mut scanner = PciScanner::new();
+        scanner.scan().unwrap();
+        let intel = scanner.intel_devices();
+        for dev in &intel {
+            assert!(
+                !dev.bars.is_empty(),
+                "Intel mock devices should have at least one BAR"
+            );
+        }
+    }
+}

--- a/arch/intel_gpu/src/spirv_kernels.rs
+++ b/arch/intel_gpu/src/spirv_kernels.rs
@@ -1,0 +1,767 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! SPIR-V kernel definitions and registry.
+//!
+//! Maintains a registry of SPIR-V kernels that implement ONNX operators on
+//! Intel GPUs. Each [`SpirvKernel`] records its required Xe generation,
+//! shared local memory footprint, and data precision. The [`SpirvRegistry`]
+//! provides lookup by operator type, precision, and hardware compatibility.
+//!
+//! SPIR-V is the standard intermediate representation for Intel GPU compute
+//! kernels, consumed by the Intel Graphics Compiler (IGC) and dispatched
+//! through the Level Zero API.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use crate::gpu_id::XeVersion;
+use crate::GpuError;
+
+// ---------------------------------------------------------------------------
+// DataPrecision
+// ---------------------------------------------------------------------------
+
+/// Numeric precision for a SPIR-V kernel.
+#[derive(Clone, Debug, PartialEq)]
+pub enum DataPrecision {
+    /// 32-bit IEEE 754 single-precision float.
+    F32,
+    /// 16-bit IEEE 754 half-precision float.
+    F16,
+    /// 16-bit brain floating-point (supported natively on Xe-HPG+).
+    Bf16,
+}
+
+// ---------------------------------------------------------------------------
+// SpirvKernelType
+// ---------------------------------------------------------------------------
+
+/// Category of GPU kernel, mapping 1-to-1 with ONNX operator families.
+#[derive(Clone, Debug, PartialEq)]
+pub enum SpirvKernelType {
+    /// General matrix-matrix multiply (MatMul / Gemm).
+    Gemm,
+    /// 2-D convolution (Conv).
+    Conv2d,
+    /// Softmax normalisation.
+    Softmax,
+    /// Layer normalisation.
+    LayerNorm,
+    /// Point-wise element-wise ops (Relu, Sigmoid, Tanh, Add, Mul, Sub).
+    Elementwise,
+    /// Reduction along one or more axes (ReduceSum, ReduceMean, ReduceMax).
+    Reduce,
+    /// Transpose / permute dimensions.
+    Transpose,
+    /// Tensor concatenation along an axis.
+    Concat,
+    /// Pooling (MaxPool, AveragePool, GlobalAveragePool).
+    Pool,
+}
+
+// ---------------------------------------------------------------------------
+// SpirvKernel
+// ---------------------------------------------------------------------------
+
+/// A single SPIR-V kernel that can be dispatched on an Intel GPU.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SpirvKernel {
+    /// Human-readable kernel identifier (e.g. `"gemm_f32"`).
+    pub name: String,
+    /// Operator family this kernel implements.
+    pub kernel_type: SpirvKernelType,
+    /// Numeric precision.
+    pub precision: DataPrecision,
+    /// Minimum Xe generation required (1=LP, 2=HPG, 3=HPC, 4=LPG, 5=Xe2).
+    pub min_xe_version: XeVersion,
+    /// Shared local memory requirement in bytes.
+    pub shared_local_memory: u32,
+    /// Maximum threads per workgroup this kernel supports.
+    pub max_threads_per_workgroup: u32,
+}
+
+impl SpirvKernel {
+    /// Returns `true` when the given Xe version meets or exceeds the
+    /// kernel's minimum requirement.
+    pub fn is_compatible(&self, xe_ver: &XeVersion) -> bool {
+        xe_ver.as_version() >= self.min_xe_version.as_version()
+    }
+
+    /// Theoretical occupancy ratio for the given `threads_per_workgroup`.
+    ///
+    /// Returns a value in `0.0..=1.0` when `threads_per_workgroup` is at most
+    /// `max_threads_per_workgroup`, or > 1.0 otherwise (caller should clamp).
+    pub fn occupancy(&self, threads_per_workgroup: u32) -> f64 {
+        threads_per_workgroup as f64 / self.max_threads_per_workgroup as f64
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SpirvRegistry
+// ---------------------------------------------------------------------------
+
+/// Maximum number of kernels the registry can hold.
+pub const MAX_KERNELS: usize = 128;
+
+/// Registry of SPIR-V kernels available for dispatch.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SpirvRegistry {
+    /// Registered kernels.
+    kernels: Vec<SpirvKernel>,
+    /// Monotonically increasing id generator.
+    next_id: u64,
+}
+
+impl Default for SpirvRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SpirvRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self {
+            kernels: Vec::new(),
+            next_id: 1,
+        }
+    }
+
+    /// Register a new SPIR-V kernel and return its unique id.
+    ///
+    /// Fails with [`GpuError::QueueFull`] when the registry has reached
+    /// [`MAX_KERNELS`].
+    pub fn register(&mut self, kernel: SpirvKernel) -> Result<u64, GpuError> {
+        if self.kernels.len() >= MAX_KERNELS {
+            return Err(GpuError::QueueFull);
+        }
+        let id = self.next_id;
+        self.next_id += 1;
+        self.kernels.push(kernel);
+        Ok(id)
+    }
+
+    /// Find a registered kernel matching the requested type, precision, and
+    /// hardware capability.
+    ///
+    /// Returns the first kernel that exactly matches `kernel_type` and
+    /// `precision` and whose `min_xe_version` does not exceed the device's
+    /// Xe version.
+    pub fn find_kernel(
+        &self,
+        kernel_type: SpirvKernelType,
+        precision: DataPrecision,
+        xe_ver: &XeVersion,
+    ) -> Option<&SpirvKernel> {
+        self.kernels.iter().find(|k| {
+            k.kernel_type == kernel_type && k.precision == precision && k.is_compatible(xe_ver)
+        })
+    }
+
+    /// Populate the registry with standard kernels covering the core ONNX
+    /// operator set.
+    ///
+    /// Registers 11 default kernels:
+    /// - `gemm_f32` (Xe-LP), `gemm_f16` (Xe-LP)
+    /// - `conv2d_f32` (Xe-LP), `conv2d_f16` (Xe-HPG)
+    /// - `softmax_f32` (Xe-LP), `layernorm_f32` (Xe-LP)
+    /// - `elementwise_f32` (Xe-LP), `reduce_f32` (Xe-LP)
+    /// - `transpose_f32` (Xe-LP), `concat_f32` (Xe-LP)
+    /// - `pool_f32` (Xe-LP)
+    pub fn register_defaults(&mut self) -> Result<(), GpuError> {
+        let defaults = alloc::vec![
+            SpirvKernel {
+                name: String::from("gemm_f32"),
+                kernel_type: SpirvKernelType::Gemm,
+                precision: DataPrecision::F32,
+                min_xe_version: XeVersion::XE_LP,
+                shared_local_memory: 49152,
+                max_threads_per_workgroup: 256,
+            },
+            SpirvKernel {
+                name: String::from("gemm_f16"),
+                kernel_type: SpirvKernelType::Gemm,
+                precision: DataPrecision::F16,
+                min_xe_version: XeVersion::XE_LP,
+                shared_local_memory: 32768,
+                max_threads_per_workgroup: 256,
+            },
+            SpirvKernel {
+                name: String::from("conv2d_f32"),
+                kernel_type: SpirvKernelType::Conv2d,
+                precision: DataPrecision::F32,
+                min_xe_version: XeVersion::XE_LP,
+                shared_local_memory: 49152,
+                max_threads_per_workgroup: 256,
+            },
+            SpirvKernel {
+                name: String::from("conv2d_f16"),
+                kernel_type: SpirvKernelType::Conv2d,
+                precision: DataPrecision::F16,
+                min_xe_version: XeVersion::XE_HPG,
+                shared_local_memory: 32768,
+                max_threads_per_workgroup: 256,
+            },
+            SpirvKernel {
+                name: String::from("softmax_f32"),
+                kernel_type: SpirvKernelType::Softmax,
+                precision: DataPrecision::F32,
+                min_xe_version: XeVersion::XE_LP,
+                shared_local_memory: 16384,
+                max_threads_per_workgroup: 256,
+            },
+            SpirvKernel {
+                name: String::from("layernorm_f32"),
+                kernel_type: SpirvKernelType::LayerNorm,
+                precision: DataPrecision::F32,
+                min_xe_version: XeVersion::XE_LP,
+                shared_local_memory: 16384,
+                max_threads_per_workgroup: 256,
+            },
+            SpirvKernel {
+                name: String::from("elementwise_f32"),
+                kernel_type: SpirvKernelType::Elementwise,
+                precision: DataPrecision::F32,
+                min_xe_version: XeVersion::XE_LP,
+                shared_local_memory: 0,
+                max_threads_per_workgroup: 1024,
+            },
+            SpirvKernel {
+                name: String::from("reduce_f32"),
+                kernel_type: SpirvKernelType::Reduce,
+                precision: DataPrecision::F32,
+                min_xe_version: XeVersion::XE_LP,
+                shared_local_memory: 32768,
+                max_threads_per_workgroup: 256,
+            },
+            SpirvKernel {
+                name: String::from("transpose_f32"),
+                kernel_type: SpirvKernelType::Transpose,
+                precision: DataPrecision::F32,
+                min_xe_version: XeVersion::XE_LP,
+                shared_local_memory: 32768,
+                max_threads_per_workgroup: 256,
+            },
+            SpirvKernel {
+                name: String::from("concat_f32"),
+                kernel_type: SpirvKernelType::Concat,
+                precision: DataPrecision::F32,
+                min_xe_version: XeVersion::XE_LP,
+                shared_local_memory: 0,
+                max_threads_per_workgroup: 1024,
+            },
+            SpirvKernel {
+                name: String::from("pool_f32"),
+                kernel_type: SpirvKernelType::Pool,
+                precision: DataPrecision::F32,
+                min_xe_version: XeVersion::XE_LP,
+                shared_local_memory: 16384,
+                max_threads_per_workgroup: 256,
+            },
+        ];
+
+        for kernel in defaults {
+            self.register(kernel)?;
+        }
+
+        Ok(())
+    }
+
+    /// Number of kernels currently registered.
+    pub fn kernel_count(&self) -> usize {
+        self.kernels.len()
+    }
+
+    /// Return references to all kernels compatible with the given Xe version.
+    pub fn compatible_kernels(&self, xe_ver: &XeVersion) -> Vec<&SpirvKernel> {
+        self.kernels
+            .iter()
+            .filter(|k| k.is_compatible(xe_ver))
+            .collect()
+    }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gpu_id::identify_gpu;
+
+    // -- helpers ------------------------------------------------------------
+
+    /// Xe-HPG (Arc A-series).
+    fn test_xe_hpg() -> XeVersion {
+        XeVersion::XE_HPG
+    }
+
+    /// Xe-LP (integrated).
+    fn test_xe_lp() -> XeVersion {
+        XeVersion::XE_LP
+    }
+
+    /// A very old / hypothetical device below any supported generation.
+    fn test_xe_too_old() -> XeVersion {
+        XeVersion::new(0)
+    }
+
+    /// Build a simple test kernel with sensible defaults.
+    fn make_kernel(
+        name: &str,
+        kt: SpirvKernelType,
+        prec: DataPrecision,
+        min_xe: XeVersion,
+    ) -> SpirvKernel {
+        SpirvKernel {
+            name: String::from(name),
+            kernel_type: kt,
+            precision: prec,
+            min_xe_version: min_xe,
+            shared_local_memory: 4096,
+            max_threads_per_workgroup: 256,
+        }
+    }
+
+    // -- 1. Register kernel -------------------------------------------------
+
+    #[test]
+    fn test_register_kernel() {
+        let mut reg = SpirvRegistry::new();
+        let kernel = make_kernel(
+            "test_gemm",
+            SpirvKernelType::Gemm,
+            DataPrecision::F32,
+            XeVersion::XE_LP,
+        );
+        let id = reg.register(kernel).unwrap();
+        assert_eq!(id, 1);
+        assert_eq!(reg.kernel_count(), 1);
+    }
+
+    // -- 2. Find kernel by type and precision -------------------------------
+
+    #[test]
+    fn test_find_kernel_by_type_and_precision() {
+        let mut reg = SpirvRegistry::new();
+        reg.register(make_kernel(
+            "gemm_f32",
+            SpirvKernelType::Gemm,
+            DataPrecision::F32,
+            XeVersion::XE_LP,
+        ))
+        .unwrap();
+        reg.register(make_kernel(
+            "gemm_f16",
+            SpirvKernelType::Gemm,
+            DataPrecision::F16,
+            XeVersion::XE_LP,
+        ))
+        .unwrap();
+
+        let xe = test_xe_hpg();
+        let found = reg.find_kernel(SpirvKernelType::Gemm, DataPrecision::F16, &xe);
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().name, "gemm_f16");
+    }
+
+    // -- 3. Compatibility check with Xe version -----------------------------
+
+    #[test]
+    fn test_compatibility_check() {
+        let kernel = make_kernel(
+            "conv2d_f16",
+            SpirvKernelType::Conv2d,
+            DataPrecision::F16,
+            XeVersion::XE_HPG,
+        );
+        // Xe-HPG (2) >= Xe-HPG (2) => compatible.
+        assert!(kernel.is_compatible(&test_xe_hpg()));
+        // Xe-LP (1) < Xe-HPG (2) => not compatible.
+        assert!(!kernel.is_compatible(&test_xe_lp()));
+    }
+
+    // -- 4. Register defaults creates 11 kernels ---------------------------
+
+    #[test]
+    fn test_register_defaults_creates_11_kernels() {
+        let mut reg = SpirvRegistry::new();
+        reg.register_defaults().unwrap();
+        assert_eq!(reg.kernel_count(), 11);
+    }
+
+    // -- 5. Incompatible Xe version returns None ----------------------------
+
+    #[test]
+    fn test_incompatible_xe_returns_none() {
+        let mut reg = SpirvRegistry::new();
+        reg.register_defaults().unwrap();
+        let xe = test_xe_too_old();
+        let found = reg.find_kernel(SpirvKernelType::Gemm, DataPrecision::F32, &xe);
+        assert!(found.is_none());
+    }
+
+    // -- 6. Compatible kernels filtering ------------------------------------
+
+    #[test]
+    fn test_compatible_kernels_filtering() {
+        let mut reg = SpirvRegistry::new();
+        reg.register_defaults().unwrap();
+
+        // Xe-LP: everything except conv2d_f16 (requires Xe-HPG).
+        let compat = reg.compatible_kernels(&test_xe_lp());
+        assert_eq!(compat.len(), 10);
+
+        // Xe-HPG: all 11 kernels.
+        let compat = reg.compatible_kernels(&test_xe_hpg());
+        assert_eq!(compat.len(), 11);
+    }
+
+    // -- 7. Kernel count ----------------------------------------------------
+
+    #[test]
+    fn test_kernel_count() {
+        let mut reg = SpirvRegistry::new();
+        assert_eq!(reg.kernel_count(), 0);
+        reg.register(make_kernel(
+            "a",
+            SpirvKernelType::Pool,
+            DataPrecision::F32,
+            XeVersion::XE_LP,
+        ))
+        .unwrap();
+        assert_eq!(reg.kernel_count(), 1);
+        reg.register(make_kernel(
+            "b",
+            SpirvKernelType::Pool,
+            DataPrecision::F16,
+            XeVersion::XE_LP,
+        ))
+        .unwrap();
+        assert_eq!(reg.kernel_count(), 2);
+    }
+
+    // -- 8. Occupancy calculation -------------------------------------------
+
+    #[test]
+    fn test_occupancy_calculation() {
+        let kernel = SpirvKernel {
+            name: String::from("occ_test"),
+            kernel_type: SpirvKernelType::Elementwise,
+            precision: DataPrecision::F32,
+            min_xe_version: XeVersion::XE_LP,
+            shared_local_memory: 0,
+            max_threads_per_workgroup: 1024,
+        };
+        let occ = kernel.occupancy(512);
+        assert!((occ - 0.5).abs() < 1e-9);
+        let occ_full = kernel.occupancy(1024);
+        assert!((occ_full - 1.0).abs() < 1e-9);
+        let occ_quarter = kernel.occupancy(256);
+        assert!((occ_quarter - 0.25).abs() < 1e-9);
+    }
+
+    // -- 9. Registry full error ---------------------------------------------
+
+    #[test]
+    fn test_registry_full_error() {
+        let mut reg = SpirvRegistry::new();
+        for i in 0..MAX_KERNELS {
+            let name = alloc::format!("k{}", i);
+            reg.register(make_kernel(
+                &name,
+                SpirvKernelType::Gemm,
+                DataPrecision::F32,
+                XeVersion::XE_LP,
+            ))
+            .unwrap();
+        }
+        assert_eq!(reg.kernel_count(), MAX_KERNELS);
+        let result = reg.register(make_kernel(
+            "overflow",
+            SpirvKernelType::Gemm,
+            DataPrecision::F32,
+            XeVersion::XE_LP,
+        ));
+        assert_eq!(result, Err(GpuError::QueueFull));
+    }
+
+    // -- 10. All kernel types exist in defaults -----------------------------
+
+    #[test]
+    fn test_all_kernel_types_in_defaults() {
+        let mut reg = SpirvRegistry::new();
+        reg.register_defaults().unwrap();
+        let xe = test_xe_hpg();
+
+        let types = [
+            SpirvKernelType::Gemm,
+            SpirvKernelType::Conv2d,
+            SpirvKernelType::Softmax,
+            SpirvKernelType::LayerNorm,
+            SpirvKernelType::Elementwise,
+            SpirvKernelType::Reduce,
+            SpirvKernelType::Transpose,
+            SpirvKernelType::Concat,
+            SpirvKernelType::Pool,
+        ];
+        for kt in &types {
+            let found = reg.find_kernel(kt.clone(), DataPrecision::F32, &xe);
+            assert!(found.is_some(), "Expected default F32 kernel for {:?}", kt);
+        }
+    }
+
+    // -- 11. F16 kernels require higher Xe version --------------------------
+
+    #[test]
+    fn test_f16_kernels_require_higher_xe() {
+        let mut reg = SpirvRegistry::new();
+        reg.register_defaults().unwrap();
+
+        // conv2d_f16 requires Xe-HPG. Xe-LP should fail.
+        let found = reg.find_kernel(SpirvKernelType::Conv2d, DataPrecision::F16, &test_xe_lp());
+        assert!(
+            found.is_none(),
+            "conv2d_f16 should not be compatible with Xe-LP"
+        );
+
+        // But Xe-HPG should succeed.
+        let found = reg.find_kernel(SpirvKernelType::Conv2d, DataPrecision::F16, &test_xe_hpg());
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().name, "conv2d_f16");
+    }
+
+    // -- 12. Default kernel shared memory values ----------------------------
+
+    #[test]
+    fn test_default_kernel_shared_memory() {
+        let mut reg = SpirvRegistry::new();
+        reg.register_defaults().unwrap();
+        let xe = test_xe_hpg();
+
+        let gemm = reg
+            .find_kernel(SpirvKernelType::Gemm, DataPrecision::F32, &xe)
+            .unwrap();
+        assert_eq!(gemm.shared_local_memory, 49152); // 48 KiB
+
+        let eltwise = reg
+            .find_kernel(SpirvKernelType::Elementwise, DataPrecision::F32, &xe)
+            .unwrap();
+        assert_eq!(eltwise.shared_local_memory, 0);
+
+        let softmax = reg
+            .find_kernel(SpirvKernelType::Softmax, DataPrecision::F32, &xe)
+            .unwrap();
+        assert_eq!(softmax.shared_local_memory, 16384); // 16 KiB
+    }
+
+    // -- 13. SpirvKernelType variants -----------------------------------------
+
+    #[test]
+    fn test_spirv_kernel_type_variants() {
+        let variants = [
+            SpirvKernelType::Gemm,
+            SpirvKernelType::Conv2d,
+            SpirvKernelType::Softmax,
+            SpirvKernelType::LayerNorm,
+            SpirvKernelType::Elementwise,
+            SpirvKernelType::Reduce,
+            SpirvKernelType::Transpose,
+            SpirvKernelType::Concat,
+            SpirvKernelType::Pool,
+        ];
+        assert_eq!(variants.len(), 9);
+        for (i, a) in variants.iter().enumerate() {
+            for (j, b) in variants.iter().enumerate() {
+                if i == j {
+                    assert_eq!(a, b);
+                } else {
+                    assert_ne!(a, b);
+                }
+            }
+        }
+    }
+
+    // -- 14. DataPrecision variants -----------------------------------------
+
+    #[test]
+    fn test_data_precision_variants() {
+        let variants = [DataPrecision::F32, DataPrecision::F16, DataPrecision::Bf16];
+        assert_eq!(variants.len(), 3);
+        for (i, a) in variants.iter().enumerate() {
+            for (j, b) in variants.iter().enumerate() {
+                if i == j {
+                    assert_eq!(a, b);
+                } else {
+                    assert_ne!(a, b);
+                }
+            }
+        }
+    }
+
+    // -- 15. Clone and Debug derive work ------------------------------------
+
+    #[test]
+    fn test_kernel_clone_debug() {
+        let kernel = make_kernel(
+            "clone_test",
+            SpirvKernelType::Softmax,
+            DataPrecision::F32,
+            XeVersion::XE_LP,
+        );
+        let cloned = kernel.clone();
+        assert_eq!(kernel, cloned);
+        let dbg = alloc::format!("{:?}", kernel);
+        assert!(dbg.contains("clone_test"));
+        assert!(dbg.contains("Softmax"));
+    }
+
+    // -- 16. Find non-existent type returns None ----------------------------
+
+    #[test]
+    fn test_find_nonexistent_precision_returns_none() {
+        let mut reg = SpirvRegistry::new();
+        reg.register_defaults().unwrap();
+        let xe = test_xe_hpg();
+
+        // There is no Bf16 kernel in the defaults.
+        let found = reg.find_kernel(SpirvKernelType::Gemm, DataPrecision::Bf16, &xe);
+        assert!(found.is_none());
+    }
+
+    // -- 17. identify_gpu produces usable XeVersion -------------------------
+
+    #[test]
+    fn test_identify_gpu_xe_works_with_registry() {
+        let gpu = identify_gpu(0x56A0).unwrap();
+        let mut reg = SpirvRegistry::new();
+        reg.register_defaults().unwrap();
+
+        // Arc A770 (Xe-HPG) should be compatible with all 11 default kernels.
+        let compat = reg.compatible_kernels(&gpu.xe_version);
+        assert_eq!(compat.len(), 11);
+    }
+
+    // -- 18. Registry new starts empty with id 1 ----------------------------
+
+    #[test]
+    fn test_registry_initial_state() {
+        let reg = SpirvRegistry::new();
+        assert_eq!(reg.kernel_count(), 0);
+        assert_eq!(reg.next_id, 1);
+    }
+
+    // -- 19. Multiple registrations yield increasing ids --------------------
+
+    #[test]
+    fn test_register_ids_increase() {
+        let mut reg = SpirvRegistry::new();
+        let id1 = reg
+            .register(make_kernel(
+                "k1",
+                SpirvKernelType::Pool,
+                DataPrecision::F32,
+                XeVersion::XE_LP,
+            ))
+            .unwrap();
+        let id2 = reg
+            .register(make_kernel(
+                "k2",
+                SpirvKernelType::Pool,
+                DataPrecision::F16,
+                XeVersion::XE_LP,
+            ))
+            .unwrap();
+        let id3 = reg
+            .register(make_kernel(
+                "k3",
+                SpirvKernelType::Pool,
+                DataPrecision::Bf16,
+                XeVersion::XE_LP,
+            ))
+            .unwrap();
+        assert_eq!(id1, 1);
+        assert_eq!(id2, 2);
+        assert_eq!(id3, 3);
+    }
+
+    // -- 20. Default Gemm F16 is compatible with Xe-LP ----------------------
+
+    #[test]
+    fn test_gemm_f16_compatible_with_xe_lp() {
+        let mut reg = SpirvRegistry::new();
+        reg.register_defaults().unwrap();
+        // gemm_f16 has min_xe=XE_LP, Xe-LP should match.
+        let found = reg.find_kernel(SpirvKernelType::Gemm, DataPrecision::F16, &test_xe_lp());
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().name, "gemm_f16");
+    }
+
+    // -- 21. Xe-HPC compatible with all defaults ----------------------------
+
+    #[test]
+    fn test_xe_hpc_compatible_with_all_defaults() {
+        let mut reg = SpirvRegistry::new();
+        reg.register_defaults().unwrap();
+        let xe_hpc = XeVersion::XE_HPC;
+        let compat = reg.compatible_kernels(&xe_hpc);
+        assert_eq!(compat.len(), 11);
+    }
+
+    // -- 22. Xe2 compatible with all defaults --------------------------------
+
+    #[test]
+    fn test_xe2_compatible_with_all_defaults() {
+        let mut reg = SpirvRegistry::new();
+        reg.register_defaults().unwrap();
+        let xe2 = XeVersion::XE2;
+        let compat = reg.compatible_kernels(&xe2);
+        assert_eq!(compat.len(), 11);
+    }
+
+    // -- 23. XeVersion equality ---------------------------------------------
+
+    #[test]
+    fn test_xe_version_equality() {
+        assert_eq!(XeVersion::XE_LP, XeVersion::new(1));
+        assert_eq!(XeVersion::XE_HPG, XeVersion::new(2));
+        assert_ne!(XeVersion::XE_LP, XeVersion::XE_HPG);
+    }
+
+    // -- 24. Max threads per workgroup in defaults --------------------------
+
+    #[test]
+    fn test_max_threads_in_defaults() {
+        let mut reg = SpirvRegistry::new();
+        reg.register_defaults().unwrap();
+        let xe = test_xe_hpg();
+
+        // Elementwise and concat should support 1024 threads.
+        let eltwise = reg
+            .find_kernel(SpirvKernelType::Elementwise, DataPrecision::F32, &xe)
+            .unwrap();
+        assert_eq!(eltwise.max_threads_per_workgroup, 1024);
+
+        let concat = reg
+            .find_kernel(SpirvKernelType::Concat, DataPrecision::F32, &xe)
+            .unwrap();
+        assert_eq!(concat.max_threads_per_workgroup, 1024);
+
+        // GEMM should support 256 threads.
+        let gemm = reg
+            .find_kernel(SpirvKernelType::Gemm, DataPrecision::F32, &xe)
+            .unwrap();
+        assert_eq!(gemm.max_threads_per_workgroup, 256);
+    }
+
+    // -- 25. Empty registry find returns None --------------------------------
+
+    #[test]
+    fn test_empty_registry_find_returns_none() {
+        let reg = SpirvRegistry::new();
+        let found = reg.find_kernel(SpirvKernelType::Gemm, DataPrecision::F32, &XeVersion::XE_LP);
+        assert!(found.is_none());
+    }
+}

--- a/openspec/changes/intel-gpu-support-v5/design.md
+++ b/openspec/changes/intel-gpu-support-v5/design.md
@@ -1,0 +1,111 @@
+# Design: Intel GPU Support (intel-gpu-support-v5)
+
+## Architecture Overview
+
+The Intel GPU crate (`smallaios-arch-intel-gpu`) follows the identical module
+decomposition as the NVIDIA crate (`smallaios-arch-nvidia`), adapted for
+Intel GPU hardware concepts.
+
+```
+arch/intel_gpu/
+  src/
+    lib.rs                  -- Root module, GpuError enum
+    pcie.rs                 -- PCIe enumeration (vendor 0x8086)
+    gpu_id.rs               -- GPU identification (Xe-LP/HPG/HPC/LPG/Xe2)
+    memory.rs               -- VRAM/GTT allocator (static/dynamic split)
+    dma.rs                  -- DMA/Blitter copy engine
+    compute.rs              -- EU-based compute engine (SIMD8/16/32)
+    gpu_init.rs             -- GPU initialization lifecycle
+    spirv_kernels.rs        -- SPIR-V kernel registry (equiv. to ptx.rs)
+    level_zero_provider.rs  -- Level Zero provider (equiv. to cuda_provider.rs)
+```
+
+## Intel GPU vs NVIDIA GPU: Key Differences
+
+| Concept          | NVIDIA               | Intel                           |
+|------------------|----------------------|---------------------------------|
+| Compute unit     | Streaming Multiprocessor (SM) | Execution Unit (EU)    |
+| Thread grouping  | Warp (32 threads)    | SIMD lane (8/16/32 wide)       |
+| Shader IL        | PTX / SASS           | SPIR-V / IGC                    |
+| API stack        | CUDA                 | Level Zero / oneAPI             |
+| Memory           | VRAM (GDDR/HBM)     | VRAM (GDDR6) or shared (GTT)   |
+| Copy engine      | CE (Copy Engine)     | BCS (Blitter Command Streamer)  |
+| Firmware         | GSP / PMU            | GuC / HuC                       |
+
+## Module Design
+
+### pcie.rs
+- Reuses `PciAddress`, `BarType`, `BaseAddressRegister`, `PciDevice` structs
+  from the NVIDIA pattern
+- `INTEL_VENDOR_ID = 0x8086`
+- `is_intel()` and `is_display_controller()` classification methods
+- Mock scan includes Arc A770, A750, Data Center Max 1550, and a non-Intel
+  device for filter testing
+
+### gpu_id.rs
+- `GpuArchitecture`: XeLP, XeHPG, XeHPC, XeLPG, Xe2, Unknown
+- `ComputeCapability` replaced with EU count comparison for minimum
+  hardware requirements
+- `GpuInfo` fields: device_id, architecture, eu_count, slices, subslices,
+  vram_size_mb, max_threads_per_eu (always 8), name
+- `identify_gpu()` maps Intel device IDs to GpuInfo
+
+### memory.rs
+- `GPU_PAGE_SIZE = 4096` (Intel uses 4 KiB pages, vs NVIDIA's 64 KiB)
+- Same `VramAllocator` pattern with 70/30 static/dynamic split
+- `MemoryRegion::Static` for weights, `MemoryRegion::Dynamic` for workspace
+
+### dma.rs
+- Identical state machine: Pending -> InProgress -> Completed | Failed
+- Same `DmaEngine` API: submit, start, complete, fail, cancel
+- Constants adapted for Intel BCS capabilities
+
+### compute.rs
+- Intel EU model: 8 hardware threads per EU, each thread runs SIMD8/16/32
+- `SimdWidth`: Simd8, Simd16, Simd32
+- Max workgroup size: 1024 threads (same as NVIDIA block limit)
+- Max shared local memory (SLM): 64 KiB per workgroup
+- `LaunchConfig` uses `grid` (workgroup count) and `workgroup` (threads per
+  workgroup) instead of NVIDIA's grid/block terminology
+
+### gpu_init.rs
+- Same state machine: Uninitialized -> BarsMapped -> EnginesReady -> Running
+- `GpuRegisters`: MMIO BAR (registers) + Aperture BAR (VRAM/GTT)
+- Comments reference Intel GuC (graphics microcontroller) and HuC (HEVC
+  micro controller) firmware loading
+- Power states: FullPower, LowPower, Suspended
+
+### spirv_kernels.rs (equiv. to ptx.rs)
+- `SpirvKernelType`: same operator families as PtxKernelType
+- `DataPrecision`: F16, F32, BF16 (Intel Xe-HPG+ has native BF16)
+- `SpirvKernel`: name, kernel_type, precision, shared_local_memory,
+  min_xe_version (XeLP=1, XeHPG=2, XeHPC=3, XeLPG=4, Xe2=5)
+- `SpirvRegistry`: register_defaults with 11 standard kernels
+
+### level_zero_provider.rs (equiv. to cuda_provider.rs)
+- `LevelZeroProvider` owns: VramAllocator, DmaEngine, ComputeEngine,
+  SpirvRegistry
+- Same API surface: load_weights, allocate_workspace, map_operator,
+  launch_kernel, synchronize
+- Operator mapping identical to CUDA provider
+
+## Feature Flags
+
+```toml
+[features]
+default = []
+xe_lp  = []   # Xe-LP (Arc integrated, DG1)
+xe_hpg = []   # Xe-HPG (Arc A770/A750/A580/A380)
+xe_hpc = []   # Xe-HPC (Data Center GPU Max / Ponte Vecchio)
+xe_lpg = []   # Xe-LPG (Meteor Lake integrated)
+xe2    = []   # Xe2 (Battlemage)
+```
+
+## Testing Strategy
+
+Each module targets 15-25 unit tests covering:
+- Happy path for all public APIs
+- Error conditions (invalid state, out of memory, queue full)
+- Boundary conditions (max capacity, zero-size, exact limits)
+- State machine transitions (valid and invalid)
+- Mock hardware data for PCIe enumeration and GPU identification

--- a/openspec/changes/intel-gpu-support-v5/proposal.md
+++ b/openspec/changes/intel-gpu-support-v5/proposal.md
@@ -1,0 +1,67 @@
+# Proposal: Intel GPU Support (intel-gpu-support-v5)
+
+## Summary
+
+Add Intel GPU hardware abstraction layer to SmallAIOS, enabling AI inference
+workloads on Intel discrete and integrated GPUs. This covers the Xe
+architecture family: Xe-LP (integrated), Xe-HPG (Arc consumer), Xe-HPC
+(Data Center GPU Max / Ponte Vecchio), Xe-LPG (Meteor Lake), and Xe2
+(Battlemage).
+
+## Motivation
+
+Intel's discrete GPU lineup (Arc A-series, Data Center GPU Max, Flex series)
+is increasingly deployed in AI inference workloads. SmallAIOS currently
+supports NVIDIA GPUs only. Adding Intel GPU support broadens hardware
+compatibility and enables deployment on Intel-based edge and data center
+platforms without requiring NVIDIA hardware.
+
+Key Intel GPU targets:
+- **Arc A770 / A750 / A580 / A380** -- Consumer/workstation discrete GPUs
+  (Xe-HPG architecture, up to 32 Xe-cores / 512 EUs)
+- **Data Center GPU Max 1550 (Ponte Vecchio)** -- HPC/AI data center GPU
+  (Xe-HPC architecture, 128 Xe-cores / 1024 EUs, 128 GB HBM2e)
+- **Flex 170** -- Data center visual compute / light inference
+  (Xe-HPG derivative, 32 Xe-cores / 512 EUs)
+- **Meteor Lake integrated** -- Ultra-low-power edge inference
+  (Xe-LPG, up to 8 Xe-cores / 128 EUs)
+- **Battlemage** -- Next-generation discrete (Xe2 architecture)
+
+## Scope
+
+1. **PCIe enumeration** -- Discover Intel GPUs (vendor 0x8086) on the PCI bus
+2. **GPU identification** -- Map PCI device IDs to architecture, EU count,
+   VRAM size, and capabilities
+3. **VRAM/GTT memory management** -- Allocator for device-local and
+   system-shared memory with static/dynamic region split
+4. **DMA / Blitter engine** -- Asynchronous host-to-device, device-to-host,
+   and device-to-device transfers via Intel's Blitter copy engine
+5. **EU-based compute engine** -- Kernel launch using Intel's Execution Unit
+   model (SIMD8/16/32, 8 threads per EU, workgroup dispatch)
+6. **GPU initialization** -- BAR mapping, engine bring-up, GuC/HuC firmware
+   loading references, power state management
+7. **SPIR-V kernel registry** -- Kernel definitions using SPIR-V (Intel's
+   shader/compute IL), equivalent to NVIDIA's PTX registry
+8. **Level Zero execution provider** -- Top-level provider wiring all
+   subsystems together for ONNX operator dispatch, equivalent to NVIDIA's
+   CUDA provider
+
+## Non-Goals
+
+- Actual GPU hardware register programming (stub implementations)
+- Display/rendering pipeline support
+- OpenCL runtime compatibility
+- Multi-GPU / multi-tile support (future work)
+
+## Dependencies
+
+- `smallaios-kernel` crate (core types)
+- No external C dependencies (`#![no_std]` throughout)
+
+## Success Criteria
+
+- All modules compile under `#![no_std]` with `extern crate alloc`
+- 150+ unit tests passing across all modules
+- Zero clippy warnings with `-D warnings`
+- Consistent API pattern with existing NVIDIA GPU crate
+- Feature flags for each Intel GPU architecture generation

--- a/openspec/changes/intel-gpu-support-v5/tasks.md
+++ b/openspec/changes/intel-gpu-support-v5/tasks.md
@@ -1,0 +1,59 @@
+# Tasks: Intel GPU Support (intel-gpu-support-v5)
+
+## Phase 1: Crate Scaffolding
+- [x] T1: Create `arch/intel_gpu/Cargo.toml` with workspace integration and feature flags
+- [x] T2: Create `arch/intel_gpu/src/lib.rs` with module declarations and GpuError enum
+- [x] T3: Add `arch/intel_gpu` to workspace members in root `Cargo.toml`
+
+## Phase 2: PCIe Enumeration (pcie.rs)
+- [x] T4: Implement PciAddress, BarType, BaseAddressRegister structs
+- [x] T5: Implement PciDevice with is_intel(), is_display_controller(), is_3d_controller()
+- [x] T6: Implement PciScanner with scan(), intel_devices(), device_count()
+- [x] T7: Mock scan with Arc A770, A750, DC Max 1550, non-Intel device
+- [x] T8: Write 20 unit tests for pcie.rs
+
+## Phase 3: GPU Identification (gpu_id.rs)
+- [x] T9: Define GpuArchitecture enum (XeLP, XeHPG, XeHPC, XeLPG, Xe2, Unknown)
+- [x] T10: Define ComputeCapability with EU count comparison
+- [x] T11: Define GpuInfo struct with Intel-specific fields
+- [x] T12: Implement identify_gpu() for all supported device IDs
+- [x] T13: Write 20 unit tests for gpu_id.rs
+
+## Phase 4: Memory Management (memory.rs)
+- [x] T14: Implement MemoryRegion, GpuAllocation structs
+- [x] T15: Implement VramAllocator with 70/30 static/dynamic split
+- [x] T16: Implement alloc, free, used_bytes, free_bytes, total_used, total_free
+- [x] T17: Write 17 unit tests for memory.rs
+
+## Phase 5: DMA Engine (dma.rs)
+- [x] T18: Implement DmaDirection, DmaStatus, TransferId, DmaTransfer
+- [x] T19: Implement DmaEngine with submit, start, complete, fail, cancel
+- [x] T20: Write 18 unit tests for dma.rs
+
+## Phase 6: Compute Engine (compute.rs)
+- [x] T21: Define SimdWidth, Dim3, LaunchConfig for Intel EU model
+- [x] T22: Implement KernelId, KernelStatus, Kernel structs
+- [x] T23: Implement ComputeEngine with launch, dispatch, complete, fail, synchronize
+- [x] T24: Write 20 unit tests for compute.rs
+
+## Phase 7: GPU Initialization (gpu_init.rs)
+- [x] T25: Define GpuState, PowerState, GpuRegisters, InitConfig
+- [x] T26: Implement GpuContext lifecycle: map_bars, initialize_engines, start, suspend, resume, reset
+- [x] T27: Write 20 unit tests for gpu_init.rs
+
+## Phase 8: SPIR-V Kernel Registry (spirv_kernels.rs)
+- [x] T28: Define SpirvKernelType, DataPrecision, SpirvKernel
+- [x] T29: Implement SpirvRegistry with register_defaults (11 standard kernels)
+- [x] T30: Write 25 unit tests for spirv_kernels.rs
+
+## Phase 9: Level Zero Provider (level_zero_provider.rs)
+- [x] T31: Define OperatorMapping, ExecutionStep, ExecutionPlan, ProviderStatus
+- [x] T32: Implement LevelZeroProvider wiring all subsystems
+- [x] T33: Implement map_operator, launch_kernel, load_weights, allocate_workspace, synchronize
+- [x] T34: Write 22 unit tests for level_zero_provider.rs
+
+## Phase 10: Verification
+- [x] T35: cargo check passes
+- [x] T36: cargo test passes (150+ tests)
+- [x] T37: cargo clippy -- -D warnings passes with zero warnings
+- [x] T38: cargo fmt -- --check passes


### PR DESCRIPTION
## Summary
- Add `arch/intel_gpu` crate with full Intel GPU hardware abstraction layer
- PCIe enumeration (vendor 0x8086), GPU identification (Xe-LP/HPG/HPC/LPG/Xe2)
- Supports Arc A-series, Data Center GPU Max, Flex series, Battlemage
- VRAM allocator, DMA/Blitter engine, EU-based compute engine (SIMD8/16/32)
- SPIR-V kernel registry and Level Zero execution provider for ONNX inference
- OpenSpec proposal, design, and task artifacts
- **171 tests passing**, zero clippy warnings

## Test plan
- [x] `cargo test -p smallaios-arch-intel-gpu` passes (171 tests)
- [x] `cargo clippy -p smallaios-arch-intel-gpu -- -D warnings` clean
- [x] `cargo fmt -p smallaios-arch-intel-gpu -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)