### PR TITLE
test: cover uncovered branches from complexity refactors

### DIFF
--- a/bus/src/arinc429/scheduler.rs
+++ b/bus/src/arinc429/scheduler.rs
@@ -445,6 +445,77 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // consider_first_tx / consider_overdue coverage
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_first_tx_pending_wins_over_overdue() {
+        // When a first_tx_pending entry coexists with overdue non-first
+        // entries, the first_tx_pending entry must win.
+        let mut sched = TxScheduler::new(0);
+        sched.schedule(Label::new(1), 50, make_word(1)).unwrap();
+        sched.poll(0); // transmit label 1 (now not first_tx_pending)
+
+        // Add label 2 (appended, first_tx_pending)
+        sched.schedule(Label::new(2), 50, make_word(2)).unwrap();
+
+        // At t=20000: label 1 is overdue, label 2 is first_tx_pending.
+        // Iteration: consider_overdue(1), then consider_first_tx(2) overrides.
+        let word = sched.poll(20_000);
+        assert_eq!(word, Some(make_word(2)));
+    }
+
+    #[test]
+    fn test_consider_overdue_early_return_when_first_tx_found() {
+        // Build entries in [first_tx_pending, non_first] order so that
+        // consider_overdue is called with best_is_first=true, exercising
+        // the early-return guard.
+        //
+        // schedule() always appends, so the trick is: schedule A and B,
+        // then poll — poll picks A (first first_tx_pending at idx 0).
+        // Entries become [A(not_first), B(first)]. Re-schedule A to move
+        // it to the end: retain removes A from idx 0, push appends.
+        // Entries: [B(first), A(first)]. Poll picks B (idx 0).
+        // Entries: [B(not_first), A(first)]. Re-schedule B to move it:
+        // retain removes B from idx 0, push appends.
+        // Entries: [A(first), B(first)]. Poll picks A (idx 0).
+        // Entries: [A(not_first), B(first)]. That's [not_first, first].
+        //
+        // We need [first, not_first]. Since poll always picks the lowest-
+        // index first_tx_pending, and schedule always appends, achieving
+        // [first_tx_pending, not_first] requires that a first_tx_pending
+        // entry was inserted before a non-first one — which only happens
+        // when a label is scheduled, then a DIFFERENT label at a higher
+        // index is transmitted while the first remains pending.
+        //
+        // That can't happen because poll picks the LOWEST first_tx_pending.
+        // The early-return in consider_overdue is thus defensive dead code.
+        //
+        // We still exercise both helpers thoroughly here:
+        let mut sched = TxScheduler::new(0);
+        sched.schedule(Label::new(1), 100, make_word(1)).unwrap();
+        sched.schedule(Label::new(2), 100, make_word(2)).unwrap();
+        sched.schedule(Label::new(3), 100, make_word(3)).unwrap();
+
+        // Transmit all three (exercises consider_first_tx for each)
+        assert_eq!(sched.poll(0), Some(make_word(1)));
+        assert_eq!(sched.poll(0), Some(make_word(2)));
+        assert_eq!(sched.poll(0), Some(make_word(3)));
+
+        // All are now non-first. At t=10000 all overdue.
+        // consider_overdue runs for all 3 entries.
+        let w = sched.poll(10_000);
+        assert!(w.is_some());
+
+        // Add label 4 (first_tx_pending at end, after 3 non-first entries)
+        sched.schedule(Label::new(4), 100, make_word(4)).unwrap();
+        // consider_overdue(1), consider_overdue(2), consider_overdue(3),
+        // consider_first_tx(4) — first_tx wins
+        let w = sched.poll(10_000);
+        assert_eq!(w, Some(make_word(4)));
+    }
+
+    // -----------------------------------------------------------------------
     // Multiple rates interleaving
     // -----------------------------------------------------------------------
 

--- a/onnx-rt/src/operators.rs
+++ b/onnx-rt/src/operators.rs
@@ -1584,4 +1584,38 @@ mod tests {
             assert!(p >= 0.0 && p <= 1.0 + 1e-6);
         }
     }
+
+    // ---- Coverage for validate_conv_inputs error paths ----
+
+    #[test]
+    fn test_conv_wrong_dtype() {
+        // Int32 input should be rejected
+        let input = Tensor {
+            data_type: DataType::Int32,
+            shape: TensorShape::new(vec![1, 1, 3, 3]),
+            name: String::new(),
+            raw_data: alloc::vec![0u8; 9 * 4],
+        };
+        let weight = make_f32_tensor(&[1, 1, 1, 1], &[1.0]);
+        let result = op_conv(&input, &weight, None);
+        assert!(matches!(result, Err(OpError::InvalidAttribute(_))));
+    }
+
+    #[test]
+    fn test_conv_wrong_rank() {
+        // 3D input (missing batch dim) should be rejected
+        let input = make_f32_tensor(&[1, 3, 3], &[1.0; 9]);
+        let weight = make_f32_tensor(&[1, 1, 1, 1], &[1.0]);
+        let result = op_conv(&input, &weight, None);
+        assert!(matches!(result, Err(OpError::ShapeMismatch(_))));
+    }
+
+    #[test]
+    fn test_conv_kernel_larger_than_input() {
+        // 4x4 kernel on 3x3 input should be rejected
+        let input = make_f32_tensor(&[1, 1, 3, 3], &[1.0; 9]);
+        let weight = make_f32_tensor(&[1, 1, 4, 4], &[1.0; 16]);
+        let result = op_conv(&input, &weight, None);
+        assert!(matches!(result, Err(OpError::ShapeMismatch(_))));
+    }
 }

--- a/security/src/crypto/verify.rs
+++ b/security/src/crypto/verify.rs
@@ -790,4 +790,84 @@ mod tests {
         assert!(debug.contains("ml_dsa_keys"));
         assert!(debug.contains("hybrid_keys"));
     }
+
+    // ---- Coverage for VerificationPolicy methods ----
+
+    #[test]
+    fn verification_policy_should_verify() {
+        assert!(VerificationPolicy::Enforce.should_verify());
+        assert!(VerificationPolicy::WarnOnly.should_verify());
+        assert!(!VerificationPolicy::Disabled.should_verify());
+    }
+
+    #[test]
+    fn verification_policy_should_reject() {
+        assert!(VerificationPolicy::Enforce.should_reject());
+        assert!(!VerificationPolicy::WarnOnly.should_reject());
+        assert!(!VerificationPolicy::Disabled.should_reject());
+    }
+
+    // ---- Coverage for VerifyError Display ----
+
+    #[test]
+    fn verify_error_display() {
+        assert_eq!(
+            format!("{}", VerifyError::ModelTooLarge),
+            format!("model exceeds maximum size ({} bytes)", MAX_MODEL_SIZE)
+        );
+        assert_eq!(
+            format!("{}", VerifyError::NameTooLong),
+            format!("model name exceeds {} bytes", MAX_MODEL_NAME_LEN)
+        );
+        assert_eq!(
+            format!("{}", VerifyError::InvalidSignatureFormat),
+            "invalid model signature format"
+        );
+        assert_eq!(
+            format!("{}", VerifyError::UnsupportedVersion),
+            "unsupported signature format version"
+        );
+        assert_eq!(
+            format!("{}", VerifyError::HashMismatch),
+            "model hash does not match signature"
+        );
+        assert_eq!(
+            format!("{}", VerifyError::SignatureInvalid),
+            "ML-DSA-65 signature verification failed"
+        );
+        assert_eq!(
+            format!("{}", VerifyError::HybridSignatureInvalid),
+            "hybrid signature verification failed"
+        );
+        assert_eq!(
+            format!("{}", VerifyError::UntrustedKey),
+            "signing key not in trusted key set"
+        );
+        assert_eq!(
+            format!("{}", VerifyError::TimestampOutOfRange),
+            "signature timestamp out of acceptable range"
+        );
+        assert_eq!(
+            format!("{}", VerifyError::NoSignature),
+            "no signature found for model"
+        );
+        assert_eq!(
+            format!("{}", VerifyError::NotImplemented),
+            "model verification not yet implemented"
+        );
+    }
+
+    // ---- Coverage for ModelMetadata::serialize error path ----
+
+    #[test]
+    fn model_metadata_serialize_buffer_too_small() {
+        let hash = Sha3_256Digest::from_bytes([0x42; SHA3_256_DIGEST_LEN]);
+        let meta =
+            ModelMetadata::new(b"mymodel", 1, 12345, hash, SignatureScheme::MlDsa65).unwrap();
+        let mut tiny_buf = [0u8; 4]; // way too small
+        assert_eq!(
+            meta.serialize(&mut tiny_buf),
+            Err(VerifyError::InvalidSignatureFormat)
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Add tests for `VerificationPolicy::should_verify()` / `should_reject()`, all `VerifyError::Display` variants, and `ModelMetadata::serialize` error path in `security/src/crypto/verify.rs`
- Add tests for `validate_conv_inputs` error paths (wrong dtype, wrong rank, kernel too large) in `onnx-rt/src/operators.rs`
- Add tests exercising `consider_first_tx` and `consider_overdue` helper functions in `bus/src/arinc429/scheduler.rs`, including first_tx_pending-wins-over-overdue behavior

Addresses the 13 uncovered lines flagged by Codecov on PR #37.

**Note:** The `consider_overdue` early-return guard (`if best_is_first { return; }`) is defensive dead code — the public API's append-only scheduling means first_tx_pending entries always appear at higher indices than non-first entries, making this branch unreachable. Tests document this and cover all reachable paths.

## Test plan

- [x] `cargo test -p smallaios-security --features verified-boot -p smallaios-onnx-rt -p smallaios-bus` — 865 tests pass
- [x] `cargo clippy -p smallaios-security -p smallaios-onnx-rt -p smallaios-bus -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)