### PR TITLE
feat(onnx-rt): add Tier 2 operators (math, compare, activations, recurrent, transformer, quantized)

### DIFF
--- a/container/src/integration.rs
+++ b/container/src/integration.rs
@@ -327,13 +327,13 @@ mod tests {
         assert_eq!(result.nodes_fused, 0);
     }
 
-    /// Verify the operator registry covers all 29 tier-1 operators.
+    /// Verify the operator registry covers Tier 1 (29) plus Tier 2 (36) ops.
     #[test]
     fn test_operator_registry_covers_tier1() {
         use smallaios_onnx_rt::operators::{OpKind, OperatorRegistry};
 
         let registry = OperatorRegistry::new();
-        assert_eq!(registry.supported_count(), 29);
+        assert_eq!(registry.supported_count(), 65);
 
         // Verify critical operators are present.
         let critical_ops = [

--- a/onnx-rt/src/executor.rs
+++ b/onnx-rt/src/executor.rs
@@ -13,6 +13,7 @@ use crate::byte_io::{self, allocate_tensor_data, I64_SIZE};
 use crate::graph::ExecutionGraph;
 use crate::onnx_types::{AttributeProto, AttributeType, TensorProto};
 use crate::operators::{self, OpError, OpKind};
+use crate::ops;
 #[cfg(test)]
 use crate::profile::NullTimeSource;
 use crate::profile::{
@@ -270,6 +271,15 @@ fn dispatch_node(
     let kind =
         OpKind::parse_str(op_type).ok_or_else(|| OpError::UnsupportedOp(String::from(op_type)))?;
 
+    // Multi-output ops bypass the single-tensor wrapper.
+    match kind {
+        OpKind::Split => return dispatch_split(inputs, attrs),
+        OpKind::LSTM => return dispatch_lstm(inputs, attrs),
+        OpKind::GRU => return dispatch_gru(inputs, attrs),
+        OpKind::RNN => return dispatch_rnn(inputs, attrs),
+        _ => {}
+    }
+
     let result = match kind {
         OpKind::Add | OpKind::Sub | OpKind::Mul | OpKind::Div | OpKind::MatMul | OpKind::Gemm => {
             dispatch_arithmetic(kind, inputs, attrs)
@@ -296,9 +306,317 @@ fn dispatch_node(
         | OpKind::Pad
         | OpKind::Cast
         | OpKind::Clip => dispatch_shape(kind, inputs, attrs),
+        OpKind::Pow
+        | OpKind::Sqrt
+        | OpKind::Exp
+        | OpKind::Log
+        | OpKind::Erf
+        | OpKind::Neg
+        | OpKind::Abs
+        | OpKind::Floor
+        | OpKind::Ceil
+        | OpKind::Round => dispatch_math(kind, inputs, attrs),
+        OpKind::Equal
+        | OpKind::NotEqual
+        | OpKind::Less
+        | OpKind::LessOrEqual
+        | OpKind::Greater
+        | OpKind::GreaterOrEqual
+        | OpKind::Where
+        | OpKind::Min
+        | OpKind::Max
+        | OpKind::Not => dispatch_compare(kind, inputs, attrs),
+        OpKind::Gelu | OpKind::LeakyRelu | OpKind::Elu | OpKind::Swish => {
+            dispatch_composite_activation(kind, inputs, attrs)
+        }
+        OpKind::Expand | OpKind::Tile | OpKind::OneHot | OpKind::Einsum => {
+            dispatch_transformer(kind, inputs, attrs)
+        }
+        OpKind::QuantizeLinear
+        | OpKind::DequantizeLinear
+        | OpKind::QLinearMatMul
+        | OpKind::QLinearConv => dispatch_quantized(kind, inputs, attrs),
+        // Multi-output kinds handled above and returned early.
+        OpKind::Split | OpKind::LSTM | OpKind::GRU | OpKind::RNN => unreachable!(),
     };
 
     result.map(|t| alloc::vec![t])
+}
+
+// ---------------------------------------------------------------------------
+// Tier 2 dispatch helpers
+// ---------------------------------------------------------------------------
+
+/// Dispatches Tier 2 element-wise math primitives.
+fn dispatch_math(
+    kind: OpKind,
+    inputs: &[Option<&Tensor>],
+    _attrs: &[AttributeProto],
+) -> Result<Tensor, OpError> {
+    match kind {
+        OpKind::Pow => {
+            let base = require_input(inputs, 0, "Pow")?;
+            let exp = require_input(inputs, 1, "Pow")?;
+            ops::math::op_pow(base, exp)
+        }
+        OpKind::Sqrt => ops::math::op_sqrt(require_input(inputs, 0, "Sqrt")?),
+        OpKind::Exp => ops::math::op_exp(require_input(inputs, 0, "Exp")?),
+        OpKind::Log => ops::math::op_log(require_input(inputs, 0, "Log")?),
+        OpKind::Erf => ops::math::op_erf(require_input(inputs, 0, "Erf")?),
+        OpKind::Neg => ops::math::op_neg(require_input(inputs, 0, "Neg")?),
+        OpKind::Abs => ops::math::op_abs(require_input(inputs, 0, "Abs")?),
+        OpKind::Floor => ops::math::op_floor(require_input(inputs, 0, "Floor")?),
+        OpKind::Ceil => ops::math::op_ceil(require_input(inputs, 0, "Ceil")?),
+        OpKind::Round => ops::math::op_round(require_input(inputs, 0, "Round")?),
+        _ => Err(OpError::UnsupportedOp(String::from("math"))),
+    }
+}
+
+/// Dispatches Tier 2 comparison/selection operators.
+fn dispatch_compare(
+    kind: OpKind,
+    inputs: &[Option<&Tensor>],
+    _attrs: &[AttributeProto],
+) -> Result<Tensor, OpError> {
+    match kind {
+        OpKind::Equal => {
+            let a = require_input(inputs, 0, "Equal")?;
+            let b = require_input(inputs, 1, "Equal")?;
+            ops::compare::op_equal(a, b)
+        }
+        OpKind::NotEqual => {
+            let a = require_input(inputs, 0, "NotEqual")?;
+            let b = require_input(inputs, 1, "NotEqual")?;
+            ops::compare::op_not_equal(a, b)
+        }
+        OpKind::Less => {
+            let a = require_input(inputs, 0, "Less")?;
+            let b = require_input(inputs, 1, "Less")?;
+            ops::compare::op_less(a, b)
+        }
+        OpKind::LessOrEqual => {
+            let a = require_input(inputs, 0, "LessOrEqual")?;
+            let b = require_input(inputs, 1, "LessOrEqual")?;
+            ops::compare::op_less_or_equal(a, b)
+        }
+        OpKind::Greater => {
+            let a = require_input(inputs, 0, "Greater")?;
+            let b = require_input(inputs, 1, "Greater")?;
+            ops::compare::op_greater(a, b)
+        }
+        OpKind::GreaterOrEqual => {
+            let a = require_input(inputs, 0, "GreaterOrEqual")?;
+            let b = require_input(inputs, 1, "GreaterOrEqual")?;
+            ops::compare::op_greater_or_equal(a, b)
+        }
+        OpKind::Where => {
+            let cond = require_input(inputs, 0, "Where")?;
+            let x = require_input(inputs, 1, "Where")?;
+            let y = require_input(inputs, 2, "Where")?;
+            ops::compare::op_where(cond, x, y)
+        }
+        OpKind::Min => {
+            let a = require_input(inputs, 0, "Min")?;
+            let b = require_input(inputs, 1, "Min")?;
+            ops::compare::op_min(a, b)
+        }
+        OpKind::Max => {
+            let a = require_input(inputs, 0, "Max")?;
+            let b = require_input(inputs, 1, "Max")?;
+            ops::compare::op_max(a, b)
+        }
+        OpKind::Not => ops::compare::op_not(require_input(inputs, 0, "Not")?),
+        _ => Err(OpError::UnsupportedOp(String::from("compare"))),
+    }
+}
+
+/// Dispatches Tier 2 composite activations.
+fn dispatch_composite_activation(
+    kind: OpKind,
+    inputs: &[Option<&Tensor>],
+    attrs: &[AttributeProto],
+) -> Result<Tensor, OpError> {
+    match kind {
+        OpKind::Gelu => ops::activations::op_gelu(require_input(inputs, 0, "Gelu")?),
+        OpKind::LeakyRelu => {
+            let x = require_input(inputs, 0, "LeakyRelu")?;
+            let alpha = get_attr_float(attrs, "alpha", 0.01);
+            ops::activations::op_leaky_relu(x, alpha)
+        }
+        OpKind::Elu => {
+            let x = require_input(inputs, 0, "Elu")?;
+            let alpha = get_attr_float(attrs, "alpha", 1.0);
+            ops::activations::op_elu(x, alpha)
+        }
+        OpKind::Swish => ops::activations::op_swish(require_input(inputs, 0, "Swish")?),
+        _ => Err(OpError::UnsupportedOp(String::from("composite-activation"))),
+    }
+}
+
+/// Dispatches transformer building-block ops (Expand/Tile/OneHot/Einsum).
+fn dispatch_transformer(
+    kind: OpKind,
+    inputs: &[Option<&Tensor>],
+    attrs: &[AttributeProto],
+) -> Result<Tensor, OpError> {
+    match kind {
+        OpKind::Expand => {
+            let x = require_input(inputs, 0, "Expand")?;
+            let shape_tensor = require_input(inputs, 1, "Expand")?;
+            let shape = read_i64_tensor(shape_tensor);
+            ops::transformer::op_expand(x, &shape)
+        }
+        OpKind::Tile => {
+            let x = require_input(inputs, 0, "Tile")?;
+            let repeats_tensor = require_input(inputs, 1, "Tile")?;
+            let repeats = read_i64_tensor(repeats_tensor);
+            ops::transformer::op_tile(x, &repeats)
+        }
+        OpKind::OneHot => {
+            let indices = require_input(inputs, 0, "OneHot")?;
+            let depth_tensor = require_input(inputs, 1, "OneHot")?;
+            let values = require_input(inputs, 2, "OneHot")?;
+            let depth = read_i64_tensor(depth_tensor)
+                .first()
+                .copied()
+                .ok_or_else(|| OpError::InvalidAttribute(String::from("OneHot depth missing")))?;
+            let axis = get_attr_int(attrs, "axis", -1);
+            ops::transformer::op_one_hot(indices, depth, values, axis)
+        }
+        OpKind::Einsum => {
+            let equation_bytes = attrs
+                .iter()
+                .find(|a| a.name == "equation")
+                .map(|a| a.s.as_slice())
+                .ok_or_else(|| {
+                    OpError::InvalidAttribute(String::from("Einsum requires 'equation'"))
+                })?;
+            let equation = core::str::from_utf8(equation_bytes)
+                .map_err(|_| OpError::InvalidAttribute(String::from("Einsum equation utf-8")))?;
+            let refs: Vec<&Tensor> = inputs.iter().filter_map(|i| *i).collect();
+            ops::transformer::op_einsum(equation, &refs)
+        }
+        _ => Err(OpError::UnsupportedOp(String::from("transformer"))),
+    }
+}
+
+/// Dispatches quantized operators.
+fn dispatch_quantized(
+    kind: OpKind,
+    inputs: &[Option<&Tensor>],
+    _attrs: &[AttributeProto],
+) -> Result<Tensor, OpError> {
+    match kind {
+        OpKind::QuantizeLinear => {
+            let x = require_input(inputs, 0, "QuantizeLinear")?;
+            let scale = require_input(inputs, 1, "QuantizeLinear")?;
+            let zero_point = optional_input(inputs, 2);
+            ops::quantized::op_quantize_linear(x, scale, zero_point)
+        }
+        OpKind::DequantizeLinear => {
+            let x = require_input(inputs, 0, "DequantizeLinear")?;
+            let scale = require_input(inputs, 1, "DequantizeLinear")?;
+            let zero_point = optional_input(inputs, 2);
+            ops::quantized::op_dequantize_linear(x, scale, zero_point)
+        }
+        OpKind::QLinearMatMul => {
+            let a = require_input(inputs, 0, "QLinearMatMul")?;
+            let a_scale = require_input(inputs, 1, "QLinearMatMul")?;
+            let a_zp = require_input(inputs, 2, "QLinearMatMul")?;
+            let b = require_input(inputs, 3, "QLinearMatMul")?;
+            let b_scale = require_input(inputs, 4, "QLinearMatMul")?;
+            let b_zp = require_input(inputs, 5, "QLinearMatMul")?;
+            let y_scale = require_input(inputs, 6, "QLinearMatMul")?;
+            let y_zp = require_input(inputs, 7, "QLinearMatMul")?;
+            ops::quantized::op_qlinear_matmul(a, a_scale, a_zp, b, b_scale, b_zp, y_scale, y_zp)
+        }
+        OpKind::QLinearConv => {
+            let x = require_input(inputs, 0, "QLinearConv")?;
+            let x_scale = require_input(inputs, 1, "QLinearConv")?;
+            let x_zp = require_input(inputs, 2, "QLinearConv")?;
+            let w = require_input(inputs, 3, "QLinearConv")?;
+            let w_scale = require_input(inputs, 4, "QLinearConv")?;
+            let w_zp = require_input(inputs, 5, "QLinearConv")?;
+            let y_scale = require_input(inputs, 6, "QLinearConv")?;
+            let y_zp = require_input(inputs, 7, "QLinearConv")?;
+            let bias = optional_input(inputs, 8);
+            ops::quantized::op_qlinear_conv(x, x_scale, x_zp, w, w_scale, w_zp, y_scale, y_zp, bias)
+        }
+        _ => Err(OpError::UnsupportedOp(String::from("quantized"))),
+    }
+}
+
+/// Dispatches Split (multi-output).
+fn dispatch_split(
+    inputs: &[Option<&Tensor>],
+    attrs: &[AttributeProto],
+) -> Result<Vec<Tensor>, OpError> {
+    let x = require_input(inputs, 0, "Split")?;
+    let axis = get_attr_int(attrs, "axis", 0);
+    // Opset 13+: 'split' is an input tensor (i64).
+    // Older: 'split' is an int list attribute.
+    let split_input = optional_input(inputs, 1).map(read_i64_tensor);
+    let split_attr = get_attr_ints(attrs, "split").map(|s| s.to_vec());
+    let split_sizes = split_input.or(split_attr);
+    ops::transformer::op_split(x, axis, split_sizes.as_deref())
+}
+
+/// Dispatches LSTM (multi-output).
+fn dispatch_lstm(
+    inputs: &[Option<&Tensor>],
+    attrs: &[AttributeProto],
+) -> Result<Vec<Tensor>, OpError> {
+    let x = require_input(inputs, 0, "LSTM")?;
+    let w = require_input(inputs, 1, "LSTM")?;
+    let r = require_input(inputs, 2, "LSTM")?;
+    let b = optional_input(inputs, 3);
+    let h0 = optional_input(inputs, 5);
+    let c0 = optional_input(inputs, 6);
+    let direction_bytes = attrs
+        .iter()
+        .find(|a| a.name == "direction")
+        .map(|a| a.s.as_slice())
+        .unwrap_or(b"forward");
+    let direction = core::str::from_utf8(direction_bytes).unwrap_or("forward");
+    ops::recurrent::op_lstm(x, w, r, b, h0, c0, direction)
+}
+
+/// Dispatches GRU (multi-output).
+fn dispatch_gru(
+    inputs: &[Option<&Tensor>],
+    attrs: &[AttributeProto],
+) -> Result<Vec<Tensor>, OpError> {
+    let x = require_input(inputs, 0, "GRU")?;
+    let w = require_input(inputs, 1, "GRU")?;
+    let r = require_input(inputs, 2, "GRU")?;
+    let b = optional_input(inputs, 3);
+    let h0 = optional_input(inputs, 5);
+    let direction_bytes = attrs
+        .iter()
+        .find(|a| a.name == "direction")
+        .map(|a| a.s.as_slice())
+        .unwrap_or(b"forward");
+    let direction = core::str::from_utf8(direction_bytes).unwrap_or("forward");
+    ops::recurrent::op_gru(x, w, r, b, h0, direction)
+}
+
+/// Dispatches RNN (multi-output).
+fn dispatch_rnn(
+    inputs: &[Option<&Tensor>],
+    attrs: &[AttributeProto],
+) -> Result<Vec<Tensor>, OpError> {
+    let x = require_input(inputs, 0, "RNN")?;
+    let w = require_input(inputs, 1, "RNN")?;
+    let r = require_input(inputs, 2, "RNN")?;
+    let b = optional_input(inputs, 3);
+    let h0 = optional_input(inputs, 5);
+    let direction_bytes = attrs
+        .iter()
+        .find(|a| a.name == "direction")
+        .map(|a| a.s.as_slice())
+        .unwrap_or(b"forward");
+    let direction = core::str::from_utf8(direction_bytes).unwrap_or("forward");
+    ops::recurrent::op_rnn(x, w, r, b, h0, direction)
 }
 
 /// Dispatches arithmetic operators: Add, Sub, Mul, Div, MatMul, Gemm.

--- a/onnx-rt/src/lib.rs
+++ b/onnx-rt/src/lib.rs
@@ -29,6 +29,7 @@ pub mod model_policy;
 pub mod model_verify;
 pub mod onnx_types;
 pub mod operators;
+pub mod ops;
 pub mod optimizer;
 pub mod parallel;
 pub mod profile;

--- a/onnx-rt/src/operators.rs
+++ b/onnx-rt/src/operators.rs
@@ -128,6 +128,90 @@ pub enum OpKind {
     ReduceMean,
     /// Reduce tensor by computing the sum.
     ReduceSum,
+
+    // ---- Tier 2: math primitives ----
+    /// Element-wise power.
+    Pow,
+    /// Element-wise square root.
+    Sqrt,
+    /// Element-wise natural exponential.
+    Exp,
+    /// Element-wise natural logarithm.
+    Log,
+    /// Element-wise error function.
+    Erf,
+    /// Element-wise negation.
+    Neg,
+    /// Element-wise absolute value.
+    Abs,
+    /// Element-wise floor.
+    Floor,
+    /// Element-wise ceiling.
+    Ceil,
+    /// Element-wise rounding.
+    Round,
+
+    // ---- Tier 2: comparison and selection ----
+    /// Element-wise equality.
+    Equal,
+    /// Element-wise inequality.
+    NotEqual,
+    /// Element-wise less-than.
+    Less,
+    /// Element-wise less-than-or-equal.
+    LessOrEqual,
+    /// Element-wise greater-than.
+    Greater,
+    /// Element-wise greater-than-or-equal.
+    GreaterOrEqual,
+    /// Element-wise ternary select.
+    Where,
+    /// Element-wise minimum.
+    Min,
+    /// Element-wise maximum.
+    Max,
+    /// Element-wise boolean negation.
+    Not,
+
+    // ---- Tier 2: composite activations ----
+    /// Gaussian Error Linear Unit.
+    Gelu,
+    /// Leaky ReLU.
+    LeakyRelu,
+    /// Exponential Linear Unit.
+    Elu,
+    /// Sigmoid Linear Unit (Swish/SiLU).
+    Swish,
+
+    // ---- Tier 2: recurrent ----
+    /// Basic RNN.
+    RNN,
+    /// Long Short-Term Memory.
+    LSTM,
+    /// Gated Recurrent Unit.
+    GRU,
+
+    // ---- Tier 2: transformer building blocks ----
+    /// Split tensor along an axis.
+    Split,
+    /// Expand (broadcast) to a target shape.
+    Expand,
+    /// Repeat tensor along axes.
+    Tile,
+    /// One-hot encoding.
+    OneHot,
+    /// Einstein summation.
+    Einsum,
+
+    // ---- Tier 2: quantized ----
+    /// Float -> int8/uint8 quantization.
+    QuantizeLinear,
+    /// int8/uint8 -> float dequantization.
+    DequantizeLinear,
+    /// Quantized matrix multiply.
+    QLinearMatMul,
+    /// Quantized convolution.
+    QLinearConv,
 }
 
 impl OpKind {
@@ -165,6 +249,48 @@ impl OpKind {
             "Clip" => Some(OpKind::Clip),
             "ReduceMean" => Some(OpKind::ReduceMean),
             "ReduceSum" => Some(OpKind::ReduceSum),
+            // Tier 2: math
+            "Pow" => Some(OpKind::Pow),
+            "Sqrt" => Some(OpKind::Sqrt),
+            "Exp" => Some(OpKind::Exp),
+            "Log" => Some(OpKind::Log),
+            "Erf" => Some(OpKind::Erf),
+            "Neg" => Some(OpKind::Neg),
+            "Abs" => Some(OpKind::Abs),
+            "Floor" => Some(OpKind::Floor),
+            "Ceil" => Some(OpKind::Ceil),
+            "Round" => Some(OpKind::Round),
+            // Tier 2: comparison
+            "Equal" => Some(OpKind::Equal),
+            "NotEqual" => Some(OpKind::NotEqual),
+            "Less" => Some(OpKind::Less),
+            "LessOrEqual" => Some(OpKind::LessOrEqual),
+            "Greater" => Some(OpKind::Greater),
+            "GreaterOrEqual" => Some(OpKind::GreaterOrEqual),
+            "Where" => Some(OpKind::Where),
+            "Min" => Some(OpKind::Min),
+            "Max" => Some(OpKind::Max),
+            "Not" => Some(OpKind::Not),
+            // Tier 2: activations
+            "Gelu" => Some(OpKind::Gelu),
+            "LeakyRelu" => Some(OpKind::LeakyRelu),
+            "Elu" => Some(OpKind::Elu),
+            "Swish" => Some(OpKind::Swish),
+            // Tier 2: recurrent
+            "RNN" => Some(OpKind::RNN),
+            "LSTM" => Some(OpKind::LSTM),
+            "GRU" => Some(OpKind::GRU),
+            // Tier 2: transformer
+            "Split" => Some(OpKind::Split),
+            "Expand" => Some(OpKind::Expand),
+            "Tile" => Some(OpKind::Tile),
+            "OneHot" => Some(OpKind::OneHot),
+            "Einsum" => Some(OpKind::Einsum),
+            // Tier 2: quantized
+            "QuantizeLinear" => Some(OpKind::QuantizeLinear),
+            "DequantizeLinear" => Some(OpKind::DequantizeLinear),
+            "QLinearMatMul" => Some(OpKind::QLinearMatMul),
+            "QLinearConv" => Some(OpKind::QLinearConv),
             _ => None,
         }
     }
@@ -201,6 +327,42 @@ impl OpKind {
             OpKind::Clip => "Clip",
             OpKind::ReduceMean => "ReduceMean",
             OpKind::ReduceSum => "ReduceSum",
+            OpKind::Pow => "Pow",
+            OpKind::Sqrt => "Sqrt",
+            OpKind::Exp => "Exp",
+            OpKind::Log => "Log",
+            OpKind::Erf => "Erf",
+            OpKind::Neg => "Neg",
+            OpKind::Abs => "Abs",
+            OpKind::Floor => "Floor",
+            OpKind::Ceil => "Ceil",
+            OpKind::Round => "Round",
+            OpKind::Equal => "Equal",
+            OpKind::NotEqual => "NotEqual",
+            OpKind::Less => "Less",
+            OpKind::LessOrEqual => "LessOrEqual",
+            OpKind::Greater => "Greater",
+            OpKind::GreaterOrEqual => "GreaterOrEqual",
+            OpKind::Where => "Where",
+            OpKind::Min => "Min",
+            OpKind::Max => "Max",
+            OpKind::Not => "Not",
+            OpKind::Gelu => "Gelu",
+            OpKind::LeakyRelu => "LeakyRelu",
+            OpKind::Elu => "Elu",
+            OpKind::Swish => "Swish",
+            OpKind::RNN => "RNN",
+            OpKind::LSTM => "LSTM",
+            OpKind::GRU => "GRU",
+            OpKind::Split => "Split",
+            OpKind::Expand => "Expand",
+            OpKind::Tile => "Tile",
+            OpKind::OneHot => "OneHot",
+            OpKind::Einsum => "Einsum",
+            OpKind::QuantizeLinear => "QuantizeLinear",
+            OpKind::DequantizeLinear => "DequantizeLinear",
+            OpKind::QLinearMatMul => "QLinearMatMul",
+            OpKind::QLinearConv => "QLinearConv",
         }
     }
 }
@@ -240,6 +402,43 @@ const ALL_OPS: &[OpKind] = &[
     OpKind::Clip,
     OpKind::ReduceMean,
     OpKind::ReduceSum,
+    // Tier 2
+    OpKind::Pow,
+    OpKind::Sqrt,
+    OpKind::Exp,
+    OpKind::Log,
+    OpKind::Erf,
+    OpKind::Neg,
+    OpKind::Abs,
+    OpKind::Floor,
+    OpKind::Ceil,
+    OpKind::Round,
+    OpKind::Equal,
+    OpKind::NotEqual,
+    OpKind::Less,
+    OpKind::LessOrEqual,
+    OpKind::Greater,
+    OpKind::GreaterOrEqual,
+    OpKind::Where,
+    OpKind::Min,
+    OpKind::Max,
+    OpKind::Not,
+    OpKind::Gelu,
+    OpKind::LeakyRelu,
+    OpKind::Elu,
+    OpKind::Swish,
+    OpKind::RNN,
+    OpKind::LSTM,
+    OpKind::GRU,
+    OpKind::Split,
+    OpKind::Expand,
+    OpKind::Tile,
+    OpKind::OneHot,
+    OpKind::Einsum,
+    OpKind::QuantizeLinear,
+    OpKind::DequantizeLinear,
+    OpKind::QLinearMatMul,
+    OpKind::QLinearConv,
 ];
 
 /// Registry of supported ONNX operators.
@@ -312,7 +511,7 @@ const F32_MANTISSA_BITS: u32 = 23;
 /// Computes e^x for f32 using range reduction and polynomial approximation.
 ///
 /// Accurate to ~1 ULP for typical inference ranges.
-fn expf_approx(x: f32) -> f32 {
+pub(crate) fn expf_approx(x: f32) -> f32 {
     // Clamp to avoid overflow/underflow
     let x = x.clamp(EXP_CLAMP_MIN, EXP_CLAMP_MAX);
 
@@ -1681,7 +1880,7 @@ pub fn op_clip(
 // ---------------------------------------------------------------------------
 
 /// Approximate square root using Newton's method (no_std).
-fn sqrt_approx(x: f32) -> f32 {
+pub(crate) fn sqrt_approx(x: f32) -> f32 {
     if x <= 0.0 {
         return 0.0;
     }
@@ -2656,7 +2855,7 @@ mod tests {
     #[test]
     fn test_registry_supported_count() {
         let registry = OperatorRegistry::new();
-        assert_eq!(registry.supported_count(), 29);
+        assert_eq!(registry.supported_count(), 65);
     }
 
     #[test]

--- a/onnx-rt/src/ops/activations.rs
+++ b/onnx-rt/src/ops/activations.rs
@@ -1,0 +1,177 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Composite activation functions used by transformer-style models.
+
+use alloc::string::String;
+
+use crate::byte_io::{allocate_tensor_data, read_f32, write_f32};
+use crate::operators::{expf_approx, OpError};
+use crate::ops::math::erf_approx;
+use crate::tensor::{DataType, Tensor};
+
+fn require_float(t: &Tensor, op: &str) -> Result<(), OpError> {
+    if t.data_type != DataType::Float {
+        return Err(OpError::ShapeMismatch(alloc::format!(
+            "{} requires Float input",
+            op
+        )));
+    }
+    Ok(())
+}
+
+fn unary<F: Fn(f32) -> f32>(input: &Tensor, op: &str, f: F) -> Result<Tensor, OpError> {
+    require_float(input, op)?;
+    let n = input.shape.total_elements();
+    let mut data = allocate_tensor_data(n, DataType::Float);
+    for i in 0..n {
+        write_f32(&mut data, i, f(read_f32(&input.raw_data, i)));
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: input.shape.clone(),
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+/// Gaussian Error Linear Unit: `0.5 * x * (1 + erf(x / sqrt(2)))`.
+pub fn op_gelu(input: &Tensor) -> Result<Tensor, OpError> {
+    let inv_sqrt2 = core::f32::consts::FRAC_1_SQRT_2;
+    unary(input, "Gelu", |x| {
+        0.5 * x * (1.0 + erf_approx(x * inv_sqrt2))
+    })
+}
+
+/// Leaky ReLU: `x if x > 0 else alpha * x`.
+pub fn op_leaky_relu(input: &Tensor, alpha: f32) -> Result<Tensor, OpError> {
+    unary(input, "LeakyRelu", |x| if x >= 0.0 { x } else { alpha * x })
+}
+
+/// Exponential Linear Unit: `x if x >= 0 else alpha * (exp(x) - 1)`.
+pub fn op_elu(input: &Tensor, alpha: f32) -> Result<Tensor, OpError> {
+    unary(input, "Elu", |x| {
+        if x >= 0.0 {
+            x
+        } else {
+            alpha * (expf_approx(x) - 1.0)
+        }
+    })
+}
+
+/// Swish (a.k.a. SiLU): `x * sigmoid(x)`.
+pub fn op_swish(input: &Tensor) -> Result<Tensor, OpError> {
+    unary(input, "Swish", |x| x / (1.0 + expf_approx(-x)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tensor::TensorShape;
+
+    fn make_f32(dims: &[i64], vals: &[f32]) -> Tensor {
+        let mut data = allocate_tensor_data(vals.len(), DataType::Float);
+        for (i, &v) in vals.iter().enumerate() {
+            write_f32(&mut data, i, v);
+        }
+        Tensor {
+            data_type: DataType::Float,
+            shape: TensorShape::new(dims.to_vec()),
+            name: String::new(),
+            raw_data: data,
+        }
+    }
+
+    fn read_all(t: &Tensor) -> alloc::vec::Vec<f32> {
+        (0..t.shape.total_elements())
+            .map(|i| read_f32(&t.raw_data, i))
+            .collect()
+    }
+
+    #[test]
+    fn test_gelu_at_zero() {
+        let t = make_f32(&[1], &[0.0]);
+        let v = read_all(&op_gelu(&t).unwrap());
+        assert!(v[0].abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_gelu_known_values() {
+        // Reference values from PyTorch torch.nn.functional.gelu
+        let t = make_f32(&[3], &[1.0, -1.0, 2.0]);
+        let v = read_all(&op_gelu(&t).unwrap());
+        assert!((v[0] - 0.8413).abs() < 1e-2);
+        assert!((v[1] - -0.1587).abs() < 1e-2);
+        assert!((v[2] - 1.9545).abs() < 1e-2);
+    }
+
+    #[test]
+    fn test_leaky_relu_positive_unchanged() {
+        let t = make_f32(&[2], &[1.5, 3.0]);
+        let v = read_all(&op_leaky_relu(&t, 0.01).unwrap());
+        assert_eq!(v, alloc::vec![1.5, 3.0]);
+    }
+
+    #[test]
+    fn test_leaky_relu_negative_scaled() {
+        let t = make_f32(&[3], &[-1.0, -2.0, 0.0]);
+        let v = read_all(&op_leaky_relu(&t, 0.1).unwrap());
+        assert!((v[0] - -0.1).abs() < 1e-5);
+        assert!((v[1] - -0.2).abs() < 1e-5);
+        assert!(v[2].abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_elu_positive_unchanged() {
+        let t = make_f32(&[2], &[1.0, 2.5]);
+        let v = read_all(&op_elu(&t, 1.0).unwrap());
+        assert_eq!(v, alloc::vec![1.0, 2.5]);
+    }
+
+    #[test]
+    fn test_elu_negative() {
+        // ELU(-1, alpha=1) = 1 * (e^-1 - 1) ≈ -0.6321
+        let t = make_f32(&[1], &[-1.0]);
+        let v = read_all(&op_elu(&t, 1.0).unwrap());
+        assert!((v[0] - -0.6321).abs() < 1e-2);
+    }
+
+    #[test]
+    fn test_swish_at_zero() {
+        let t = make_f32(&[1], &[0.0]);
+        let v = read_all(&op_swish(&t).unwrap());
+        assert!(v[0].abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_swish_known_values() {
+        // Swish(1) = 1 * sigmoid(1) ≈ 0.7310
+        // Swish(2) = 2 * sigmoid(2) ≈ 1.7616
+        let t = make_f32(&[2], &[1.0, 2.0]);
+        let v = read_all(&op_swish(&t).unwrap());
+        assert!((v[0] - 0.7310).abs() < 1e-2);
+        assert!((v[1] - 1.7616).abs() < 1e-2);
+    }
+
+    #[test]
+    fn test_swish_negative() {
+        // Swish(-1) = -1 * sigmoid(-1) ≈ -0.2689
+        let t = make_f32(&[1], &[-1.0]);
+        let v = read_all(&op_swish(&t).unwrap());
+        assert!((v[0] - -0.2689).abs() < 1e-2);
+    }
+
+    #[test]
+    fn test_activations_reject_non_float() {
+        let t = Tensor {
+            data_type: DataType::Int32,
+            shape: TensorShape::new(alloc::vec![1]),
+            name: String::new(),
+            raw_data: alloc::vec![0u8; 4],
+        };
+        assert!(op_gelu(&t).is_err());
+        assert!(op_leaky_relu(&t, 0.1).is_err());
+        assert!(op_elu(&t, 1.0).is_err());
+        assert!(op_swish(&t).is_err());
+    }
+}

--- a/onnx-rt/src/ops/compare.rs
+++ b/onnx-rt/src/ops/compare.rs
@@ -1,0 +1,389 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tier 2 element-wise comparison and selection operators.
+//!
+//! Equal, NotEqual, Less, LessOrEqual, Greater, GreaterOrEqual return Bool
+//! tensors. Where selects between two float tensors based on a Bool
+//! condition. Min/Max are element-wise reductions over two float tensors.
+//! Not negates a Bool tensor.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use crate::byte_io::{allocate_tensor_data, read_f32, write_f32};
+use crate::operators::OpError;
+use crate::tensor::{DataType, Tensor, TensorShape};
+
+/// Returns the broadcast shape of two NumPy-style shape vectors.
+fn broadcast_shape(a: &[i64], b: &[i64]) -> Result<Vec<i64>, OpError> {
+    let max = a.len().max(b.len());
+    let mut out = alloc::vec![1i64; max];
+    for i in 0..max {
+        let ad = if i < a.len() { a[a.len() - 1 - i] } else { 1 };
+        let bd = if i < b.len() { b[b.len() - 1 - i] } else { 1 };
+        let dim = if ad == bd {
+            ad
+        } else if ad == 1 {
+            bd
+        } else if bd == 1 {
+            ad
+        } else {
+            return Err(OpError::ShapeMismatch(String::from(
+                "incompatible shapes for broadcast",
+            )));
+        };
+        out[max - 1 - i] = dim;
+    }
+    Ok(out)
+}
+
+fn broadcast_index(coord: &[usize], shape: &[i64]) -> usize {
+    let off = coord.len() - shape.len();
+    let mut idx = 0usize;
+    let mut stride = 1usize;
+    for i in (0..shape.len()).rev() {
+        let c = if shape[i] == 1 { 0 } else { coord[off + i] };
+        idx += c * stride;
+        stride *= shape[i] as usize;
+    }
+    idx
+}
+
+fn next_coord(coord: &mut [usize], dims: &[i64]) {
+    for i in (0..coord.len()).rev() {
+        coord[i] += 1;
+        if (coord[i] as i64) < dims[i] {
+            return;
+        }
+        coord[i] = 0;
+    }
+}
+
+fn require_float(t: &Tensor, op: &str) -> Result<(), OpError> {
+    if t.data_type != DataType::Float {
+        return Err(OpError::ShapeMismatch(alloc::format!(
+            "{} requires Float input",
+            op
+        )));
+    }
+    Ok(())
+}
+
+/// Element-wise comparison helper that returns a Bool tensor.
+fn compare<F: Fn(f32, f32) -> bool>(
+    a: &Tensor,
+    b: &Tensor,
+    op: &str,
+    f: F,
+) -> Result<Tensor, OpError> {
+    require_float(a, op)?;
+    require_float(b, op)?;
+    let out_dims = broadcast_shape(&a.shape.dims, &b.shape.dims)?;
+    let total: usize = out_dims
+        .iter()
+        .map(|&d| d as usize)
+        .product::<usize>()
+        .max(1);
+    let mut data = alloc::vec![0u8; total];
+    let ndim = out_dims.len();
+    let mut coord = alloc::vec![0usize; ndim];
+    for (flat, slot) in data.iter_mut().enumerate().take(total) {
+        let ai = broadcast_index(&coord, &a.shape.dims);
+        let bi = broadcast_index(&coord, &b.shape.dims);
+        let av = read_f32(&a.raw_data, ai);
+        let bv = read_f32(&b.raw_data, bi);
+        *slot = u8::from(f(av, bv));
+        if flat + 1 < total {
+            next_coord(&mut coord, &out_dims);
+        }
+    }
+    Ok(Tensor {
+        data_type: DataType::Bool,
+        shape: TensorShape::new(out_dims),
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+fn elementwise_min_max<F: Fn(f32, f32) -> f32>(
+    a: &Tensor,
+    b: &Tensor,
+    op: &str,
+    f: F,
+) -> Result<Tensor, OpError> {
+    require_float(a, op)?;
+    require_float(b, op)?;
+    let out_dims = broadcast_shape(&a.shape.dims, &b.shape.dims)?;
+    let total: usize = out_dims
+        .iter()
+        .map(|&d| d as usize)
+        .product::<usize>()
+        .max(1);
+    let mut data = allocate_tensor_data(total, DataType::Float);
+    let ndim = out_dims.len();
+    let mut coord = alloc::vec![0usize; ndim];
+    for flat in 0..total {
+        let ai = broadcast_index(&coord, &a.shape.dims);
+        let bi = broadcast_index(&coord, &b.shape.dims);
+        let av = read_f32(&a.raw_data, ai);
+        let bv = read_f32(&b.raw_data, bi);
+        write_f32(&mut data, flat, f(av, bv));
+        if flat + 1 < total {
+            next_coord(&mut coord, &out_dims);
+        }
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: TensorShape::new(out_dims),
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Public operators
+// ---------------------------------------------------------------------------
+
+pub fn op_equal(a: &Tensor, b: &Tensor) -> Result<Tensor, OpError> {
+    compare(a, b, "Equal", |x, y| x == y)
+}
+
+pub fn op_not_equal(a: &Tensor, b: &Tensor) -> Result<Tensor, OpError> {
+    compare(a, b, "NotEqual", |x, y| x != y)
+}
+
+pub fn op_less(a: &Tensor, b: &Tensor) -> Result<Tensor, OpError> {
+    compare(a, b, "Less", |x, y| x < y)
+}
+
+pub fn op_less_or_equal(a: &Tensor, b: &Tensor) -> Result<Tensor, OpError> {
+    compare(a, b, "LessOrEqual", |x, y| x <= y)
+}
+
+pub fn op_greater(a: &Tensor, b: &Tensor) -> Result<Tensor, OpError> {
+    compare(a, b, "Greater", |x, y| x > y)
+}
+
+pub fn op_greater_or_equal(a: &Tensor, b: &Tensor) -> Result<Tensor, OpError> {
+    compare(a, b, "GreaterOrEqual", |x, y| x >= y)
+}
+
+pub fn op_min(a: &Tensor, b: &Tensor) -> Result<Tensor, OpError> {
+    elementwise_min_max(a, b, "Min", |x, y| if x < y { x } else { y })
+}
+
+pub fn op_max(a: &Tensor, b: &Tensor) -> Result<Tensor, OpError> {
+    elementwise_min_max(a, b, "Max", |x, y| if x > y { x } else { y })
+}
+
+/// Element-wise ternary select: `out[i] = if cond[i] { x[i] } else { y[i] }`.
+/// Supports broadcasting across all three inputs.
+pub fn op_where(cond: &Tensor, x: &Tensor, y: &Tensor) -> Result<Tensor, OpError> {
+    if cond.data_type != DataType::Bool {
+        return Err(OpError::ShapeMismatch(String::from(
+            "Where requires Bool condition",
+        )));
+    }
+    require_float(x, "Where")?;
+    require_float(y, "Where")?;
+
+    let xy = broadcast_shape(&x.shape.dims, &y.shape.dims)?;
+    let out_dims = broadcast_shape(&xy, &cond.shape.dims)?;
+    let total: usize = out_dims
+        .iter()
+        .map(|&d| d as usize)
+        .product::<usize>()
+        .max(1);
+    let mut data = allocate_tensor_data(total, DataType::Float);
+    let ndim = out_dims.len();
+    let mut coord = alloc::vec![0usize; ndim];
+    for flat in 0..total {
+        let ci = broadcast_index(&coord, &cond.shape.dims);
+        let xi = broadcast_index(&coord, &x.shape.dims);
+        let yi = broadcast_index(&coord, &y.shape.dims);
+        let v = if cond.raw_data[ci] != 0 {
+            read_f32(&x.raw_data, xi)
+        } else {
+            read_f32(&y.raw_data, yi)
+        };
+        write_f32(&mut data, flat, v);
+        if flat + 1 < total {
+            next_coord(&mut coord, &out_dims);
+        }
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: TensorShape::new(out_dims),
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+/// Element-wise boolean negation. Input must be a Bool tensor.
+pub fn op_not(input: &Tensor) -> Result<Tensor, OpError> {
+    if input.data_type != DataType::Bool {
+        return Err(OpError::ShapeMismatch(String::from(
+            "Not requires Bool input",
+        )));
+    }
+    let mut out = input.raw_data.clone();
+    for byte in out.iter_mut() {
+        *byte = if *byte == 0 { 1 } else { 0 };
+    }
+    Ok(Tensor {
+        data_type: DataType::Bool,
+        shape: input.shape.clone(),
+        name: String::new(),
+        raw_data: out,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_f32(dims: &[i64], vals: &[f32]) -> Tensor {
+        let mut data = allocate_tensor_data(vals.len(), DataType::Float);
+        for (i, &v) in vals.iter().enumerate() {
+            write_f32(&mut data, i, v);
+        }
+        Tensor {
+            data_type: DataType::Float,
+            shape: TensorShape::new(dims.to_vec()),
+            name: String::new(),
+            raw_data: data,
+        }
+    }
+
+    fn make_bool(dims: &[i64], vals: &[bool]) -> Tensor {
+        let data: Vec<u8> = vals.iter().map(|&b| if b { 1 } else { 0 }).collect();
+        Tensor {
+            data_type: DataType::Bool,
+            shape: TensorShape::new(dims.to_vec()),
+            name: String::new(),
+            raw_data: data,
+        }
+    }
+
+    fn read_bool_all(t: &Tensor) -> Vec<bool> {
+        t.raw_data.iter().map(|&b| b != 0).collect()
+    }
+
+    fn read_f32_all(t: &Tensor) -> Vec<f32> {
+        (0..t.shape.total_elements())
+            .map(|i| read_f32(&t.raw_data, i))
+            .collect()
+    }
+
+    #[test]
+    fn test_equal() {
+        let a = make_f32(&[3], &[1.0, 2.0, 3.0]);
+        let b = make_f32(&[3], &[1.0, 5.0, 3.0]);
+        let v = read_bool_all(&op_equal(&a, &b).unwrap());
+        assert_eq!(v, alloc::vec![true, false, true]);
+    }
+
+    #[test]
+    fn test_not_equal() {
+        let a = make_f32(&[3], &[1.0, 2.0, 3.0]);
+        let b = make_f32(&[3], &[1.0, 5.0, 3.0]);
+        let v = read_bool_all(&op_not_equal(&a, &b).unwrap());
+        assert_eq!(v, alloc::vec![false, true, false]);
+    }
+
+    #[test]
+    fn test_less_and_greater() {
+        let a = make_f32(&[3], &[1.0, 2.0, 3.0]);
+        let b = make_f32(&[3], &[2.0, 2.0, 1.0]);
+        assert_eq!(
+            read_bool_all(&op_less(&a, &b).unwrap()),
+            alloc::vec![true, false, false]
+        );
+        assert_eq!(
+            read_bool_all(&op_greater(&a, &b).unwrap()),
+            alloc::vec![false, false, true]
+        );
+        assert_eq!(
+            read_bool_all(&op_less_or_equal(&a, &b).unwrap()),
+            alloc::vec![true, true, false]
+        );
+        assert_eq!(
+            read_bool_all(&op_greater_or_equal(&a, &b).unwrap()),
+            alloc::vec![false, true, true]
+        );
+    }
+
+    #[test]
+    fn test_min_max() {
+        let a = make_f32(&[3], &[1.0, 5.0, 3.0]);
+        let b = make_f32(&[3], &[2.0, 4.0, 3.0]);
+        assert_eq!(
+            read_f32_all(&op_min(&a, &b).unwrap()),
+            alloc::vec![1.0, 4.0, 3.0]
+        );
+        assert_eq!(
+            read_f32_all(&op_max(&a, &b).unwrap()),
+            alloc::vec![2.0, 5.0, 3.0]
+        );
+    }
+
+    #[test]
+    fn test_min_max_broadcast() {
+        let a = make_f32(&[2, 2], &[1.0, 5.0, 3.0, 7.0]);
+        let b = make_f32(&[1], &[4.0]);
+        assert_eq!(
+            read_f32_all(&op_min(&a, &b).unwrap()),
+            alloc::vec![1.0, 4.0, 3.0, 4.0]
+        );
+        assert_eq!(
+            read_f32_all(&op_max(&a, &b).unwrap()),
+            alloc::vec![4.0, 5.0, 4.0, 7.0]
+        );
+    }
+
+    #[test]
+    fn test_where() {
+        let cond = make_bool(&[3], &[true, false, true]);
+        let x = make_f32(&[3], &[1.0, 2.0, 3.0]);
+        let y = make_f32(&[3], &[10.0, 20.0, 30.0]);
+        let out = op_where(&cond, &x, &y).unwrap();
+        assert_eq!(read_f32_all(&out), alloc::vec![1.0, 20.0, 3.0]);
+    }
+
+    #[test]
+    fn test_where_broadcast() {
+        let cond = make_bool(&[1], &[true]);
+        let x = make_f32(&[3], &[1.0, 2.0, 3.0]);
+        let y = make_f32(&[3], &[10.0, 20.0, 30.0]);
+        let out = op_where(&cond, &x, &y).unwrap();
+        assert_eq!(read_f32_all(&out), alloc::vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn test_not() {
+        let t = make_bool(&[3], &[true, false, true]);
+        let out = op_not(&t).unwrap();
+        assert_eq!(read_bool_all(&out), alloc::vec![false, true, false]);
+    }
+
+    #[test]
+    fn test_compare_broadcast() {
+        let a = make_f32(&[2, 2], &[1.0, 2.0, 3.0, 4.0]);
+        let b = make_f32(&[1], &[2.0]);
+        let v = read_bool_all(&op_less(&a, &b).unwrap());
+        assert_eq!(v, alloc::vec![true, false, false, false]);
+    }
+
+    #[test]
+    fn test_compare_rejects_non_float() {
+        let t = Tensor {
+            data_type: DataType::Int32,
+            shape: TensorShape::new(alloc::vec![1]),
+            name: String::new(),
+            raw_data: alloc::vec![0u8; 4],
+        };
+        let f = make_f32(&[1], &[1.0]);
+        assert!(op_equal(&t, &f).is_err());
+    }
+}

--- a/onnx-rt/src/ops/math.rs
+++ b/onnx-rt/src/ops/math.rs
@@ -1,0 +1,468 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tier 2 element-wise math primitives.
+//!
+//! Implements Pow, Sqrt, Exp, Log, Erf, Neg, Abs, Floor, Ceil, Round.
+//! All operators consume f32 tensors and produce f32 tensors. Pow supports
+//! NumPy-style broadcasting; the rest are unary element-wise.
+
+use alloc::string::String;
+
+use crate::byte_io::{allocate_tensor_data, read_f32, write_f32};
+use crate::operators::{expf_approx, sqrt_approx, OpError};
+use crate::tensor::{DataType, Tensor, TensorShape};
+
+/// Returns the broadcast output shape for two NumPy-style shapes.
+fn broadcast_shape(a: &[i64], b: &[i64]) -> Result<alloc::vec::Vec<i64>, OpError> {
+    let max = a.len().max(b.len());
+    let mut out = alloc::vec![1i64; max];
+    for i in 0..max {
+        let ad = if i < a.len() { a[a.len() - 1 - i] } else { 1 };
+        let bd = if i < b.len() { b[b.len() - 1 - i] } else { 1 };
+        let dim = if ad == bd {
+            ad
+        } else if ad == 1 {
+            bd
+        } else if bd == 1 {
+            ad
+        } else {
+            return Err(OpError::ShapeMismatch(String::from(
+                "incompatible shapes for broadcast",
+            )));
+        };
+        out[max - 1 - i] = dim;
+    }
+    Ok(out)
+}
+
+/// Computes the linear index for a coordinate in a (broadcast) tensor.
+fn broadcast_index(coord: &[usize], shape: &[i64]) -> usize {
+    // Right-aligned. coord is in output space; shape is the input shape.
+    let off = coord.len() - shape.len();
+    let mut idx = 0usize;
+    let mut stride = 1usize;
+    for i in (0..shape.len()).rev() {
+        let c = if shape[i] == 1 { 0 } else { coord[off + i] };
+        idx += c * stride;
+        stride *= shape[i] as usize;
+    }
+    idx
+}
+
+fn next_coord(coord: &mut [usize], dims: &[i64]) {
+    for i in (0..coord.len()).rev() {
+        coord[i] += 1;
+        if (coord[i] as i64) < dims[i] {
+            return;
+        }
+        coord[i] = 0;
+    }
+}
+
+fn require_float(t: &Tensor, op: &str) -> Result<(), OpError> {
+    if t.data_type != DataType::Float {
+        return Err(OpError::ShapeMismatch(alloc::format!(
+            "{} requires Float input",
+            op
+        )));
+    }
+    Ok(())
+}
+
+/// Element-wise unary helper that allocates an output tensor with the same
+/// shape and applies a function to each element.
+fn unary<F: Fn(f32) -> f32>(input: &Tensor, op: &str, f: F) -> Result<Tensor, OpError> {
+    require_float(input, op)?;
+    let n = input.shape.total_elements();
+    let mut out = allocate_tensor_data(n, DataType::Float);
+    for i in 0..n {
+        write_f32(&mut out, i, f(read_f32(&input.raw_data, i)));
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: input.shape.clone(),
+        name: String::new(),
+        raw_data: out,
+    })
+}
+
+/// Natural log via `ln(x) = log2(x) * ln(2)`. Uses the IEEE-754 exponent
+/// for `log2` and a 5-term polynomial in the mantissa. Accurate to ~2 ULP
+/// for typical inference ranges.
+fn lnf_approx(x: f32) -> f32 {
+    if x <= 0.0 {
+        // Return -inf (or NaN for negatives) — match libm semantics loosely.
+        if x == 0.0 {
+            return f32::NEG_INFINITY;
+        }
+        return f32::NAN;
+    }
+    let bits = x.to_bits();
+    let mut exp = ((bits >> 23) & 0xff) as i32 - 127;
+    let mantissa_bits = (bits & 0x7f_ffff) | 0x3f80_0000; // m in [1, 2)
+    let mut m = f32::from_bits(mantissa_bits);
+    // Range-reduce m to [sqrt(0.5), sqrt(2)] ≈ [0.707, 1.414] so the
+    // artanh series converges much faster.
+    if m > core::f32::consts::SQRT_2 {
+        m *= 0.5;
+        exp += 1;
+    }
+    // ln(m) = 2 * artanh((m-1)/(m+1))
+    // artanh(y) = y + y^3/3 + y^5/5 + y^7/7 + y^9/9 + ...
+    // For m in [0.707, 1.414], y is in [-0.172, 0.172]; a 5-term series is
+    // accurate to ~1e-7.
+    let y = (m - 1.0) / (m + 1.0);
+    let y2 = y * y;
+    let y3 = y2 * y;
+    let y5 = y3 * y2;
+    let y7 = y5 * y2;
+    let y9 = y7 * y2;
+    let ln_m = 2.0 * (y + y3 / 3.0 + y5 / 5.0 + y7 / 7.0 + y9 / 9.0);
+    (exp as f32) * core::f32::consts::LN_2 + ln_m
+}
+
+/// Error function via the Abramowitz & Stegun 7.1.26 polynomial
+/// approximation. Maximum error ~1.5e-7.
+pub(crate) fn erf_approx(x: f32) -> f32 {
+    let sign = if x < 0.0 { -1.0 } else { 1.0 };
+    let ax = if x < 0.0 { -x } else { x };
+    // Abramowitz & Stegun 7.1.26
+    let a1 = 0.254_829_6_f32;
+    let a2 = -0.284_496_74_f32;
+    let a3 = 1.421_413_7_f32;
+    let a4 = -1.453_152_f32;
+    let a5 = 1.061_405_4_f32;
+    let p = 0.327_591_1_f32;
+    let t = 1.0 / (1.0 + p * ax);
+    let y = 1.0 - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * expf_approx(-ax * ax);
+    sign * y
+}
+
+// ---------------------------------------------------------------------------
+// Public operators
+// ---------------------------------------------------------------------------
+
+/// Element-wise power with broadcasting: `out[i] = base[i] ^ exp[i]`.
+pub fn op_pow(base: &Tensor, exponent: &Tensor) -> Result<Tensor, OpError> {
+    require_float(base, "Pow")?;
+    require_float(exponent, "Pow")?;
+    let out_dims = broadcast_shape(&base.shape.dims, &exponent.shape.dims)?;
+    let total: usize = out_dims
+        .iter()
+        .map(|&d| d as usize)
+        .product::<usize>()
+        .max(1);
+    let mut data = allocate_tensor_data(total, DataType::Float);
+    let ndim = out_dims.len();
+    let mut coord = alloc::vec![0usize; ndim];
+    for flat in 0..total {
+        let bi = broadcast_index(&coord, &base.shape.dims);
+        let ei = broadcast_index(&coord, &exponent.shape.dims);
+        let b = read_f32(&base.raw_data, bi);
+        let e = read_f32(&exponent.raw_data, ei);
+        // pow(x, y) = exp(y * ln(x)) for positive x; handle integer y for negatives.
+        let v = if b == 0.0 {
+            if e == 0.0 {
+                1.0
+            } else {
+                0.0
+            }
+        } else if b < 0.0 {
+            // Only support integer exponents for negative bases.
+            let e_int = e as i32;
+            if (e_int as f32 - e).abs() < 1e-6 {
+                let mut p = 1.0_f32;
+                let n = e_int.unsigned_abs();
+                for _ in 0..n {
+                    p *= b;
+                }
+                if e_int < 0 {
+                    1.0 / p
+                } else {
+                    p
+                }
+            } else {
+                f32::NAN
+            }
+        } else {
+            expf_approx(e * lnf_approx(b))
+        };
+        write_f32(&mut data, flat, v);
+        if flat + 1 < total {
+            next_coord(&mut coord, &out_dims);
+        }
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: TensorShape::new(out_dims),
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+/// Element-wise square root.
+pub fn op_sqrt(input: &Tensor) -> Result<Tensor, OpError> {
+    unary(input, "Sqrt", sqrt_approx)
+}
+
+/// Element-wise natural exponential.
+pub fn op_exp(input: &Tensor) -> Result<Tensor, OpError> {
+    unary(input, "Exp", expf_approx)
+}
+
+/// Element-wise natural logarithm.
+pub fn op_log(input: &Tensor) -> Result<Tensor, OpError> {
+    unary(input, "Log", lnf_approx)
+}
+
+/// Element-wise error function.
+pub fn op_erf(input: &Tensor) -> Result<Tensor, OpError> {
+    unary(input, "Erf", erf_approx)
+}
+
+/// Element-wise negation.
+pub fn op_neg(input: &Tensor) -> Result<Tensor, OpError> {
+    unary(input, "Neg", |x| -x)
+}
+
+/// Element-wise absolute value.
+pub fn op_abs(input: &Tensor) -> Result<Tensor, OpError> {
+    unary(input, "Abs", |x| if x < 0.0 { -x } else { x })
+}
+
+/// Element-wise floor.
+pub fn op_floor(input: &Tensor) -> Result<Tensor, OpError> {
+    unary(input, "Floor", floor_f32)
+}
+
+/// Element-wise ceiling.
+pub fn op_ceil(input: &Tensor) -> Result<Tensor, OpError> {
+    unary(input, "Ceil", ceil_f32)
+}
+
+/// Element-wise round (banker's rounding to nearest, ties to even).
+pub fn op_round(input: &Tensor) -> Result<Tensor, OpError> {
+    unary(input, "Round", round_half_even)
+}
+
+fn floor_f32(x: f32) -> f32 {
+    let i = x as i64 as f32;
+    if x < 0.0 && i != x {
+        i - 1.0
+    } else {
+        i
+    }
+}
+
+fn ceil_f32(x: f32) -> f32 {
+    let i = x as i64 as f32;
+    if x > 0.0 && i != x {
+        i + 1.0
+    } else {
+        i
+    }
+}
+
+fn round_half_even(x: f32) -> f32 {
+    let f = floor_f32(x);
+    let frac = x - f;
+    if frac < 0.5 {
+        f
+    } else if frac > 0.5 {
+        f + 1.0
+    } else {
+        // Tie: round to even
+        let fi = f as i64;
+        if fi % 2 == 0 {
+            f
+        } else {
+            f + 1.0
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    fn make_f32(dims: &[i64], vals: &[f32]) -> Tensor {
+        let mut data = allocate_tensor_data(vals.len(), DataType::Float);
+        for (i, &v) in vals.iter().enumerate() {
+            write_f32(&mut data, i, v);
+        }
+        Tensor {
+            data_type: DataType::Float,
+            shape: TensorShape::new(dims.to_vec()),
+            name: String::new(),
+            raw_data: data,
+        }
+    }
+
+    fn read_all(t: &Tensor) -> alloc::vec::Vec<f32> {
+        (0..t.shape.total_elements())
+            .map(|i| read_f32(&t.raw_data, i))
+            .collect()
+    }
+
+    #[test]
+    fn test_sqrt_basic() {
+        let t = make_f32(&[3], &[4.0, 9.0, 16.0]);
+        let out = op_sqrt(&t).unwrap();
+        let v = read_all(&out);
+        assert!((v[0] - 2.0).abs() < 1e-3);
+        assert!((v[1] - 3.0).abs() < 1e-3);
+        assert!((v[2] - 4.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_sqrt_zero() {
+        let t = make_f32(&[1], &[0.0]);
+        let out = op_sqrt(&t).unwrap();
+        assert_eq!(read_f32(&out.raw_data, 0), 0.0);
+    }
+
+    #[test]
+    fn test_exp_basic() {
+        let t = make_f32(&[3], &[0.0, 1.0, -1.0]);
+        let out = op_exp(&t).unwrap();
+        let v = read_all(&out);
+        assert!((v[0] - 1.0).abs() < 1e-3);
+        assert!((v[1] - core::f32::consts::E).abs() < 1e-3);
+        assert!((v[2] - 1.0 / core::f32::consts::E).abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_log_basic() {
+        let t = make_f32(&[3], &[1.0, core::f32::consts::E, 4.0]);
+        let out = op_log(&t).unwrap();
+        let v = read_all(&out);
+        assert!(v[0].abs() < 1e-3);
+        assert!((v[1] - 1.0).abs() < 1e-3);
+        assert!((v[2] - 4.0_f32.ln()).abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_log_zero_returns_neg_inf() {
+        let t = make_f32(&[1], &[0.0]);
+        let out = op_log(&t).unwrap();
+        assert!(read_f32(&out.raw_data, 0).is_infinite());
+    }
+
+    #[test]
+    fn test_log_exp_round_trip() {
+        let t = make_f32(&[5], &[0.5, 1.0, 2.0, 3.5, 7.7]);
+        let l = op_log(&t).unwrap();
+        let e = op_exp(&l).unwrap();
+        let original = read_all(&t);
+        let restored = read_all(&e);
+        for i in 0..5 {
+            assert!(
+                (original[i] - restored[i]).abs() / original[i] < 1e-2,
+                "round trip failed: {} vs {}",
+                original[i],
+                restored[i]
+            );
+        }
+    }
+
+    #[test]
+    fn test_erf_known_values() {
+        // erf(0)=0, erf(1)≈0.8427, erf(-1)≈-0.8427
+        let t = make_f32(&[3], &[0.0, 1.0, -1.0]);
+        let out = op_erf(&t).unwrap();
+        let v = read_all(&out);
+        assert!(v[0].abs() < 1e-4);
+        assert!((v[1] - 0.8427).abs() < 1e-3);
+        assert!((v[2] + 0.8427).abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_neg() {
+        let t = make_f32(&[4], &[1.0, -2.0, 0.0, 3.5]);
+        let v = read_all(&op_neg(&t).unwrap());
+        assert_eq!(v, vec![-1.0, 2.0, -0.0, -3.5]);
+    }
+
+    #[test]
+    fn test_abs() {
+        let t = make_f32(&[4], &[1.0, -2.0, 0.0, -3.5]);
+        let v = read_all(&op_abs(&t).unwrap());
+        assert_eq!(v, vec![1.0, 2.0, 0.0, 3.5]);
+    }
+
+    #[test]
+    fn test_floor() {
+        let t = make_f32(&[5], &[1.7, -1.7, 0.0, 2.0, -2.0]);
+        let v = read_all(&op_floor(&t).unwrap());
+        assert_eq!(v, vec![1.0, -2.0, 0.0, 2.0, -2.0]);
+    }
+
+    #[test]
+    fn test_ceil() {
+        let t = make_f32(&[5], &[1.3, -1.3, 0.0, 2.0, -2.0]);
+        let v = read_all(&op_ceil(&t).unwrap());
+        assert_eq!(v, vec![2.0, -1.0, 0.0, 2.0, -2.0]);
+    }
+
+    #[test]
+    fn test_round_half_even() {
+        let t = make_f32(&[6], &[0.5, 1.5, 2.5, -0.5, 1.4, 1.6]);
+        let v = read_all(&op_round(&t).unwrap());
+        // 0.5 → 0 (even), 1.5 → 2 (even), 2.5 → 2 (even), -0.5 → 0
+        assert_eq!(v, vec![0.0, 2.0, 2.0, 0.0, 1.0, 2.0]);
+    }
+
+    #[test]
+    fn test_pow_scalar() {
+        let base = make_f32(&[3], &[2.0, 3.0, 4.0]);
+        let exp = make_f32(&[3], &[2.0, 2.0, 2.0]);
+        let v = read_all(&op_pow(&base, &exp).unwrap());
+        assert!((v[0] - 4.0).abs() < 1e-2);
+        assert!((v[1] - 9.0).abs() < 1e-2);
+        assert!((v[2] - 16.0).abs() < 1e-2);
+    }
+
+    #[test]
+    fn test_pow_broadcast() {
+        let base = make_f32(&[2, 2], &[2.0, 3.0, 4.0, 5.0]);
+        let exp = make_f32(&[1], &[2.0]);
+        let out = op_pow(&base, &exp).unwrap();
+        let v = read_all(&out);
+        assert!((v[0] - 4.0).abs() < 1e-2);
+        assert!((v[1] - 9.0).abs() < 1e-2);
+        assert!((v[2] - 16.0).abs() < 1e-2);
+        assert!((v[3] - 25.0).abs() < 1e-2);
+    }
+
+    #[test]
+    fn test_pow_negative_integer_exponent() {
+        let base = make_f32(&[2], &[-2.0, -3.0]);
+        let exp = make_f32(&[2], &[3.0, 2.0]);
+        let v = read_all(&op_pow(&base, &exp).unwrap());
+        assert!((v[0] - -8.0).abs() < 1e-3);
+        assert!((v[1] - 9.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_pow_zero_zero_is_one() {
+        let base = make_f32(&[1], &[0.0]);
+        let exp = make_f32(&[1], &[0.0]);
+        let v = read_all(&op_pow(&base, &exp).unwrap());
+        assert_eq!(v[0], 1.0);
+    }
+
+    #[test]
+    fn test_unary_rejects_non_float() {
+        let t = Tensor {
+            data_type: DataType::Int32,
+            shape: TensorShape::new(vec![1]),
+            name: String::new(),
+            raw_data: alloc::vec![0u8; 4],
+        };
+        assert!(op_sqrt(&t).is_err());
+        assert!(op_exp(&t).is_err());
+        assert!(op_neg(&t).is_err());
+    }
+}

--- a/onnx-rt/src/ops/mod.rs
+++ b/onnx-rt/src/ops/mod.rs
@@ -1,0 +1,23 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tier 2 operator implementations for the SmallAIOS ONNX runtime.
+//!
+//! These operators expand support beyond the original Tier 1 set to cover
+//! transformer building blocks (Einsum, Split, Expand, …), recurrent layers
+//! (RNN, LSTM, GRU), composite activations (GELU, LeakyReLU, ELU, Swish),
+//! quantized INT8 ops (QuantizeLinear, DequantizeLinear, QLinearMatMul,
+//! QLinearConv), comparison/selection ops, and additional element-wise math
+//! primitives (Pow, Sqrt, Exp, Log, Erf, Neg, Abs, Floor, Ceil, Round).
+//!
+//! Each submodule is independent and depends only on `tensor`, `byte_io`,
+//! and `operators::OpError`. Tier 1 operators continue to live in
+//! `crate::operators` to keep the diff focused and to avoid churning
+//! existing call sites.
+
+pub mod activations;
+pub mod compare;
+pub mod math;
+pub mod quantized;
+pub mod recurrent;
+pub mod transformer;

--- a/onnx-rt/src/ops/quantized.rs
+++ b/onnx-rt/src/ops/quantized.rs
@@ -1,0 +1,400 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Quantized operators: QuantizeLinear, DequantizeLinear, QLinearMatMul,
+//! QLinearConv.
+//!
+//! The strategy for QLinearMatMul/QLinearConv is "dequantize → compute in
+//! f32 → requantize". This trades performance for correctness; a real i8
+//! GEMM kernel is future work.
+
+use alloc::string::String;
+
+use crate::byte_io::{allocate_tensor_data, read_f32, write_f32};
+use crate::operators::{op_conv, op_matmul, OpError};
+use crate::tensor::{DataType, Tensor};
+
+/// Banker's rounding (round half to even) without depending on the
+/// nightly `f32::round_ties_even` inherent method.
+fn round_half_even(x: f32) -> f32 {
+    // Floor.
+    let i = x as i64 as f32;
+    let f = if x < 0.0 && i != x { i - 1.0 } else { i };
+    let frac = x - f;
+    if frac < 0.5 {
+        f
+    } else if frac > 0.5 {
+        f + 1.0
+    } else {
+        let fi = f as i64;
+        if (fi & 1) == 0 {
+            f
+        } else {
+            f + 1.0
+        }
+    }
+}
+
+/// Returns the per-tensor scale (first element of the scale tensor).
+fn read_scale(scale: &Tensor) -> Result<f32, OpError> {
+    if scale.data_type != DataType::Float || scale.raw_data.len() < 4 {
+        return Err(OpError::ShapeMismatch(String::from(
+            "quantized: scale must be Float",
+        )));
+    }
+    Ok(read_f32(&scale.raw_data, 0))
+}
+
+/// Returns the zero-point as an i32 (read from int8 / uint8 / int32).
+fn read_zero_point(zp: Option<&Tensor>) -> Result<i32, OpError> {
+    match zp {
+        None => Ok(0),
+        Some(t) => match t.data_type {
+            DataType::Int8 => Ok(t.raw_data.first().map(|&b| b as i8 as i32).unwrap_or(0)),
+            DataType::Uint8 => Ok(t.raw_data.first().map(|&b| b as i32).unwrap_or(0)),
+            DataType::Int32 => {
+                if t.raw_data.len() < 4 {
+                    Ok(0)
+                } else {
+                    Ok(crate::byte_io::read_i32(&t.raw_data, 0))
+                }
+            }
+            _ => Err(OpError::ShapeMismatch(String::from(
+                "quantized: zero_point must be Int8/Uint8/Int32",
+            ))),
+        },
+    }
+}
+
+/// Quantizes a Float tensor to Int8 or Uint8 using a per-tensor scale and
+/// zero point.
+///
+/// Output dtype matches the dtype of `zero_point` (defaulting to Int8 when
+/// none is provided).
+pub fn op_quantize_linear(
+    input: &Tensor,
+    scale: &Tensor,
+    zero_point: Option<&Tensor>,
+) -> Result<Tensor, OpError> {
+    if input.data_type != DataType::Float {
+        return Err(OpError::ShapeMismatch(String::from(
+            "QuantizeLinear input must be Float",
+        )));
+    }
+    let s = read_scale(scale)?;
+    if s == 0.0 {
+        return Err(OpError::InvalidAttribute(String::from(
+            "QuantizeLinear: scale must be non-zero",
+        )));
+    }
+    let zp = read_zero_point(zero_point)?;
+    let out_dtype = zero_point.map(|z| z.data_type).unwrap_or(DataType::Int8);
+    let n = input.shape.total_elements();
+    let mut data = alloc::vec![0u8; n];
+    match out_dtype {
+        DataType::Int8 => {
+            for (i, slot) in data.iter_mut().enumerate().take(n) {
+                let v = read_f32(&input.raw_data, i);
+                let q = round_half_even(v / s) as i32 + zp;
+                let clipped = q.clamp(-128, 127) as i8;
+                *slot = clipped as u8;
+            }
+        }
+        DataType::Uint8 => {
+            for (i, slot) in data.iter_mut().enumerate().take(n) {
+                let v = read_f32(&input.raw_data, i);
+                let q = round_half_even(v / s) as i32 + zp;
+                *slot = q.clamp(0, 255) as u8;
+            }
+        }
+        _ => {
+            return Err(OpError::ShapeMismatch(String::from(
+                "QuantizeLinear: zero_point dtype must be Int8 or Uint8",
+            )));
+        }
+    }
+    Ok(Tensor {
+        data_type: out_dtype,
+        shape: input.shape.clone(),
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+/// Dequantizes an Int8 / Uint8 tensor back to Float.
+pub fn op_dequantize_linear(
+    input: &Tensor,
+    scale: &Tensor,
+    zero_point: Option<&Tensor>,
+) -> Result<Tensor, OpError> {
+    let s = read_scale(scale)?;
+    let zp = read_zero_point(zero_point)?;
+    let n = input.shape.total_elements();
+    let mut data = allocate_tensor_data(n, DataType::Float);
+    match input.data_type {
+        DataType::Int8 => {
+            for i in 0..n {
+                let q = input.raw_data[i] as i8 as i32;
+                write_f32(&mut data, i, (q - zp) as f32 * s);
+            }
+        }
+        DataType::Uint8 => {
+            for i in 0..n {
+                let q = input.raw_data[i] as i32;
+                write_f32(&mut data, i, (q - zp) as f32 * s);
+            }
+        }
+        _ => {
+            return Err(OpError::ShapeMismatch(String::from(
+                "DequantizeLinear input must be Int8 or Uint8",
+            )));
+        }
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: input.shape.clone(),
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// QLinearMatMul / QLinearConv
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::too_many_arguments)]
+pub fn op_qlinear_matmul(
+    a: &Tensor,
+    a_scale: &Tensor,
+    a_zp: &Tensor,
+    b: &Tensor,
+    b_scale: &Tensor,
+    b_zp: &Tensor,
+    y_scale: &Tensor,
+    y_zp: &Tensor,
+) -> Result<Tensor, OpError> {
+    let a_f32 = op_dequantize_linear(a, a_scale, Some(a_zp))?;
+    let b_f32 = op_dequantize_linear(b, b_scale, Some(b_zp))?;
+    let y_f32 = op_matmul(&a_f32, &b_f32)?;
+    op_quantize_linear(&y_f32, y_scale, Some(y_zp))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn op_qlinear_conv(
+    x: &Tensor,
+    x_scale: &Tensor,
+    x_zp: &Tensor,
+    w: &Tensor,
+    w_scale: &Tensor,
+    w_zp: &Tensor,
+    y_scale: &Tensor,
+    y_zp: &Tensor,
+    bias: Option<&Tensor>,
+) -> Result<Tensor, OpError> {
+    let x_f32 = op_dequantize_linear(x, x_scale, Some(x_zp))?;
+    let w_f32 = op_dequantize_linear(w, w_scale, Some(w_zp))?;
+    // Bias for QLinearConv is typically Int32 (pre-scaled by x_scale*w_scale).
+    // For the dequantize-then-quantize approach we accept None or a Float bias.
+    let bias_f32: Option<Tensor> = match bias {
+        None => None,
+        Some(b) if b.data_type == DataType::Float => Some(b.clone()),
+        Some(b) if b.data_type == DataType::Int32 => {
+            // Approximate: bias_f32[i] = bias_i32[i] * (x_scale * w_scale)
+            let xs = read_scale(x_scale)?;
+            let ws = read_scale(w_scale)?;
+            let n = b.shape.total_elements();
+            let mut data = allocate_tensor_data(n, DataType::Float);
+            for i in 0..n {
+                let q = crate::byte_io::read_i32(&b.raw_data, i);
+                write_f32(&mut data, i, q as f32 * xs * ws);
+            }
+            Some(Tensor {
+                data_type: DataType::Float,
+                shape: b.shape.clone(),
+                name: String::new(),
+                raw_data: data,
+            })
+        }
+        Some(_) => {
+            return Err(OpError::ShapeMismatch(String::from(
+                "QLinearConv bias must be Float or Int32",
+            )))
+        }
+    };
+    let y_f32 = op_conv(&x_f32, &w_f32, bias_f32.as_ref())?;
+    op_quantize_linear(&y_f32, y_scale, Some(y_zp))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::byte_io::{write_f32, write_i32};
+    use crate::tensor::TensorShape;
+    use alloc::vec::Vec;
+
+    fn make_f32(dims: &[i64], vals: &[f32]) -> Tensor {
+        let mut data = allocate_tensor_data(vals.len(), DataType::Float);
+        for (i, &v) in vals.iter().enumerate() {
+            write_f32(&mut data, i, v);
+        }
+        Tensor {
+            data_type: DataType::Float,
+            shape: TensorShape::new(dims.to_vec()),
+            name: String::new(),
+            raw_data: data,
+        }
+    }
+
+    fn scalar_f32(v: f32) -> Tensor {
+        let mut data = alloc::vec![0u8; 4];
+        write_f32(&mut data, 0, v);
+        Tensor {
+            data_type: DataType::Float,
+            shape: TensorShape::new(alloc::vec![1]),
+            name: String::new(),
+            raw_data: data,
+        }
+    }
+
+    fn scalar_i8(v: i8) -> Tensor {
+        Tensor {
+            data_type: DataType::Int8,
+            shape: TensorShape::new(alloc::vec![1]),
+            name: String::new(),
+            raw_data: alloc::vec![v as u8],
+        }
+    }
+
+    fn scalar_u8(v: u8) -> Tensor {
+        Tensor {
+            data_type: DataType::Uint8,
+            shape: TensorShape::new(alloc::vec![1]),
+            name: String::new(),
+            raw_data: alloc::vec![v],
+        }
+    }
+
+    fn read_int8(t: &Tensor) -> Vec<i8> {
+        t.raw_data.iter().map(|&b| b as i8).collect()
+    }
+
+    #[test]
+    fn test_quantize_int8_basic() {
+        let x = make_f32(&[4], &[0.0, 0.1, 0.2, -0.1]);
+        let s = scalar_f32(0.1);
+        let zp = scalar_i8(0);
+        let out = op_quantize_linear(&x, &s, Some(&zp)).unwrap();
+        assert_eq!(out.data_type, DataType::Int8);
+        assert_eq!(read_int8(&out), alloc::vec![0, 1, 2, -1]);
+    }
+
+    #[test]
+    fn test_quantize_uint8_basic() {
+        let x = make_f32(&[3], &[0.0, 0.5, 1.0]);
+        let s = scalar_f32(0.1);
+        let zp = scalar_u8(128);
+        let out = op_quantize_linear(&x, &s, Some(&zp)).unwrap();
+        assert_eq!(out.data_type, DataType::Uint8);
+        assert_eq!(out.raw_data, alloc::vec![128u8, 133, 138]);
+    }
+
+    #[test]
+    fn test_quantize_clipping() {
+        let x = make_f32(&[2], &[100.0, -100.0]);
+        let s = scalar_f32(0.1);
+        let zp = scalar_i8(0);
+        let out = op_quantize_linear(&x, &s, Some(&zp)).unwrap();
+        let v = read_int8(&out);
+        assert_eq!(v, alloc::vec![127, -128]);
+    }
+
+    #[test]
+    fn test_dequantize_int8_basic() {
+        let q = Tensor {
+            data_type: DataType::Int8,
+            shape: TensorShape::new(alloc::vec![3]),
+            name: String::new(),
+            raw_data: alloc::vec![0u8, 1u8, (-1i8) as u8],
+        };
+        let s = scalar_f32(0.1);
+        let zp = scalar_i8(0);
+        let out = op_dequantize_linear(&q, &s, Some(&zp)).unwrap();
+        assert_eq!(out.data_type, DataType::Float);
+        let v: Vec<f32> = (0..3).map(|i| read_f32(&out.raw_data, i)).collect();
+        assert!((v[0] - 0.0).abs() < 1e-6);
+        assert!((v[1] - 0.1).abs() < 1e-6);
+        assert!((v[2] - -0.1).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_quantize_dequantize_round_trip() {
+        let original = make_f32(&[5], &[0.0, 0.3, -0.7, 1.2, -1.5]);
+        let s = scalar_f32(0.05);
+        let zp = scalar_i8(0);
+        let q = op_quantize_linear(&original, &s, Some(&zp)).unwrap();
+        let dq = op_dequantize_linear(&q, &s, Some(&zp)).unwrap();
+        for i in 0..5 {
+            let o = read_f32(&original.raw_data, i);
+            let r = read_f32(&dq.raw_data, i);
+            // Round-trip error must be within scale.
+            assert!((o - r).abs() <= 0.05 + 1e-6, "{} vs {}", o, r);
+        }
+    }
+
+    #[test]
+    fn test_qlinear_matmul_matches_f32() {
+        // 2x3 * 3x2 = 2x2
+        let a_f = make_f32(&[2, 3], &[0.5, -0.5, 1.0, 0.0, 0.5, -0.5]);
+        let b_f = make_f32(&[3, 2], &[1.0, 0.5, -0.5, 1.0, 0.0, -1.0]);
+        let s = scalar_f32(0.01);
+        let zp = scalar_i8(0);
+        let a_q = op_quantize_linear(&a_f, &s, Some(&zp)).unwrap();
+        let b_q = op_quantize_linear(&b_f, &s, Some(&zp)).unwrap();
+        let y_s = scalar_f32(0.01);
+        let y_zp = scalar_i8(0);
+        let q_out = op_qlinear_matmul(&a_q, &s, &zp, &b_q, &s, &zp, &y_s, &y_zp).unwrap();
+        let dq_out = op_dequantize_linear(&q_out, &y_s, Some(&y_zp)).unwrap();
+
+        let f_out = op_matmul(&a_f, &b_f).unwrap();
+        for i in 0..4 {
+            let f = read_f32(&f_out.raw_data, i);
+            let dq = read_f32(&dq_out.raw_data, i);
+            // Quantized result within 1% of f32 result (or 0.05 absolute).
+            let tol = (f.abs() * 0.05).max(0.05);
+            assert!((f - dq).abs() <= tol, "{} vs {} tol {}", f, dq, tol);
+        }
+    }
+
+    #[test]
+    fn test_quantize_zero_scale_fails() {
+        let x = make_f32(&[1], &[1.0]);
+        let s = scalar_f32(0.0);
+        let zp = scalar_i8(0);
+        assert!(op_quantize_linear(&x, &s, Some(&zp)).is_err());
+    }
+
+    #[test]
+    fn test_dequantize_int32_zero_point() {
+        // Verify Int32 zero point is accepted.
+        let q = Tensor {
+            data_type: DataType::Int8,
+            shape: TensorShape::new(alloc::vec![2]),
+            name: String::new(),
+            raw_data: alloc::vec![10u8, 20u8],
+        };
+        let s = scalar_f32(0.5);
+        let mut zp_data = alloc::vec![0u8; 4];
+        write_i32(&mut zp_data, 0, 5);
+        let zp = Tensor {
+            data_type: DataType::Int32,
+            shape: TensorShape::new(alloc::vec![1]),
+            name: String::new(),
+            raw_data: zp_data,
+        };
+        let out = op_dequantize_linear(&q, &s, Some(&zp)).unwrap();
+        let v: Vec<f32> = (0..2).map(|i| read_f32(&out.raw_data, i)).collect();
+        // (10-5)*0.5 = 2.5, (20-5)*0.5 = 7.5
+        assert!((v[0] - 2.5).abs() < 1e-6);
+        assert!((v[1] - 7.5).abs() < 1e-6);
+    }
+}

--- a/onnx-rt/src/ops/recurrent.rs
+++ b/onnx-rt/src/ops/recurrent.rs
@@ -1,0 +1,668 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Recurrent operators: RNN, LSTM, GRU.
+//!
+//! All ops accept ONNX-style weight layouts where the leading dimension is
+//! the direction (1 for forward/reverse, 2 for bidirectional). The shapes
+//! follow the ONNX opset 14+ spec.
+//!
+//! Implementations are sequence-major and use a simple per-timestep loop.
+//! Output Y has shape `[seq_length, num_directions, batch, hidden_size]`.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use crate::byte_io::{allocate_tensor_data, read_f32, write_f32};
+use crate::operators::{expf_approx, OpError};
+use crate::tensor::{DataType, Tensor, TensorShape};
+
+fn require_float(t: &Tensor, op: &str) -> Result<(), OpError> {
+    if t.data_type != DataType::Float {
+        return Err(OpError::ShapeMismatch(alloc::format!(
+            "{} requires Float input",
+            op
+        )));
+    }
+    Ok(())
+}
+
+fn sigmoid(x: f32) -> f32 {
+    1.0 / (1.0 + expf_approx(-x))
+}
+
+fn tanh_approx(x: f32) -> f32 {
+    let ep = expf_approx(x);
+    let em = expf_approx(-x);
+    (ep - em) / (ep + em)
+}
+
+fn parse_direction(direction: &str) -> Result<(usize, bool), OpError> {
+    // returns (num_directions, is_bidirectional)
+    match direction {
+        "forward" | "reverse" => Ok((1, false)),
+        "bidirectional" => Ok((2, true)),
+        _ => Err(OpError::InvalidAttribute(alloc::format!(
+            "unknown direction: {}",
+            direction
+        ))),
+    }
+}
+
+/// Reads a slice of the form `data[base..base+n]` as f32.
+fn slice_f32(data: &[u8], base: usize, n: usize) -> Vec<f32> {
+    (0..n).map(|i| read_f32(data, base + i)).collect()
+}
+
+// ---------------------------------------------------------------------------
+// RNN
+// ---------------------------------------------------------------------------
+
+/// Basic RNN with tanh activation.
+///
+/// X: [seq_length, batch, input_size]
+/// W: [num_directions, hidden_size, input_size]
+/// R: [num_directions, hidden_size, hidden_size]
+/// B: [num_directions, 2*hidden_size] (concat of W bias and R bias) — optional
+/// h0: [num_directions, batch, hidden_size] — optional, default zeros
+///
+/// Returns:
+/// - Y: [seq_length, num_directions, batch, hidden_size]
+/// - Y_h: [num_directions, batch, hidden_size]
+pub fn op_rnn(
+    x: &Tensor,
+    w: &Tensor,
+    r: &Tensor,
+    b: Option<&Tensor>,
+    h0: Option<&Tensor>,
+    direction: &str,
+) -> Result<Vec<Tensor>, OpError> {
+    require_float(x, "RNN")?;
+    require_float(w, "RNN")?;
+    require_float(r, "RNN")?;
+    let (num_dir, _bi) = parse_direction(direction)?;
+
+    if x.shape.dims.len() != 3 {
+        return Err(OpError::ShapeMismatch(String::from(
+            "RNN: X must be 3D [seq, batch, input]",
+        )));
+    }
+    let seq = x.shape.dims[0] as usize;
+    let batch = x.shape.dims[1] as usize;
+    let input_size = x.shape.dims[2] as usize;
+
+    if w.shape.dims.len() != 3 || w.shape.dims[0] as usize != num_dir {
+        return Err(OpError::ShapeMismatch(String::from(
+            "RNN: W shape must be [num_dir, hidden, input]",
+        )));
+    }
+    let hidden = w.shape.dims[1] as usize;
+    if w.shape.dims[2] as usize != input_size {
+        return Err(OpError::ShapeMismatch(String::from(
+            "RNN: W input dim mismatch",
+        )));
+    }
+    if r.shape.dims.len() != 3
+        || r.shape.dims[0] as usize != num_dir
+        || r.shape.dims[1] as usize != hidden
+        || r.shape.dims[2] as usize != hidden
+    {
+        return Err(OpError::ShapeMismatch(String::from(
+            "RNN: R shape must be [num_dir, hidden, hidden]",
+        )));
+    }
+
+    // Output buffers.
+    let y_total = seq * num_dir * batch * hidden;
+    let mut y_data = allocate_tensor_data(y_total, DataType::Float);
+    let mut yh_data = allocate_tensor_data(num_dir * batch * hidden, DataType::Float);
+
+    for d in 0..num_dir {
+        let reverse = direction == "reverse" || (direction == "bidirectional" && d == 1);
+        // Read this direction's weights / biases.
+        let w_off = d * hidden * input_size;
+        let r_off = d * hidden * hidden;
+        let w_dir = slice_f32(&w.raw_data, w_off, hidden * input_size);
+        let r_dir = slice_f32(&r.raw_data, r_off, hidden * hidden);
+        let b_dir: Vec<f32> = if let Some(bt) = b {
+            require_float(bt, "RNN")?;
+            // B is [num_dir, 2*hidden]; final bias is sum of W bias and R bias halves.
+            let off = d * 2 * hidden;
+            let wb = slice_f32(&bt.raw_data, off, hidden);
+            let rb = slice_f32(&bt.raw_data, off + hidden, hidden);
+            wb.iter().zip(rb.iter()).map(|(a, b)| a + b).collect()
+        } else {
+            alloc::vec![0.0f32; hidden]
+        };
+        // Initial hidden state.
+        let mut h: Vec<f32> = if let Some(h0t) = h0 {
+            require_float(h0t, "RNN")?;
+            slice_f32(&h0t.raw_data, d * batch * hidden, batch * hidden)
+        } else {
+            alloc::vec![0.0f32; batch * hidden]
+        };
+
+        for step in 0..seq {
+            let t = if reverse { seq - 1 - step } else { step };
+            // Compute h_t = tanh(x_t W^T + h_{t-1} R^T + b)
+            let x_off = t * batch * input_size;
+            let mut new_h = alloc::vec![0.0f32; batch * hidden];
+            for bi in 0..batch {
+                for hi in 0..hidden {
+                    let mut acc = b_dir[hi];
+                    for ii in 0..input_size {
+                        acc += read_f32(&x.raw_data, x_off + bi * input_size + ii)
+                            * w_dir[hi * input_size + ii];
+                    }
+                    for hh in 0..hidden {
+                        acc += h[bi * hidden + hh] * r_dir[hi * hidden + hh];
+                    }
+                    new_h[bi * hidden + hi] = tanh_approx(acc);
+                }
+            }
+            h = new_h;
+            // Write Y[t, d, :, :].
+            let y_off = t * num_dir * batch * hidden + d * batch * hidden;
+            for (i, &v) in h.iter().enumerate() {
+                write_f32(&mut y_data, y_off + i, v);
+            }
+        }
+        // Final hidden state for this direction.
+        let yh_off = d * batch * hidden;
+        for (i, &v) in h.iter().enumerate() {
+            write_f32(&mut yh_data, yh_off + i, v);
+        }
+    }
+
+    Ok(alloc::vec![
+        Tensor {
+            data_type: DataType::Float,
+            shape: TensorShape::new(alloc::vec![
+                seq as i64,
+                num_dir as i64,
+                batch as i64,
+                hidden as i64
+            ]),
+            name: String::new(),
+            raw_data: y_data,
+        },
+        Tensor {
+            data_type: DataType::Float,
+            shape: TensorShape::new(alloc::vec![num_dir as i64, batch as i64, hidden as i64]),
+            name: String::new(),
+            raw_data: yh_data,
+        },
+    ])
+}
+
+// ---------------------------------------------------------------------------
+// LSTM
+// ---------------------------------------------------------------------------
+
+/// LSTM with input, forget, cell, output gates (i, o, f, c order per ONNX).
+///
+/// W: [num_dir, 4*hidden, input]
+/// R: [num_dir, 4*hidden, hidden]
+/// B: [num_dir, 8*hidden]
+///
+/// Returns: Y, Y_h, Y_c
+#[allow(clippy::too_many_arguments)]
+pub fn op_lstm(
+    x: &Tensor,
+    w: &Tensor,
+    r: &Tensor,
+    b: Option<&Tensor>,
+    h0: Option<&Tensor>,
+    c0: Option<&Tensor>,
+    direction: &str,
+) -> Result<Vec<Tensor>, OpError> {
+    require_float(x, "LSTM")?;
+    require_float(w, "LSTM")?;
+    require_float(r, "LSTM")?;
+    let (num_dir, _bi) = parse_direction(direction)?;
+
+    if x.shape.dims.len() != 3 {
+        return Err(OpError::ShapeMismatch(String::from(
+            "LSTM: X must be 3D [seq, batch, input]",
+        )));
+    }
+    let seq = x.shape.dims[0] as usize;
+    let batch = x.shape.dims[1] as usize;
+    let input_size = x.shape.dims[2] as usize;
+
+    if w.shape.dims.len() != 3 || w.shape.dims[0] as usize != num_dir {
+        return Err(OpError::ShapeMismatch(String::from(
+            "LSTM: W shape must be [num_dir, 4*hidden, input]",
+        )));
+    }
+    let four_h = w.shape.dims[1] as usize;
+    if !four_h.is_multiple_of(4) {
+        return Err(OpError::ShapeMismatch(String::from(
+            "LSTM: W second dim must be 4*hidden",
+        )));
+    }
+    let hidden = four_h / 4;
+
+    let y_total = seq * num_dir * batch * hidden;
+    let mut y_data = allocate_tensor_data(y_total, DataType::Float);
+    let mut yh_data = allocate_tensor_data(num_dir * batch * hidden, DataType::Float);
+    let mut yc_data = allocate_tensor_data(num_dir * batch * hidden, DataType::Float);
+
+    for d in 0..num_dir {
+        let reverse = direction == "reverse" || (direction == "bidirectional" && d == 1);
+
+        let w_off = d * 4 * hidden * input_size;
+        let r_off = d * 4 * hidden * hidden;
+        let w_dir = slice_f32(&w.raw_data, w_off, 4 * hidden * input_size);
+        let r_dir = slice_f32(&r.raw_data, r_off, 4 * hidden * hidden);
+        let b_dir: Vec<f32> = if let Some(bt) = b {
+            require_float(bt, "LSTM")?;
+            // B is [num_dir, 8*hidden]; collapse W bias + R bias.
+            let off = d * 8 * hidden;
+            let wb = slice_f32(&bt.raw_data, off, 4 * hidden);
+            let rb = slice_f32(&bt.raw_data, off + 4 * hidden, 4 * hidden);
+            wb.iter().zip(rb.iter()).map(|(a, b)| a + b).collect()
+        } else {
+            alloc::vec![0.0f32; 4 * hidden]
+        };
+
+        let mut h: Vec<f32> = if let Some(h0t) = h0 {
+            require_float(h0t, "LSTM")?;
+            slice_f32(&h0t.raw_data, d * batch * hidden, batch * hidden)
+        } else {
+            alloc::vec![0.0f32; batch * hidden]
+        };
+        let mut c: Vec<f32> = if let Some(c0t) = c0 {
+            require_float(c0t, "LSTM")?;
+            slice_f32(&c0t.raw_data, d * batch * hidden, batch * hidden)
+        } else {
+            alloc::vec![0.0f32; batch * hidden]
+        };
+
+        // Gate layout per ONNX: i, o, f, c (input, output, forget, cell).
+        let gate_offset = |g: usize| g * hidden;
+
+        for step in 0..seq {
+            let t = if reverse { seq - 1 - step } else { step };
+            let x_off = t * batch * input_size;
+            let mut new_h = alloc::vec![0.0f32; batch * hidden];
+            let mut new_c = alloc::vec![0.0f32; batch * hidden];
+            for bi in 0..batch {
+                // Compute gate pre-activations: g[k] = X·W^T_k + H·R^T_k + b_k
+                let mut gates = alloc::vec![0.0f32; 4 * hidden];
+                for k in 0..4 * hidden {
+                    let mut acc = b_dir[k];
+                    for ii in 0..input_size {
+                        acc += read_f32(&x.raw_data, x_off + bi * input_size + ii)
+                            * w_dir[k * input_size + ii];
+                    }
+                    for hh in 0..hidden {
+                        acc += h[bi * hidden + hh] * r_dir[k * hidden + hh];
+                    }
+                    gates[k] = acc;
+                }
+                // Apply activations: i, o, f use sigmoid; c uses tanh.
+                for hi in 0..hidden {
+                    let i_g = sigmoid(gates[gate_offset(0) + hi]);
+                    let o_g = sigmoid(gates[gate_offset(1) + hi]);
+                    let f_g = sigmoid(gates[gate_offset(2) + hi]);
+                    let c_g = tanh_approx(gates[gate_offset(3) + hi]);
+                    let c_prev = c[bi * hidden + hi];
+                    let c_new = f_g * c_prev + i_g * c_g;
+                    let h_new = o_g * tanh_approx(c_new);
+                    new_c[bi * hidden + hi] = c_new;
+                    new_h[bi * hidden + hi] = h_new;
+                }
+            }
+            h = new_h;
+            c = new_c;
+            let y_off = t * num_dir * batch * hidden + d * batch * hidden;
+            for (i, &v) in h.iter().enumerate() {
+                write_f32(&mut y_data, y_off + i, v);
+            }
+        }
+        let off = d * batch * hidden;
+        for (i, (&hv, &cv)) in h.iter().zip(c.iter()).enumerate() {
+            write_f32(&mut yh_data, off + i, hv);
+            write_f32(&mut yc_data, off + i, cv);
+        }
+    }
+
+    Ok(alloc::vec![
+        Tensor {
+            data_type: DataType::Float,
+            shape: TensorShape::new(alloc::vec![
+                seq as i64,
+                num_dir as i64,
+                batch as i64,
+                hidden as i64
+            ]),
+            name: String::new(),
+            raw_data: y_data,
+        },
+        Tensor {
+            data_type: DataType::Float,
+            shape: TensorShape::new(alloc::vec![num_dir as i64, batch as i64, hidden as i64]),
+            name: String::new(),
+            raw_data: yh_data,
+        },
+        Tensor {
+            data_type: DataType::Float,
+            shape: TensorShape::new(alloc::vec![num_dir as i64, batch as i64, hidden as i64]),
+            name: String::new(),
+            raw_data: yc_data,
+        },
+    ])
+}
+
+// ---------------------------------------------------------------------------
+// GRU
+// ---------------------------------------------------------------------------
+
+/// GRU with reset, update, and hidden gates (z, r, h order per ONNX).
+///
+/// W: [num_dir, 3*hidden, input]
+/// R: [num_dir, 3*hidden, hidden]
+/// B: [num_dir, 6*hidden]
+pub fn op_gru(
+    x: &Tensor,
+    w: &Tensor,
+    r: &Tensor,
+    b: Option<&Tensor>,
+    h0: Option<&Tensor>,
+    direction: &str,
+) -> Result<Vec<Tensor>, OpError> {
+    require_float(x, "GRU")?;
+    require_float(w, "GRU")?;
+    require_float(r, "GRU")?;
+    let (num_dir, _bi) = parse_direction(direction)?;
+
+    if x.shape.dims.len() != 3 {
+        return Err(OpError::ShapeMismatch(String::from(
+            "GRU: X must be 3D [seq, batch, input]",
+        )));
+    }
+    let seq = x.shape.dims[0] as usize;
+    let batch = x.shape.dims[1] as usize;
+    let input_size = x.shape.dims[2] as usize;
+
+    if w.shape.dims.len() != 3 || w.shape.dims[0] as usize != num_dir {
+        return Err(OpError::ShapeMismatch(String::from(
+            "GRU: W shape must be [num_dir, 3*hidden, input]",
+        )));
+    }
+    let three_h = w.shape.dims[1] as usize;
+    if !three_h.is_multiple_of(3) {
+        return Err(OpError::ShapeMismatch(String::from(
+            "GRU: W second dim must be 3*hidden",
+        )));
+    }
+    let hidden = three_h / 3;
+
+    let y_total = seq * num_dir * batch * hidden;
+    let mut y_data = allocate_tensor_data(y_total, DataType::Float);
+    let mut yh_data = allocate_tensor_data(num_dir * batch * hidden, DataType::Float);
+
+    for d in 0..num_dir {
+        let reverse = direction == "reverse" || (direction == "bidirectional" && d == 1);
+        let w_off = d * 3 * hidden * input_size;
+        let r_off = d * 3 * hidden * hidden;
+        let w_dir = slice_f32(&w.raw_data, w_off, 3 * hidden * input_size);
+        let r_dir = slice_f32(&r.raw_data, r_off, 3 * hidden * hidden);
+        // For GRU, ONNX keeps W bias and R bias separate because the hidden
+        // gate (h) needs to add R bias *after* multiplying by reset. We split.
+        let (wb_dir, rb_dir): (Vec<f32>, Vec<f32>) = if let Some(bt) = b {
+            require_float(bt, "GRU")?;
+            let off = d * 6 * hidden;
+            (
+                slice_f32(&bt.raw_data, off, 3 * hidden),
+                slice_f32(&bt.raw_data, off + 3 * hidden, 3 * hidden),
+            )
+        } else {
+            (
+                alloc::vec![0.0f32; 3 * hidden],
+                alloc::vec![0.0f32; 3 * hidden],
+            )
+        };
+        let mut h: Vec<f32> = if let Some(h0t) = h0 {
+            require_float(h0t, "GRU")?;
+            slice_f32(&h0t.raw_data, d * batch * hidden, batch * hidden)
+        } else {
+            alloc::vec![0.0f32; batch * hidden]
+        };
+
+        for step in 0..seq {
+            let t = if reverse { seq - 1 - step } else { step };
+            let x_off = t * batch * input_size;
+            let mut new_h = alloc::vec![0.0f32; batch * hidden];
+            for bi in 0..batch {
+                // Compute z, r gates from W and R linearly.
+                let mut z_g = alloc::vec![0.0f32; hidden];
+                let mut r_g = alloc::vec![0.0f32; hidden];
+                let mut h_pre_w = alloc::vec![0.0f32; hidden]; // x·W^T_h + wb_h
+                let mut h_pre_r = alloc::vec![0.0f32; hidden]; // h·R^T_h + rb_h
+                for hi in 0..hidden {
+                    let mut z_acc = wb_dir[hi] + rb_dir[hi];
+                    let mut r_acc = wb_dir[hidden + hi] + rb_dir[hidden + hi];
+                    let mut hw_acc = wb_dir[2 * hidden + hi];
+                    let mut hr_acc = rb_dir[2 * hidden + hi];
+                    for ii in 0..input_size {
+                        let xv = read_f32(&x.raw_data, x_off + bi * input_size + ii);
+                        z_acc += xv * w_dir[hi * input_size + ii];
+                        r_acc += xv * w_dir[(hidden + hi) * input_size + ii];
+                        hw_acc += xv * w_dir[(2 * hidden + hi) * input_size + ii];
+                    }
+                    for hh in 0..hidden {
+                        let hv = h[bi * hidden + hh];
+                        z_acc += hv * r_dir[hi * hidden + hh];
+                        r_acc += hv * r_dir[(hidden + hi) * hidden + hh];
+                        hr_acc += hv * r_dir[(2 * hidden + hi) * hidden + hh];
+                    }
+                    z_g[hi] = sigmoid(z_acc);
+                    r_g[hi] = sigmoid(r_acc);
+                    h_pre_w[hi] = hw_acc;
+                    h_pre_r[hi] = hr_acc;
+                }
+                // Hidden gate: h_tilde = tanh(h_pre_w + r * h_pre_r)
+                for hi in 0..hidden {
+                    let h_tilde = tanh_approx(h_pre_w[hi] + r_g[hi] * h_pre_r[hi]);
+                    let h_prev = h[bi * hidden + hi];
+                    new_h[bi * hidden + hi] = (1.0 - z_g[hi]) * h_tilde + z_g[hi] * h_prev;
+                }
+            }
+            h = new_h;
+            let y_off = t * num_dir * batch * hidden + d * batch * hidden;
+            for (i, &v) in h.iter().enumerate() {
+                write_f32(&mut y_data, y_off + i, v);
+            }
+        }
+        let off = d * batch * hidden;
+        for (i, &v) in h.iter().enumerate() {
+            write_f32(&mut yh_data, off + i, v);
+        }
+    }
+
+    Ok(alloc::vec![
+        Tensor {
+            data_type: DataType::Float,
+            shape: TensorShape::new(alloc::vec![
+                seq as i64,
+                num_dir as i64,
+                batch as i64,
+                hidden as i64
+            ]),
+            name: String::new(),
+            raw_data: y_data,
+        },
+        Tensor {
+            data_type: DataType::Float,
+            shape: TensorShape::new(alloc::vec![num_dir as i64, batch as i64, hidden as i64]),
+            name: String::new(),
+            raw_data: yh_data,
+        },
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_f32(dims: &[i64], vals: &[f32]) -> Tensor {
+        let mut data = allocate_tensor_data(vals.len(), DataType::Float);
+        for (i, &v) in vals.iter().enumerate() {
+            write_f32(&mut data, i, v);
+        }
+        Tensor {
+            data_type: DataType::Float,
+            shape: TensorShape::new(dims.to_vec()),
+            name: String::new(),
+            raw_data: data,
+        }
+    }
+
+    #[test]
+    fn test_rnn_forward_shape() {
+        // seq=2, batch=1, input=3, hidden=4
+        let x = make_f32(&[2, 1, 3], &[0.1, 0.2, 0.3, 0.4, 0.5, 0.6]);
+        let w = make_f32(&[1, 4, 3], &alloc::vec![0.1f32; 12]);
+        let r = make_f32(&[1, 4, 4], &alloc::vec![0.1f32; 16]);
+        let outs = op_rnn(&x, &w, &r, None, None, "forward").unwrap();
+        assert_eq!(outs.len(), 2);
+        assert_eq!(outs[0].shape.dims, alloc::vec![2, 1, 1, 4]);
+        assert_eq!(outs[1].shape.dims, alloc::vec![1, 1, 4]);
+    }
+
+    #[test]
+    fn test_rnn_zero_input_zero_state_yields_zero_h() {
+        let x = make_f32(&[3, 2, 4], &alloc::vec![0.0f32; 24]);
+        let w = make_f32(&[1, 5, 4], &alloc::vec![0.5f32; 20]);
+        let r = make_f32(&[1, 5, 5], &alloc::vec![0.5f32; 25]);
+        let outs = op_rnn(&x, &w, &r, None, None, "forward").unwrap();
+        let yh = &outs[1];
+        for i in 0..yh.shape.total_elements() {
+            assert!(read_f32(&yh.raw_data, i).abs() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn test_rnn_reverse_runs() {
+        let x = make_f32(&[2, 1, 2], &[1.0, 0.0, 0.0, 1.0]);
+        let w = make_f32(&[1, 3, 2], &alloc::vec![0.1f32; 6]);
+        let r = make_f32(&[1, 3, 3], &alloc::vec![0.1f32; 9]);
+        let outs = op_rnn(&x, &w, &r, None, None, "reverse").unwrap();
+        assert_eq!(outs[0].shape.dims, alloc::vec![2, 1, 1, 3]);
+    }
+
+    #[test]
+    fn test_rnn_bidirectional_shape() {
+        let x = make_f32(&[2, 1, 2], &[0.1, 0.2, 0.3, 0.4]);
+        let w = make_f32(&[2, 3, 2], &alloc::vec![0.1f32; 12]);
+        let r = make_f32(&[2, 3, 3], &alloc::vec![0.1f32; 18]);
+        let outs = op_rnn(&x, &w, &r, None, None, "bidirectional").unwrap();
+        assert_eq!(outs[0].shape.dims, alloc::vec![2, 2, 1, 3]);
+        assert_eq!(outs[1].shape.dims, alloc::vec![2, 1, 3]);
+    }
+
+    #[test]
+    fn test_lstm_forward_shape() {
+        // seq=2, batch=1, input=3, hidden=4
+        let x = make_f32(&[2, 1, 3], &[0.1, 0.2, 0.3, 0.4, 0.5, 0.6]);
+        let w = make_f32(&[1, 16, 3], &alloc::vec![0.05f32; 48]);
+        let r = make_f32(&[1, 16, 4], &alloc::vec![0.05f32; 64]);
+        let outs = op_lstm(&x, &w, &r, None, None, None, "forward").unwrap();
+        assert_eq!(outs.len(), 3);
+        assert_eq!(outs[0].shape.dims, alloc::vec![2, 1, 1, 4]);
+        assert_eq!(outs[1].shape.dims, alloc::vec![1, 1, 4]);
+        assert_eq!(outs[2].shape.dims, alloc::vec![1, 1, 4]);
+    }
+
+    #[test]
+    fn test_lstm_zero_input_state_stays_zero() {
+        let x = make_f32(&[3, 1, 2], &alloc::vec![0.0f32; 6]);
+        let w = make_f32(&[1, 12, 2], &alloc::vec![0.0f32; 24]);
+        let r = make_f32(&[1, 12, 3], &alloc::vec![0.0f32; 36]);
+        let outs = op_lstm(&x, &w, &r, None, None, None, "forward").unwrap();
+        let yh = &outs[1];
+        let yc = &outs[2];
+        for i in 0..yh.shape.total_elements() {
+            // With zero W/R/B and zero state, gates are sigmoid(0)=0.5,
+            // cell candidate tanh(0)=0, so c stays 0 and h = 0.5 * tanh(0) = 0.
+            assert!(read_f32(&yh.raw_data, i).abs() < 1e-6);
+            assert!(read_f32(&yc.raw_data, i).abs() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn test_lstm_bidirectional_shape() {
+        let x = make_f32(&[2, 1, 2], &[0.1, 0.2, 0.3, 0.4]);
+        let w = make_f32(&[2, 8, 2], &alloc::vec![0.05f32; 32]);
+        let r = make_f32(&[2, 8, 2], &alloc::vec![0.05f32; 32]);
+        let outs = op_lstm(&x, &w, &r, None, None, None, "bidirectional").unwrap();
+        assert_eq!(outs[0].shape.dims, alloc::vec![2, 2, 1, 2]);
+        assert_eq!(outs[1].shape.dims, alloc::vec![2, 1, 2]);
+        assert_eq!(outs[2].shape.dims, alloc::vec![2, 1, 2]);
+    }
+
+    #[test]
+    fn test_gru_forward_shape() {
+        // seq=2, batch=1, input=3, hidden=4
+        let x = make_f32(&[2, 1, 3], &[0.1, 0.2, 0.3, 0.4, 0.5, 0.6]);
+        let w = make_f32(&[1, 12, 3], &alloc::vec![0.05f32; 36]);
+        let r = make_f32(&[1, 12, 4], &alloc::vec![0.05f32; 48]);
+        let outs = op_gru(&x, &w, &r, None, None, "forward").unwrap();
+        assert_eq!(outs.len(), 2);
+        assert_eq!(outs[0].shape.dims, alloc::vec![2, 1, 1, 4]);
+        assert_eq!(outs[1].shape.dims, alloc::vec![1, 1, 4]);
+    }
+
+    #[test]
+    fn test_gru_zero_input_zero_state() {
+        let x = make_f32(&[3, 1, 2], &alloc::vec![0.0f32; 6]);
+        let w = make_f32(&[1, 9, 2], &alloc::vec![0.0f32; 18]);
+        let r = make_f32(&[1, 9, 3], &alloc::vec![0.0f32; 27]);
+        let outs = op_gru(&x, &w, &r, None, None, "forward").unwrap();
+        // z = sigmoid(0)=0.5, h_tilde = tanh(0+0)=0, h_new = 0.5 * 0 + 0.5 * 0 = 0
+        for i in 0..outs[1].shape.total_elements() {
+            assert!(read_f32(&outs[1].raw_data, i).abs() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn test_gru_with_bias() {
+        let x = make_f32(&[1, 1, 2], &[0.0, 0.0]);
+        let w = make_f32(&[1, 6, 2], &alloc::vec![0.0f32; 12]);
+        let r = make_f32(&[1, 6, 2], &alloc::vec![0.0f32; 12]);
+        let b = make_f32(&[1, 12], &alloc::vec![0.0f32; 12]);
+        let outs = op_gru(&x, &w, &r, Some(&b), None, "forward").unwrap();
+        assert_eq!(outs[1].shape.dims, alloc::vec![1, 1, 2]);
+    }
+
+    #[test]
+    fn test_rnn_with_initial_state_and_bias() {
+        // seq=1, batch=1, input=2, hidden=2
+        // x = [1, 0]; W = I; R = 0; B = 0; h0 = [0, 1]
+        // h_t = tanh(W·x + R·h0 + b) = tanh([1, 0]) = [tanh(1), 0] ≈ [0.7616, 0]
+        let x = make_f32(&[1, 1, 2], &[1.0, 0.0]);
+        let w = make_f32(&[1, 2, 2], &[1.0, 0.0, 0.0, 1.0]);
+        let r = make_f32(&[1, 2, 2], &[0.0, 0.0, 0.0, 0.0]);
+        let h0 = make_f32(&[1, 1, 2], &[0.0, 1.0]);
+        let outs = op_rnn(&x, &w, &r, None, Some(&h0), "forward").unwrap();
+        let yh = &outs[1];
+        let h0_out = read_f32(&yh.raw_data, 0);
+        let h1_out = read_f32(&yh.raw_data, 1);
+        assert!((h0_out - 0.7616).abs() < 1e-3);
+        assert!(h1_out.abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_lstm_validation_errors() {
+        let x = make_f32(&[2, 1, 3], &[0.0; 6]);
+        // Wrong direction
+        let w = make_f32(&[1, 16, 3], &alloc::vec![0.0f32; 48]);
+        let r = make_f32(&[1, 16, 4], &alloc::vec![0.0f32; 64]);
+        assert!(op_lstm(&x, &w, &r, None, None, None, "sideways").is_err());
+        // Wrong W rank
+        let w_bad = make_f32(&[16, 3], &alloc::vec![0.0f32; 48]);
+        assert!(op_lstm(&x, &w_bad, &r, None, None, None, "forward").is_err());
+    }
+}

--- a/onnx-rt/src/ops/transformer.rs
+++ b/onnx-rt/src/ops/transformer.rs
@@ -1,0 +1,663 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Transformer building-block operators: Split, Expand, Tile, OneHot,
+//! Einsum.
+//!
+//! Einsum supports the equation patterns commonly used in transformer
+//! attention (e.g. `bij,bjk->bik`, `bhij,bhkj->bhik`, `ij,jk->ik`).
+//! Generic einsum implementations are out of scope; the parser dispatches
+//! to a small set of contraction templates.
+
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use crate::byte_io::{allocate_tensor_data, read_f32, read_i64, write_f32};
+use crate::operators::OpError;
+use crate::tensor::{DataType, Tensor, TensorShape};
+
+fn require_float(t: &Tensor, op: &str) -> Result<(), OpError> {
+    if t.data_type != DataType::Float {
+        return Err(OpError::ShapeMismatch(alloc::format!(
+            "{} requires Float input",
+            op
+        )));
+    }
+    Ok(())
+}
+
+fn product(dims: &[i64]) -> usize {
+    dims.iter().map(|&d| d as usize).product::<usize>().max(1)
+}
+
+fn next_coord(coord: &mut [usize], dims: &[i64]) {
+    for i in (0..coord.len()).rev() {
+        coord[i] += 1;
+        if (coord[i] as i64) < dims[i] {
+            return;
+        }
+        coord[i] = 0;
+    }
+}
+
+fn broadcast_index(coord: &[usize], shape: &[i64]) -> usize {
+    let off = coord.len() - shape.len();
+    let mut idx = 0usize;
+    let mut stride = 1usize;
+    for i in (0..shape.len()).rev() {
+        let c = if shape[i] == 1 { 0 } else { coord[off + i] };
+        idx += c * stride;
+        stride *= shape[i] as usize;
+    }
+    idx
+}
+
+// ---------------------------------------------------------------------------
+// Split
+// ---------------------------------------------------------------------------
+
+/// Splits a float tensor along the given axis.
+///
+/// If `split_sizes` is `None`, the input is split into equal parts based on
+/// the axis dimension. The number of outputs is determined by the length of
+/// `split_sizes` (or by axis dim when None and dim is divisible).
+pub fn op_split(
+    input: &Tensor,
+    axis: i64,
+    split_sizes: Option<&[i64]>,
+) -> Result<Vec<Tensor>, OpError> {
+    require_float(input, "Split")?;
+    let ndim = input.shape.dims.len() as i64;
+    let axis = if axis < 0 { axis + ndim } else { axis };
+    if axis < 0 || axis >= ndim {
+        return Err(OpError::InvalidAttribute(String::from(
+            "Split: axis out of range",
+        )));
+    }
+    let axis = axis as usize;
+    let axis_dim = input.shape.dims[axis];
+
+    let sizes: Vec<i64> = match split_sizes {
+        Some(s) => s.to_vec(),
+        None => {
+            // Equal split into 2 by default if no info — this matches a common
+            // case where the model has num_outputs implicit.
+            if axis_dim % 2 == 0 {
+                alloc::vec![axis_dim / 2, axis_dim / 2]
+            } else {
+                return Err(OpError::InvalidAttribute(String::from(
+                    "Split requires explicit sizes for non-even dim",
+                )));
+            }
+        }
+    };
+    let sum: i64 = sizes.iter().sum();
+    if sum != axis_dim {
+        return Err(OpError::ShapeMismatch(alloc::format!(
+            "Split sizes sum {} != axis dim {}",
+            sum,
+            axis_dim
+        )));
+    }
+
+    // Compute outer/inner sizes around axis.
+    let outer: usize = input.shape.dims[..axis]
+        .iter()
+        .map(|&d| d as usize)
+        .product::<usize>()
+        .max(1);
+    let inner: usize = input.shape.dims[axis + 1..]
+        .iter()
+        .map(|&d| d as usize)
+        .product::<usize>()
+        .max(1);
+    let axis_dim_us = axis_dim as usize;
+
+    let mut outputs = Vec::with_capacity(sizes.len());
+    let mut axis_offset = 0usize;
+    for &size in &sizes {
+        let size_us = size as usize;
+        let mut new_dims = input.shape.dims.clone();
+        new_dims[axis] = size;
+        let total = outer * size_us * inner;
+        let mut data = allocate_tensor_data(total, DataType::Float);
+        for o in 0..outer {
+            for s in 0..size_us {
+                for i in 0..inner {
+                    let src_idx = o * axis_dim_us * inner + (axis_offset + s) * inner + i;
+                    let dst_idx = o * size_us * inner + s * inner + i;
+                    write_f32(&mut data, dst_idx, read_f32(&input.raw_data, src_idx));
+                }
+            }
+        }
+        outputs.push(Tensor {
+            data_type: DataType::Float,
+            shape: TensorShape::new(new_dims),
+            name: String::new(),
+            raw_data: data,
+        });
+        axis_offset += size_us;
+    }
+    Ok(outputs)
+}
+
+// ---------------------------------------------------------------------------
+// Expand
+// ---------------------------------------------------------------------------
+
+/// Broadcasts the input to the target shape using NumPy semantics.
+pub fn op_expand(input: &Tensor, target: &[i64]) -> Result<Tensor, OpError> {
+    require_float(input, "Expand")?;
+    // Validate input shape can broadcast to target.
+    let in_dims = &input.shape.dims;
+    let max = in_dims.len().max(target.len());
+    let mut out_dims = alloc::vec![1i64; max];
+    for i in 0..max {
+        let id = if i < in_dims.len() {
+            in_dims[in_dims.len() - 1 - i]
+        } else {
+            1
+        };
+        let td = if i < target.len() {
+            target[target.len() - 1 - i]
+        } else {
+            1
+        };
+        let d = if id == td || id == 1 {
+            td
+        } else if td == 1 {
+            id
+        } else {
+            return Err(OpError::ShapeMismatch(String::from(
+                "Expand: shapes incompatible",
+            )));
+        };
+        out_dims[max - 1 - i] = d;
+    }
+    let total = product(&out_dims);
+    let mut data = allocate_tensor_data(total, DataType::Float);
+    let mut coord = alloc::vec![0usize; out_dims.len()];
+    for flat in 0..total {
+        let src = broadcast_index(&coord, in_dims);
+        write_f32(&mut data, flat, read_f32(&input.raw_data, src));
+        if flat + 1 < total {
+            next_coord(&mut coord, &out_dims);
+        }
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: TensorShape::new(out_dims),
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tile
+// ---------------------------------------------------------------------------
+
+/// Repeats the input tensor along each axis according to `repeats`.
+pub fn op_tile(input: &Tensor, repeats: &[i64]) -> Result<Tensor, OpError> {
+    require_float(input, "Tile")?;
+    if repeats.len() != input.shape.dims.len() {
+        return Err(OpError::ShapeMismatch(String::from(
+            "Tile: repeats length must match input rank",
+        )));
+    }
+    let in_dims = &input.shape.dims;
+    let out_dims: Vec<i64> = in_dims
+        .iter()
+        .zip(repeats.iter())
+        .map(|(&d, &r)| d * r)
+        .collect();
+    let total = product(&out_dims);
+    let mut data = allocate_tensor_data(total, DataType::Float);
+    let mut coord = alloc::vec![0usize; out_dims.len()];
+    for flat in 0..total {
+        // Map output coord to input coord by modulo input dim.
+        let src_idx = {
+            let mut idx = 0usize;
+            let mut stride = 1usize;
+            for i in (0..in_dims.len()).rev() {
+                let c = coord[i] % in_dims[i] as usize;
+                idx += c * stride;
+                stride *= in_dims[i] as usize;
+            }
+            idx
+        };
+        write_f32(&mut data, flat, read_f32(&input.raw_data, src_idx));
+        if flat + 1 < total {
+            next_coord(&mut coord, &out_dims);
+        }
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: TensorShape::new(out_dims),
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// OneHot
+// ---------------------------------------------------------------------------
+
+/// Produces a one-hot tensor from integer indices.
+///
+/// `values[0]` is `off_value`, `values[1]` is `on_value`. New axis is
+/// inserted at `axis` of the output.
+pub fn op_one_hot(
+    indices: &Tensor,
+    depth: i64,
+    values: &Tensor,
+    axis: i64,
+) -> Result<Tensor, OpError> {
+    if values.data_type != DataType::Float || values.shape.total_elements() < 2 {
+        return Err(OpError::ShapeMismatch(String::from(
+            "OneHot values must be Float tensor of length 2",
+        )));
+    }
+    if depth <= 0 {
+        return Err(OpError::InvalidAttribute(String::from(
+            "OneHot depth must be > 0",
+        )));
+    }
+    let off_value = read_f32(&values.raw_data, 0);
+    let on_value = read_f32(&values.raw_data, 1);
+
+    // Decode indices as i64. Accept Int64 only for simplicity.
+    let n_indices = indices.shape.total_elements();
+    let idx_vals: Vec<i64> = match indices.data_type {
+        DataType::Int64 => (0..n_indices)
+            .map(|i| read_i64(&indices.raw_data, i))
+            .collect(),
+        DataType::Int32 => (0..n_indices)
+            .map(|i| crate::byte_io::read_i32(&indices.raw_data, i) as i64)
+            .collect(),
+        _ => {
+            return Err(OpError::ShapeMismatch(String::from(
+                "OneHot indices must be Int32 or Int64",
+            )));
+        }
+    };
+
+    // Build output shape: insert depth at axis position.
+    let in_dims = &indices.shape.dims;
+    let in_rank = in_dims.len() as i64;
+    let axis_norm = if axis < 0 { axis + in_rank + 1 } else { axis };
+    if axis_norm < 0 || axis_norm > in_rank {
+        return Err(OpError::InvalidAttribute(String::from(
+            "OneHot axis out of range",
+        )));
+    }
+    let axis_pos = axis_norm as usize;
+    let mut out_dims = in_dims.clone();
+    out_dims.insert(axis_pos, depth);
+    let total = product(&out_dims);
+    let mut data = allocate_tensor_data(total, DataType::Float);
+
+    // Outer/inner sizes around axis_pos in the output.
+    let outer: usize = out_dims[..axis_pos]
+        .iter()
+        .map(|&d| d as usize)
+        .product::<usize>()
+        .max(1);
+    let inner: usize = out_dims[axis_pos + 1..]
+        .iter()
+        .map(|&d| d as usize)
+        .product::<usize>()
+        .max(1);
+    let depth_us = depth as usize;
+    // Fill with off_value first.
+    for i in 0..total {
+        write_f32(&mut data, i, off_value);
+    }
+    // For each index, set on_value at the right position.
+    for o in 0..outer {
+        for i in 0..inner {
+            // The index for this (outer, inner) cell is at position o*inner + i
+            // in the flattened indices tensor.
+            let idx_flat = o * inner + i;
+            if idx_flat >= idx_vals.len() {
+                continue;
+            }
+            let idx = idx_vals[idx_flat];
+            if idx >= 0 && (idx as usize) < depth_us {
+                let dst = o * depth_us * inner + (idx as usize) * inner + i;
+                write_f32(&mut data, dst, on_value);
+            }
+        }
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: TensorShape::new(out_dims),
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Einsum
+// ---------------------------------------------------------------------------
+
+/// Computes Einstein summation for a small set of well-known patterns
+/// commonly used in transformer attention.
+///
+/// Supported patterns:
+/// - `ij,jk->ik` — 2D matrix multiply
+/// - `bij,bjk->bik` — batched matmul
+/// - `bhij,bhkj->bhik` — batched/headed Q·K^T
+pub fn op_einsum(equation: &str, inputs: &[&Tensor]) -> Result<Tensor, OpError> {
+    let eq = equation.replace(' ', "");
+    let eq = eq.as_str();
+    match (eq, inputs.len()) {
+        ("ij,jk->ik", 2) => einsum_matmul(inputs[0], inputs[1]),
+        ("bij,bjk->bik", 2) => einsum_batched_matmul(inputs[0], inputs[1]),
+        ("bhij,bhkj->bhik", 2) => einsum_qkt(inputs[0], inputs[1]),
+        _ => Err(OpError::InvalidAttribute(alloc::format!(
+            "Einsum equation not supported: {}",
+            equation
+        ))),
+    }
+}
+
+fn einsum_matmul(a: &Tensor, b: &Tensor) -> Result<Tensor, OpError> {
+    require_float(a, "Einsum")?;
+    require_float(b, "Einsum")?;
+    if a.shape.dims.len() != 2 || b.shape.dims.len() != 2 {
+        return Err(OpError::ShapeMismatch(
+            "Einsum ij,jk requires 2D".to_string(),
+        ));
+    }
+    let m = a.shape.dims[0] as usize;
+    let k = a.shape.dims[1] as usize;
+    let k2 = b.shape.dims[0] as usize;
+    let n = b.shape.dims[1] as usize;
+    if k != k2 {
+        return Err(OpError::ShapeMismatch("Einsum dim mismatch".to_string()));
+    }
+    let mut data = allocate_tensor_data(m * n, DataType::Float);
+    for i in 0..m {
+        for j in 0..n {
+            let mut sum = 0.0f32;
+            for kk in 0..k {
+                sum += read_f32(&a.raw_data, i * k + kk) * read_f32(&b.raw_data, kk * n + j);
+            }
+            write_f32(&mut data, i * n + j, sum);
+        }
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: TensorShape::new(alloc::vec![m as i64, n as i64]),
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+fn einsum_batched_matmul(a: &Tensor, b: &Tensor) -> Result<Tensor, OpError> {
+    require_float(a, "Einsum")?;
+    require_float(b, "Einsum")?;
+    if a.shape.dims.len() != 3 || b.shape.dims.len() != 3 {
+        return Err(OpError::ShapeMismatch(
+            "Einsum bij,bjk requires 3D".to_string(),
+        ));
+    }
+    let bsz = a.shape.dims[0] as usize;
+    let m = a.shape.dims[1] as usize;
+    let k = a.shape.dims[2] as usize;
+    if b.shape.dims[0] as usize != bsz || b.shape.dims[1] as usize != k {
+        return Err(OpError::ShapeMismatch("Einsum dim mismatch".to_string()));
+    }
+    let n = b.shape.dims[2] as usize;
+    let mut data = allocate_tensor_data(bsz * m * n, DataType::Float);
+    for batch in 0..bsz {
+        let a_off = batch * m * k;
+        let b_off = batch * k * n;
+        let o_off = batch * m * n;
+        for i in 0..m {
+            for j in 0..n {
+                let mut sum = 0.0f32;
+                for kk in 0..k {
+                    sum += read_f32(&a.raw_data, a_off + i * k + kk)
+                        * read_f32(&b.raw_data, b_off + kk * n + j);
+                }
+                write_f32(&mut data, o_off + i * n + j, sum);
+            }
+        }
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: TensorShape::new(alloc::vec![bsz as i64, m as i64, n as i64]),
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+fn einsum_qkt(q: &Tensor, k: &Tensor) -> Result<Tensor, OpError> {
+    // bhij,bhkj->bhik : Q is (b,h,i,j), K is (b,h,k,j), out is (b,h,i,k)
+    require_float(q, "Einsum")?;
+    require_float(k, "Einsum")?;
+    if q.shape.dims.len() != 4 || k.shape.dims.len() != 4 {
+        return Err(OpError::ShapeMismatch(
+            "Einsum bhij requires 4D".to_string(),
+        ));
+    }
+    let b = q.shape.dims[0] as usize;
+    let h = q.shape.dims[1] as usize;
+    let i_dim = q.shape.dims[2] as usize;
+    let j_dim = q.shape.dims[3] as usize;
+    if k.shape.dims[0] as usize != b
+        || k.shape.dims[1] as usize != h
+        || k.shape.dims[3] as usize != j_dim
+    {
+        return Err(OpError::ShapeMismatch("Einsum dim mismatch".to_string()));
+    }
+    let k_dim = k.shape.dims[2] as usize;
+    let total = b * h * i_dim * k_dim;
+    let mut data = allocate_tensor_data(total, DataType::Float);
+    for bb in 0..b {
+        for hh in 0..h {
+            let q_off = ((bb * h) + hh) * i_dim * j_dim;
+            let k_off = ((bb * h) + hh) * k_dim * j_dim;
+            let o_off = ((bb * h) + hh) * i_dim * k_dim;
+            for ii in 0..i_dim {
+                for kk in 0..k_dim {
+                    let mut sum = 0.0f32;
+                    for jj in 0..j_dim {
+                        sum += read_f32(&q.raw_data, q_off + ii * j_dim + jj)
+                            * read_f32(&k.raw_data, k_off + kk * j_dim + jj);
+                    }
+                    write_f32(&mut data, o_off + ii * k_dim + kk, sum);
+                }
+            }
+        }
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: TensorShape::new(alloc::vec![b as i64, h as i64, i_dim as i64, k_dim as i64]),
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_f32(dims: &[i64], vals: &[f32]) -> Tensor {
+        let mut data = allocate_tensor_data(vals.len(), DataType::Float);
+        for (i, &v) in vals.iter().enumerate() {
+            write_f32(&mut data, i, v);
+        }
+        Tensor {
+            data_type: DataType::Float,
+            shape: TensorShape::new(dims.to_vec()),
+            name: String::new(),
+            raw_data: data,
+        }
+    }
+
+    fn make_i64(dims: &[i64], vals: &[i64]) -> Tensor {
+        let mut data = allocate_tensor_data(vals.len(), DataType::Int64);
+        for (i, &v) in vals.iter().enumerate() {
+            crate::byte_io::write_i64(&mut data, i, v);
+        }
+        Tensor {
+            data_type: DataType::Int64,
+            shape: TensorShape::new(dims.to_vec()),
+            name: String::new(),
+            raw_data: data,
+        }
+    }
+
+    fn read_all(t: &Tensor) -> Vec<f32> {
+        (0..t.shape.total_elements())
+            .map(|i| read_f32(&t.raw_data, i))
+            .collect()
+    }
+
+    #[test]
+    fn test_split_equal() {
+        // [2,6] split axis=1 into 3 → three [2,2]
+        let t = make_f32(
+            &[2, 6],
+            &[
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+            ],
+        );
+        let outs = op_split(&t, 1, Some(&[2, 2, 2])).unwrap();
+        assert_eq!(outs.len(), 3);
+        assert_eq!(outs[0].shape.dims, alloc::vec![2, 2]);
+        assert_eq!(read_all(&outs[0]), alloc::vec![1.0, 2.0, 7.0, 8.0]);
+        assert_eq!(read_all(&outs[1]), alloc::vec![3.0, 4.0, 9.0, 10.0]);
+        assert_eq!(read_all(&outs[2]), alloc::vec![5.0, 6.0, 11.0, 12.0]);
+    }
+
+    #[test]
+    fn test_split_custom_sizes() {
+        let t = make_f32(&[6], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let outs = op_split(&t, 0, Some(&[2, 3, 1])).unwrap();
+        assert_eq!(outs.len(), 3);
+        assert_eq!(outs[0].shape.dims, alloc::vec![2]);
+        assert_eq!(outs[1].shape.dims, alloc::vec![3]);
+        assert_eq!(outs[2].shape.dims, alloc::vec![1]);
+        assert_eq!(read_all(&outs[2]), alloc::vec![6.0]);
+    }
+
+    #[test]
+    fn test_split_axis_validation() {
+        let t = make_f32(&[3], &[1.0, 2.0, 3.0]);
+        assert!(op_split(&t, 5, None).is_err());
+        let bad = op_split(&t, 0, Some(&[1, 1])).unwrap_err();
+        assert!(matches!(bad, OpError::ShapeMismatch(_)));
+    }
+
+    #[test]
+    fn test_expand_scalar_to_matrix() {
+        let t = make_f32(&[1], &[7.0]);
+        let out = op_expand(&t, &[2, 3]).unwrap();
+        assert_eq!(out.shape.dims, alloc::vec![2, 3]);
+        assert_eq!(read_all(&out), alloc::vec![7.0; 6]);
+    }
+
+    #[test]
+    fn test_expand_broadcast_axis() {
+        // [1,3] → [2,3]
+        let t = make_f32(&[1, 3], &[1.0, 2.0, 3.0]);
+        let out = op_expand(&t, &[2, 3]).unwrap();
+        assert_eq!(read_all(&out), alloc::vec![1.0, 2.0, 3.0, 1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn test_tile_2d() {
+        // [2,3] tiled by [2,1] → [4,3]
+        let t = make_f32(&[2, 3], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let out = op_tile(&t, &[2, 1]).unwrap();
+        assert_eq!(out.shape.dims, alloc::vec![4, 3]);
+        assert_eq!(
+            read_all(&out),
+            alloc::vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+        );
+    }
+
+    #[test]
+    fn test_tile_inner() {
+        let t = make_f32(&[2], &[1.0, 2.0]);
+        let out = op_tile(&t, &[3]).unwrap();
+        assert_eq!(read_all(&out), alloc::vec![1.0, 2.0, 1.0, 2.0, 1.0, 2.0]);
+    }
+
+    #[test]
+    fn test_one_hot_basic() {
+        let indices = make_i64(&[3], &[0, 1, 2]);
+        let values = make_f32(&[2], &[0.0, 1.0]);
+        let out = op_one_hot(&indices, 3, &values, -1).unwrap();
+        assert_eq!(out.shape.dims, alloc::vec![3, 3]);
+        // Identity-like
+        let v = read_all(&out);
+        assert_eq!(v, alloc::vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]);
+    }
+
+    #[test]
+    fn test_one_hot_oob_index_no_op() {
+        let indices = make_i64(&[3], &[0, 5, -1]);
+        let values = make_f32(&[2], &[0.0, 1.0]);
+        let out = op_one_hot(&indices, 3, &values, -1).unwrap();
+        let v = read_all(&out);
+        // First row hit; rows for 5 and -1 stay at off_value
+        assert_eq!(v[0], 1.0);
+        assert_eq!(v[3], 0.0);
+        assert_eq!(v[6], 0.0);
+    }
+
+    #[test]
+    fn test_einsum_2d_matmul() {
+        let a = make_f32(&[2, 3], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let b = make_f32(&[3, 2], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let out = op_einsum("ij,jk->ik", &[&a, &b]).unwrap();
+        assert_eq!(out.shape.dims, alloc::vec![2, 2]);
+        // [[22,28],[49,64]]
+        assert_eq!(read_all(&out), alloc::vec![22.0, 28.0, 49.0, 64.0]);
+    }
+
+    #[test]
+    fn test_einsum_batched_matmul() {
+        // batch=2, [2,2,3] @ [2,3,2] → [2,2,2]
+        let a = make_f32(
+            &[2, 2, 3],
+            &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+        );
+        let b = make_f32(
+            &[2, 3, 2],
+            &[1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+        );
+        let out = op_einsum("bij,bjk->bik", &[&a, &b]).unwrap();
+        assert_eq!(out.shape.dims, alloc::vec![2, 2, 2]);
+        // First batch: [[1,2],[4,5]]
+        // Second batch: [[1,0],[0,1]]
+        let v = read_all(&out);
+        assert_eq!(v[0], 1.0);
+        assert_eq!(v[1], 2.0);
+        assert_eq!(v[2], 4.0);
+        assert_eq!(v[3], 5.0);
+        assert_eq!(v[4], 1.0);
+        assert_eq!(v[7], 1.0);
+    }
+
+    #[test]
+    fn test_einsum_qkt() {
+        // Q,K shape (1,1,2,3), expected QK^T shape (1,1,2,2)
+        let q = make_f32(&[1, 1, 2, 3], &[1.0, 0.0, 0.0, 0.0, 1.0, 0.0]);
+        let k = make_f32(&[1, 1, 2, 3], &[1.0, 0.0, 0.0, 0.0, 1.0, 0.0]);
+        let out = op_einsum("bhij,bhkj->bhik", &[&q, &k]).unwrap();
+        assert_eq!(out.shape.dims, alloc::vec![1, 1, 2, 2]);
+        // Identity-like dot products: [[1,0],[0,1]]
+        assert_eq!(read_all(&out), alloc::vec![1.0, 0.0, 0.0, 1.0]);
+    }
+
+    #[test]
+    fn test_einsum_unsupported_equation() {
+        let a = make_f32(&[2, 2], &[1.0, 2.0, 3.0, 4.0]);
+        assert!(op_einsum("ii->", &[&a]).is_err());
+    }
+}

--- a/onnx-rt/src/profile.rs
+++ b/onnx-rt/src/profile.rs
@@ -70,10 +70,25 @@ pub fn classify_op(op_type: &str) -> OperatorClass {
     match op_type {
         "Add" | "Sub" | "Mul" | "Div" | "Relu" | "Sigmoid" | "Tanh" | "Clip" | "Cast"
         | "Reshape" | "Flatten" | "Squeeze" | "Unsqueeze" | "Transpose" | "Concat" | "Slice"
-        | "Pad" | "Gather" => OperatorClass::Elementwise,
+        | "Pad" | "Gather"
+        // Tier 2 element-wise math
+        | "Pow" | "Sqrt" | "Exp" | "Log" | "Erf" | "Neg" | "Abs" | "Floor" | "Ceil" | "Round"
+        // Tier 2 comparison/selection
+        | "Equal" | "NotEqual" | "Less" | "LessOrEqual" | "Greater" | "GreaterOrEqual"
+        | "Where" | "Min" | "Max" | "Not"
+        // Tier 2 composite activations
+        | "Gelu" | "LeakyRelu" | "Elu" | "Swish"
+        // Tier 2 transformer shape ops
+        | "Split" | "Expand" | "Tile" | "OneHot"
+        // Tier 2 quantization conversion
+        | "QuantizeLinear" | "DequantizeLinear" => OperatorClass::Elementwise,
         "Softmax" | "LayerNormalization" | "BatchNormalization" | "MaxPool" | "AveragePool"
         | "GlobalAveragePool" | "ReduceMean" | "ReduceSum" => OperatorClass::Reduction,
-        "MatMul" | "Gemm" | "Conv" => OperatorClass::Gemm,
+        "MatMul" | "Gemm" | "Conv"
+        // Tier 2: Einsum is matmul-like; quantized GEMM/Conv same.
+        | "Einsum" | "QLinearMatMul" | "QLinearConv" => OperatorClass::Gemm,
+        // Recurrent layers do many GEMMs across time; classify as Attention budget.
+        "RNN" | "LSTM" | "GRU" => OperatorClass::Attention,
         _ => OperatorClass::Elementwise,
     }
 }

--- a/openspec/changes/additional-operators-v1/.openspec.yaml
+++ b/openspec/changes/additional-operators-v1/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-11

--- a/openspec/changes/additional-operators-v1/design.md
+++ b/openspec/changes/additional-operators-v1/design.md
@@ -1,0 +1,112 @@
+## Context
+
+Current operator coverage in `onnx-rt/src/operators.rs`:
+
+| Tier | Status | Operators |
+|------|--------|-----------|
+| 1 | **Done (29)** | Add, Sub, Mul, Div, MatMul, Gemm, Relu, Sigmoid, Tanh, Softmax, Conv, BatchNorm, LayerNorm, MaxPool, AvgPool, GlobalAvgPool, ReduceSum, ReduceMean, Reshape, Transpose, Flatten, Squeeze, Unsqueeze, Concat, Cast, Gather, Slice, Pad, Clip |
+| 2 | This change | LSTM, GRU, GELU, Pow, Sqrt, Exp, Log, Erf, Equal, Where, Einsum, Split, Expand, Tile, OneHot, QuantizeLinear, DequantizeLinear, QLinearMatMul, QLinearConv, etc. |
+| 3 | Future | DFT, STFT, NMS, RoiAlign, Loop, If, Scan |
+
+The hot path for adding operators is mechanical: implement `pub fn op_X(...) -> Result<Tensor, OpError>`, add to `OpKind` enum, add to dispatch helper match. The `byte_io::read_f32` / `write_f32` helpers handle data conversion. Every operator follows the same pattern.
+
+The interesting design questions are:
+1. **LSTM/GRU state management** — RNNs maintain hidden state across timesteps
+2. **Quantized integer math** — different from f32 operators
+3. **Einsum** — needs a parser for the equation string
+
+## Goals / Non-Goals
+
+**Goals:**
+- Cover the operators needed by BERT, GPT-2-small, Whisper-tiny, quantized MobileNet/ResNet
+- INT8 quantized inference path (smaller models, edge deployment)
+- All operators behave correctly per ONNX spec
+- Tests: at least 2 per operator (basic + edge case)
+- All operators work in both sequential and (where applicable) parallel modes
+
+**Non-Goals:**
+- Performance optimization beyond correctness (future work)
+- INT4 quantization (not in standard ONNX yet)
+- Sparse tensors
+- Control flow ops (Loop, If, Scan) — separate change
+- Custom ops or external operator libraries
+
+## Decisions
+
+### D1: One Module Per Operator Group
+
+Rather than appending 30 functions to the already-large `operators.rs`, split into logical groups:
+
+```
+onnx-rt/src/
+├── operators.rs                  (existing — Tier 1)
+├── ops/
+│   ├── mod.rs                    (re-exports)
+│   ├── math.rs                   (Pow, Sqrt, Exp, Log, Erf, Neg, Abs, Floor, Ceil, Round)
+│   ├── compare.rs                (Equal, Less, Greater, Where, Min, Max, Not)
+│   ├── activations.rs            (Gelu, LeakyRelu, Elu, Swish)
+│   ├── recurrent.rs              (LSTM, GRU, RNN)
+│   ├── transformer.rs            (Einsum, Split, Expand, Tile, OneHot, ScaledDotProductAttention)
+│   └── quantized.rs              (QuantizeLinear, DequantizeLinear, QLinearMatMul, QLinearConv)
+```
+
+This keeps the codebase navigable. The existing `operators.rs` stays as-is — new ops go in `ops/`.
+
+### D2: LSTM Hidden State as Output Tensor
+
+ONNX LSTM returns `(Y, Y_h, Y_c)` where Y is the output sequence, Y_h is the final hidden state, Y_c is the final cell state. Our `op_lstm` returns a `Vec<Tensor>` with all three outputs. The session executor already supports multi-output operators (Y, Y_h, Y_c → 3 names in `node.outputs`).
+
+### D3: INT8 Quantization Math
+
+Quantized ops use the formula:
+```
+quantized = round(float / scale) + zero_point  // clipped to [0, 255] for u8 or [-128, 127] for i8
+float = (quantized - zero_point) * scale
+```
+
+The `QLinearMatMul` operator does:
+```
+output = (a - a_zero) * a_scale @ (b - b_zero) * b_scale / output_scale + output_zero
+```
+This is implemented as integer math (i32 accumulator) for speed, then dequantized at the boundary. For the initial implementation, we can use a simpler "dequantize-compute-requantize" approach that just calls existing `op_matmul` after dequantization, then quantizes the result. This is correct but slower; real INT8 acceleration is a future change.
+
+### D4: Einsum Parser
+
+Einsum uses a string equation like `"bij,bjk->bik"` (batched matmul). For the initial implementation:
+1. Parse the equation into input subscripts and output subscript
+2. Identify the contraction axes (subscripts in inputs but not output)
+3. Implement common cases (matmul, dot product, batched matmul) directly
+4. Fall back to a generic loop-based contraction for other cases
+
+We don't need to support every possible einsum expression — just the ones used by transformer models (typically `bhij,bhjk->bhik` for attention).
+
+### D5: GELU via Polynomial Approximation
+
+GELU is `x * Phi(x)` where Phi is the standard normal CDF. The exact form uses `erf`:
+```
+GELU(x) = 0.5 * x * (1 + erf(x / sqrt(2)))
+```
+
+We need an `erf` implementation. The Abramowitz & Stegun polynomial approximation is `~1.5e-7` accurate, which is enough for inference:
+```
+erf(x) ≈ 1 - (a1*t + a2*t^2 + a3*t^3 + a4*t^4 + a5*t^5) * exp(-x^2)
+where t = 1 / (1 + p*x), p = 0.3275911
+a1 = 0.254829592, a2 = -0.284496736, a3 = 1.421413741, a4 = -1.453152027, a5 = 1.061405429
+```
+
+This is `no_std` compatible and uses our existing `expf_approx`.
+
+## Risks / Trade-offs
+
+**[Risk] LSTM correctness on long sequences** — RNNs accumulate numerical error. Mitigation: Test against known reference outputs from PyTorch/ONNX Runtime for short sequences (length 5-10). Long-sequence accuracy can be validated later with real model tests.
+
+**[Risk] Quantization precision loss** — INT8 inference is inherently lossy. Mitigation: Test accuracy on a quantized MobileNet against the f32 reference; expect 1-2% top-1 accuracy drop, which is acceptable.
+
+**[Risk] Code volume** — ~2,000 lines is significant. Mitigation: Split into modules (D1), each module gets its own agent for parallel implementation. Each operator is independent.
+
+**[Trade-off] Initial INT8 is slow (dequantize-compute-requantize)** — Real INT8 needs i8 GEMM kernels. Acceptable for v0.3 — quantized models load and run, even if not at full speed. Optimization is a future change.
+
+## Open Questions
+
+- **Q1:** Should `op_lstm` support `forget_bias` parameter (some old models)? *Leaning toward: yes, default 1.0*
+- **Q2:** Should we add `op_einsum` or just the specific cases needed by attention? *Leaning toward: einsum with common-case fast paths, fallback for others*

--- a/openspec/changes/additional-operators-v1/proposal.md
+++ b/openspec/changes/additional-operators-v1/proposal.md
@@ -1,0 +1,73 @@
+## Why
+
+SmallAIOS v0.2.1 has 29 working ONNX operators (Tier 1 — arithmetic, activations, shape, normalization, pooling, reduction). This covers MLPs and basic CNNs but excludes:
+
+- **Recurrent networks** — LSTM, GRU (used in audio, time-series, classic NLP)
+- **Transformer ops** — `MatMul + Softmax + scaled dot-product attention`, layer norm with proper dims, embedding gather + positional encoding (the basic blocks for any transformer-derived model)
+- **Quantized inference** — INT8 ops (smaller models, faster inference, edge deployment)
+- **More activations** — `Erf` (for GELU), `Pow`, `Sqrt`, `Exp`, `Log`, `Where`, `Equal`, `Greater`, `Less` (logical/comparison ops needed by attention masking)
+
+This change adds the second tier of operators needed to run real transformer models (BERT, GPT-2-small, Whisper-tiny) and quantized variants of common CNNs.
+
+## What Changes
+
+### Tier 2A: Math primitives (needed by other ops)
+- `op_pow` — element-wise power
+- `op_sqrt` — element-wise square root
+- `op_exp` — element-wise exponential
+- `op_log` — element-wise natural log
+- `op_erf` — error function (for GELU)
+- `op_neg` — unary negation
+- `op_abs` — absolute value
+- `op_floor`, `op_ceil`, `op_round`
+
+### Tier 2B: Comparison and selection
+- `op_equal`, `op_not_equal`, `op_less`, `op_less_or_equal`, `op_greater`, `op_greater_or_equal`
+- `op_where` — element-wise select based on condition
+- `op_min`, `op_max` — element-wise min/max with broadcasting
+- `op_not` — logical not
+
+### Tier 2C: Composite activations
+- `op_gelu` — Gaussian Error Linear Unit (uses Erf)
+- `op_leaky_relu`
+- `op_elu` — Exponential Linear Unit
+- `op_swish` / `op_silu` — Sigmoid-weighted Linear Unit
+
+### Tier 2D: Recurrent
+- `op_lstm` — Long Short-Term Memory
+- `op_gru` — Gated Recurrent Unit
+- `op_rnn` — Vanilla RNN
+
+### Tier 2E: Transformer building blocks
+- `op_einsum` — for general tensor contractions (attention uses this)
+- `op_scaled_dot_product_attention` — fused attention op (newer ONNX opset)
+- `op_split` — split tensor along axis (used in QKV projection)
+- `op_expand` — broadcast a tensor to a target shape
+- `op_tile` — repeat a tensor
+- `op_one_hot` — one-hot encoding for classification
+
+### Tier 2F: Quantized (INT8)
+- `op_quantize_linear` — float32 → int8 with scale and zero point
+- `op_dequantize_linear` — int8 → float32
+- `op_qlinear_matmul` — INT8 matrix multiply (for quantized models)
+- `op_qlinear_conv` — INT8 convolution
+
+## Capabilities
+
+### New Capabilities
+- `onnx-recurrent-operators`: LSTM, GRU, RNN with bidirectional support
+- `onnx-transformer-operators`: Attention building blocks (einsum, split, expand, tile, scaled dot-product)
+- `onnx-quantized-operators`: INT8 quantize/dequantize and quantized matmul/conv
+
+### Modified Capabilities
+- `onnx-cpu-execution`: Add ~30 new operators to the dispatch table
+- `onnx-runtime`: Update OpKind enum and registry
+
+## Impact
+
+- **Code:** ~2,000 lines of new operator implementations in `onnx-rt/src/operators.rs`
+- **OpKind:** ~30 new variants
+- **Dispatch:** ~30 new arms in executor `dispatch_*` helpers
+- **Tests:** Each operator gets unit tests (target: 60+ new tests)
+- **Models unlocked:** BERT-base, GPT-2-small, MobileNet-v3 (quantized), Whisper-tiny, ResNet-50 quantized
+- **No new dependencies:** All in pure Rust no_std + alloc

--- a/openspec/changes/additional-operators-v1/specs/onnx-cpu-execution/spec.md
+++ b/openspec/changes/additional-operators-v1/specs/onnx-cpu-execution/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Tier 2 Operator Coverage
+The ONNX runtime SHALL implement the second tier of operators required for transformer and quantized model execution.
+
+#### Scenario: Math primitives
+- **WHEN** the executor encounters Pow, Sqrt, Exp, Log, Erf, Neg, Abs, Floor, Ceil, or Round operators
+- **THEN** the operator MUST execute correctly with element-wise semantics
+
+#### Scenario: Comparison and selection
+- **WHEN** the executor encounters Equal, Less, Greater, LessOrEqual, GreaterOrEqual, NotEqual, Where, Min, Max, or Not
+- **THEN** the operator MUST produce the correct boolean or selected output with broadcasting
+
+#### Scenario: Composite activations
+- **WHEN** the executor encounters Gelu, LeakyRelu, Elu, or Swish
+- **THEN** the operator MUST compute the activation per its mathematical definition
+
+### Requirement: Operator Registry Update
+The OperatorRegistry SHALL include all new Tier 2 operator names.
+
+#### Scenario: Tier 2 operators are registered
+- **WHEN** a model contains an LSTM, GRU, Gelu, QuantizeLinear, or any other Tier 2 op
+- **THEN** the registry MUST recognize it as supported
+- **AND** the validator MUST allow the model to load
+- **AND** the executor MUST dispatch to the correct implementation

--- a/openspec/changes/additional-operators-v1/specs/onnx-quantized-operators/spec.md
+++ b/openspec/changes/additional-operators-v1/specs/onnx-quantized-operators/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: QuantizeLinear Operator
+The ONNX runtime SHALL implement the QuantizeLinear operator that converts float32 tensors to int8/uint8.
+
+#### Scenario: Quantize float to int8
+- **WHEN** `op_quantize_linear` is called with input float tensor, scale=0.1, zero_point=0
+- **THEN** it MUST return a tensor of i8 values where each element is `clip(round(input/scale) + zero_point, -128, 127)`
+
+#### Scenario: Per-axis quantization
+- **WHEN** the scale and zero_point are 1D tensors (per-channel quantization)
+- **THEN** the operator MUST broadcast them along the appropriate axis
+
+### Requirement: DequantizeLinear Operator
+The ONNX runtime SHALL implement the DequantizeLinear operator that converts int8/uint8 back to float32.
+
+#### Scenario: Dequantize int8 to float
+- **WHEN** `op_dequantize_linear` is called with int8 input, scale=0.1, zero_point=0
+- **THEN** it MUST return float32 values where each element is `(input - zero_point) * scale`
+
+#### Scenario: Round-trip preservation
+- **WHEN** values are quantized then dequantized
+- **THEN** the result MUST be within `scale` of the original (within rounding precision)
+
+### Requirement: QLinearMatMul Operator
+The ONNX runtime SHALL implement quantized matrix multiplication.
+
+#### Scenario: Quantized matmul produces correct output
+- **WHEN** `op_qlinear_matmul` is called with quantized inputs A, B, their scales, zero_points, and output scale/zero_point
+- **THEN** it MUST produce a quantized result that, when dequantized, matches the f32 matmul result within 1% tolerance
+
+### Requirement: QLinearConv Operator
+The ONNX runtime SHALL implement quantized convolution.
+
+#### Scenario: Quantized convolution produces correct output
+- **WHEN** `op_qlinear_conv` is called with quantized inputs and weights
+- **THEN** it MUST produce a quantized result equivalent (after dequantization) to f32 convolution within 1% tolerance

--- a/openspec/changes/additional-operators-v1/specs/onnx-recurrent-operators/spec.md
+++ b/openspec/changes/additional-operators-v1/specs/onnx-recurrent-operators/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: LSTM Operator
+The ONNX runtime SHALL implement the LSTM (Long Short-Term Memory) operator per ONNX opset 14+.
+
+#### Scenario: LSTM forward pass
+- **WHEN** `op_lstm` is called with input X (sequence_length × batch × input_size), weights W and R, bias B, and initial states (h0, c0)
+- **THEN** it MUST return the output sequence Y, final hidden state Y_h, and final cell state Y_c
+- **AND** the forward direction MUST compute `(i, f, g, o) = sigmoid(...), tanh(...), sigmoid(...)` per timestep with peephole connections optional
+
+#### Scenario: LSTM bidirectional
+- **WHEN** `op_lstm` is called with `direction="bidirectional"`
+- **THEN** it MUST run a forward and reverse pass and concatenate the outputs along the direction axis
+
+### Requirement: GRU Operator
+The ONNX runtime SHALL implement the GRU (Gated Recurrent Unit) operator.
+
+#### Scenario: GRU forward pass
+- **WHEN** `op_gru` is called with the standard W/R/B weights and initial hidden state
+- **THEN** it MUST return the output sequence Y and final hidden state Y_h
+- **AND** the gate computation MUST follow `r_t = sigmoid(W_r·x_t + R_r·h_{t-1} + b_r)`, etc.
+
+### Requirement: RNN Operator
+The ONNX runtime SHALL implement the basic RNN operator with tanh activation by default.
+
+#### Scenario: RNN forward pass
+- **WHEN** `op_rnn` is called with X, W, R, B, and initial hidden state
+- **THEN** the per-timestep computation MUST be `h_t = tanh(W·x_t + R·h_{t-1} + b)`

--- a/openspec/changes/additional-operators-v1/specs/onnx-transformer-operators/spec.md
+++ b/openspec/changes/additional-operators-v1/specs/onnx-transformer-operators/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Einsum Operator
+The ONNX runtime SHALL implement the Einsum operator with support for the equation patterns commonly used in transformer models.
+
+#### Scenario: Batched matmul via einsum
+- **WHEN** `op_einsum` is called with equation `"bij,bjk->bik"` and two 3D input tensors
+- **THEN** it MUST compute the batched matrix multiply
+
+#### Scenario: Attention QK^T via einsum
+- **WHEN** `op_einsum` is called with `"bhij,bhkj->bhik"` for attention scores
+- **THEN** it MUST compute the QK^T product across batch and head dimensions
+
+### Requirement: Split Operator
+The ONNX runtime SHALL implement the Split operator that divides a tensor along a specified axis.
+
+#### Scenario: Equal split
+- **WHEN** `op_split` is called with axis=1 and num_outputs=3 on a tensor with shape [2, 6]
+- **THEN** it MUST return three tensors of shape [2, 2]
+
+#### Scenario: Custom split sizes
+- **WHEN** `op_split` is called with `split=[2, 3, 1]` along axis=0
+- **THEN** it MUST return three tensors of the specified sizes
+
+### Requirement: Expand Operator
+The ONNX runtime SHALL implement the Expand operator that broadcasts a tensor to a target shape.
+
+#### Scenario: Broadcast scalar to tensor
+- **WHEN** `op_expand` is called with a scalar input and target shape [2, 3]
+- **THEN** it MUST return a [2, 3] tensor with the scalar value
+
+### Requirement: Tile Operator
+The ONNX runtime SHALL implement the Tile operator that repeats a tensor.
+
+#### Scenario: Tile along axes
+- **WHEN** `op_tile` is called with input shape [2, 3] and repeats [2, 1]
+- **THEN** it MUST return a tensor with shape [4, 3] containing two copies of the input
+
+### Requirement: OneHot Operator
+The ONNX runtime SHALL implement the OneHot operator for classification.
+
+#### Scenario: One-hot encoding
+- **WHEN** `op_one_hot` is called with indices [0, 1, 2], depth=3, on_value=1.0, off_value=0.0
+- **THEN** it MUST return a 3x3 identity-like matrix

--- a/openspec/changes/additional-operators-v1/tasks.md
+++ b/openspec/changes/additional-operators-v1/tasks.md
@@ -1,0 +1,80 @@
+## 1. Module Structure
+
+- [ ] 1.1 Create `onnx-rt/src/ops/` directory
+- [ ] 1.2 Create `onnx-rt/src/ops/mod.rs` with re-exports
+- [ ] 1.3 Register the new module in `onnx-rt/src/lib.rs`
+- [ ] 1.4 Decide whether to keep existing `operators.rs` as-is or move Tier 1 ops into `ops/tier1/` (initial answer: keep as-is for diff hygiene)
+
+## 2. Math Primitives (ops/math.rs)
+
+- [ ] 2.1 Implement `op_pow(base, exponent)` — element-wise with broadcasting
+- [ ] 2.2 Implement `op_sqrt(input)` — element-wise sqrt (use sqrt_approx)
+- [ ] 2.3 Implement `op_exp(input)` — element-wise exp (use expf_approx)
+- [ ] 2.4 Implement `op_log(input)` — element-wise natural log
+- [ ] 2.5 Implement `op_erf(input)` — error function via Abramowitz & Stegun polynomial
+- [ ] 2.6 Implement `op_neg(input)`, `op_abs(input)`, `op_floor`, `op_ceil`, `op_round`
+- [ ] 2.7 Unit tests for each math op (basic, edge cases, special values)
+
+## 3. Comparison and Selection (ops/compare.rs)
+
+- [ ] 3.1 Implement `op_equal`, `op_not_equal`, `op_less`, `op_less_or_equal`, `op_greater`, `op_greater_or_equal`
+- [ ] 3.2 Implement `op_where(cond, x, y)` — element-wise select
+- [ ] 3.3 Implement `op_min`, `op_max` — element-wise with broadcasting
+- [ ] 3.4 Implement `op_not(bool_input)`
+- [ ] 3.5 Unit tests for each comparison op
+
+## 4. Composite Activations (ops/activations.rs)
+
+- [ ] 4.1 Implement `op_gelu(input)` using `op_erf` and the formula `0.5 * x * (1 + erf(x/sqrt(2)))`
+- [ ] 4.2 Implement `op_leaky_relu(input, alpha)` 
+- [ ] 4.3 Implement `op_elu(input, alpha)`
+- [ ] 4.4 Implement `op_swish(input)` (also called silu): `x * sigmoid(x)`
+- [ ] 4.5 Unit tests with reference values from PyTorch
+
+## 5. Recurrent (ops/recurrent.rs)
+
+- [ ] 5.1 Implement `op_rnn(x, w, r, b, h0)` — basic RNN with tanh
+- [ ] 5.2 Implement `op_lstm(x, w, r, b, h0, c0)` — full LSTM with i/f/g/o gates
+- [ ] 5.3 Implement `op_gru(x, w, r, b, h0)` — GRU with reset/update gates
+- [ ] 5.4 Bidirectional support: forward + reverse pass, concat outputs
+- [ ] 5.5 Unit tests against known reference outputs (small sequences, hand-computed)
+
+## 6. Transformer Building Blocks (ops/transformer.rs)
+
+- [ ] 6.1 Implement `op_split(input, axis, num_outputs_or_sizes)` returning `Vec<Tensor>`
+- [ ] 6.2 Implement `op_expand(input, target_shape)` with broadcasting
+- [ ] 6.3 Implement `op_tile(input, repeats)`
+- [ ] 6.4 Implement `op_one_hot(indices, depth, on_value, off_value)`
+- [ ] 6.5 Implement `op_einsum(equation, inputs)` — parse equation, dispatch to matmul/dot/contraction
+- [ ] 6.6 Unit tests, especially for einsum with `bij,bjk->bik` and attention patterns
+
+## 7. Quantized (ops/quantized.rs)
+
+- [ ] 7.1 Implement `op_quantize_linear(input, scale, zero_point)` — float → int8/uint8
+- [ ] 7.2 Implement `op_dequantize_linear(input, scale, zero_point)` — int8/uint8 → float
+- [ ] 7.3 Implement `op_qlinear_matmul` — initial implementation: dequantize, matmul, requantize
+- [ ] 7.4 Implement `op_qlinear_conv` — same approach
+- [ ] 7.5 Unit tests: round-trip quantize/dequantize, qlinear matmul accuracy vs f32
+
+## 8. OpKind and Registry Updates
+
+- [ ] 8.1 Add new variants to `OpKind` enum (~30 entries)
+- [ ] 8.2 Update `OpKind::parse_str` to handle new operator names
+- [ ] 8.3 Update `OperatorRegistry` to include the new ops
+- [ ] 8.4 Update `classify_op` in profile.rs to assign new ops to budget categories
+
+## 9. Executor Dispatch
+
+- [ ] 9.1 Add new ops to the appropriate `dispatch_*` helper in `executor.rs`
+- [ ] 9.2 Math/comparison/activations → `dispatch_arithmetic` or new `dispatch_math` helper
+- [ ] 9.3 LSTM/GRU/RNN → new `dispatch_recurrent` helper (multi-output)
+- [ ] 9.4 Transformer ops → new `dispatch_transformer` helper
+- [ ] 9.5 Quantized ops → new `dispatch_quantized` helper
+
+## 10. Validation
+
+- [ ] 10.1 `just fmt` clean
+- [ ] 10.2 `just clippy --all-targets` clean
+- [ ] 10.3 `just test` all passing
+- [ ] 10.4 New test count: at least 60 unit tests across all new operators
+- [ ] 10.5 Update `docs/scheduling-model.md` operator class table if needed


### PR DESCRIPTION
## Summary
- Adds 36 new ONNX operators across 6 categories, growing the registry from 29 → 65
- New module layout: \`onnx-rt/src/ops/{math,compare,activations,recurrent,transformer,quantized}.rs\`
- 70 new unit tests, full \`just test\` and \`just clippy\` clean

## Categories
- **Math (10):** Pow, Sqrt, Exp, Log, Erf, Neg, Abs, Floor, Ceil, Round
- **Compare (10):** Equal, NotEqual, Less/LessOrEqual, Greater/GreaterOrEqual, Where, Min, Max, Not
- **Activations (4):** Gelu, LeakyRelu, Elu, Swish
- **Recurrent (3):** RNN, LSTM, GRU with bidirectional support
- **Transformer (5):** Split, Expand, Tile, OneHot, Einsum (bij/bjk, bhij/bhkj patterns)
- **Quantized (4):** QuantizeLinear, DequantizeLinear, QLinearMatMul, QLinearConv

OpenSpec change: \`additional-operators-v1\`

## Test plan
- [x] \`just test\` — 438 onnx-rt tests pass (was 368)
- [x] \`just clippy\` — clean
- [x] \`just fmt\` — clean
- [ ] CI gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)