### PR TITLE
fix: resolve Miri-detected UB in Multiboot2 parser

### DIFF
--- a/kernel/src/mem/phys.rs
+++ b/kernel/src/mem/phys.rs
@@ -170,13 +170,13 @@ const MB2_MEM_ACPI_RECLAIMABLE: u32 = 3;
 /// # Safety
 /// `mb_info_addr` must point to a valid Multiboot2 boot information structure.
 pub unsafe fn parse_multiboot2(mb_info_addr: usize, map: &mut PhysMemoryMap) {
-    let total_size = *(mb_info_addr as *const u32);
+    let total_size = core::ptr::read_unaligned(mb_info_addr as *const u32);
     let mut offset: usize = 8; // Skip total_size and reserved fields
 
     while offset < total_size as usize {
         let tag_ptr = (mb_info_addr + offset) as *const u32;
-        let tag_type = *tag_ptr;
-        let tag_size = *tag_ptr.add(1);
+        let tag_type = core::ptr::read_unaligned(tag_ptr);
+        let tag_size = core::ptr::read_unaligned(tag_ptr.add(1));
 
         if tag_type == MB2_TAG_END {
             break;
@@ -197,7 +197,7 @@ pub unsafe fn parse_multiboot2(mb_info_addr: usize, map: &mut PhysMemoryMap) {
 /// `tag_addr` must point to a valid Multiboot2 memory map tag.
 unsafe fn parse_mb2_mmap_tag(tag_addr: usize, tag_size: usize, map: &mut PhysMemoryMap) {
     // Tag header: type(4) + size(4) + entry_size(4) + entry_version(4)
-    let entry_size = *((tag_addr + 8) as *const u32) as usize;
+    let entry_size = core::ptr::read_unaligned((tag_addr + 8) as *const u32) as usize;
     if entry_size == 0 {
         return;
     }
@@ -208,9 +208,9 @@ unsafe fn parse_mb2_mmap_tag(tag_addr: usize, tag_size: usize, map: &mut PhysMem
 
     while entry_addr + entry_size <= entries_end {
         // Entry: base_addr(8) + length(8) + type(4) + reserved(4)
-        let base = *((entry_addr) as *const u64) as usize;
-        let length = *((entry_addr + 8) as *const u64) as usize;
-        let mem_type = *((entry_addr + 16) as *const u32);
+        let base = core::ptr::read_unaligned(entry_addr as *const u64) as usize;
+        let length = core::ptr::read_unaligned((entry_addr + 8) as *const u64) as usize;
+        let mem_type = core::ptr::read_unaligned((entry_addr + 16) as *const u32);
 
         let kind = match mem_type {
             MB2_MEM_AVAILABLE => RegionKind::Usable,

--- a/security/src/crypto/csprng.rs
+++ b/security/src/crypto/csprng.rs
@@ -494,6 +494,7 @@ mod tests {
         assert_eq!(format!("{}", CsprngError::NotSeeded), "CSPRNG not seeded");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[test]
     fn csprng_seed_from_hardware() {
         let mut rng = Csprng::new();


### PR DESCRIPTION
## Summary

- Fix alignment UB in `parse_multiboot2()` and `parse_mb2_mmap_tag()`: use `core::ptr::read_unaligned()` instead of raw `*ptr` dereference for packed Multiboot2 fields
- Add `#[cfg_attr(miri, ignore)]` to `csprng_seed_from_hardware` test (Miri doesn't support `rdrand` inline asm)

## Context

Found by running `cargo miri test` locally as part of the safety-critical-tooling-v1 OpenSpec. The Multiboot2 boot info structure has u32/u64 fields at byte offsets that may not be naturally aligned — the test creates a `Vec<u8>` whose pointer isn't guaranteed to be 4/8-byte aligned.

## Test plan

- [x] `make test` passes (865 kernel + security tests)
- [x] `cargo miri test -p smallaios-kernel` — alignment UB resolved
- [x] `cargo miri test -p smallaios-security` — asm test properly ignored
- [ ] CI: all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)