### PR TITLE
feat(release): fix dry-run side effects, complete release-semver-v1

### DIFF
--- a/openspec/changes/release-semver-v1/tasks.md
+++ b/openspec/changes/release-semver-v1/tasks.md
@@ -9,7 +9,7 @@
 
 - [x] 2.1 Add `changelog` target to Makefile that invokes `git-cliff --config cliff.toml -o CHANGELOG.md`
 - [x] 2.2 Verify `make changelog` preserves existing versioned sections while updating the `[Unreleased]` section
-- [ ] 2.3 Verify `make changelog` produces empty `[Unreleased]` when no new commits exist since the last tag
+- [x] 2.3 Verify `make changelog` produces empty `[Unreleased]` when no new commits exist since the last tag
 
 ## 3. Version Bump Decision Script
 
@@ -23,8 +23,8 @@
 
 - [x] 4.1 Update `release.toml` pre-release-hook to run both `make test` and `make changelog` before the version bump commit
 - [x] 4.2 Create a `scripts/pre-release.sh` wrapper script that runs tests, generates changelog, and stages CHANGELOG.md for the version bump commit
-- [ ] 4.3 Verify that `make release-dry-run BUMP=patch` correctly invokes the updated hook chain without modifying files
-- [ ] 4.4 Verify that a hook failure (e.g., test failure) aborts the release without creating a commit or tag
+- [x] 4.3 Verify that `make release-dry-run BUMP=patch` correctly invokes the updated hook chain without modifying files
+- [x] 4.4 Verify that a hook failure (e.g., test failure) aborts the release without creating a commit or tag
 
 ## 5. Release Runbook
 
@@ -44,5 +44,5 @@
 
 - [x] 7.1 Test full release dry-run cycle: `suggest-release-bump.sh` -> `make changelog` -> `make release-dry-run BUMP=<suggested>`
 - [x] 7.2 Verify CHANGELOG.md output format matches Keep a Changelog with correct group headers and scope prefixes
-- [ ] 7.3 Verify release.yml changelog extraction (`awk` command) works with git-cliff-generated sections
-- [ ] 7.4 Verify the sync-back workflow: squash-merge develop->main, merge main->develop, confirm `git log develop..main` returns zero commits
+- [x] 7.3 Verify release.yml changelog extraction (`awk` command) works with git-cliff-generated sections
+- [x] 7.4 Verify the sync-back workflow: squash-merge develop->main, merge main->develop, confirm `git log develop..main` returns zero commits

--- a/release.toml
+++ b/release.toml
@@ -8,4 +8,4 @@ consolidate-commits = true                   # one commit for all 18 crates
 pre-release-commit-message = "chore: release v{{version}}"
 shared-version = true                        # all crates share one version
 allow-branch = ["main"]                      # Gitflow: only release from main
-pre-release-hook = ["bash", "-c", "ROOT=$(git rev-parse --show-toplevel) && make -C $ROOT test && make -C $ROOT changelog && git add $ROOT/CHANGELOG.md"]
+pre-release-hook = ["bash", "-c", "ROOT=$(git rev-parse --show-toplevel) && make -C $ROOT test && if [ \"${DRY_RUN:-}\" != \"true\" ]; then make -C $ROOT changelog && git add $ROOT/CHANGELOG.md; else echo 'Dry-run: skipping changelog generation'; fi"]


### PR DESCRIPTION
## Summary
- Fix pre-release hook to skip changelog generation during `cargo release` dry-run (respects `DRY_RUN` env var)
- Mark all 28/28 release-semver-v1 tasks complete

## Verified
- `make release-dry-run BUMP=patch` runs tests but doesn't modify CHANGELOG.md
- Hook failure (non-zero exit) aborts the release
- `awk` changelog extraction in `release.yml` correctly parses git-cliff output
- `git-cliff --unreleased` produces empty `[Unreleased]` when tag is at HEAD
- Sync-back workflow (squash-merge develop→main, merge main→develop) confirmed working

## Test plan
- [x] `make test` passes
- [x] `make release-dry-run BUMP=patch` leaves no modified files
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)