### PR TITLE
fix(clippy): clean up --all-targets warnings across workspace

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -179,6 +179,7 @@ test:
 # Run clippy lints
 clippy:
     {{cargo}} clippy \
+        --all-targets \
         -p smallaios-kernel \
         -p smallaios-security \
         -p smallaios-compute \

--- a/bench/benches/memory.rs
+++ b/bench/benches/memory.rs
@@ -14,11 +14,10 @@ fn heap_pool() -> Box<TensorPool> {
     let layout = std::alloc::Layout::new::<TensorPool>();
     // Safety: TensorPool is valid when zero-initialized (all entries inactive),
     // and we immediately call init() to set it up properly.
-    let ptr = unsafe {
+    unsafe {
         let p = std::alloc::alloc_zeroed(layout) as *mut TensorPool;
         Box::from_raw(p)
-    };
-    ptr
+    }
 }
 
 fn bench_tensor_alloc_free(c: &mut Criterion) {

--- a/bus/src/dds/cdr.rs
+++ b/bus/src/dds/cdr.rs
@@ -477,12 +477,12 @@ mod tests {
     fn test_f32_roundtrip() {
         let mut ser = CdrSerializer::new(Endianness::LittleEndian);
         ser.serialize_f32(0.0);
-        ser.serialize_f32(3.14);
+        ser.serialize_f32(2.5);
         ser.serialize_f32(-1.0e10);
         let data = ser.into_bytes();
         let mut de = CdrDeserializer::new(&data, Endianness::LittleEndian);
         assert_eq!(de.deserialize_f32().unwrap(), 0.0);
-        assert!((de.deserialize_f32().unwrap() - 3.14).abs() < 1e-6);
+        assert!((de.deserialize_f32().unwrap() - 2.5).abs() < 1e-6);
         assert_eq!(de.deserialize_f32().unwrap(), -1.0e10);
     }
 

--- a/bus/src/dds/loopback.rs
+++ b/bus/src/dds/loopback.rs
@@ -119,7 +119,7 @@ mod tests {
         // Step 1: CDR serialize payload
         let mut ser = CdrSerializer::new(Endianness::LittleEndian);
         ser.serialize_u32(42);
-        ser.serialize_f32(3.14);
+        ser.serialize_f32(2.5);
         let cdr_payload = ser.into_bytes();
 
         // Step 2: Writer publishes
@@ -149,7 +149,7 @@ mod tests {
         assert_eq!(samples.len(), 1);
         let mut de = CdrDeserializer::new(&samples[0], Endianness::LittleEndian);
         assert_eq!(de.deserialize_u32().unwrap(), 42);
-        assert_eq!(de.deserialize_f32().unwrap(), 3.14);
+        assert_eq!(de.deserialize_f32().unwrap(), 2.5);
     }
 
     // -----------------------------------------------------------------------

--- a/bus/src/mil1553/mode_code.rs
+++ b/bus/src/mil1553/mode_code.rs
@@ -446,7 +446,7 @@ mod tests {
         match result {
             ModeCodeResult::StatusWithData(_, data) => {
                 // The last command is the TransmitLastCommand itself
-                let expected: u16 = (5 << 11) | (1 << 10) | (0 << 5) | 0b10010;
+                let expected: u16 = (5 << 11) | (1 << 10) | 0b10010;
                 assert_eq!(data, expected);
             }
             _ => panic!("expected StatusWithData"),

--- a/compute/src/lib.rs
+++ b/compute/src/lib.rs
@@ -303,6 +303,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::clone_on_copy)]
     fn test_backend_type_clone_copy() {
         let a = BackendType::Metal;
         let b = a;
@@ -513,7 +514,7 @@ mod tests {
 
     #[test]
     fn test_cpu_fallback_default() {
-        let fb = CpuFallback::default();
+        let fb = CpuFallback;
         let info = fb.device_info();
         assert_eq!(info.backend_type, BackendType::Cpu);
     }

--- a/container/src/config.rs
+++ b/container/src/config.rs
@@ -361,8 +361,10 @@ mod tests {
 
     #[test]
     fn test_validate_zero_workers() {
-        let mut cfg = ContainerConfig::default();
-        cfg.num_workers = 0;
+        let cfg = ContainerConfig {
+            num_workers: 0,
+            ..ContainerConfig::default()
+        };
         assert_eq!(
             cfg.validate(),
             Err(ContainerError::InvalidConfig(String::from(
@@ -385,8 +387,10 @@ mod tests {
 
     #[test]
     fn test_validate_zero_max_memory() {
-        let mut cfg = ContainerConfig::default();
-        cfg.max_memory_mb = 0;
+        let cfg = ContainerConfig {
+            max_memory_mb: 0,
+            ..ContainerConfig::default()
+        };
         assert_eq!(
             cfg.validate(),
             Err(ContainerError::InvalidConfig(String::from(

--- a/container/src/integration.rs
+++ b/container/src/integration.rs
@@ -158,8 +158,8 @@ mod tests {
         let src_mac = MacAddress::new(0x02, 0x00, 0x00, 0x00, 0x00, 0x01);
         let dst_mac = MacAddress::new(0x02, 0x00, 0x00, 0x00, 0x00, 0x02);
         let frame = EthernetFrame {
-            dst_mac: dst_mac.clone(),
-            src_mac: src_mac.clone(),
+            dst_mac,
+            src_mac,
             ether_type: ETHERTYPE_IPV4,
             payload: Vec::from(&ip_bytes[..]),
         };
@@ -190,7 +190,7 @@ mod tests {
         let target_ip: [u8; 4] = [10, 0, 0, 2];
 
         // Create an ARP request.
-        let request = create_request(sender_mac.clone(), sender_ip, target_ip);
+        let request = create_request(sender_mac, sender_ip, target_ip);
         assert_eq!(request.operation, ArpOperation::Request);
         assert_eq!(request.sender_ip, sender_ip);
         assert_eq!(request.target_ip, target_ip);
@@ -202,12 +202,12 @@ mod tests {
 
         // Simulate a reply.
         let target_mac = MacAddress::new(0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x02);
-        let reply = create_reply(target_mac.clone(), target_ip, sender_mac.clone(), sender_ip);
+        let reply = create_reply(target_mac, target_ip, sender_mac, sender_ip);
         assert_eq!(reply.operation, ArpOperation::Reply);
 
         // Insert into ARP table.
         let mut arp_table = ArpTable::new();
-        let _ = arp_table.insert(target_ip, target_mac.clone(), 1000);
+        let _ = arp_table.insert(target_ip, target_mac, 1000);
         assert_eq!(arp_table.len(), 1);
         let resolved = arp_table.lookup(&target_ip);
         assert!(resolved.is_some());
@@ -271,7 +271,7 @@ mod tests {
         // Construct a tensor with the decoded type.
         let shape = TensorShape::new(vec![1, 3, 224, 224]);
         assert_eq!(shape.ndim(), 4);
-        assert_eq!(shape.total_elements(), 1 * 3 * 224 * 224);
+        assert_eq!(shape.total_elements(), 3 * 224 * 224);
         assert!(shape.is_valid());
 
         let tensor = Tensor::new(dtype, shape, String::from("input"));
@@ -287,8 +287,10 @@ mod tests {
         use smallaios_onnx_rt::optimizer::{optimize, OptimizationLevel, OptimizerConfig};
 
         // Build a simple graph: input -> Relu -> output.
-        let mut graph_proto = GraphProto::default();
-        graph_proto.name = String::from("test_graph");
+        let mut graph_proto = GraphProto {
+            name: String::from("test_graph"),
+            ..GraphProto::default()
+        };
         graph_proto.input.push(ValueInfoProto {
             name: String::from("X"),
             elem_type: 1, // Float

--- a/container/src/json.rs
+++ b/container/src/json.rs
@@ -398,7 +398,7 @@ mod tests {
 
     #[test]
     fn parse_negative_number() {
-        assert_eq!(JsonValue::parse("-3.14").unwrap(), JsonValue::Number(-3.14));
+        assert_eq!(JsonValue::parse("-2.5").unwrap(), JsonValue::Number(-2.5));
     }
 
     #[test]
@@ -503,7 +503,7 @@ mod tests {
     #[test]
     fn roundtrip_number() {
         assert_eq!(JsonValue::Number(42.0).serialize(), "42");
-        assert_eq!(JsonValue::Number(3.14).serialize(), "3.14");
+        assert_eq!(JsonValue::Number(2.5).serialize(), "2.5");
     }
 
     #[test]

--- a/kernel/src/mem/phys.rs
+++ b/kernel/src/mem/phys.rs
@@ -626,7 +626,7 @@ mod tests {
 
     /// Pad buffer to 4-byte alignment.
     fn pad4(buf: &mut Vec<u8>) {
-        while buf.len() % 4 != 0 {
+        while !buf.len().is_multiple_of(4) {
             buf.push(0);
         }
     }
@@ -858,7 +858,7 @@ mod tests {
         buf[tag_size_offset..tag_size_offset + 4].copy_from_slice(&tag_size.to_le_bytes());
 
         // Pad to 8-byte alignment before end tag
-        while buf.len() % 8 != 0 {
+        while !buf.len().is_multiple_of(8) {
             buf.push(0);
         }
 
@@ -924,6 +924,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::manual_c_str_literals)]
     fn test_cstr_helpers() {
         // cstr_len: simple string
         let s = b"hello\0";
@@ -954,6 +955,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::manual_c_str_literals)]
     fn test_is_memory_node() {
         // Exact "memory" (length 6)
         assert!(unsafe { is_memory_node(b"memory\0".as_ptr(), 6) });
@@ -1045,7 +1047,7 @@ mod tests {
         buf[tag_size_offset..tag_size_offset + 4].copy_from_slice(&tag_size.to_le_bytes());
 
         // Pad to 8-byte alignment
-        while buf.len() % 8 != 0 {
+        while !buf.len().is_multiple_of(8) {
             buf.push(0);
         }
 
@@ -1091,7 +1093,7 @@ mod tests {
         let tag_size = (buf.len() - tag_start) as u32;
         buf[tag_size_offset..tag_size_offset + 4].copy_from_slice(&tag_size.to_le_bytes());
 
-        while buf.len() % 8 != 0 {
+        while !buf.len().is_multiple_of(8) {
             buf.push(0);
         }
 

--- a/kernel/src/syscall/memory.rs
+++ b/kernel/src/syscall/memory.rs
@@ -388,7 +388,7 @@ mod tests {
         let args = SyscallArgs::new(0x00, [4096, 0, 0, 0, 0, 0]);
         let result = sys_mem_alloc(&args);
         // Allocator not initialized, so expect OutOfMemory or a valid pointer
-        assert!(result < 0 || result > 0);
+        assert!(result != 0);
     }
 
     #[test]
@@ -396,7 +396,7 @@ mod tests {
         let args = SyscallArgs::new(0x00, [4096, 16, 0, 0, 0, 0]);
         let result = sys_mem_alloc(&args);
         // Allocator not initialized, will return an error
-        assert!(result < 0 || result > 0);
+        assert!(result != 0);
     }
 
     #[test]

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -2338,7 +2338,7 @@ mod tests {
     #[test]
     fn test_mcdc_syscall_error_from_i64_boundaries() {
         // All defined values
-        for val in 0..=-16i64 {
+        for val in (-16i64..=0).rev() {
             let result = SyscallError::from_i64(val);
             assert!(result.is_some(), "value {} should be a valid error", val);
         }

--- a/onnx-rt/src/byte_io.rs
+++ b/onnx-rt/src/byte_io.rs
@@ -136,10 +136,10 @@ mod tests {
     #[test]
     fn test_f64_round_trip() {
         let mut buf = vec![0u8; 16];
-        write_f64(&mut buf, 0, 3.14159);
-        write_f64(&mut buf, 1, -2.71828);
-        assert_eq!(read_f64(&buf, 0), 3.14159);
-        assert_eq!(read_f64(&buf, 1), -2.71828);
+        write_f64(&mut buf, 0, 1.23456);
+        write_f64(&mut buf, 1, -9.87654);
+        assert_eq!(read_f64(&buf, 0), 1.23456);
+        assert_eq!(read_f64(&buf, 1), -9.87654);
     }
 
     #[test]

--- a/onnx-rt/src/gemm.rs
+++ b/onnx-rt/src/gemm.rs
@@ -390,11 +390,11 @@ mod tests {
             let mut a = vec![0.0f32; m * k];
             let mut b = vec![0.0f32; k * n];
             // Fill with deterministic values
-            for i in 0..a.len() {
-                a[i] = ((i % 7) as f32 - 3.0) * 0.1;
+            for (i, v) in a.iter_mut().enumerate() {
+                *v = ((i % 7) as f32 - 3.0) * 0.1;
             }
-            for i in 0..b.len() {
-                b[i] = ((i % 11) as f32 - 5.0) * 0.1;
+            for (i, v) in b.iter_mut().enumerate() {
+                *v = ((i % 11) as f32 - 5.0) * 0.1;
             }
 
             let mut c_opt = vec![0.0f32; m * n];
@@ -428,11 +428,11 @@ mod tests {
             let k = size;
             let mut a = vec![1.0f32; m * k];
             let mut b = vec![1.0f32; k * n];
-            for i in 0..a.len() {
-                a[i] = (i % 100) as f32 * 0.01;
+            for (i, v) in a.iter_mut().enumerate() {
+                *v = (i % 100) as f32 * 0.01;
             }
-            for i in 0..b.len() {
-                b[i] = (i % 100) as f32 * 0.01;
+            for (i, v) in b.iter_mut().enumerate() {
+                *v = (i % 100) as f32 * 0.01;
             }
             let mut c = vec![0.0f32; m * n];
 
@@ -522,11 +522,11 @@ mod tests {
         let pool = CorePool::new(4);
         let mut a = vec![0.0f32; n * n];
         let mut b = vec![0.0f32; n * n];
-        for i in 0..a.len() {
-            a[i] = ((i % 7) as f32 - 3.0) * 0.1;
+        for (i, v) in a.iter_mut().enumerate() {
+            *v = ((i % 7) as f32 - 3.0) * 0.1;
         }
-        for i in 0..b.len() {
-            b[i] = ((i % 11) as f32 - 5.0) * 0.1;
+        for (i, v) in b.iter_mut().enumerate() {
+            *v = ((i % 11) as f32 - 5.0) * 0.1;
         }
         let mut c_seq = vec![0.0f32; n * n];
         let mut c_par = vec![0.0f32; n * n];
@@ -551,11 +551,11 @@ mod tests {
         let pool = CorePool::new(4);
         let mut a = vec![0.0f32; n * n];
         let mut b = vec![0.0f32; n * n];
-        for i in 0..a.len() {
-            a[i] = ((i % 13) as f32 - 6.0) * 0.05;
+        for (i, v) in a.iter_mut().enumerate() {
+            *v = ((i % 13) as f32 - 6.0) * 0.05;
         }
-        for i in 0..b.len() {
-            b[i] = ((i % 17) as f32 - 8.0) * 0.05;
+        for (i, v) in b.iter_mut().enumerate() {
+            *v = ((i % 17) as f32 - 8.0) * 0.05;
         }
         let mut c_seq = vec![0.0f32; n * n];
         let mut c_par = vec![0.0f32; n * n];
@@ -580,11 +580,11 @@ mod tests {
         let pool = CorePool::new(4);
         let mut a = vec![0.0f32; n * n];
         let mut b = vec![0.0f32; n * n];
-        for i in 0..a.len() {
-            a[i] = ((i % 19) as f32 - 9.0) * 0.02;
+        for (i, v) in a.iter_mut().enumerate() {
+            *v = ((i % 19) as f32 - 9.0) * 0.02;
         }
-        for i in 0..b.len() {
-            b[i] = ((i % 23) as f32 - 11.0) * 0.02;
+        for (i, v) in b.iter_mut().enumerate() {
+            *v = ((i % 23) as f32 - 11.0) * 0.02;
         }
         let mut c_seq = vec![0.0f32; n * n];
         let mut c_par = vec![0.0f32; n * n];
@@ -620,11 +620,11 @@ mod tests {
         let pool = CorePool::new(2);
         let mut a = vec![0.0f32; n * n];
         let mut b = vec![0.0f32; n * n];
-        for i in 0..a.len() {
-            a[i] = ((i % 7) as f32 - 3.0) * 0.1;
+        for (i, v) in a.iter_mut().enumerate() {
+            *v = ((i % 7) as f32 - 3.0) * 0.1;
         }
-        for i in 0..b.len() {
-            b[i] = ((i % 11) as f32 - 5.0) * 0.1;
+        for (i, v) in b.iter_mut().enumerate() {
+            *v = ((i % 11) as f32 - 5.0) * 0.1;
         }
         let mut c_seq = vec![0.0f32; n * n];
         let mut c_par = vec![0.0f32; n * n];

--- a/onnx-rt/src/operators.rs
+++ b/onnx-rt/src/operators.rs
@@ -3212,7 +3212,7 @@ mod tests {
         let sum: f32 = prob_vals.iter().sum();
         assert!((sum - 1.0).abs() < 1e-4, "sum = {}, expected ~1.0", sum);
         for &p in &prob_vals {
-            assert!(p >= 0.0 && p <= 1.0 + 1e-6);
+            assert!((0.0..=1.0 + 1e-6).contains(&p));
         }
     }
 
@@ -3986,10 +3986,8 @@ mod tests {
             let mut d = alloc::vec![0u8; 2 * 8];
             let b1 = 1i64.to_le_bytes();
             let b3 = 3i64.to_le_bytes();
-            for j in 0..8 {
-                d[j] = b1[j];
-                d[8 + j] = b3[j];
-            }
+            d[..8].copy_from_slice(&b1);
+            d[8..16].copy_from_slice(&b3);
             d
         };
         let indices = Tensor {

--- a/onnx-rt/src/protobuf.rs
+++ b/onnx-rt/src/protobuf.rs
@@ -1332,11 +1332,11 @@ mod tests {
 
     #[test]
     fn packed_f64_single() {
-        let data = 2.718f64.to_le_bytes();
+        let data = 1.25f64.to_le_bytes();
         let mut dec = ProtoDecoder::new(&data);
         let result = dec.read_packed_f64(8).unwrap();
         assert_eq!(result.len(), 1);
-        assert!((result[0] - 2.718).abs() < 1e-10);
+        assert!((result[0] - 1.25).abs() < 1e-10);
     }
 
     #[test]
@@ -1697,12 +1697,12 @@ mod tests {
         let mut data = Vec::new();
         data.extend(encode_varint_field(2, 11)); // DOUBLE
         let mut double_bytes = Vec::new();
-        double_bytes.extend(3.14f64.to_le_bytes());
+        double_bytes.extend(2.5f64.to_le_bytes());
         data.extend(encode_length_delimited(10, &double_bytes));
         let tensor = decode_tensor(&data).unwrap();
         assert_eq!(tensor.data_type, 11);
         assert_eq!(tensor.double_data.len(), 1);
-        assert!((tensor.double_data[0] - 3.14).abs() < 1e-10);
+        assert!((tensor.double_data[0] - 2.5).abs() < 1e-10);
     }
 
     #[test]

--- a/onnx-rt/tests/integration_inference.rs
+++ b/onnx-rt/tests/integration_inference.rs
@@ -78,14 +78,14 @@ fn session_no_optimization_config() {
 fn tensor_with_float32_shape() {
     let shape = TensorShape::new(vec![1, 3, 224, 224]);
     assert_eq!(shape.ndim(), 4);
-    assert_eq!(shape.total_elements(), 1 * 3 * 224 * 224);
+    assert_eq!(shape.total_elements(), 3 * 224 * 224);
     assert!(shape.is_valid());
 
     let tensor = Tensor::new(DataType::Float, shape, String::from("images"));
     assert_eq!(tensor.data_type, DataType::Float);
     assert_eq!(tensor.name, "images");
     assert!(tensor.is_empty());
-    assert_eq!(tensor.byte_size(), 1 * 3 * 224 * 224 * 4);
+    assert_eq!(tensor.byte_size(), 3 * 224 * 224 * 4);
 }
 
 #[test]

--- a/security/src/audit/retention.rs
+++ b/security/src/audit/retention.rs
@@ -196,7 +196,7 @@ mod tests {
     fn should_not_retain_past_window() {
         let policy = RetentionPolicy::for_deployment(DeploymentClass::Edge);
         let now = 10 * NS_PER_DAY;
-        let batch_ts = 1 * NS_PER_DAY;
+        let batch_ts = NS_PER_DAY;
         assert!(!policy.should_retain(batch_ts, now)); // 9 days old > 7 day limit
     }
 
@@ -206,7 +206,7 @@ mod tests {
         let now = 20 * NS_PER_DAY;
         // Batches at day 1, 5, 10, 15, 18
         let timestamps = [
-            1 * NS_PER_DAY,
+            NS_PER_DAY,
             5 * NS_PER_DAY,
             10 * NS_PER_DAY,
             15 * NS_PER_DAY,
@@ -226,12 +226,7 @@ mod tests {
         let policy = RetentionPolicy::for_deployment(DeploymentClass::Edge).with_max_batches(3);
         let now = 5 * NS_PER_DAY;
         // All within retention window, but too many
-        let timestamps = [
-            1 * NS_PER_DAY,
-            2 * NS_PER_DAY,
-            3 * NS_PER_DAY,
-            4 * NS_PER_DAY,
-        ];
+        let timestamps = [NS_PER_DAY, 2 * NS_PER_DAY, 3 * NS_PER_DAY, 4 * NS_PER_DAY];
         let prune = policy.batches_to_prune(&timestamps, now, 4);
         assert_eq!(prune, 1); // 4 - 3 = 1 excess
     }

--- a/security/src/audit/syslog.rs
+++ b/security/src/audit/syslog.rs
@@ -353,7 +353,12 @@ mod tests {
             };
             let severity = entry_severity(&entry);
             let p = pri(severity);
-            assert!(p >= 160 && p <= 167, "PRI {} out of range for {:?}", p, et);
+            assert!(
+                (160..=167).contains(&p),
+                "PRI {} out of range for {:?}",
+                p,
+                et
+            );
         }
     }
 }

--- a/security/src/crypto/ed25519.rs
+++ b/security/src/crypto/ed25519.rs
@@ -838,7 +838,7 @@ mod tests {
         let mut msg = alloc::string::String::new();
         for i in 0..24 {
             if a[i] != py_limbs[i] {
-                write!(&mut msg, "a[{}]: rust={} py={}\n", i, a[i], py_limbs[i]).unwrap();
+                writeln!(&mut msg, "a[{}]: rust={} py={}", i, a[i], py_limbs[i]).unwrap();
                 bad = true;
             }
         }

--- a/security/src/crypto/hybrid.rs
+++ b/security/src/crypto/hybrid.rs
@@ -718,8 +718,8 @@ mod tests {
     #[test]
     fn hybrid_kem_keygen_encaps_decaps_roundtrip() {
         let mut seed = [0u8; 96];
-        for i in 0..96 {
-            seed[i] = i as u8;
+        for (i, b) in seed.iter_mut().enumerate() {
+            *b = i as u8;
         }
         let kp = hybrid_kem_keygen(&seed).expect("keygen should succeed");
         assert_eq!(kp.public_key.len(), HYBRID_KEM_PK_LEN);

--- a/security/src/gate_noop.rs
+++ b/security/src/gate_noop.rs
@@ -100,7 +100,7 @@ mod tests {
 
     #[test]
     fn noop_default() {
-        let gate = SecurityGate::default();
+        let gate = SecurityGate;
         assert_eq!(gate.check_noop(), GateVerdict::Allowed);
     }
 }

--- a/security/src/monitoring/latency_stats.rs
+++ b/security/src/monitoring/latency_stats.rs
@@ -310,7 +310,7 @@ mod tests {
         }
         let p50 = tracker.p50_ns();
         // Median of 10,20,...,1000 should be around 500-510
-        assert!(p50 >= 490 && p50 <= 510, "p50={}", p50);
+        assert!((490..=510).contains(&p50), "p50={}", p50);
     }
 
     #[test]
@@ -321,7 +321,7 @@ mod tests {
         }
         let p99 = tracker.p99_ns();
         // p99 of 1..=1000 should be around 990
-        assert!(p99 >= 985 && p99 <= 1000, "p99={}", p99);
+        assert!((985..=1000).contains(&p99), "p99={}", p99);
     }
 
     #[test]
@@ -332,7 +332,7 @@ mod tests {
         }
         let p999 = tracker.p999_ns();
         // p999 of 1..=1000 should be very close to 1000
-        assert!(p999 >= 998 && p999 <= 1000, "p999={}", p999);
+        assert!((998..=1000).contains(&p999), "p999={}", p999);
     }
 
     #[test]

--- a/security/src/supply_chain/attestation.rs
+++ b/security/src/supply_chain/attestation.rs
@@ -258,7 +258,6 @@ mod tests {
         );
         let payload = att.signing_payload();
         assert!(!payload.is_empty());
-        assert!(payload.len() > 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix accumulated clippy warnings in test code, benches, and examples. Add `--all-targets` to the `Justfile` clippy recipe so CI catches future warnings in test code.

Pure cleanup — zero behavior changes.

## Test plan
- [x] cargo clippy --all-targets clean (workspace, excluding HAL crates)
- [x] just clippy clean
- [x] just test passes (one pre-existing SIGILL in csprng_seed_from_hardware unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)