### PR TITLE
test(container): add full inference pipeline E2E test

### DIFF
--- a/container/src/handlers.rs
+++ b/container/src/handlers.rs
@@ -10,6 +10,9 @@
 use crate::json::JsonValue;
 use crate::model_manager::ModelManager;
 use crate::server::{HttpRequest, HttpResponse};
+use smallaios_onnx_rt::session::{InferenceInput, Session};
+use smallaios_onnx_rt::tensor::{DataType, Tensor, TensorShape};
+use std::collections::BTreeMap;
 
 /// POST /v1/inference — run inference on a named model.
 ///
@@ -55,6 +58,215 @@ pub fn handle_inference(req: &HttpRequest, manager: &ModelManager) -> HttpRespon
             &format!(r#"{{"error":"model '{}' not found"}}"#, model_name),
         ),
     }
+}
+
+/// POST /v1/inference — execute inference against a pre-initialised session.
+///
+/// Parses the JSON body into a model name and a set of named input
+/// tensors, looks up the pre-loaded [`Session`] in `sessions`, runs
+/// [`Session::run`], and serialises the resulting output tensors back
+/// into the wire format documented in `docs/inference-bus.md`:
+///
+/// ```json
+/// {"outputs":{"y":{"shape":[3,4,5],"dtype":"float32","data":[...]}},
+///  "timing_us":12}
+/// ```
+///
+/// Returns 400 on bad JSON / shape mismatches, 404 on unknown model,
+/// and 500 on executor failure.
+pub fn handle_inference_exec(
+    req: &HttpRequest,
+    sessions: &BTreeMap<String, Session>,
+) -> HttpResponse {
+    if req.method != "POST" {
+        return HttpResponse::json(405, r#"{"error":"method not allowed, use POST"}"#);
+    }
+
+    let body_str = core::str::from_utf8(&req.body).unwrap_or("");
+    let json = match JsonValue::parse(body_str) {
+        Ok(j) => j,
+        Err(e) => {
+            return HttpResponse::json(400, &format!(r#"{{"error":"invalid JSON: {}"}}"#, e));
+        }
+    };
+
+    let model_name = match json.get("model").and_then(|v| v.as_str()) {
+        Some(n) => n,
+        None => return HttpResponse::json(400, r#"{"error":"missing 'model' field"}"#),
+    };
+
+    let session = match sessions.get(model_name) {
+        Some(s) => s,
+        None => {
+            return HttpResponse::json(
+                404,
+                &format!(r#"{{"error":"model '{}' not found"}}"#, model_name),
+            );
+        }
+    };
+
+    let inputs_json = match json.get("inputs") {
+        Some(v) => v,
+        None => return HttpResponse::json(400, r#"{"error":"missing 'inputs' field"}"#),
+    };
+    let input_entries = match inputs_json.as_object() {
+        Some(o) => o,
+        None => return HttpResponse::json(400, r#"{"error":"'inputs' must be an object"}"#),
+    };
+
+    // Build typed InferenceInput list from the JSON object.
+    let mut inference_inputs: Vec<InferenceInput> = Vec::with_capacity(input_entries.len());
+    for (name, val) in input_entries {
+        let tensor = match json_to_tensor(name, val) {
+            Ok(t) => t,
+            Err(e) => {
+                return HttpResponse::json(
+                    400,
+                    &format!(r#"{{"error":"invalid input '{}': {}"}}"#, name, e),
+                );
+            }
+        };
+        inference_inputs.push(InferenceInput {
+            name: name.clone(),
+            tensor,
+        });
+    }
+
+    let start = std::time::Instant::now();
+    let outputs = match session.run(&inference_inputs) {
+        Ok(o) => o,
+        Err(e) => {
+            // Invalid-input errors from the executor should surface as 400,
+            // everything else as 500.
+            let msg = format!("{}", e);
+            let lower = msg.to_lowercase();
+            let status = if lower.contains("invalid")
+                || lower.contains("shape")
+                || lower.contains("mismatch")
+            {
+                400
+            } else {
+                500
+            };
+            return HttpResponse::json(
+                status,
+                &format!(
+                    r#"{{"error":"inference failed: {}"}}"#,
+                    msg.replace('"', "\\\"")
+                ),
+            );
+        }
+    };
+    let elapsed_us = start.elapsed().as_micros();
+
+    HttpResponse::json(200, &serialize_outputs(&outputs, elapsed_us))
+}
+
+/// Convert a JSON `{"shape":[..],"dtype":"float32","data":[..]}` object
+/// into a typed `Tensor`. Only `float32` is supported for now — add
+/// more dtypes as the runtime grows.
+fn json_to_tensor(name: &str, val: &JsonValue) -> Result<Tensor, String> {
+    let shape_json = val
+        .get("shape")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| "missing or non-array 'shape'".to_string())?;
+    let dtype = val
+        .get("dtype")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "missing 'dtype'".to_string())?;
+    let data_json = val
+        .get("data")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| "missing or non-array 'data'".to_string())?;
+
+    if dtype != "float32" {
+        return Err(format!(
+            "unsupported dtype '{}': only float32 is wired",
+            dtype
+        ));
+    }
+
+    let dims: Vec<i64> = shape_json
+        .iter()
+        .map(|d| {
+            d.as_f64()
+                .map(|f| f as i64)
+                .ok_or_else(|| "shape entries must be numbers".to_string())
+        })
+        .collect::<Result<_, _>>()?;
+
+    let shape = TensorShape::new(dims);
+    let expected_elems = shape.total_elements();
+    if data_json.len() != expected_elems {
+        return Err(format!(
+            "data length {} does not match shape element count {}",
+            data_json.len(),
+            expected_elems
+        ));
+    }
+
+    let mut raw_data = Vec::with_capacity(expected_elems * 4);
+    for v in data_json {
+        let f = v
+            .as_f64()
+            .ok_or_else(|| "data entries must be numbers".to_string())? as f32;
+        raw_data.extend_from_slice(&f.to_le_bytes());
+    }
+
+    let mut tensor = Tensor::new(DataType::Float, shape, name.to_string());
+    tensor.raw_data = raw_data;
+    Ok(tensor)
+}
+
+/// Serialise a slice of `InferenceOutput` (all assumed float32) into
+/// the JSON wire format.
+fn serialize_outputs(
+    outputs: &[smallaios_onnx_rt::session::InferenceOutput],
+    elapsed_us: u128,
+) -> String {
+    let mut buf = String::from("{\"outputs\":{");
+    for (i, out) in outputs.iter().enumerate() {
+        if i > 0 {
+            buf.push(',');
+        }
+        buf.push('"');
+        buf.push_str(&out.name);
+        buf.push_str("\":{\"shape\":[");
+        for (j, d) in out.tensor.shape.dims.iter().enumerate() {
+            if j > 0 {
+                buf.push(',');
+            }
+            buf.push_str(&d.to_string());
+        }
+        buf.push_str("],\"dtype\":\"");
+        buf.push_str(out.tensor.data_type.name());
+        buf.push_str("\",\"data\":[");
+
+        // Serialise the raw_data as little-endian f32 array. Non-float
+        // tensors fall back to an empty array — callers only wire
+        // float32 for now.
+        if out.tensor.data_type == DataType::Float {
+            let n = out.tensor.raw_data.len() / 4;
+            for k in 0..n {
+                if k > 0 {
+                    buf.push(',');
+                }
+                let bytes = [
+                    out.tensor.raw_data[k * 4],
+                    out.tensor.raw_data[k * 4 + 1],
+                    out.tensor.raw_data[k * 4 + 2],
+                    out.tensor.raw_data[k * 4 + 3],
+                ];
+                let v = f32::from_le_bytes(bytes);
+                buf.push_str(&format!("{}", v));
+            }
+        }
+        buf.push_str("]}");
+    }
+    buf.push_str("},\"timing_us\":");
+    buf.push_str(&elapsed_us.to_string());
+    buf.push('}');
+    buf
 }
 
 /// GET /v1/models — list all loaded models.

--- a/container/src/main.rs
+++ b/container/src/main.rs
@@ -61,6 +61,12 @@ fn main() {
     // Wrap manager in Arc for sharing with route closures.
     let manager = Arc::new(manager);
 
+    // Build the inference session map for the HTTP handler. This
+    // parses each .onnx file once at startup so request handling is
+    // pure dispatch. Failures are logged by `load_sessions` itself.
+    let http_sessions: Arc<BTreeMap<String, Session>> = Arc::new(load_sessions(&manager));
+    println!("HTTP inference sessions ready: {}", http_sessions.len());
+
     // Bus/dataflow runner startup (zenoh/dds/can/none).
     let runner_handles =
         enable_dataflow_runner(&bus_backend, Arc::clone(&manager), Arc::clone(&shutdown));
@@ -75,11 +81,20 @@ fn main() {
         }
     };
 
-    // Inference
-    let mgr = Arc::clone(&manager);
-    http.route_fn("POST", "/v1/inference", move |req| {
-        handlers::handle_inference(req, &mgr)
-    });
+    // Inference — use the real executor-backed handler if any session
+    // loaded, otherwise fall back to the metadata-only handler that
+    // still reports 404 / 400 for missing or malformed requests.
+    if !http_sessions.is_empty() {
+        let sessions = Arc::clone(&http_sessions);
+        http.route_fn("POST", "/v1/inference", move |req| {
+            handlers::handle_inference_exec(req, &sessions)
+        });
+    } else {
+        let mgr = Arc::clone(&manager);
+        http.route_fn("POST", "/v1/inference", move |req| {
+            handlers::handle_inference(req, &mgr)
+        });
+    }
 
     // Model registry — specific model must be registered before the list
     // route so the longer prefix matches first.

--- a/container/tests/test_full_inference_e2e.rs
+++ b/container/tests/test_full_inference_e2e.rs
@@ -1,0 +1,368 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end test for the full inference pipeline.
+//!
+//! This test exercises every layer of the stack:
+//! 1. Write a real ONNX model to disk
+//! 2. Start the container binary as a subprocess
+//! 3. Wait for the HTTP server to become healthy
+//! 4. Query the model registry to verify the model loaded
+//! 5. POST a JSON inference request
+//! 6. Verify the Relu output values are correct
+//!
+//! If this test fails, something is broken in: protobuf parser,
+//! graph executor, operator dispatch, model manager, HTTP server,
+//! JSON parser, or the inference handler.
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::Path;
+use std::process::{Child, Command};
+use std::time::{Duration, Instant};
+
+/// Real ONNX Relu model bytes — copied verbatim from
+/// `onnx-rt/tests/test_real_model.rs::RELU_MODEL`.
+///
+/// Shape: `[3, 4, 5]` (60 elements). Input name `"x"`, output `"y"`.
+const RELU_MODEL: &[u8] = &[
+    0x08, 0x07, 0x12, 0x0c, 0x62, 0x61, 0x63, 0x6b, 0x65, 0x6e, 0x64, 0x2d, 0x74, 0x65, 0x73, 0x74,
+    0x3a, 0x4b, 0x0a, 0x0c, 0x0a, 0x01, 0x78, 0x12, 0x01, 0x79, 0x22, 0x04, 0x52, 0x65, 0x6c, 0x75,
+    0x12, 0x09, 0x74, 0x65, 0x73, 0x74, 0x5f, 0x72, 0x65, 0x6c, 0x75, 0x5a, 0x17, 0x0a, 0x01, 0x78,
+    0x12, 0x12, 0x0a, 0x10, 0x08, 0x01, 0x12, 0x0c, 0x0a, 0x02, 0x08, 0x03, 0x0a, 0x02, 0x08, 0x04,
+    0x0a, 0x02, 0x08, 0x05, 0x62, 0x17, 0x0a, 0x01, 0x79, 0x12, 0x12, 0x0a, 0x10, 0x08, 0x01, 0x12,
+    0x0c, 0x0a, 0x02, 0x08, 0x03, 0x0a, 0x02, 0x08, 0x04, 0x0a, 0x02, 0x08, 0x05, 0x42, 0x04, 0x0a,
+    0x00, 0x10, 0x09,
+];
+
+// ---------------------------------------------------------------------------
+// Test helpers — subprocess + HTTP
+// ---------------------------------------------------------------------------
+
+/// RAII guard that kills the child process on drop so a panicking test
+/// never leaks a background container.
+struct ChildGuard(Child);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Pick an OS-assigned free port by binding to port 0, reading the
+/// assigned port, and dropping the listener.
+fn pick_free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind 127.0.0.1:0");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+/// Spawn the `smallaios-container` binary with the given model directory
+/// and port. Uses the CARGO_BIN_EXE env var so the path is always
+/// correct under `cargo test`, `cargo llvm-cov`, and friends.
+fn start_container(model_dir: &Path, port: u16) -> Child {
+    Command::new(env!("CARGO_BIN_EXE_smallaios-container"))
+        .env("SMALLAIOS_PORT", port.to_string())
+        .env(
+            "SMALLAIOS_MODEL_DIR",
+            model_dir.to_string_lossy().to_string(),
+        )
+        .env("SMALLAIOS_GPU_BACKEND", "cpu")
+        .env("SMALLAIOS_BUS_BACKEND", "none")
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("failed to start smallaios-container")
+}
+
+/// Poll `/healthz` until it returns 200 OK or the timeout expires.
+fn wait_for_healthz(addr: &str, timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if let Ok(mut stream) = TcpStream::connect(addr) {
+            let _ = stream.set_read_timeout(Some(Duration::from_millis(500)));
+            let _ = stream.set_write_timeout(Some(Duration::from_millis(500)));
+            let req = "GET /healthz HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+            if stream.write_all(req.as_bytes()).is_ok() {
+                let _ = stream.shutdown(std::net::Shutdown::Write);
+                let mut buf = String::new();
+                if stream.read_to_string(&mut buf).is_ok() && buf.contains("200 OK") {
+                    return true;
+                }
+            }
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    false
+}
+
+/// Send a raw HTTP request string and return the full response.
+fn http_request(addr: &str, request: &str) -> String {
+    let mut stream = TcpStream::connect(addr).expect("connect failed");
+    stream.set_read_timeout(Some(Duration::from_secs(10))).ok();
+    stream.set_write_timeout(Some(Duration::from_secs(5))).ok();
+    stream.write_all(request.as_bytes()).expect("write failed");
+    stream.flush().ok();
+    stream.shutdown(std::net::Shutdown::Write).ok();
+    let mut response = String::new();
+    let _ = stream.read_to_string(&mut response);
+    response
+}
+
+fn http_get(addr: &str, path: &str) -> String {
+    let req = format!(
+        "GET {} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+        path
+    );
+    http_request(addr, &req)
+}
+
+fn http_post(addr: &str, path: &str, body: &str) -> String {
+    let req = format!(
+        "POST {} HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        path,
+        body.len(),
+        body
+    );
+    http_request(addr, &req)
+}
+
+// ---------------------------------------------------------------------------
+// JSON helpers — hand-built to avoid a serde_json dep in the tests.
+// ---------------------------------------------------------------------------
+
+/// Build an inference request body matching the wire format documented
+/// in `docs/inference-bus.md`:
+///
+/// ```json
+/// {"model":"relu","inputs":{"x":{"shape":[3,4,5],"dtype":"float32","data":[...]}}}
+/// ```
+fn build_inference_request(model: &str, input_name: &str, shape: &[i64], data: &[f32]) -> String {
+    let shape_str = shape
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    let data_str = data
+        .iter()
+        .map(|v| format!("{}", v))
+        .collect::<Vec<_>>()
+        .join(",");
+    format!(
+        r#"{{"model":"{}","inputs":{{"{}":{{"shape":[{}],"dtype":"float32","data":[{}]}}}}}}"#,
+        model, input_name, shape_str, data_str
+    )
+}
+
+/// Extract the body (after the blank line) from a raw HTTP response.
+fn response_body(response: &str) -> &str {
+    response
+        .find("\r\n\r\n")
+        .map(|i| &response[i + 4..])
+        .unwrap_or(response)
+}
+
+/// Pull the first `"data":[...]` float array that appears after the
+/// named output key in the JSON response body. Good enough for the
+/// Relu single-output case — we don't need a full JSON parser here.
+fn extract_output_data(response: &str, output_name: &str) -> Vec<f32> {
+    let body = response_body(response);
+    let needle = format!("\"{}\"", output_name);
+    let start_idx = body.find(&needle).unwrap_or_else(|| {
+        panic!(
+            "output name {:?} not found in response body: {}",
+            output_name, body
+        )
+    });
+    let after_name = &body[start_idx..];
+    let data_idx = after_name
+        .find("\"data\"")
+        .expect("data field not found after output name");
+    let after_data = &after_name[data_idx..];
+    let bracket_start = after_data
+        .find('[')
+        .expect("opening bracket not found after data field");
+    let bracket_end = after_data[bracket_start..]
+        .find(']')
+        .expect("closing bracket not found after data field");
+    let nums = &after_data[bracket_start + 1..bracket_start + bracket_end];
+    if nums.trim().is_empty() {
+        return Vec::new();
+    }
+    nums.split(',')
+        .map(|s| {
+            s.trim()
+                .parse::<f32>()
+                .expect("non-numeric element in data array")
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests for the JSON helpers
+// ---------------------------------------------------------------------------
+
+#[test]
+fn build_inference_request_shape_matches_wire_format() {
+    let body = build_inference_request("relu", "x", &[1, 2], &[1.0, 2.0, 3.0, 4.0]);
+    assert!(body.contains(r#""model":"relu""#));
+    assert!(body.contains(r#""inputs":{"x":"#));
+    assert!(body.contains(r#""shape":[1,2]"#));
+    assert!(body.contains(r#""dtype":"float32""#));
+    assert!(body.contains(r#""data":[1,2,3,4]"#));
+}
+
+#[test]
+fn extract_output_data_parses_simple_response() {
+    let resp = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n\
+                {\"outputs\":{\"y\":{\"shape\":[3],\"dtype\":\"float32\",\"data\":[0,1.5,2]}}}";
+    let out = extract_output_data(resp, "y");
+    assert_eq!(out, vec![0.0, 1.5, 2.0]);
+}
+
+#[test]
+fn extract_output_data_handles_negative_and_exponent() {
+    let resp = "HTTP/1.1 200 OK\r\n\r\n{\"y\":{\"data\":[-1,2.5,1e2]}}";
+    let out = extract_output_data(resp, "y");
+    assert_eq!(out, vec![-1.0, 2.5, 100.0]);
+}
+
+// ---------------------------------------------------------------------------
+// Full end-to-end inference pipeline
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_full_inference_pipeline_relu() {
+    // 1. Setup: write model file
+    let tmp = tempfile::tempdir().expect("tempdir failed");
+    let model_path = tmp.path().join("relu.onnx");
+    std::fs::write(&model_path, RELU_MODEL).expect("write model failed");
+
+    // 2. Start container
+    let port = pick_free_port();
+    let child = start_container(tmp.path(), port);
+    let _guard = ChildGuard(child);
+
+    let addr = format!("127.0.0.1:{}", port);
+
+    // 3. Wait for server to become healthy
+    assert!(
+        wait_for_healthz(&addr, Duration::from_secs(10)),
+        "container did not become healthy within 10s"
+    );
+
+    // 4. Verify model is listed
+    let models_response = http_get(&addr, "/v1/models");
+    assert!(
+        models_response.contains("200 OK"),
+        "models endpoint did not return 200: {}",
+        models_response
+    );
+    assert!(
+        models_response.contains("\"relu\""),
+        "model 'relu' not in /v1/models response: {}",
+        models_response
+    );
+
+    // 5. Build inference request. The Relu model expects shape [3, 4, 5]
+    //    (60 elements). Fill with -30..29 so every element exercises
+    //    either the negative or positive branch of Relu.
+    let input_data: Vec<f32> = (0..60).map(|i| (i as f32) - 30.0).collect();
+    let request_body = build_inference_request("relu", "x", &[3, 4, 5], &input_data);
+
+    // 6. POST inference
+    let response = http_post(&addr, "/v1/inference", &request_body);
+    assert!(
+        response.contains("200 OK"),
+        "inference did not return 200: {}",
+        response
+    );
+
+    // 7. Verify output: Relu of [-30..29] should be max(0, x)
+    let output_data = extract_output_data(&response, "y");
+    assert_eq!(
+        output_data.len(),
+        60,
+        "expected 60 output values, got {}: {}",
+        output_data.len(),
+        response
+    );
+    for (i, &val) in output_data.iter().enumerate() {
+        let input_val = (i as f32) - 30.0;
+        let expected = input_val.max(0.0);
+        assert!(
+            (val - expected).abs() < 1e-5,
+            "mismatch at index {}: got {} expected {}",
+            i,
+            val,
+            expected
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Negative tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_inference_unknown_model_returns_404() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("relu.onnx"), RELU_MODEL).unwrap();
+
+    let port = pick_free_port();
+    let child = start_container(tmp.path(), port);
+    let _guard = ChildGuard(child);
+    let addr = format!("127.0.0.1:{}", port);
+    assert!(
+        wait_for_healthz(&addr, Duration::from_secs(10)),
+        "container did not become healthy"
+    );
+
+    let body = build_inference_request("nonexistent", "x", &[3, 4, 5], &[0.0; 60]);
+    let response = http_post(&addr, "/v1/inference", &body);
+    assert!(response.contains("404"), "expected 404, got: {}", response);
+}
+
+#[test]
+fn test_inference_malformed_json_returns_400() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("relu.onnx"), RELU_MODEL).unwrap();
+
+    let port = pick_free_port();
+    let child = start_container(tmp.path(), port);
+    let _guard = ChildGuard(child);
+    let addr = format!("127.0.0.1:{}", port);
+    assert!(
+        wait_for_healthz(&addr, Duration::from_secs(10)),
+        "container did not become healthy"
+    );
+
+    let response = http_post(&addr, "/v1/inference", "not json {{{");
+    assert!(response.contains("400"), "expected 400, got: {}", response);
+}
+
+#[test]
+fn test_inference_invalid_input_shape_returns_400() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("relu.onnx"), RELU_MODEL).unwrap();
+
+    let port = pick_free_port();
+    let child = start_container(tmp.path(), port);
+    let _guard = ChildGuard(child);
+    let addr = format!("127.0.0.1:{}", port);
+    assert!(
+        wait_for_healthz(&addr, Duration::from_secs(10)),
+        "container did not become healthy"
+    );
+
+    // Shape [2, 2] = 4 elements but we send 10 — should be rejected as 400.
+    let body = build_inference_request("relu", "x", &[2, 2], &[0.0; 10]);
+    let response = http_post(&addr, "/v1/inference", &body);
+    assert!(
+        response.contains("400"),
+        "expected 400 for shape/data mismatch, got: {}",
+        response
+    );
+}

--- a/docs/inference-bus.md
+++ b/docs/inference-bus.md
@@ -168,6 +168,62 @@ Both surfaces share the same loaded models, the same request path inside
 the ONNX runtime, and the same Prometheus metric counters — the bus
 simply bypasses JSON parsing and HTTP framing for hot-loop use cases.
 
+## End-to-End Test Pattern
+
+The canonical proof that the HTTP surface is wired end-to-end lives in
+`container/tests/test_full_inference_e2e.rs`. That test:
+
+1. Writes a known-good ONNX Relu model (shape `[3, 4, 5]`, 60 elements)
+   to a temp directory.
+2. Spawns the `smallaios-container` binary as a subprocess pointing at
+   that directory, on an OS-assigned free port, with
+   `SMALLAIOS_BUS_BACKEND=none`.
+3. Polls `/healthz` until it returns 200 OK or a 10-second budget
+   expires.
+4. Asserts `/v1/models` lists the `relu` model.
+5. POSTs a JSON inference request of the form:
+   ```json
+   {
+     "model": "relu",
+     "inputs": {
+       "x": {
+         "shape": [3, 4, 5],
+         "dtype": "float32",
+         "data": [-30.0, -29.0, ..., 29.0]
+       }
+     }
+   }
+   ```
+6. Verifies the response has `200 OK`, extracts the `y` output data
+   from the JSON, and checks that every element equals
+   `max(0, input_element)`.
+
+The response shape is:
+```json
+{
+  "outputs": {
+    "y": {
+      "shape": [3, 4, 5],
+      "dtype": "float32",
+      "data": [0, 0, ..., 29]
+    }
+  },
+  "timing_us": 12
+}
+```
+
+Because this test spans protobuf decode, session initialisation, graph
+executor dispatch, the `Relu` operator, the HTTP server, JSON parse,
+handler dispatch, and JSON serialise, a regression in *any* of those
+layers will surface here first. Run it with:
+
+```
+cargo test -p smallaios-container --test test_full_inference_e2e
+```
+
+The test is not `#[ignore]`d and is executed by default in CI alongside
+every other container integration test.
+
 ## See Also
 
 - `ipc/src/inference_proto.rs` — binary wire format definition

--- a/openspec/changes/model-inference-e2e-test-v1/.openspec.yaml
+++ b/openspec/changes/model-inference-e2e-test-v1/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-11

--- a/openspec/changes/model-inference-e2e-test-v1/design.md
+++ b/openspec/changes/model-inference-e2e-test-v1/design.md
@@ -1,0 +1,127 @@
+## Context
+
+The full inference pipeline now works in isolation. We have these tested pieces:
+
+| Component | Test file | What it covers |
+|-----------|-----------|----------------|
+| Protobuf decode | `onnx-rt/src/protobuf.rs` (in-file tests) | Parses individual ONNX messages |
+| Real model decode | `onnx-rt/tests/test_real_model.rs` | Decodes a real Relu .onnx + runs Session::run |
+| Operator execution | `onnx-rt/src/operators.rs` (in-file tests) | Each of 29 operators independently |
+| Graph executor | `onnx-rt/src/executor.rs` (in-file tests) | Operator dispatch with mock graphs |
+| HTTP routes | `container/tests/e2e_server.rs` | HTTP endpoints with empty model manager |
+| Bus runner | `container/tests/e2e_bus.rs` | Runner spawn with empty manager |
+
+What's missing: the end-to-end path that combines them all in one test. The container's `inference_handler` parses the JSON request, looks up the session in the model manager, calls `Session::run()`, and serializes the response — but no test exercises this path with a real model loaded from the filesystem.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One test that goes: write .onnx file → start container → POST JSON → verify response
+- Use the same minimal Relu model from `test_real_model.rs` for known-good behavior
+- Subprocess-based (not in-process) to validate the actual binary
+- Catches regressions in any layer (parser, executor, HTTP, JSON, model manager)
+- Runs in CI without needing real hardware
+
+**Non-Goals:**
+- Multiple models — one is enough to prove the pipeline
+- GPU backend testing — that's a separate concern
+- Bus backend testing — already covered by `e2e_bus.rs`
+- Performance benchmarking — separate work
+- Loading from actual ONNX zoo URLs — keep tests offline
+
+## Decisions
+
+### D1: Subprocess-based Test, Not In-process
+
+The test starts the actual `smallaios-container` binary as a subprocess via `Command::new(env!("CARGO_BIN_EXE_smallaios-container"))`. This catches:
+- Binary startup issues
+- Env var parsing
+- HTTP server binding
+- Real model loading from disk
+- Real signal handling for shutdown
+
+Trade-off: subprocess tests are slower than in-process. Acceptable for one comprehensive test.
+
+### D2: Reuse Existing Relu Model Bytes
+
+The bytes for a minimal valid Relu ONNX file are already in `onnx-rt/tests/test_real_model.rs::RELU_MODEL`. Copy these into the new test (or extract to a shared module). The model expects a tensor of shape `[3, 4, 5]` (60 elements).
+
+### D3: Hand-rolled JSON for Test Requests
+
+The container's JSON parser is hand-written and the request format is documented. The test can construct JSON requests and parse responses without depending on `serde_json`. Format:
+
+```json
+{
+  "model": "relu",
+  "inputs": {
+    "x": {
+      "shape": [3, 4, 5],
+      "dtype": "float32",
+      "data": [-30.0, -29.0, ..., 29.0]
+    }
+  }
+}
+```
+
+Response:
+```json
+{
+  "outputs": {
+    "y": {
+      "shape": [3, 4, 5],
+      "dtype": "float32",
+      "data": [0.0, 0.0, ..., 29.0]
+    }
+  },
+  "timing_ms": 0.5
+}
+```
+
+### D4: Test Structure
+
+```rust
+#[test]
+fn test_full_inference_pipeline() {
+    // 1. Setup
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let model_path = tmp_dir.path().join("relu.onnx");
+    std::fs::write(&model_path, RELU_MODEL).unwrap();
+    
+    // 2. Start container
+    let port = pick_free_port();
+    let mut child = start_container(&tmp_dir.path(), port);
+    let _guard = ChildGuard(&mut child);  // RAII cleanup
+    
+    let addr = format!("127.0.0.1:{}", port);
+    wait_for_healthz(&addr, Duration::from_secs(5)).expect("server didn't start");
+    
+    // 3. Verify model is listed
+    let models_response = http_get(&addr, "/v1/models");
+    assert!(models_response.contains("\"relu\""));
+    
+    // 4. POST inference request
+    let request_body = build_inference_json("relu", "x", &[3,4,5], &input_data);
+    let response = http_post(&addr, "/v1/inference", &request_body);
+    
+    // 5. Parse response and verify
+    assert!(response.contains("\"y\""));
+    let output_data = extract_output_data(&response);
+    // Relu: negatives become 0, positives stay
+    for (i, val) in output_data.iter().enumerate() {
+        let expected = (i as f32 - 30.0).max(0.0);
+        assert!((val - expected).abs() < 1e-6);
+    }
+}
+```
+
+The test should be marked **NOT `#[ignore]`** so it runs in CI by default.
+
+## Risks / Trade-offs
+
+**[Risk] Race condition between server startup and request** — Mitigation: poll `/healthz` until 200 with timeout, then proceed.
+
+**[Risk] Port collision** — Mitigation: bind to port 0 first to get an OS-assigned port, OR use a high random port (50000+) and retry on bind failure.
+
+**[Risk] Subprocess leakage on test panic** — Mitigation: RAII guard struct that calls `child.kill()` in Drop. Existing `e2e_bus.rs` and `e2e_server.rs` already have this pattern — copy it.
+
+**[Trade-off] JSON parsing in tests is verbose** — Acceptable since the test is one-off and the verbose parsing doubles as documentation of the wire format.

--- a/openspec/changes/model-inference-e2e-test-v1/proposal.md
+++ b/openspec/changes/model-inference-e2e-test-v1/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+We have all the pieces for end-to-end ONNX inference:
+- Protobuf parser that loads real .onnx files (PR #60, #61)
+- 29 CPU operators (PR #55)
+- Graph executor (PR #55)
+- HTTP inference server (PR #59)
+- Inference handler that calls Session::run (PR #59)
+
+But there's no test that exercises the **whole stack together**: write a real .onnx file to a model directory, start the container, POST a JSON inference request via HTTP, parse the JSON response, verify the output values are correct. The closest we have is `test_real_model.rs` (decoder + executor) and `e2e_server.rs` (HTTP routes with stub model manager). Neither runs the entire pipeline.
+
+This change adds the missing test that proves SmallAIOS works as advertised: `docker run → POST inference → correct result`.
+
+## What Changes
+
+- Add a new integration test `container/tests/test_full_inference_e2e.rs` that:
+  - Creates a temp directory with a real Relu .onnx model (using the bytes from `onnx-rt/tests/test_real_model.rs`)
+  - Starts the container binary as a subprocess with `SMALLAIOS_MODEL_DIR` pointing at the temp dir
+  - Waits for `/healthz` to return 200 (server ready)
+  - Verifies `/v1/models` lists the loaded model
+  - POSTs a JSON inference request to `/v1/inference` with input tensor data
+  - Parses the JSON response and verifies the Relu output values
+  - Cleans up the subprocess on test exit
+- Add helper functions for JSON encoding/decoding of inference requests in tests
+- Document the E2E test pattern in `docs/inference-bus.md` for future test additions
+
+## Capabilities
+
+### Modified Capabilities
+- `container-inference-server`: Add E2E validation that the full HTTP → load_model → Session::run → output → JSON pipeline works
+
+## Impact
+
+- **Code:** New `container/tests/test_full_inference_e2e.rs` (~200 lines), no source changes
+- **Behavior:** No new functionality — pure validation of existing capability
+- **CI:** New e2e test runs as part of `cargo test -p smallaios-container`
+- **Documentation:** Updates to inference-bus.md showing the test pattern

--- a/openspec/changes/model-inference-e2e-test-v1/specs/container-inference-server/spec.md
+++ b/openspec/changes/model-inference-e2e-test-v1/specs/container-inference-server/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Full Inference Pipeline E2E Test
+The container test suite SHALL include an end-to-end test that exercises the complete inference pipeline from .onnx file on disk to JSON inference response.
+
+#### Scenario: Real Relu model produces correct output
+- **WHEN** the test writes a real ONNX Relu model file to a temp directory
+- **AND** starts the container binary as a subprocess pointing at that directory
+- **AND** waits for `/healthz` to return 200
+- **AND** POSTs a `/v1/inference` request with input tensor [-30.0, ..., 29.0]
+- **THEN** the response MUST contain output tensor data
+- **AND** all negative input values MUST map to 0.0
+- **AND** all non-negative input values MUST map to themselves
+
+#### Scenario: Model registry lists the loaded model
+- **WHEN** the test queries `/v1/models` after server startup
+- **THEN** the response MUST list the relu model with its metadata
+- **AND** MUST indicate the model is loaded
+
+#### Scenario: Container shutdown is clean
+- **WHEN** the test ends and the subprocess guard's Drop runs
+- **THEN** the container subprocess MUST be terminated
+- **AND** no zombie processes MUST remain

--- a/openspec/changes/model-inference-e2e-test-v1/tasks.md
+++ b/openspec/changes/model-inference-e2e-test-v1/tasks.md
@@ -1,41 +1,58 @@
 ## 1. Test Helper Setup
 
-- [ ] 1.1 Create `container/tests/test_full_inference_e2e.rs`
-- [ ] 1.2 Copy `RELU_MODEL` bytes from `onnx-rt/tests/test_real_model.rs`
-- [ ] 1.3 Add `ChildGuard` RAII struct (or copy from `e2e_bus.rs`)
-- [ ] 1.4 Add `pick_free_port()` helper using `TcpListener::bind("127.0.0.1:0")`
-- [ ] 1.5 Add `start_container(model_dir, port)` helper
-- [ ] 1.6 Add `wait_for_healthz(addr, timeout)` helper
-- [ ] 1.7 Add `http_get(addr, path)` and `http_post(addr, path, body)` helpers
+- [x] 1.1 Create `container/tests/test_full_inference_e2e.rs`
+- [x] 1.2 Copy `RELU_MODEL` bytes from `onnx-rt/tests/test_real_model.rs`
+- [x] 1.3 Add `ChildGuard` RAII struct (or copy from `e2e_bus.rs`)
+- [x] 1.4 Add `pick_free_port()` helper using `TcpListener::bind("127.0.0.1:0")`
+- [x] 1.5 Add `start_container(model_dir, port)` helper
+- [x] 1.6 Add `wait_for_healthz(addr, timeout)` helper
+- [x] 1.7 Add `http_get(addr, path)` and `http_post(addr, path, body)` helpers
 
 ## 2. JSON Helpers
 
-- [ ] 2.1 Add `build_inference_request_json(model, input_name, shape, data)` that constructs the JSON request body
-- [ ] 2.2 Add `extract_output_data(response_body, output_name)` that parses the JSON response and returns Vec<f32>
-- [ ] 2.3 Use simple string/regex parsing to avoid serde_json dependency
-- [ ] 2.4 Unit tests for the JSON helpers
+- [x] 2.1 Add `build_inference_request_json(model, input_name, shape, data)` that constructs the JSON request body
+- [x] 2.2 Add `extract_output_data(response_body, output_name)` that parses the JSON response and returns Vec<f32>
+- [x] 2.3 Use simple string/regex parsing to avoid serde_json dependency
+- [x] 2.4 Unit tests for the JSON helpers
 
 ## 3. End-to-End Test
 
-- [ ] 3.1 Implement `test_full_inference_pipeline_relu` test
-- [ ] 3.2 Test flow: write model → start container → wait healthz → list models → POST inference → verify Relu output
-- [ ] 3.3 Test should NOT be `#[ignore]` — runs in CI by default
-- [ ] 3.4 Verify all 60 output values match expected Relu output
+- [x] 3.1 Implement `test_full_inference_pipeline_relu` test
+- [x] 3.2 Test flow: write model → start container → wait healthz → list models → POST inference → verify Relu output
+- [x] 3.3 Test should NOT be `#[ignore]` — runs in CI by default
+- [x] 3.4 Verify all 60 output values match expected Relu output
 
 ## 4. Negative Tests
 
-- [ ] 4.1 Add `test_inference_unknown_model_returns_404`
-- [ ] 4.2 Add `test_inference_invalid_input_shape_returns_400`
-- [ ] 4.3 Add `test_inference_malformed_json_returns_400`
+- [x] 4.1 Add `test_inference_unknown_model_returns_404`
+- [x] 4.2 Add `test_inference_invalid_input_shape_returns_400`
+- [x] 4.3 Add `test_inference_malformed_json_returns_400`
 
 ## 5. Documentation
 
-- [ ] 5.1 Update `docs/inference-bus.md` with a section on the E2E test pattern
-- [ ] 5.2 Document the JSON request/response format with the working test as canonical example
+- [x] 5.1 Update `docs/inference-bus.md` with a section on the E2E test pattern
+- [x] 5.2 Document the JSON request/response format with the working test as canonical example
 
 ## 6. Validation
 
-- [ ] 6.1 `just fmt` clean
-- [ ] 6.2 `just clippy --all-targets` clean
-- [ ] 6.3 `cargo test -p smallaios-container --test test_full_inference_e2e` passes
-- [ ] 6.4 Full `just test` workspace clean
+- [x] 6.1 `just fmt` clean
+- [x] 6.2 `just clippy --all-targets` clean
+- [x] 6.3 `cargo test -p smallaios-container --test test_full_inference_e2e` passes
+- [x] 6.4 Full `just test` workspace clean (container package — all 84 unit + 7 e2e + 4 bus + 5 integration_boot tests pass)
+
+## 7. Handler Wiring (discovered during implementation)
+
+The handler at `container/src/handlers.rs::handle_inference` was a
+metadata-only stub — it looked up the model by name and returned a
+placeholder `"inference endpoint ready, model execution pending"`
+message without ever calling `Session::run`. The E2E test exposed this
+gap immediately, so as part of landing the test we:
+
+- [x] 7.1 Add `handle_inference_exec(req, &BTreeMap<String, Session>)` that actually runs the executor
+- [x] 7.2 Parse `inputs` JSON objects into typed `Tensor` with `float32` support
+- [x] 7.3 Serialise `InferenceOutput` tensors back into the documented response format
+- [x] 7.4 Build a shared `Arc<BTreeMap<String, Session>>` in `main.rs` at startup and wire it into the `/v1/inference` route
+- [x] 7.5 Fall back to the metadata handler when no sessions loaded so unit-test coverage for the stub path is preserved
+
+Additional dtypes beyond `float32`, multi-input graphs, and richer
+error taxonomies remain future work.

--- a/openspec/changes/model-inference-e2e-test-v1/tasks.md
+++ b/openspec/changes/model-inference-e2e-test-v1/tasks.md
@@ -1,0 +1,41 @@
+## 1. Test Helper Setup
+
+- [ ] 1.1 Create `container/tests/test_full_inference_e2e.rs`
+- [ ] 1.2 Copy `RELU_MODEL` bytes from `onnx-rt/tests/test_real_model.rs`
+- [ ] 1.3 Add `ChildGuard` RAII struct (or copy from `e2e_bus.rs`)
+- [ ] 1.4 Add `pick_free_port()` helper using `TcpListener::bind("127.0.0.1:0")`
+- [ ] 1.5 Add `start_container(model_dir, port)` helper
+- [ ] 1.6 Add `wait_for_healthz(addr, timeout)` helper
+- [ ] 1.7 Add `http_get(addr, path)` and `http_post(addr, path, body)` helpers
+
+## 2. JSON Helpers
+
+- [ ] 2.1 Add `build_inference_request_json(model, input_name, shape, data)` that constructs the JSON request body
+- [ ] 2.2 Add `extract_output_data(response_body, output_name)` that parses the JSON response and returns Vec<f32>
+- [ ] 2.3 Use simple string/regex parsing to avoid serde_json dependency
+- [ ] 2.4 Unit tests for the JSON helpers
+
+## 3. End-to-End Test
+
+- [ ] 3.1 Implement `test_full_inference_pipeline_relu` test
+- [ ] 3.2 Test flow: write model → start container → wait healthz → list models → POST inference → verify Relu output
+- [ ] 3.3 Test should NOT be `#[ignore]` — runs in CI by default
+- [ ] 3.4 Verify all 60 output values match expected Relu output
+
+## 4. Negative Tests
+
+- [ ] 4.1 Add `test_inference_unknown_model_returns_404`
+- [ ] 4.2 Add `test_inference_invalid_input_shape_returns_400`
+- [ ] 4.3 Add `test_inference_malformed_json_returns_400`
+
+## 5. Documentation
+
+- [ ] 5.1 Update `docs/inference-bus.md` with a section on the E2E test pattern
+- [ ] 5.2 Document the JSON request/response format with the working test as canonical example
+
+## 6. Validation
+
+- [ ] 6.1 `just fmt` clean
+- [ ] 6.2 `just clippy --all-targets` clean
+- [ ] 6.3 `cargo test -p smallaios-container --test test_full_inference_e2e` passes
+- [ ] 6.4 Full `just test` workspace clean


### PR DESCRIPTION
## Summary

Add the missing end-to-end test that proves the v0.2.0 stack works as advertised. Writes a real ONNX Relu model to disk, starts the container binary, POSTs a JSON inference request, and verifies the output values are correct (`Relu(x) = max(0, x)` across 60 elements).

If anything in protobuf / executor / HTTP / JSON / handler breaks, this test catches it.

While adding the test, we discovered that `handle_inference` was never actually wired to the executor — it only looked up the model by name and returned a placeholder string. This PR also fixes that:

- New `handle_inference_exec` in `container/src/handlers.rs` parses typed inputs, calls `Session::run`, and serialises `InferenceOutput` tensors back into the documented JSON wire format.
- `main.rs` now builds an `Arc<BTreeMap<String, Session>>` at startup and routes `/v1/inference` to the real handler (falls back to the metadata stub if no sessions loaded so existing unit tests still cover that path).
- `docs/inference-bus.md` documents the E2E test pattern and the request/response wire format.

## Test plan
- [x] `test_full_inference_pipeline_relu` passes
- [x] `test_inference_unknown_model_returns_404` passes
- [x] `test_inference_malformed_json_returns_400` passes
- [x] `test_inference_invalid_input_shape_returns_400` passes
- [x] All existing container tests still pass (84 bin unit tests, 5 integration_boot, 4 e2e_bus)
- [x] `cargo clippy -p smallaios-container --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean

Generated with Claude Code