### PR TITLE
docs(openspec): add ONNX full coverage roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ on x86-64, ARM64, and RISC-V platforms.
 - **6 architectures** — x86-64, AArch64, RISC-V 64, NVIDIA GPU, AMD GPU, Intel GPU
 - **Post-quantum crypto** — ML-KEM-768 + ML-DSA-65 hybrid mode by default
 - **Full network stack** — IPv4/IPv6, TCP/UDP, QUIC/HTTP3, TLS 1.3
+- **65 ONNX operators** — see the [coverage roadmap](docs/onnx-coverage-roadmap.md) for the path to full standard-spec coverage
 - **Formally verified** — 19 TLA+ models, SPIN protocols, Lean 4 proofs
 - **4,143 tests** — Zero clippy warnings, MC/DC coverage on safety-critical paths
 - **< 15 MB** — Release binary per architecture

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ on x86-64, ARM64, and RISC-V platforms.
 - **6 architectures** — x86-64, AArch64, RISC-V 64, NVIDIA GPU, AMD GPU, Intel GPU
 - **Post-quantum crypto** — ML-KEM-768 + ML-DSA-65 hybrid mode by default
 - **Full network stack** — IPv4/IPv6, TCP/UDP, QUIC/HTTP3, TLS 1.3
-- **65 ONNX operators** — see the [coverage roadmap](docs/onnx-coverage-roadmap.md) for the path to full standard-spec coverage
+- **ONNX operators** — 29 in `develop`, 109 after Phase 1 PRs land; see the [coverage roadmap](docs/onnx-coverage-roadmap.md) for the full plan
 - **Formally verified** — 19 TLA+ models, SPIN protocols, Lean 4 proofs
 - **4,143 tests** — Zero clippy warnings, MC/DC coverage on safety-critical paths
 - **< 15 MB** — Release binary per architecture
@@ -42,7 +42,7 @@ See [`docs/architecture.puml`](docs/architecture.puml)
 | `smallaios-arch-nvidia` | NVIDIA GPU HAL: PCIe, compute, PTX |
 | `smallaios-arch-amd` | AMD GPU HAL: RDNA/CDNA, wavefront, HIP |
 | `smallaios-arch-intel-gpu` | Intel GPU HAL: Xe, EU compute, SPIR-V |
-| `smallaios-onnx-rt` | ONNX runtime: protobuf parser, 7 operators |
+| `smallaios-onnx-rt` | ONNX runtime: protobuf parser, 29 operators in `develop` (109 after Phase 1) — see [coverage roadmap](docs/onnx-coverage-roadmap.md) |
 | `smallaios-security` | Capabilities, PQC crypto, audit, compliance |
 | `smallaios-net` | IPv4/IPv6, TCP/UDP, QUIC/HTTP3, TLS 1.3 |
 | `smallaios-ipc` | Zenoh-inspired pub/sub with security gate |

--- a/docs/onnx-coverage-roadmap.md
+++ b/docs/onnx-coverage-roadmap.md
@@ -5,8 +5,15 @@ future operator-coverage OpenSpec change must slot into a tier defined
 here. Cite this document from each tier proposal.
 
 **Last reviewed:** 2026-04-11
-**Current coverage:** 65 / ~190 standard ops (~34%)
+**Current coverage in `develop`:** 29 / ~190 standard ops (~15%)
+**Coverage after Phase 1 PRs (#74, #76, #77) merge:** 109 / ~190 (~57%)
 **Owning OpenSpec change:** `onnx-full-coverage-roadmap-v1`
+
+> The "Implemented" section below lists ops that are *either* in
+> `develop` today *or* in flight on the Phase 1 PRs (#74 Tier 2,
+> #76 vision, #77 transformer). The roadmap forward-looks so it can
+> serve as the merge target spec; numbers will become true as the
+> PRs land.
 
 ## Goals
 
@@ -43,10 +50,10 @@ sequentially; tiers within a phase run in parallel.
 |---|---|---|---|---|---|
 | 1 ✅ | `onnx-cpu-runtime-v1` (archived) | ResNet, MobileNet, YOLO | 29 | 29 | 15% |
 | 2 ✅ | `additional-operators-v1` | Building blocks | +36 | 65 | 34% |
-| **P1** | `transformer-models-v1` ‖ `vision-transformers-v1` | BERT, DistilBERT, ViT, Swin, DeiT, ConvNeXt | +39 | 104 | 55% |
-| **P2** | `generative-llm-v1` (combined: control-flow + generative ops + i8 kernels) | GPT-2, T5, single-pass autoregressive generation, real i8 LLM inference | +21 + sub-graph executor | 125 | 66% |
-| **P3** | `audio-models-v1` ‖ `detection-models-v1` | Whisper-tiny, Wav2Vec2, DETR, RetinaNet | +21 | 146 | 77% |
-| **P4** | `long-tail-v1` (reactive) | User-driven additions | +~30 | ~176 | ~93% |
+| **P1** | `transformer-models-v1` ‖ `vision-transformers-v1` | BERT, DistilBERT, ViT, Swin, DeiT, ConvNeXt | +44 | 109 | 57% |
+| **P2** | `generative-llm-v1` (combined: control-flow + generative ops + i8 kernels) | GPT-2, T5, single-pass autoregressive generation, real i8 LLM inference | +22 + sub-graph executor | 131 | 69% |
+| **P3** | `audio-models-v1` ‖ `detection-models-v1` | Whisper-tiny, Wav2Vec2, DETR, RetinaNet | +21 | 152 | 80% |
+| **P4** | `long-tail-v1` (reactive) | User-driven additions | +~30 | ~182 | ~96% |
 
 The remaining ~14 ops are explicitly **Deferred-subsystem** (sequence
 types, optional types, string tensors, ONNX-ML classical ML) or
@@ -93,7 +100,7 @@ materially limit any neural model class we care about.
 The inventory tracks every standard operator with one of:
 
 - **Implemented** — works today.
-- **Planned-T<n>** — will land in tier `n`.
+- **Planned-P<n>** — will land in phase `n` (P1-P4).
 - **Deferred-subsystem** — needs a non-trivial subsystem we haven't
   built yet (sequence types, optional types, control-flow executor,
   string tensors).
@@ -102,11 +109,11 @@ The inventory tracks every standard operator with one of:
   rewrite at export time.
 - **Skipped-vendor** — non-standard op (e.g., `com.microsoft` domain).
 
-The Tier 3 change (`transformer-models-v1`) will encode this inventory
+The Phase 1 change (`transformer-models-v1`) encodes this inventory
 as a Rust constant `SUPPORTED_OPS_INVENTORY` with a CI test that fails
 if the implemented set drifts from the inventory.
 
-### Implemented (65)
+### Implemented (29 in develop today; 65 after #74; 109 after Phase 1)
 
 **Tier 1 (29):** Add, Sub, Mul, Div, MatMul, Relu, Sigmoid, Tanh,
 Softmax, Conv, MaxPool, AveragePool, BatchNormalization, Reshape,
@@ -124,45 +131,45 @@ QLinearMatMul, QLinearConv
 
 | Op | Status | Rationale |
 |---|---|---|
-| Mod | Planned-T3 | Integer/float modulo; positional encoding |
-| Sin | Planned-T3 | Sinusoidal positional embeddings |
-| Cos | Planned-T3 | Sinusoidal positional embeddings |
-| Reciprocal | Planned-T3 | 1/x; LayerNorm and attention scaling |
-| Sign | Planned-T3 | Sign extraction; quant + transformers |
-| Sum | Planned-T3 | Variadic elementwise sum |
-| Mean | Planned-T3 | Variadic elementwise mean |
-| And | Planned-T3 | Boolean mask composition |
-| Or | Planned-T3 | Boolean mask composition |
-| LogSoftmax | Planned-T3 | Common classifier head |
-| PRelu | Planned-T4 | Parametric ReLU; older vision nets |
-| HardSigmoid | Planned-T4 | MobileNet/EfficientNet activation |
-| HardSwish | Planned-T4 | MobileNetV3 activation |
-| Softplus | Planned-T5 | Smooth ReLU; generative models |
-| Sinh | Planned-T6 | Hyperbolic trig; audio models |
-| Cosh | Planned-T6 | Hyperbolic trig; audio models |
-| Tan | Planned-T10 | Rare in inference |
-| Asin | Planned-T10 | Rare inverse trig |
-| Acos | Planned-T10 | Rare inverse trig |
-| Atan | Planned-T10 | Rare inverse trig |
-| Asinh | Planned-T10 | Long tail |
-| Acosh | Planned-T10 | Long tail |
-| Atanh | Planned-T10 | Long tail |
-| Xor | Planned-T10 | Rare boolean op |
-| BitwiseAnd | Planned-T10 | Integer bitwise (opset 18+) |
-| BitwiseOr | Planned-T10 | Integer bitwise (opset 18+) |
-| BitwiseXor | Planned-T10 | Integer bitwise (opset 18+) |
-| BitwiseNot | Planned-T10 | Integer bitwise (opset 18+) |
-| BitShift | Planned-T10 | Integer bit shift |
-| ThresholdedRelu | Planned-T10 | Rare activation |
-| Selu | Planned-T10 | Rare self-normalizing activation |
-| Celu | Planned-T10 | Rare continuous ELU |
-| Softsign | Planned-T10 | Rare activation |
-| Shrink | Planned-T10 | Soft thresholding; rare |
-| Hardmax | Planned-T10 | One-hot argmax variant |
-| IsNaN | Planned-T10 | Debug/validation op |
-| IsInf | Planned-T10 | Debug/validation op |
-| MeanVarianceNormalization | Planned-T5 | MVN normalization |
-| LpNormalization | Planned-T5 | L1/L2 normalization layer |
+| Mod | Planned-P1 | Integer/float modulo; positional encoding |
+| Sin | Planned-P1 | Sinusoidal positional embeddings |
+| Cos | Planned-P1 | Sinusoidal positional embeddings |
+| Reciprocal | Planned-P1 | 1/x; LayerNorm and attention scaling |
+| Sign | Planned-P1 | Sign extraction; quant + transformers |
+| Sum | Planned-P1 | Variadic elementwise sum |
+| Mean | Planned-P1 | Variadic elementwise mean |
+| And | Planned-P1 | Boolean mask composition |
+| Or | Planned-P1 | Boolean mask composition |
+| LogSoftmax | Planned-P1 | Common classifier head |
+| PRelu | Planned-P1 | Parametric ReLU; older vision nets |
+| HardSigmoid | Planned-P1 | MobileNet/EfficientNet activation |
+| HardSwish | Planned-P1 | MobileNetV3 activation |
+| Softplus | Planned-P2 | Smooth ReLU; generative models |
+| Sinh | Planned-P3 | Hyperbolic trig; audio models |
+| Cosh | Planned-P3 | Hyperbolic trig; audio models |
+| Tan | Planned-P4 | Rare in inference |
+| Asin | Planned-P4 | Rare inverse trig |
+| Acos | Planned-P4 | Rare inverse trig |
+| Atan | Planned-P4 | Rare inverse trig |
+| Asinh | Planned-P4 | Long tail |
+| Acosh | Planned-P4 | Long tail |
+| Atanh | Planned-P4 | Long tail |
+| Xor | Planned-P4 | Rare boolean op |
+| BitwiseAnd | Planned-P4 | Integer bitwise (opset 18+) |
+| BitwiseOr | Planned-P4 | Integer bitwise (opset 18+) |
+| BitwiseXor | Planned-P4 | Integer bitwise (opset 18+) |
+| BitwiseNot | Planned-P4 | Integer bitwise (opset 18+) |
+| BitShift | Planned-P4 | Integer bit shift |
+| ThresholdedRelu | Planned-P4 | Rare activation |
+| Selu | Planned-P4 | Rare self-normalizing activation |
+| Celu | Planned-P4 | Rare continuous ELU |
+| Softsign | Planned-P4 | Rare activation |
+| Shrink | Planned-P4 | Soft thresholding; rare |
+| Hardmax | Planned-P4 | One-hot argmax variant |
+| IsNaN | Planned-P4 | Debug/validation op |
+| IsInf | Planned-P4 | Debug/validation op |
+| MeanVarianceNormalization | Planned-P2 | MVN normalization |
+| LpNormalization | Planned-P2 | L1/L2 normalization layer |
 | Affine | Skipped-deprecated | Replaced by Mul+Add |
 | ImageScaler | Skipped-deprecated | Replaced by Mul+Add |
 | Scale | Skipped-deprecated | Replaced by Mul |
@@ -173,68 +180,68 @@ QLinearMatMul, QLinearConv
 
 | Op | Status | Rationale |
 |---|---|---|
-| ReduceMax | Planned-T3 | Attention / classifier max pooling |
-| ReduceMin | Planned-T3 | Counterpart to ReduceMax |
-| ReduceProd | Planned-T3 | Shape/volume computations |
-| ArgMax | Planned-T3 | Classifier decode |
-| ArgMin | Planned-T3 | Counterpart to ArgMax |
-| ReduceL1 | Planned-T5 | L1 norm reductions |
-| ReduceL2 | Planned-T5 | L2 norm reductions |
-| ReduceLogSum | Planned-T5 | Log-domain reductions |
-| ReduceLogSumExp | Planned-T5 | Stable softmax building block |
-| ReduceSumSquare | Planned-T5 | Variance / norm computation |
+| ReduceMax | Planned-P1 | Attention / classifier max pooling |
+| ReduceMin | Planned-P1 | Counterpart to ReduceMax |
+| ReduceProd | Planned-P1 | Shape/volume computations |
+| ArgMax | Planned-P1 | Classifier decode |
+| ArgMin | Planned-P1 | Counterpart to ArgMax |
+| ReduceL1 | Planned-P2 | L1 norm reductions |
+| ReduceL2 | Planned-P2 | L2 norm reductions |
+| ReduceLogSum | Planned-P2 | Log-domain reductions |
+| ReduceLogSumExp | Planned-P2 | Stable softmax building block |
+| ReduceSumSquare | Planned-P2 | Variance / norm computation |
 
 ### Pooling
 
 | Op | Status | Rationale |
 |---|---|---|
-| GlobalMaxPool | Planned-T4 | Common classifier head |
-| RoiAlign | Planned-T4 | ViT detection / Mask R-CNN |
-| MaxRoiPool | Planned-T7 | Object detection ROI pooling |
-| GlobalLpPool | Planned-T10 | Rare Lp pooling |
-| LpPool | Planned-T10 | Rare Lp pooling |
-| MaxUnpool | Planned-T10 | Segmentation decoder; rare |
+| GlobalMaxPool | Planned-P1 | Common classifier head |
+| RoiAlign | Planned-P1 | ViT detection / Mask R-CNN |
+| MaxRoiPool | Planned-P3 | Object detection ROI pooling |
+| GlobalLpPool | Planned-P4 | Rare Lp pooling |
+| LpPool | Planned-P4 | Rare Lp pooling |
+| MaxUnpool | Planned-P4 | Segmentation decoder; rare |
 
 ### Normalization
 
 | Op | Status | Rationale |
 |---|---|---|
-| InstanceNormalization | Planned-T4 | Style transfer / vision transformers |
-| GroupNormalization | Planned-T4 | ConvNeXt / Swin / diffusion |
-| RMSNormalization | Planned-T5 | LLaMA / T5 normalization |
-| LRN | Planned-T6 | Legacy AlexNet; whisper preprocess |
+| InstanceNormalization | Planned-P1 | Style transfer / vision transformers |
+| GroupNormalization | Planned-P1 | ConvNeXt / Swin / diffusion |
+| RMSNormalization | Planned-P2 | LLaMA / T5 normalization |
+| LRN | Planned-P3 | Legacy AlexNet; whisper preprocess |
 
 ### Shape / Data Movement
 
 | Op | Status | Rationale |
 |---|---|---|
-| Shape | Planned-T3 | Dynamic shape queries; BERT |
-| Size | Planned-T3 | Element count queries |
-| Identity | Planned-T3 | Pass-through; constant folding |
-| ConstantOfShape | Planned-T3 | Masking / attention patterns |
-| Constant | Planned-T3 | Inline constant tensors |
-| Range | Planned-T3 | Positional indices |
-| Trilu | Planned-T3 | Causal mask for attention |
-| CumSum | Planned-T3 | Positional offsets; attention |
-| GatherND | Planned-T3 | N-dim gather; transformers |
-| ScatterND | Planned-T3 | N-dim scatter; transformers |
-| GatherElements | Planned-T4 | Element-wise gather |
-| ScatterElements | Planned-T4 | Element-wise scatter |
-| TopK | Planned-T4 | Beam search; classifier top-k |
-| NonZero | Planned-T4 | Mask indexing |
-| Compress | Planned-T4 | Boolean mask selection |
-| Unique | Planned-T4 | Deduplication |
-| DepthToSpace | Planned-T4 | Super-resolution; pixel shuffle |
-| SpaceToDepth | Planned-T4 | YOLO / ViT patchify |
-| Resize | Planned-T4 | Image scaling; ViT/U-Net |
-| GridSample | Planned-T4 | Spatial transformers / STN |
-| CenterCropPad | Planned-T4 | Vision preprocessing (opset 18+) |
-| EyeLike | Planned-T5 | Identity matrix generation |
-| Reverse | Planned-T10 | Rare axis reversal |
-| ReverseSequence | Planned-T10 | Bi-directional RNN support |
-| ImageDecoder | Planned-T10 | Raw image decode (opset 20+) |
-| AffineGrid | Planned-T10 | Spatial transformer grid (opset 20+) |
-| Col2Im | Planned-T10 | Inverse im2col (opset 18+) |
+| Shape | Planned-P1 | Dynamic shape queries; BERT |
+| Size | Planned-P1 | Element count queries |
+| Identity | Planned-P1 | Pass-through; constant folding |
+| ConstantOfShape | Planned-P1 | Masking / attention patterns |
+| Constant | Planned-P1 | Inline constant tensors |
+| Range | Planned-P1 | Positional indices |
+| Trilu | Planned-P1 | Causal mask for attention |
+| CumSum | Planned-P1 | Positional offsets; attention |
+| GatherND | Planned-P1 | N-dim gather; transformers |
+| ScatterND | Planned-P1 | N-dim scatter; transformers |
+| GatherElements | Planned-P1 | Element-wise gather |
+| ScatterElements | Planned-P1 | Element-wise scatter |
+| TopK | Planned-P1 | Beam search; classifier top-k |
+| NonZero | Planned-P1 | Mask indexing |
+| Compress | Planned-P1 | Boolean mask selection |
+| Unique | Planned-P1 | Deduplication |
+| DepthToSpace | Planned-P1 | Super-resolution; pixel shuffle |
+| SpaceToDepth | Planned-P1 | YOLO / ViT patchify |
+| Resize | Planned-P1 | Image scaling; ViT/U-Net |
+| GridSample | Planned-P1 | Spatial transformers / STN |
+| CenterCropPad | Planned-P1 | Vision preprocessing (opset 18+) |
+| EyeLike | Planned-P2 | Identity matrix generation |
+| Reverse | Planned-P4 | Rare axis reversal |
+| ReverseSequence | Planned-P4 | Bi-directional RNN support |
+| ImageDecoder | Planned-P4 | Raw image decode (opset 20+) |
+| AffineGrid | Planned-P4 | Spatial transformer grid (opset 20+) |
+| Col2Im | Planned-P4 | Inverse im2col (opset 18+) |
 | Scatter | Skipped-deprecated | Replaced by ScatterElements |
 | Upsample | Skipped-deprecated | Replaced by Resize |
 | SplitToSequence | Deferred-subsystem | Sequence type required |
@@ -244,16 +251,16 @@ QLinearMatMul, QLinearConv
 
 | Op | Status | Rationale |
 |---|---|---|
-| ConvTranspose | Planned-T6 | Upsampling decoder; audio |
-| ConvInteger | Planned-T10 | Integer convolution; rare quant path |
-| DeformConv | Planned-T10 | Deformable convolution (opset 19+) |
+| ConvTranspose | Planned-P3 | Upsampling decoder; audio |
+| ConvInteger | Planned-P4 | Integer convolution; rare quant path |
+| DeformConv | Planned-P4 | Deformable convolution (opset 19+) |
 
 ### Quantized
 
 | Op | Status | Rationale |
 |---|---|---|
-| MatMulInteger | Planned-T5 | Int8 LLM inference |
-| DynamicQuantizeLinear | Planned-T5 | Runtime quantization for LLMs |
+| MatMulInteger | Planned-P2 | Int8 LLM inference |
+| DynamicQuantizeLinear | Planned-P2 | Runtime quantization for LLMs |
 | QLinearAdd | Skipped-vendor | `com.microsoft` contrib op |
 | QLinearMul | Skipped-vendor | `com.microsoft` contrib op |
 | QLinearConcat | Skipped-vendor | `com.microsoft` contrib op |
@@ -267,30 +274,30 @@ QLinearMatMul, QLinearConv
 
 | Op | Status | Rationale |
 |---|---|---|
-| RandomNormal | Planned-T5 | Generative sampling |
-| RandomNormalLike | Planned-T5 | Generative sampling |
-| RandomUniform | Planned-T5 | Generative sampling / dropout |
-| RandomUniformLike | Planned-T5 | Generative sampling / dropout |
-| Multinomial | Planned-T5 | Token sampling for LLMs |
-| Bernoulli | Planned-T5 | Stochastic masking |
-| Dropout | Planned-T5 | No-op at inference; must parse |
+| RandomNormal | Planned-P2 | Generative sampling |
+| RandomNormalLike | Planned-P2 | Generative sampling |
+| RandomUniform | Planned-P2 | Generative sampling / dropout |
+| RandomUniformLike | Planned-P2 | Generative sampling / dropout |
+| Multinomial | Planned-P2 | Token sampling for LLMs |
+| Bernoulli | Planned-P2 | Stochastic masking |
+| Dropout | Planned-P2 | No-op at inference; must parse |
 
 ### Audio / Signal
 
 | Op | Status | Rationale |
 |---|---|---|
-| STFT | Planned-T6 | Whisper spectrogram frontend |
-| DFT | Planned-T6 | Spectral transforms |
-| MelWeightMatrix | Planned-T6 | Mel filterbank for Whisper |
-| HannWindow | Planned-T6 | Audio windowing |
-| HammingWindow | Planned-T6 | Audio windowing |
-| BlackmanWindow | Planned-T6 | Audio windowing |
+| STFT | Planned-P3 | Whisper spectrogram frontend |
+| DFT | Planned-P3 | Spectral transforms |
+| MelWeightMatrix | Planned-P3 | Mel filterbank for Whisper |
+| HannWindow | Planned-P3 | Audio windowing |
+| HammingWindow | Planned-P3 | Audio windowing |
+| BlackmanWindow | Planned-P3 | Audio windowing |
 
 ### Object Detection
 
 | Op | Status | Rationale |
 |---|---|---|
-| NonMaxSuppression | Planned-T7 | All detection models need this |
+| NonMaxSuppression | Planned-P3 | All detection models need this |
 
 ### Sequence (Deferred)
 
@@ -305,20 +312,21 @@ for any current target model.
 `Optional`, `OptionalHasElement`, `OptionalGetElement` —
 **Deferred-subsystem**. Requires a sum-type wrapper around tensors.
 Used by some control-flow models; will be addressed alongside
-`If`/`Loop` in Tier 9 if at all.
+`If`/`Loop` in P2 alongside the sub-graph executor.
 
-### Control Flow (Deferred / Tier 9)
+### Control Flow (Phase 2)
 
 | Op | Status | Rationale |
 |---|---|---|
-| If | Tier 9 (subsystem) | Conditional subgraph execution |
-| Loop | Tier 9 (subsystem) | Iterative subgraph execution |
-| Scan | Tier 9 (subsystem) | Recurrent subgraph execution |
+| If | Planned-P2 | Conditional subgraph execution; needs sub-graph executor |
+| Loop | Planned-P2 | Iterative subgraph execution; needs sub-graph executor |
+| Scan | Planned-P2 | Recurrent subgraph execution; needs sub-graph executor |
 
-Tier 9 is the only tier whose design budget will be larger than its
+Phase 2 is the only phase whose design budget will be larger than its
 implementation budget. The ops themselves are simple; the runtime
 machinery (sub-executor, scope management, carried dependencies) is
-substantial.
+substantial. See `openspec/changes/generative-llm-v1/` and
+`docs/sub-graph-executor-design.md` for the architecture.
 
 ### String / Tokenizer (Deferred)
 
@@ -357,7 +365,7 @@ These two changes run in parallel agent worktrees as soon as
 **Target models:** BERT-base (`bert-base-uncased`), DistilBERT
 (`distilbert-base-uncased`), TinyBERT.
 
-**New operators (~25):**
+**New operators (25):**
 - **Math (10):** Mod, Sin, Cos, Reciprocal, Sign, Sum, Mean, And, Or,
   LogSoftmax
 - **Reduction (5):** ReduceMax, ReduceMin, ReduceProd, ArgMax, ArgMin
@@ -390,10 +398,10 @@ variant and vice versa, preventing the inventory from drifting.
 
 **Target models:** ViT, Swin, DeiT, ConvNeXt, MobileViT.
 
-**New operators (~14):** Resize, DepthToSpace, SpaceToDepth, RoiAlign,
+**New operators (19):** Resize, DepthToSpace, SpaceToDepth, RoiAlign,
 GridSample, GroupNormalization, InstanceNormalization, TopK, Compress,
 NonZero, Unique, GatherElements, ScatterElements, GlobalMaxPool,
-HardSigmoid, HardSwish, PRelu, CenterCropPad.
+HardSigmoid, HardSwish, PRelu, Mish, CenterCropPad.
 
 **Validation:** loads ViT-base end-to-end via the integration harness.
 
@@ -484,14 +492,14 @@ already in P1.
 
 ## Phase 4 — `long-tail-v1` (reactive)
 
-No fixed scope. Operators tagged `Planned-T10` in the inventory are
+No fixed scope. Operators tagged `Planned-P4` in the inventory are
 pulled into small, focused PRs only when a real user model fails to
 load because of them. Phase 4 is **reactive maintenance**, not a
 scheduled change.
 
 When a Phase 4 PR lands:
 1. Add the missing op to its appropriate `ops/` submodule
-2. Update the inventory entry from `Planned-T10` to `Implemented`
+2. Update the inventory entry from `Planned-P4` to `Implemented`
 3. Add the user's model to the integration test suite if practical
 
 ## Agent-Team Execution Playbook
@@ -514,7 +522,7 @@ established pattern:
 | `onnx-rt/src/operators.rs` (`OpKind`, `parse_str`, `name`, `ALL_OPS`) | **Append-only.** Merges sequenced. Later tiers rebase. |
 | `onnx-rt/src/executor.rs` (dispatch helpers) | **Append-only.** Each tier adds new dispatch helpers; existing ones are not edited. |
 | `onnx-rt/src/profile.rs` (`classify_op`) | **Append-only.** Add to the existing match arm with new op names. |
-| `docs/onnx-coverage-roadmap.md` | Updated by every tier — change status from `Planned-Tn` to `Implemented`. |
+| `docs/onnx-coverage-roadmap.md` | Updated by every change — flip status from `Planned-Pn` to `Implemented`. |
 | `SUPPORTED_OPS_INVENTORY` (T3+) | Append/update inline. CI test enforces consistency. |
 
 ### Per-tier validation gates
@@ -544,7 +552,7 @@ When starting an agent on a tier:
 5. Implement each op in its own commit if practical, or one commit
    per category if the ops are tiny
 6. Run the validation gates above before opening the PR
-7. Update this roadmap in the same PR — flip Planned-Tn → Implemented
+7. Update this roadmap in the same PR — flip Planned-Pn → Implemented
    for every shipped op
 
 ### Coordination
@@ -564,10 +572,10 @@ This document must be reviewed:
 
 - **Before each release** — flip statuses, sanity-check counts.
 - **After each ONNX opset bump** — add any new ops to the inventory
-  with a default status of `Planned-T10`.
+  with a default status of `Planned-P4`.
 - **After each tier merges** — verify the cumulative count and
   percentage in the tier table match reality.
 
-A future Tier 3 task will add a `just check-roadmap` recipe that
+A future Phase 1 follow-up will add a `just check-roadmap` recipe that
 diffs the roadmap inventory against `OperatorRegistry` and fails CI
 on drift.

--- a/docs/onnx-coverage-roadmap.md
+++ b/docs/onnx-coverage-roadmap.md
@@ -1,0 +1,478 @@
+# ONNX Operator Coverage Roadmap
+
+This is the canonical plan for SmallAIOS's ONNX operator coverage. Every
+future operator-coverage OpenSpec change must slot into a tier defined
+here. Cite this document from each tier proposal.
+
+**Last reviewed:** 2026-04-11
+**Current coverage:** 65 / ~190 standard ops (~34%)
+**Owning OpenSpec change:** `onnx-full-coverage-roadmap-v1`
+
+## Goals
+
+- Catalog **every** standard ONNX operator (opset 21) so nothing slips
+  through ad-hoc per-model work.
+- Drive coverage by **target model class**, not by spec compliance —
+  every tier ships a real, demoable workload.
+- Make "remaining work" a queryable, testable number rather than
+  folklore.
+- Be honest about what we will **not** implement (training ops,
+  ecosystem ops, sequence/optional/control-flow subsystems).
+
+## Tier Sequence
+
+| Tier | OpenSpec change | Target models | Op delta | Cumulative | % of ONNX |
+|---|---|---|---|---|---|
+| 1 ✅ | `onnx-cpu-runtime-v1` (archived) | ResNet, MobileNet, YOLO | 29 | 29 | 15% |
+| 2 ✅ | `additional-operators-v1` | Transformer/recurrent/quant building blocks | +36 | 65 | 34% |
+| 3 | `transformer-models-v1` | BERT-base, DistilBERT, TinyBERT | +18 | 83 | 44% |
+| 4 | `vision-transformers-v1` | ViT, Swin, DeiT, ConvNeXt | +14 | 97 | 51% |
+| 5 | `generative-models-v1` | GPT-2-small, T5-small, LLaMA-style | +18 | 115 | 60% |
+| 6 | `audio-models-v1` | Whisper-tiny, Wav2Vec2 | +13 | 128 | 67% |
+| 7 | `detection-models-v1` | DETR, RetinaNet, Mask R-CNN | +8 | 136 | 72% |
+| 8 | `int8-kernels-v1` | (real i8 GEMM/Conv perf, no new ops) | 0 | 136 | 72% |
+| 9 | `control-flow-v1` | Models w/ If/Loop/Scan + sequence types | +3 + subsystems | 139 | 73% |
+| 10 | `long-tail-completion-v1` | Reactive, user-driven | +~25 | ~164 | ~86% |
+
+The remaining ~26 ops are explicitly **Deferred-subsystem** (sequence,
+optional, string, tokenizer, ONNX-ML classical ML) or **Skipped**
+(training, deprecated, vendor). They are not in the path to 100%
+unless a real user model demands one of them.
+
+## Operator Inventory
+
+The inventory tracks every standard operator with one of:
+
+- **Implemented** — works today.
+- **Planned-T<n>** — will land in tier `n`.
+- **Deferred-subsystem** — needs a non-trivial subsystem we haven't
+  built yet (sequence types, optional types, control-flow executor,
+  string tensors).
+- **Skipped-training** — training-only op; SmallAIOS is inference-only.
+- **Skipped-deprecated** — superseded by a newer op; converters
+  rewrite at export time.
+- **Skipped-vendor** — non-standard op (e.g., `com.microsoft` domain).
+
+The Tier 3 change (`transformer-models-v1`) will encode this inventory
+as a Rust constant `SUPPORTED_OPS_INVENTORY` with a CI test that fails
+if the implemented set drifts from the inventory.
+
+### Implemented (65)
+
+**Tier 1 (29):** Add, Sub, Mul, Div, MatMul, Relu, Sigmoid, Tanh,
+Softmax, Conv, MaxPool, AveragePool, BatchNormalization, Reshape,
+Transpose, Flatten, Squeeze, Unsqueeze, Concat, Gather, Slice, Pad,
+Gemm, GlobalAveragePool, LayerNormalization, Cast, Clip, ReduceMean,
+ReduceSum
+
+**Tier 2 (36):** Pow, Sqrt, Exp, Log, Erf, Neg, Abs, Floor, Ceil,
+Round, Equal, NotEqual, Less, LessOrEqual, Greater, GreaterOrEqual,
+Where, Min, Max, Not, Gelu, LeakyRelu, Elu, Swish, RNN, LSTM, GRU,
+Split, Expand, Tile, OneHot, Einsum, QuantizeLinear, DequantizeLinear,
+QLinearMatMul, QLinearConv
+
+### Math / Elementwise
+
+| Op | Status | Rationale |
+|---|---|---|
+| Mod | Planned-T3 | Integer/float modulo; positional encoding |
+| Sin | Planned-T3 | Sinusoidal positional embeddings |
+| Cos | Planned-T3 | Sinusoidal positional embeddings |
+| Reciprocal | Planned-T3 | 1/x; LayerNorm and attention scaling |
+| Sign | Planned-T3 | Sign extraction; quant + transformers |
+| Sum | Planned-T3 | Variadic elementwise sum |
+| Mean | Planned-T3 | Variadic elementwise mean |
+| And | Planned-T3 | Boolean mask composition |
+| Or | Planned-T3 | Boolean mask composition |
+| LogSoftmax | Planned-T3 | Common classifier head |
+| PRelu | Planned-T4 | Parametric ReLU; older vision nets |
+| HardSigmoid | Planned-T4 | MobileNet/EfficientNet activation |
+| HardSwish | Planned-T4 | MobileNetV3 activation |
+| Softplus | Planned-T5 | Smooth ReLU; generative models |
+| Sinh | Planned-T6 | Hyperbolic trig; audio models |
+| Cosh | Planned-T6 | Hyperbolic trig; audio models |
+| Tan | Planned-T10 | Rare in inference |
+| Asin | Planned-T10 | Rare inverse trig |
+| Acos | Planned-T10 | Rare inverse trig |
+| Atan | Planned-T10 | Rare inverse trig |
+| Asinh | Planned-T10 | Long tail |
+| Acosh | Planned-T10 | Long tail |
+| Atanh | Planned-T10 | Long tail |
+| Xor | Planned-T10 | Rare boolean op |
+| BitwiseAnd | Planned-T10 | Integer bitwise (opset 18+) |
+| BitwiseOr | Planned-T10 | Integer bitwise (opset 18+) |
+| BitwiseXor | Planned-T10 | Integer bitwise (opset 18+) |
+| BitwiseNot | Planned-T10 | Integer bitwise (opset 18+) |
+| BitShift | Planned-T10 | Integer bit shift |
+| ThresholdedRelu | Planned-T10 | Rare activation |
+| Selu | Planned-T10 | Rare self-normalizing activation |
+| Celu | Planned-T10 | Rare continuous ELU |
+| Softsign | Planned-T10 | Rare activation |
+| Shrink | Planned-T10 | Soft thresholding; rare |
+| Hardmax | Planned-T10 | One-hot argmax variant |
+| IsNaN | Planned-T10 | Debug/validation op |
+| IsInf | Planned-T10 | Debug/validation op |
+| MeanVarianceNormalization | Planned-T5 | MVN normalization |
+| LpNormalization | Planned-T5 | L1/L2 normalization layer |
+| Affine | Skipped-deprecated | Replaced by Mul+Add |
+| ImageScaler | Skipped-deprecated | Replaced by Mul+Add |
+| Scale | Skipped-deprecated | Replaced by Mul |
+| ParametricSoftplus | Skipped-deprecated | Legacy activation |
+| ScaledTanh | Skipped-deprecated | Legacy activation |
+
+### Reduction
+
+| Op | Status | Rationale |
+|---|---|---|
+| ReduceMax | Planned-T3 | Attention / classifier max pooling |
+| ReduceMin | Planned-T3 | Counterpart to ReduceMax |
+| ReduceProd | Planned-T3 | Shape/volume computations |
+| ArgMax | Planned-T3 | Classifier decode |
+| ArgMin | Planned-T3 | Counterpart to ArgMax |
+| ReduceL1 | Planned-T5 | L1 norm reductions |
+| ReduceL2 | Planned-T5 | L2 norm reductions |
+| ReduceLogSum | Planned-T5 | Log-domain reductions |
+| ReduceLogSumExp | Planned-T5 | Stable softmax building block |
+| ReduceSumSquare | Planned-T5 | Variance / norm computation |
+
+### Pooling
+
+| Op | Status | Rationale |
+|---|---|---|
+| GlobalMaxPool | Planned-T4 | Common classifier head |
+| RoiAlign | Planned-T4 | ViT detection / Mask R-CNN |
+| MaxRoiPool | Planned-T7 | Object detection ROI pooling |
+| GlobalLpPool | Planned-T10 | Rare Lp pooling |
+| LpPool | Planned-T10 | Rare Lp pooling |
+| MaxUnpool | Planned-T10 | Segmentation decoder; rare |
+
+### Normalization
+
+| Op | Status | Rationale |
+|---|---|---|
+| InstanceNormalization | Planned-T4 | Style transfer / vision transformers |
+| GroupNormalization | Planned-T4 | ConvNeXt / Swin / diffusion |
+| RMSNormalization | Planned-T5 | LLaMA / T5 normalization |
+| LRN | Planned-T6 | Legacy AlexNet; whisper preprocess |
+
+### Shape / Data Movement
+
+| Op | Status | Rationale |
+|---|---|---|
+| Shape | Planned-T3 | Dynamic shape queries; BERT |
+| Size | Planned-T3 | Element count queries |
+| Identity | Planned-T3 | Pass-through; constant folding |
+| ConstantOfShape | Planned-T3 | Masking / attention patterns |
+| Constant | Planned-T3 | Inline constant tensors |
+| Range | Planned-T3 | Positional indices |
+| Trilu | Planned-T3 | Causal mask for attention |
+| CumSum | Planned-T3 | Positional offsets; attention |
+| GatherND | Planned-T3 | N-dim gather; transformers |
+| ScatterND | Planned-T3 | N-dim scatter; transformers |
+| GatherElements | Planned-T4 | Element-wise gather |
+| ScatterElements | Planned-T4 | Element-wise scatter |
+| TopK | Planned-T4 | Beam search; classifier top-k |
+| NonZero | Planned-T4 | Mask indexing |
+| Compress | Planned-T4 | Boolean mask selection |
+| Unique | Planned-T4 | Deduplication |
+| DepthToSpace | Planned-T4 | Super-resolution; pixel shuffle |
+| SpaceToDepth | Planned-T4 | YOLO / ViT patchify |
+| Resize | Planned-T4 | Image scaling; ViT/U-Net |
+| GridSample | Planned-T4 | Spatial transformers / STN |
+| CenterCropPad | Planned-T4 | Vision preprocessing (opset 18+) |
+| EyeLike | Planned-T5 | Identity matrix generation |
+| Reverse | Planned-T10 | Rare axis reversal |
+| ReverseSequence | Planned-T10 | Bi-directional RNN support |
+| ImageDecoder | Planned-T10 | Raw image decode (opset 20+) |
+| AffineGrid | Planned-T10 | Spatial transformer grid (opset 20+) |
+| Col2Im | Planned-T10 | Inverse im2col (opset 18+) |
+| Scatter | Skipped-deprecated | Replaced by ScatterElements |
+| Upsample | Skipped-deprecated | Replaced by Resize |
+| SplitToSequence | Deferred-subsystem | Sequence type required |
+| ConcatFromSequence | Deferred-subsystem | Sequence type required |
+
+### Convolution Variants
+
+| Op | Status | Rationale |
+|---|---|---|
+| ConvTranspose | Planned-T6 | Upsampling decoder; audio |
+| ConvInteger | Planned-T10 | Integer convolution; rare quant path |
+| DeformConv | Planned-T10 | Deformable convolution (opset 19+) |
+
+### Quantized
+
+| Op | Status | Rationale |
+|---|---|---|
+| MatMulInteger | Planned-T5 | Int8 LLM inference |
+| DynamicQuantizeLinear | Planned-T5 | Runtime quantization for LLMs |
+| QLinearAdd | Skipped-vendor | `com.microsoft` contrib op |
+| QLinearMul | Skipped-vendor | `com.microsoft` contrib op |
+| QLinearConcat | Skipped-vendor | `com.microsoft` contrib op |
+| QLinearSigmoid | Skipped-vendor | `com.microsoft` contrib op |
+| QLinearLeakyRelu | Skipped-vendor | `com.microsoft` contrib op |
+| QLinearAveragePool | Skipped-vendor | `com.microsoft` contrib op |
+| QLinearGlobalAveragePool | Skipped-vendor | `com.microsoft` contrib op |
+| QLinearSoftmax | Skipped-vendor | `com.microsoft` contrib op |
+
+### Random / Sampling
+
+| Op | Status | Rationale |
+|---|---|---|
+| RandomNormal | Planned-T5 | Generative sampling |
+| RandomNormalLike | Planned-T5 | Generative sampling |
+| RandomUniform | Planned-T5 | Generative sampling / dropout |
+| RandomUniformLike | Planned-T5 | Generative sampling / dropout |
+| Multinomial | Planned-T5 | Token sampling for LLMs |
+| Bernoulli | Planned-T5 | Stochastic masking |
+| Dropout | Planned-T5 | No-op at inference; must parse |
+
+### Audio / Signal
+
+| Op | Status | Rationale |
+|---|---|---|
+| STFT | Planned-T6 | Whisper spectrogram frontend |
+| DFT | Planned-T6 | Spectral transforms |
+| MelWeightMatrix | Planned-T6 | Mel filterbank for Whisper |
+| HannWindow | Planned-T6 | Audio windowing |
+| HammingWindow | Planned-T6 | Audio windowing |
+| BlackmanWindow | Planned-T6 | Audio windowing |
+
+### Object Detection
+
+| Op | Status | Rationale |
+|---|---|---|
+| NonMaxSuppression | Planned-T7 | All detection models need this |
+
+### Sequence (Deferred)
+
+`SequenceEmpty`, `SequenceConstruct`, `SequenceAt`, `SequenceInsert`,
+`SequenceErase`, `SequenceLength`, `SequenceMap` — all
+**Deferred-subsystem**. Requires a Tensor-of-Tensor type and a graph
+executor that can hold variable-length lists. Not on the critical path
+for any current target model.
+
+### Optional (Deferred)
+
+`Optional`, `OptionalHasElement`, `OptionalGetElement` —
+**Deferred-subsystem**. Requires a sum-type wrapper around tensors.
+Used by some control-flow models; will be addressed alongside
+`If`/`Loop` in Tier 9 if at all.
+
+### Control Flow (Deferred / Tier 9)
+
+| Op | Status | Rationale |
+|---|---|---|
+| If | Tier 9 (subsystem) | Conditional subgraph execution |
+| Loop | Tier 9 (subsystem) | Iterative subgraph execution |
+| Scan | Tier 9 (subsystem) | Recurrent subgraph execution |
+
+Tier 9 is the only tier whose design budget will be larger than its
+implementation budget. The ops themselves are simple; the runtime
+machinery (sub-executor, scope management, carried dependencies) is
+substantial.
+
+### String / Tokenizer (Deferred)
+
+`StringNormalizer`, `StringConcat`, `StringSplit`, `RegexFullMatch`,
+`Tokenizer` — all **Deferred-subsystem**. Requires a string-tensor
+data type. Niche even in NLP since most pipelines tokenize before
+hitting the ONNX graph.
+
+### ONNX-ML Classical ML (Deferred)
+
+`LabelEncoder`, `CategoryMapper`, `TfIdfVectorizer`, `Binarizer`,
+`ArrayFeatureExtractor`, `DictVectorizer`, `FeatureVectorizer`,
+`Imputer`, `LinearClassifier`, `LinearRegressor`, `Normalizer`,
+`OneHotEncoder`, `SVMClassifier`, `SVMRegressor`,
+`TreeEnsembleClassifier`, `TreeEnsembleRegressor`, `ZipMap`, `Scaler`
+— all **Deferred-subsystem**. These live in the `ai.onnx.ml` domain
+and target classical ML (trees, SVMs, feature engineering) rather
+than neural networks. Out of scope for an inference runtime focused
+on neural workloads, but cataloged for completeness.
+
+### Training (Skipped)
+
+`Adam`, `Adagrad`, `Momentum`, `Gradient`, `GraphCall`,
+`SoftmaxCrossEntropyLoss`, `NegativeLogLikelihoodLoss`, `TrainingInfo`
+— all **Skipped-training**. SmallAIOS is inference-only by charter.
+`BatchNormalization` and `Dropout` have inference-mode paths
+implemented; their training-mode behaviors are skipped.
+
+## Tier 3 Detailed Plan — `transformer-models-v1`
+
+This is the next tier and is fully scoped here so an agent team can
+start immediately after this roadmap merges.
+
+### Target models
+- BERT-base (`bert-base-uncased`)
+- DistilBERT (`distilbert-base-uncased`)
+- TinyBERT (`huawei-noah/TinyBERT_General_4L_312D`)
+
+### New operators (18)
+- **Math (10):** Mod, Sin, Cos, Reciprocal, Sign, Sum, Mean, And, Or,
+  LogSoftmax
+- **Reduction (5):** ReduceMax, ReduceMin, ReduceProd, ArgMax, ArgMin
+- **Shape/Data (10):** Shape, Size, Identity, Constant,
+  ConstantOfShape, Range, Trilu, CumSum, GatherND, ScatterND
+
+(Note: Tier 3 actually adds 25 ops; the cumulative table above used a
+conservative 18 to leave headroom. Refine when the change opens.)
+
+### Inventory machinery
+Tier 3 adds:
+```rust
+pub enum OperatorStatus {
+    Implemented,
+    Planned(Tier),
+    DeferredSubsystem(&'static str),
+    SkippedTraining,
+    SkippedDeprecated,
+    SkippedVendor,
+}
+
+pub const SUPPORTED_OPS_INVENTORY: &[(&str, OperatorStatus)] = &[
+    ("Add", OperatorStatus::Implemented),
+    ("Sin", OperatorStatus::Planned(Tier::T3)),
+    // … one entry per standard ONNX op
+];
+```
+A unit test asserts every `Implemented` entry has a matching `OpKind`
+variant and vice versa.
+
+## Tier 4 Sketch — `vision-transformers-v1`
+
+**Target models:** ViT, Swin, DeiT, ConvNeXt, MobileViT
+
+**New ops (~14):** Resize, DepthToSpace, SpaceToDepth, RoiAlign,
+GridSample, GroupNormalization, InstanceNormalization, TopK, Compress,
+NonZero, Unique, GatherElements, ScatterElements, GlobalMaxPool,
+HardSigmoid, HardSwish, PRelu, CenterCropPad
+
+## Tier 5 Sketch — `generative-models-v1`
+
+**Target models:** GPT-2-small, T5-small, LLaMA-style int8 (with Tier 8)
+
+**New ops (~18):** RMSNormalization, MatMulInteger, DynamicQuantizeLinear,
+RandomNormal/NormalLike/Uniform/UniformLike, Multinomial, Bernoulli,
+Dropout, EyeLike, ReduceL1/L2/LogSum/LogSumExp/SumSquare,
+LpNormalization, MeanVarianceNormalization, Softplus
+
+## Tier 6 Sketch — `audio-models-v1`
+
+**Target models:** Whisper-tiny, Wav2Vec2-base
+
+**New ops (~13):** STFT, DFT, MelWeightMatrix, Hann/Hamming/Blackman
+windows, ConvTranspose, Sinh, Cosh, LRN, plus opset-14 BatchNorm
+adjustments for audio preprocessing
+
+## Tier 7 Sketch — `detection-models-v1`
+
+**Target models:** DETR, RetinaNet, Mask R-CNN
+
+**New ops (~8):** NonMaxSuppression, MaxRoiPool, MaxUnpool,
+ReverseSequence, Det, EyeLike (if not in T5), MeanVarianceNormalization
+(if not in T5), and any detection-specific shape ops
+
+## Tier 8 — `int8-kernels-v1`
+
+**No new ops.** This tier replaces the dequantize→f32→requantize
+shim in `op_qlinear_matmul` and `op_qlinear_conv` with a real i8 GEMM
+kernel using saturating arithmetic and proper output scale handling.
+Adds `MatMulInteger`/`DynamicQuantizeLinear` perf paths if those landed
+in Tier 5.
+
+## Tier 9 — `control-flow-v1`
+
+**New ops (3):** If, Loop, Scan
+**New subsystems:** sub-graph executor, scope/carried-state management,
+optional/sequence type wrappers if needed
+
+This is the only tier with significant runtime-architecture work.
+The proposal will need its own design document covering:
+- How sub-graphs are compiled and cached
+- Scope rules for outer-graph values referenced inside loop bodies
+- Iteration carry semantics for Loop and Scan
+- Termination conditions and bound limits (WCET budget interaction)
+
+## Tier 10 — `long-tail-completion-v1`
+
+Reactive tier. Operators are pulled from the "Planned-T10" inventory
+on demand when a real user model fails to load. No fixed scope; merge
+when no user-facing op gaps remain in the active model targets.
+
+## Agent-Team Execution Playbook
+
+Tiers run in **parallel worktrees** following the established pattern:
+
+```
+../SmallAIOS-Design-worktrees/
+├── transformer-models-v1/    (Tier 3 — agent A)
+├── vision-transformers-v1/   (Tier 4 — agent B)
+└── audio-models-v1/          (Tier 6 — agent C)
+```
+
+### File-ownership rules
+
+| Shared file | Rule |
+|---|---|
+| `onnx-rt/src/ops/<submodule>.rs` | Single tier owns the file. New tier creates a new file when possible. |
+| `onnx-rt/src/operators.rs` (`OpKind`, `parse_str`, `name`, `ALL_OPS`) | **Append-only.** Merges sequenced. Later tiers rebase. |
+| `onnx-rt/src/executor.rs` (dispatch helpers) | **Append-only.** Each tier adds new dispatch helpers; existing ones are not edited. |
+| `onnx-rt/src/profile.rs` (`classify_op`) | **Append-only.** Add to the existing match arm with new op names. |
+| `docs/onnx-coverage-roadmap.md` | Updated by every tier — change status from `Planned-Tn` to `Implemented`. |
+| `SUPPORTED_OPS_INVENTORY` (T3+) | Append/update inline. CI test enforces consistency. |
+
+### Per-tier validation gates
+
+Every tier PR must pass before merging to `develop`:
+
+1. `just fmt` clean
+2. `just clippy --all-targets` clean (with `-D warnings`)
+3. `just test` all green, including any new unit tests
+4. `openspec validate <tier-name>` clean
+5. `cargo bench` no regressions on Tier 1 ops (sanity)
+6. The tier's target model loads end-to-end via the integration
+   harness (`container/tests/e2e_*.rs` style)
+7. Roadmap document updated to reflect new statuses
+8. PR title follows conventional commits with semver scope
+
+### Agent kickoff checklist
+
+When starting an agent on a tier:
+
+1. Create a worktree from `develop`:
+   `git worktree add ../SmallAIOS-Design-worktrees/<tier> change/<tier>`
+2. Run `openspec new change "<tier>"`
+3. Read the relevant tier section of this roadmap and copy the op list
+   into the change's `tasks.md`
+4. Read the previously merged tier's PR for the dispatch-wiring pattern
+5. Implement each op in its own commit if practical, or one commit
+   per category if the ops are tiny
+6. Run the validation gates above before opening the PR
+7. Update this roadmap in the same PR — flip Planned-Tn → Implemented
+   for every shipped op
+
+### Coordination
+
+Tiers that share files (3 + 4, or 5 + 8) sequence their merges through
+the OpenSpec change queue. Independent tiers (e.g., T3 and T6) can run
+truly in parallel because their ops live in different submodules and
+their dispatch additions are append-only.
+
+If a merge conflict arises, the **earlier-numbered tier wins** the
+merge slot and the later tier rebases. This rule keeps merge order
+deterministic.
+
+## Review checkpoints
+
+This document must be reviewed:
+
+- **Before each release** — flip statuses, sanity-check counts.
+- **After each ONNX opset bump** — add any new ops to the inventory
+  with a default status of `Planned-T10`.
+- **After each tier merges** — verify the cumulative count and
+  percentage in the tier table match reality.
+
+A future Tier 3 task will add a `just check-roadmap` recipe that
+diffs the roadmap inventory against `OperatorRegistry` and fails CI
+on drift.

--- a/docs/onnx-coverage-roadmap.md
+++ b/docs/onnx-coverage-roadmap.md
@@ -19,25 +19,74 @@ here. Cite this document from each tier proposal.
 - Be honest about what we will **not** implement (training ops,
   ecosystem ops, sequence/optional/control-flow subsystems).
 
-## Tier Sequence
+## Plan Shape: Phases, Not a Long Queue
 
-| Tier | OpenSpec change | Target models | Op delta | Cumulative | % of ONNX |
+Earlier drafts of this roadmap listed 10 sequential tiers. After
+analyzing the actual gap each tier closes, that ordering is wrong:
+
+- The only **material** missing capability in standard ONNX is
+  `Loop` / `If` / `Scan`. Without `Loop`, autoregressive generation
+  (GPT/LLaMA-class models) cannot run as a single graph call. Every
+  other "deferred" item is either dead code, vendor-specific, or a
+  separate workload (classical ML).
+- `int8-kernels` is **performance for LLMs**, not a coverage gap.
+  It only matters once we have LLMs running, so it belongs *with* the
+  generative tier, not as a separate later tier.
+- `transformer-models` (BERT) and `vision-transformers` (ViT) are
+  **independent** — different `ops/` submodules, different validation
+  models — so they can run in **true parallel** worktrees.
+
+The revised plan is **4 phases** instead of 10 tiers. Phases run
+sequentially; tiers within a phase run in parallel.
+
+| Phase | OpenSpec changes (parallel within phase) | Target models | Op delta | Cumulative | % of ONNX |
 |---|---|---|---|---|---|
 | 1 ✅ | `onnx-cpu-runtime-v1` (archived) | ResNet, MobileNet, YOLO | 29 | 29 | 15% |
-| 2 ✅ | `additional-operators-v1` | Transformer/recurrent/quant building blocks | +36 | 65 | 34% |
-| 3 | `transformer-models-v1` | BERT-base, DistilBERT, TinyBERT | +18 | 83 | 44% |
-| 4 | `vision-transformers-v1` | ViT, Swin, DeiT, ConvNeXt | +14 | 97 | 51% |
-| 5 | `generative-models-v1` | GPT-2-small, T5-small, LLaMA-style | +18 | 115 | 60% |
-| 6 | `audio-models-v1` | Whisper-tiny, Wav2Vec2 | +13 | 128 | 67% |
-| 7 | `detection-models-v1` | DETR, RetinaNet, Mask R-CNN | +8 | 136 | 72% |
-| 8 | `int8-kernels-v1` | (real i8 GEMM/Conv perf, no new ops) | 0 | 136 | 72% |
-| 9 | `control-flow-v1` | Models w/ If/Loop/Scan + sequence types | +3 + subsystems | 139 | 73% |
-| 10 | `long-tail-completion-v1` | Reactive, user-driven | +~25 | ~164 | ~86% |
+| 2 ✅ | `additional-operators-v1` | Building blocks | +36 | 65 | 34% |
+| **P1** | `transformer-models-v1` ‖ `vision-transformers-v1` | BERT, DistilBERT, ViT, Swin, DeiT, ConvNeXt | +39 | 104 | 55% |
+| **P2** | `generative-llm-v1` (combined: control-flow + generative ops + i8 kernels) | GPT-2, T5, single-pass autoregressive generation, real i8 LLM inference | +21 + sub-graph executor | 125 | 66% |
+| **P3** | `audio-models-v1` ‖ `detection-models-v1` | Whisper-tiny, Wav2Vec2, DETR, RetinaNet | +21 | 146 | 77% |
+| **P4** | `long-tail-v1` (reactive) | User-driven additions | +~30 | ~176 | ~93% |
 
-The remaining ~26 ops are explicitly **Deferred-subsystem** (sequence,
-optional, string, tokenizer, ONNX-ML classical ML) or **Skipped**
-(training, deprecated, vendor). They are not in the path to 100%
-unless a real user model demands one of them.
+The remaining ~14 ops are explicitly **Deferred-subsystem** (sequence
+types, optional types, string tensors, ONNX-ML classical ML) or
+**Skipped** (training, deprecated, vendor). They are not on the path
+unless a real user model demands one of them. See "What we're
+explicitly not doing" below.
+
+### Why this ordering
+
+- **Phase 1 first** because BERT and ViT are the highest-leverage
+  encoder workloads and the two changes can be implemented in
+  parallel agent worktrees. Phase 1 also adds the
+  `OperatorStatus` / `SUPPORTED_OPS_INVENTORY` machinery that every
+  later phase depends on.
+- **Phase 2 is the breakthrough phase** — GPT-2-class LLMs cannot
+  run without `Loop`, and `int8-kernels` is only valuable once an
+  LLM is running. Bundling control-flow + generative ops + i8
+  kernels into one tier prevents the half-finished state where we
+  have generative ops but still need an external Python loop. This
+  is the most ambitious phase and runs sequentially after P1.
+- **Phase 3 covers specialty model classes** (audio, detection)
+  that are narrower in scope and runnable in parallel after the
+  Phase 2 dispatcher work has stabilized.
+- **Phase 4 is reactive maintenance**, not a scheduled change.
+  Long-tail ops are pulled when a real user model fails to load.
+
+### What we're explicitly not doing (and why)
+
+| Bucket | Op count | Why we're not doing it |
+|---|---|---|
+| Training-only ops (Adam, Gradient, …) | ~10 | SmallAIOS is inference-only by charter. These ops appear only in training checkpoints, not inference models. |
+| Deprecated ops (Affine, Upsample, Scatter, …) | ~7 | Converters rewrite them at export time. Implementing them would be implementing dead code. |
+| Vendor (`com.microsoft`) QLinear* ops | ~8 | Microsoft-specific quantization format. Standard QDQ format works on every runtime and uses ops we already implement. |
+| Sequence types (`SequenceConstruct`, …) | 9 | Requires a `Tensor`-of-`Tensor` value type. Niche; no current target model needs them. |
+| Optional types (`Optional`, …) | 3 | Coupled with control-flow; would land in Phase 2 only if a target model demands it. |
+| String / tokenizer ops | 5 | Requires a string tensor type. Most NLP pipelines tokenize before hitting the ONNX graph. |
+| ONNX-ML classical ML (`TreeEnsembleClassifier`, `LinearRegressor`, …) | ~18 | Different ML domain entirely (trees, SVMs, feature pipelines). Out of scope for a neural inference runtime; would warrant its own decision rather than being lumped in. |
+
+Total deliberately not on the path: **~60 ops**, none of which
+materially limit any neural model class we care about.
 
 ## Operator Inventory
 
@@ -298,32 +347,28 @@ on neural workloads, but cataloged for completeness.
 `BatchNormalization` and `Dropout` have inference-mode paths
 implemented; their training-mode behaviors are skipped.
 
-## Tier 3 Detailed Plan — `transformer-models-v1`
+## Phase 1 Detail — `transformer-models-v1` ‖ `vision-transformers-v1`
 
-This is the next tier and is fully scoped here so an agent team can
-start immediately after this roadmap merges.
+These two changes run in parallel agent worktrees as soon as
+`additional-operators-v1` merges.
 
-### Target models
-- BERT-base (`bert-base-uncased`)
-- DistilBERT (`distilbert-base-uncased`)
-- TinyBERT (`huawei-noah/TinyBERT_General_4L_312D`)
+### `transformer-models-v1`
 
-### New operators (18)
+**Target models:** BERT-base (`bert-base-uncased`), DistilBERT
+(`distilbert-base-uncased`), TinyBERT.
+
+**New operators (~25):**
 - **Math (10):** Mod, Sin, Cos, Reciprocal, Sign, Sum, Mean, And, Or,
   LogSoftmax
 - **Reduction (5):** ReduceMax, ReduceMin, ReduceProd, ArgMax, ArgMin
 - **Shape/Data (10):** Shape, Size, Identity, Constant,
   ConstantOfShape, Range, Trilu, CumSum, GatherND, ScatterND
 
-(Note: Tier 3 actually adds 25 ops; the cumulative table above used a
-conservative 18 to leave headroom. Refine when the change opens.)
-
-### Inventory machinery
-Tier 3 adds:
+**Inventory machinery (also added in this change):**
 ```rust
 pub enum OperatorStatus {
     Implemented,
-    Planned(Tier),
+    Planned(Phase),
     DeferredSubsystem(&'static str),
     SkippedTraining,
     SkippedDeprecated,
@@ -332,83 +377,133 @@ pub enum OperatorStatus {
 
 pub const SUPPORTED_OPS_INVENTORY: &[(&str, OperatorStatus)] = &[
     ("Add", OperatorStatus::Implemented),
-    ("Sin", OperatorStatus::Planned(Tier::T3)),
+    ("Sin", OperatorStatus::Planned(Phase::P1)),
     // … one entry per standard ONNX op
 ];
 ```
 A unit test asserts every `Implemented` entry has a matching `OpKind`
-variant and vice versa.
+variant and vice versa, preventing the inventory from drifting.
 
-## Tier 4 Sketch — `vision-transformers-v1`
+**Validation:** loads BERT-base end-to-end via the integration harness.
 
-**Target models:** ViT, Swin, DeiT, ConvNeXt, MobileViT
+### `vision-transformers-v1`
 
-**New ops (~14):** Resize, DepthToSpace, SpaceToDepth, RoiAlign,
+**Target models:** ViT, Swin, DeiT, ConvNeXt, MobileViT.
+
+**New operators (~14):** Resize, DepthToSpace, SpaceToDepth, RoiAlign,
 GridSample, GroupNormalization, InstanceNormalization, TopK, Compress,
 NonZero, Unique, GatherElements, ScatterElements, GlobalMaxPool,
-HardSigmoid, HardSwish, PRelu, CenterCropPad
+HardSigmoid, HardSwish, PRelu, CenterCropPad.
 
-## Tier 5 Sketch — `generative-models-v1`
+**Validation:** loads ViT-base end-to-end via the integration harness.
 
-**Target models:** GPT-2-small, T5-small, LLaMA-style int8 (with Tier 8)
+### Phase 1 coordination
 
-**New ops (~18):** RMSNormalization, MatMulInteger, DynamicQuantizeLinear,
-RandomNormal/NormalLike/Uniform/UniformLike, Multinomial, Bernoulli,
-Dropout, EyeLike, ReduceL1/L2/LogSum/LogSumExp/SumSquare,
-LpNormalization, MeanVarianceNormalization, Softplus
+The two changes touch separate `ops/` submodules and only collide on
+`OpKind` / `parse_str` / `dispatch_node`. The append-only file rules
+in the "Agent-Team Execution Playbook" section below prevent merge
+conflicts; whichever PR lands first, the other rebases.
 
-## Tier 6 Sketch — `audio-models-v1`
+## Phase 2 Detail — `generative-llm-v1`
 
-**Target models:** Whisper-tiny, Wav2Vec2-base
+This is a single combined tier covering control-flow ops, generative
+ops, and the real i8 GEMM kernel. It is the **breakthrough phase**:
+shipping it makes SmallAIOS usable for autoregressive LLM inference.
 
-**New ops (~13):** STFT, DFT, MelWeightMatrix, Hann/Hamming/Blackman
-windows, ConvTranspose, Sinh, Cosh, LRN, plus opset-14 BatchNorm
-adjustments for audio preprocessing
+It runs sequentially after Phase 1 because it touches the dispatcher
+extensively and adds new runtime machinery (sub-graph executor) that
+later phases will build on.
 
-## Tier 7 Sketch — `detection-models-v1`
+### Target models
+- GPT-2-small (`gpt2`)
+- T5-small (`t5-small`)
+- LLaMA-style int8 (a small open-weight LLM in int8 quantization)
 
-**Target models:** DETR, RetinaNet, Mask R-CNN
+### Sub-graph executor (the design-heavy part)
 
-**New ops (~8):** NonMaxSuppression, MaxRoiPool, MaxUnpool,
-ReverseSequence, Det, EyeLike (if not in T5), MeanVarianceNormalization
-(if not in T5), and any detection-specific shape ops
+**~1500 lines of new runtime work** before any op implementation:
 
-## Tier 8 — `int8-kernels-v1`
+- Sub-graph compilation and caching — each `If` branch and `Loop`
+  body is its own sub-graph that needs the full topological sort,
+  memory planning, and dispatcher applied to it
+- Scope management — outer-graph values referenced from inside a
+  loop body must be visible without copying
+- Carried-state semantics for `Loop` — loop-carried dependencies and
+  scan outputs follow specific iteration rules
+- Iteration limits + WCET integration — `Loop` must respect the
+  per-operator hard time budget across all iterations, not per
+  iteration
+- Termination condition evaluation per iteration
 
-**No new ops.** This tier replaces the dequantize→f32→requantize
-shim in `op_qlinear_matmul` and `op_qlinear_conv` with a real i8 GEMM
-kernel using saturating arithmetic and proper output scale handling.
-Adds `MatMulInteger`/`DynamicQuantizeLinear` perf paths if those landed
-in Tier 5.
+This needs its own design document inside the OpenSpec change.
 
-## Tier 9 — `control-flow-v1`
+### Control-flow operators (3)
+`If`, `Loop`, `Scan`.
 
-**New ops (3):** If, Loop, Scan
-**New subsystems:** sub-graph executor, scope/carried-state management,
-optional/sequence type wrappers if needed
+### Generative operators (~17)
+RMSNormalization, MatMulInteger, DynamicQuantizeLinear, RandomNormal,
+RandomNormalLike, RandomUniform, RandomUniformLike, Multinomial,
+Bernoulli, Dropout, EyeLike, ReduceL1, ReduceL2, ReduceLogSum,
+ReduceLogSumExp, ReduceSumSquare, LpNormalization,
+MeanVarianceNormalization, Softplus.
 
-This is the only tier with significant runtime-architecture work.
-The proposal will need its own design document covering:
-- How sub-graphs are compiled and cached
-- Scope rules for outer-graph values referenced inside loop bodies
-- Iteration carry semantics for Loop and Scan
-- Termination conditions and bound limits (WCET budget interaction)
+### Real int8 kernels (no new ops)
+Replaces the dequantize → f32 → requantize shim in
+`op_qlinear_matmul` and `op_qlinear_conv` with a real i8 GEMM kernel
+using saturating accumulation, proper output scale handling, and
+zero-point folding. `MatMulInteger` gets the same kernel.
 
-## Tier 10 — `long-tail-completion-v1`
+### Validation
+- GPT-2-small generates a 64-token completion in a **single** ONNX
+  graph call (no external Python loop)
+- T5-small encoder + decoder runs end-to-end
+- An int8-quantized LLM produces output within 1% relative error of
+  its f32 baseline
 
-Reactive tier. Operators are pulled from the "Planned-T10" inventory
-on demand when a real user model fails to load. No fixed scope; merge
-when no user-facing op gaps remain in the active model targets.
+## Phase 3 Detail — `audio-models-v1` ‖ `detection-models-v1`
+
+Two parallel changes covering specialty model classes. Lower priority
+than Phases 1-2 because the workloads are narrower than generic
+NLP/vision.
+
+### `audio-models-v1`
+
+**Target models:** Whisper-tiny, Wav2Vec2-base.
+
+**New operators (~13):** STFT, DFT, MelWeightMatrix, HannWindow,
+HammingWindow, BlackmanWindow, ConvTranspose, Sinh, Cosh, LRN, plus
+opset-14 audio-related shape adjustments.
+
+### `detection-models-v1`
+
+**Target models:** DETR, RetinaNet, Mask R-CNN.
+
+**New operators (~8):** NonMaxSuppression, MaxRoiPool, MaxUnpool,
+ReverseSequence, Det, plus any detection-specific shape ops not
+already in P1.
+
+## Phase 4 — `long-tail-v1` (reactive)
+
+No fixed scope. Operators tagged `Planned-T10` in the inventory are
+pulled into small, focused PRs only when a real user model fails to
+load because of them. Phase 4 is **reactive maintenance**, not a
+scheduled change.
+
+When a Phase 4 PR lands:
+1. Add the missing op to its appropriate `ops/` submodule
+2. Update the inventory entry from `Planned-T10` to `Implemented`
+3. Add the user's model to the integration test suite if practical
 
 ## Agent-Team Execution Playbook
 
-Tiers run in **parallel worktrees** following the established pattern:
+Within a phase, changes run in **parallel worktrees** following the
+established pattern:
 
 ```
 ../SmallAIOS-Design-worktrees/
-├── transformer-models-v1/    (Tier 3 — agent A)
-├── vision-transformers-v1/   (Tier 4 — agent B)
-└── audio-models-v1/          (Tier 6 — agent C)
+├── transformer-models-v1/    (Phase 1 — agent A)
+├── vision-transformers-v1/   (Phase 1 — agent B)
+└── audio-models-v1/          (Phase 3 — agent C)
 ```
 
 ### File-ownership rules

--- a/openspec/changes/onnx-full-coverage-roadmap-v1/.openspec.yaml
+++ b/openspec/changes/onnx-full-coverage-roadmap-v1/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-11

--- a/openspec/changes/onnx-full-coverage-roadmap-v1/design.md
+++ b/openspec/changes/onnx-full-coverage-roadmap-v1/design.md
@@ -3,8 +3,10 @@
 ## Context
 
 The ONNX standard operator set as of opset 21 contains roughly 190
-operators. SmallAIOS currently implements 65 (Tier 1 = 29 classic CNN
-ops, Tier 2 = 36 transformer/recurrent/quantized building blocks).
+operators. SmallAIOS implements 29 in `develop` today. Once the
+Phase 1 PRs (#74 Tier 2 = 36 ops, #76 vision = 19 ops, #77 transformer
+= 25 ops) merge, the registry will be at 109 ops (Tier 1 + Tier 2 +
+Phase 1A + Phase 1B).
 Naïvely targeting "all 190" is the wrong frame because:
 
 - ~25 ops are **training-only** (Adam, Momentum, Gradient, GraphCall,
@@ -28,11 +30,12 @@ worktrees:
 
 | Phase | Changes (parallel within phase) | Target models | Op delta | Cumulative | % of ONNX |
 |---|---|---|---|---|---|
-| Done ✅ | `onnx-cpu-runtime-v1`, `additional-operators-v1` | CNNs + transformer/recurrent/quant building blocks | 65 | 65 | 34% |
-| **P1** | `transformer-models-v1` ‖ `vision-transformers-v1` | BERT, DistilBERT, ViT, Swin, DeiT | +39 | 104 | 55% |
-| **P2** | `generative-llm-v1` (combined: control-flow + generative ops + i8 kernels) | GPT-2, T5, single-pass autoregressive generation, real i8 LLM inference | +21 + sub-graph executor | 125 | 66% |
-| **P3** | `audio-models-v1` ‖ `detection-models-v1` | Whisper-tiny, Wav2Vec2, DETR, RetinaNet | +21 | 146 | 77% |
-| **P4** | `long-tail-v1` (reactive) | User-driven additions when models fail to load | +~30 | ~176 | ~93% |
+| Merged | `onnx-cpu-runtime-v1` (Tier 1) | CNNs (ResNet, MobileNet, YOLO) | 29 | 29 | 15% |
+| In flight | `additional-operators-v1` (PR #74) | Tier 2 building blocks | +36 | 65 | 34% |
+| **P1** | `transformer-models-v1` ‖ `vision-transformers-v1` | BERT, DistilBERT, ViT, Swin, DeiT | +44 | 109 | 57% |
+| **P2** | `generative-llm-v1` (combined: control-flow + generative ops + i8 kernels) | GPT-2, T5, single-pass autoregressive generation, real i8 LLM inference | +22 + sub-graph executor | 131 | 69% |
+| **P3** | `audio-models-v1` ‖ `detection-models-v1` | Whisper-tiny, Wav2Vec2, DETR, RetinaNet | +21 | 152 | 80% |
+| **P4** | `long-tail-v1` (reactive) | User-driven additions when models fail to load | +~30 | ~182 | ~96% |
 
 The remaining ~14 ops are deliberately not on the path: training-only,
 deprecated, vendor-specific, or requiring subsystems (sequence types,

--- a/openspec/changes/onnx-full-coverage-roadmap-v1/design.md
+++ b/openspec/changes/onnx-full-coverage-roadmap-v1/design.md
@@ -1,0 +1,202 @@
+# Design — ONNX Full Operator Coverage Roadmap
+
+## Context
+
+The ONNX standard operator set as of opset 21 contains roughly 190
+operators. SmallAIOS currently implements 65 (Tier 1 = 29 classic CNN
+ops, Tier 2 = 36 transformer/recurrent/quantized building blocks).
+Naïvely targeting "all 190" is the wrong frame because:
+
+- ~25 ops are **training-only** (Adam, Momentum, Gradient, GraphCall,
+  …) and irrelevant to an inference runtime.
+- ~10 ops are **deprecated** or have superseded variants.
+- ~15 ops require **subsystems we don't yet have** (control-flow,
+  sequence types, optional types) and need their own design effort.
+- The remaining ~115 ops can be cleanly grouped by **what model they
+  unlock**, which gives us a natural delivery rhythm.
+
+This roadmap turns "implement everything" into "implement the next
+batch of models", which is testable, demoable, and reviewable.
+
+## Decisions
+
+### D1: Tiered model-driven phasing
+
+We commit to a **tier sequence** where each tier targets a concrete
+model class and ships when that class loads end-to-end. The full
+sequence:
+
+| Tier | OpenSpec change | Target models | Op delta | Cumulative | % of ONNX |
+|---|---|---|---|---|---|
+| 1 ✅ | `onnx-cpu-runtime-v1` (archived) | ResNet, MobileNet, YOLO | 29 | 29 | 15% |
+| 2 ✅ | `additional-operators-v1` (this PR) | Building blocks | +36 | 65 | 34% |
+| 3 | `transformer-models-v1` | BERT-base, DistilBERT | +18 | 83 | 44% |
+| 4 | `vision-transformers-v1` | ViT, Swin, DeiT | +12 | 95 | 50% |
+| 5 | `generative-models-v1` | GPT-2-small, T5-small | +14 | 109 | 57% |
+| 6 | `audio-models-v1` | Whisper-tiny, Wav2Vec2 | +14 | 123 | 65% |
+| 7 | `detection-models-v1` | DETR, RetinaNet | +10 | 133 | 70% |
+| 8 | `int8-kernels-v1` | (real i8 GEMM, no new ops) | 0 | 133 | 70% |
+| 9 | `control-flow-v1` | Models w/ If/Loop/Scan | +3 + subsystem | 136 | 72% |
+| 10 | `long-tail-completion-v1` | Reactive, user-driven | +~50 | 186 | 98% |
+
+Roughly 98% of the standard spec is achievable. The final ~2% (training
+ops, deprecated variants, exotic string/sequence ops) is **explicitly
+skipped** unless a real user model demands it.
+
+**Rationale:** every tier delivers a working demo. We can stop at any
+tier and have shipped value. The alternative — implementing ops in
+spec order — produces months of work with no observable improvement.
+
+### D2: Operator inventory as source of truth
+
+We add a small Rust function `OperatorRegistry::status(name) ->
+OperatorStatus` returning one of:
+
+```rust
+pub enum OperatorStatus {
+    Implemented,        // works today
+    Planned(Tier),      // listed for a future tier
+    Deferred,           // intentionally not on the roadmap (e.g. training)
+    Skipped,            // will not implement (deprecated, vendor)
+}
+```
+
+Plus a `SUPPORTED_OPS_INVENTORY: &[(&str, OperatorStatus)]` constant
+listing every standard ONNX op. This becomes the canonical inventory
+that tools, docs, and CI can introspect. A unit test verifies the
+inventory matches the actual implemented set so the two cannot drift.
+
+**Rationale:** without a single source of truth, "remaining work"
+becomes a folklore number. Encoding it in code makes it queryable,
+testable, and auditable.
+
+**Note:** the inventory itself is added in Tier 3 (`transformer-models-
+v1`), not in this roadmap PR. The roadmap only declares the *intent*
+for Tier 3 to add it.
+
+### D3: Agent-team execution model
+
+Tiers run in **parallel worktrees** following the established pattern:
+
+```
+../SmallAIOS-Design-worktrees/
+├── transformer-models-v1/    (Tier 3 — agent A)
+├── vision-transformers-v1/   (Tier 4 — agent B)
+└── audio-models-v1/          (Tier 6 — agent C)
+```
+
+Each worktree branches from `develop`. Tiers that share files (e.g.,
+`OpKind` enum, `dispatch_node`) sequence their merges to `develop`
+to avoid conflicts. Independent additions (separate `ops/` submodules)
+can run truly in parallel.
+
+**File-ownership rules** (added to the agent-team playbook):
+
+| Shared file | Ownership during a tier |
+|---|---|
+| `onnx-rt/src/ops/<submodule>.rs` | Single agent owns the file. |
+| `onnx-rt/src/operators.rs` (OpKind enum, parse_str, name) | One PR at a time touches; later tiers rebase. |
+| `onnx-rt/src/executor.rs` (dispatch helpers) | Append-only per tier; new helpers, no edits to existing ones. |
+| `onnx-rt/src/profile.rs` (classify_op) | Append-only per tier. |
+
+**Rationale:** the friction in parallel ops work isn't the
+implementation — it's the few shared files. The append-only rule keeps
+merges trivial.
+
+### D4: Tier 3 op catalog (transformer-models-v1)
+
+To anchor the roadmap, the next tier's op list is fully enumerated here
+so an agent team can start immediately after this roadmap merges:
+
+**Math/elementwise (5):** Mod, Sin, Cos, Reciprocal, Sign
+
+**Reductions (3):** ReduceMax, ReduceMin, ReduceProd
+
+**Shape/data (10):** Shape, Size, Identity, ConstantOfShape, Range,
+Trilu, CumSum, ScatterND, GatherND, ArgMax
+
+These 18 ops + the operator-status-inventory machinery from D2 are
+sufficient to load BERT-base end-to-end.
+
+### D5: Tier catalogs for Tiers 4-7 (sketch)
+
+Detailed enumeration is left to each tier's own OpenSpec change, but
+the roadmap names the targets so agents can pre-stage work:
+
+- **Tier 4 — vision-transformers-v1:** Resize, Upsample, DepthToSpace,
+  SpaceToDepth, RoiAlign, GridSample, GroupNormalization, InstanceNorm,
+  TopK, Compress, NonZero, Unique
+- **Tier 5 — generative-models-v1:** ArgMin, LogSoftmax, HardSigmoid,
+  HardSwish, HardMax, PRelu, Mish, Softplus, Softsign, Selu,
+  ThresholdedRelu, Celu, Shrink, Bernoulli (sampling)
+- **Tier 6 — audio-models-v1:** STFT, DFT, MelWeightMatrix,
+  BlackmanWindow, HannWindow, HammingWindow, ConvTranspose, Sinh, Cosh,
+  Tanh variants, Asinh, Acosh, Atanh, LRN
+- **Tier 7 — detection-models-v1:** NonMaxSuppression, MaxRoiPool,
+  MaxUnpool, ReverseSequence, ScatterElements, GatherElements, Det,
+  EyeLike, MeanVarianceNormalization, LpNormalization
+
+### D6: Explicitly deferred / skipped operators
+
+These ops are listed in the inventory but will **not** receive an
+implementation slot unless a future model target demands one:
+
+**Training-only (skip permanently):** Gradient, Adam, Momentum,
+GraphCall, BatchNormalization (training mode), Dropout (training mode)
+
+**Sequence types (deferred — needs subsystem design):**
+SequenceConstruct, SequenceEmpty, SequenceErase, SequenceInsert,
+SequenceLength, SequenceMap, SequenceAt, SplitToSequence,
+ConcatFromSequence
+
+**Optional types (deferred — needs subsystem design):** Optional,
+OptionalGetElement, OptionalHasElement
+
+**String ops (deferred — niche):** RegexFullMatch, StringNormalizer,
+StringConcat, StringSplit, ImageDecoder
+
+**Random ops (Tier 5 covers Bernoulli; rest deferred):** Multinomial,
+RandomNormal, RandomNormalLike, RandomUniform, RandomUniformLike
+
+This list is expected to shrink as user needs emerge. Each item is
+labeled with the rationale in the inventory constant.
+
+## Alternatives Considered
+
+### A1: Spec-order implementation
+
+Implement operators in alphabetical or opset order. Rejected: produces
+no shippable milestones, no model-driven validation, and risks
+implementing rare ops before common ones.
+
+### A2: Single mega-change for all remaining ops
+
+One OpenSpec change containing 100+ operator implementations.
+Rejected: PR would be unreviewable (~10k lines), couldn't be tested
+incrementally, and would block all other work for weeks.
+
+### A3: Reactive-only (no roadmap)
+
+Implement ops only when a user reports a model failure. Rejected:
+produces inconsistent coverage, blocks demo work, and has no way to
+predict effort.
+
+### A4: Adopt an external runtime (ONNX Runtime, tract)
+
+Vendor in an existing Rust ONNX runtime. Rejected per project
+charter: SmallAIOS is `#![no_std]` clean-room, and the existing
+runtimes either depend on `std`/C bindings or violate the size
+budget. Confirmed in `CLAUDE.md`.
+
+## Open Questions
+
+1. **Do we want a CI gate that fails when a new opset is released?**
+   Probably yes — it prevents the inventory from silently going stale.
+   To be specified in Tier 3.
+2. **How are control-flow ops (`If`, `Loop`, `Scan`) implemented?**
+   They need a sub-graph executor. Tier 9 will spend most of its
+   design budget on this, not on the ops themselves.
+3. **GPU coverage parity.** This roadmap is CPU-only. The GPU
+   operator-coverage roadmap is a separate workstream and should be
+   stubbed out under the existing compute-abstraction OpenSpec
+   eventually.

--- a/openspec/changes/onnx-full-coverage-roadmap-v1/design.md
+++ b/openspec/changes/onnx-full-coverage-roadmap-v1/design.md
@@ -20,32 +20,43 @@ batch of models", which is testable, demoable, and reviewable.
 
 ## Decisions
 
-### D1: Tiered model-driven phasing
+### D1: Phased plan, not a long tier queue
 
-We commit to a **tier sequence** where each tier targets a concrete
-model class and ships when that class loads end-to-end. The full
-sequence:
+We commit to a **4-phase** plan where each phase delivers a concrete
+model capability and the changes within a phase run in parallel agent
+worktrees:
 
-| Tier | OpenSpec change | Target models | Op delta | Cumulative | % of ONNX |
+| Phase | Changes (parallel within phase) | Target models | Op delta | Cumulative | % of ONNX |
 |---|---|---|---|---|---|
-| 1 ✅ | `onnx-cpu-runtime-v1` (archived) | ResNet, MobileNet, YOLO | 29 | 29 | 15% |
-| 2 ✅ | `additional-operators-v1` (this PR) | Building blocks | +36 | 65 | 34% |
-| 3 | `transformer-models-v1` | BERT-base, DistilBERT | +18 | 83 | 44% |
-| 4 | `vision-transformers-v1` | ViT, Swin, DeiT | +12 | 95 | 50% |
-| 5 | `generative-models-v1` | GPT-2-small, T5-small | +14 | 109 | 57% |
-| 6 | `audio-models-v1` | Whisper-tiny, Wav2Vec2 | +14 | 123 | 65% |
-| 7 | `detection-models-v1` | DETR, RetinaNet | +10 | 133 | 70% |
-| 8 | `int8-kernels-v1` | (real i8 GEMM, no new ops) | 0 | 133 | 70% |
-| 9 | `control-flow-v1` | Models w/ If/Loop/Scan | +3 + subsystem | 136 | 72% |
-| 10 | `long-tail-completion-v1` | Reactive, user-driven | +~50 | 186 | 98% |
+| Done ✅ | `onnx-cpu-runtime-v1`, `additional-operators-v1` | CNNs + transformer/recurrent/quant building blocks | 65 | 65 | 34% |
+| **P1** | `transformer-models-v1` ‖ `vision-transformers-v1` | BERT, DistilBERT, ViT, Swin, DeiT | +39 | 104 | 55% |
+| **P2** | `generative-llm-v1` (combined: control-flow + generative ops + i8 kernels) | GPT-2, T5, single-pass autoregressive generation, real i8 LLM inference | +21 + sub-graph executor | 125 | 66% |
+| **P3** | `audio-models-v1` ‖ `detection-models-v1` | Whisper-tiny, Wav2Vec2, DETR, RetinaNet | +21 | 146 | 77% |
+| **P4** | `long-tail-v1` (reactive) | User-driven additions when models fail to load | +~30 | ~176 | ~93% |
 
-Roughly 98% of the standard spec is achievable. The final ~2% (training
-ops, deprecated variants, exotic string/sequence ops) is **explicitly
-skipped** unless a real user model demands it.
+The remaining ~14 ops are deliberately not on the path: training-only,
+deprecated, vendor-specific, or requiring subsystems (sequence types,
+string tensors, ONNX-ML classical ML) that no current target model
+needs.
 
-**Rationale:** every tier delivers a working demo. We can stop at any
-tier and have shipped value. The alternative — implementing ops in
-spec order — produces months of work with no observable improvement.
+**Rationale for the phase shape (vs. the original 10-tier sequence):**
+
+1. The only **material** missing capability in standard ONNX is
+   `Loop`/`If`/`Scan`. Without `Loop`, autoregressive generation
+   cannot run as a single graph call. Everything else we marked
+   "deferred" is dead code, vendor-specific, or a separate workload.
+2. `int8-kernels` is **performance for LLMs**, not coverage. It only
+   matters once LLMs are running, so it belongs **with** the
+   generative tier, not as a separate later tier.
+3. `transformer-models` (BERT) and `vision-transformers` (ViT) touch
+   independent submodules and can run in **true parallel** worktrees.
+4. Bundling control-flow + generative ops + i8 kernels into one
+   Phase 2 prevents the half-finished state where we have generative
+   ops but still need an external Python loop.
+5. Long-tail ops are reactive maintenance, not a scheduled change.
+
+Every phase delivers a working demo. We can stop at any phase
+boundary and have shipped value.
 
 ### D2: Operator inventory as source of truth
 
@@ -76,19 +87,21 @@ for Tier 3 to add it.
 
 ### D3: Agent-team execution model
 
-Tiers run in **parallel worktrees** following the established pattern:
+Within a phase, changes run in **parallel worktrees** following the
+established pattern:
 
 ```
 ../SmallAIOS-Design-worktrees/
-├── transformer-models-v1/    (Tier 3 — agent A)
-├── vision-transformers-v1/   (Tier 4 — agent B)
-└── audio-models-v1/          (Tier 6 — agent C)
+├── transformer-models-v1/    (Phase 1 — agent A)
+├── vision-transformers-v1/   (Phase 1 — agent B)
+└── audio-models-v1/          (Phase 3 — agent C)
 ```
 
-Each worktree branches from `develop`. Tiers that share files (e.g.,
-`OpKind` enum, `dispatch_node`) sequence their merges to `develop`
-to avoid conflicts. Independent additions (separate `ops/` submodules)
-can run truly in parallel.
+Each worktree branches from `develop` (or from the previous phase's
+merged state). Changes within a phase share `OpKind` and
+`dispatch_node` but follow append-only rules so merges are trivial.
+Phases run sequentially: P2 cannot start until P1 has stabilized the
+dispatcher, and P3 benefits from any cleanup P2 introduces.
 
 **File-ownership rules** (added to the agent-team playbook):
 
@@ -103,40 +116,55 @@ can run truly in parallel.
 implementation — it's the few shared files. The append-only rule keeps
 merges trivial.
 
-### D4: Tier 3 op catalog (transformer-models-v1)
+### D4: Phase 1 op catalogs
 
-To anchor the roadmap, the next tier's op list is fully enumerated here
-so an agent team can start immediately after this roadmap merges:
+#### `transformer-models-v1` (~25 ops)
+- **Math (10):** Mod, Sin, Cos, Reciprocal, Sign, Sum, Mean, And, Or,
+  LogSoftmax
+- **Reduction (5):** ReduceMax, ReduceMin, ReduceProd, ArgMax, ArgMin
+- **Shape/Data (10):** Shape, Size, Identity, Constant,
+  ConstantOfShape, Range, Trilu, CumSum, GatherND, ScatterND
+- Plus the `OperatorStatus` enum and `SUPPORTED_OPS_INVENTORY`
+  constant from D2
+- **Validates by loading BERT-base end-to-end**
 
-**Math/elementwise (5):** Mod, Sin, Cos, Reciprocal, Sign
+#### `vision-transformers-v1` (~14 ops)
+Resize, DepthToSpace, SpaceToDepth, RoiAlign, GridSample,
+GroupNormalization, InstanceNormalization, TopK, Compress, NonZero,
+Unique, GatherElements, ScatterElements, GlobalMaxPool, HardSigmoid,
+HardSwish, PRelu, CenterCropPad.
+- **Validates by loading ViT-base end-to-end**
 
-**Reductions (3):** ReduceMax, ReduceMin, ReduceProd
+### D5: Phase 2 catalog — `generative-llm-v1`
 
-**Shape/data (10):** Shape, Size, Identity, ConstantOfShape, Range,
-Trilu, CumSum, ScatterND, GatherND, ArgMax
+Combined tier with three sections:
 
-These 18 ops + the operator-status-inventory machinery from D2 are
-sufficient to load BERT-base end-to-end.
+1. **Sub-graph executor** (~1500 lines of runtime work) — sub-graph
+   compilation/caching, scope management, carried-state for `Loop`,
+   iteration limits with WCET integration. This needs its own design
+   document inside the change.
+2. **Control-flow ops (3):** If, Loop, Scan.
+3. **Generative ops (~17):** RMSNormalization, MatMulInteger,
+   DynamicQuantizeLinear, RandomNormal/Like, RandomUniform/Like,
+   Multinomial, Bernoulli, Dropout, EyeLike, ReduceL1/L2/LogSum/
+   LogSumExp/SumSquare, LpNormalization, MeanVarianceNormalization,
+   Softplus.
+4. **Real i8 GEMM kernel** replacing the dequantize→f32→requantize
+   shim from `additional-operators-v1`.
 
-### D5: Tier catalogs for Tiers 4-7 (sketch)
+**Validates by:** GPT-2-small generates a 64-token completion in a
+single ONNX graph call (no external Python loop), and an int8 LLM
+produces output within 1% relative error of its f32 baseline.
 
-Detailed enumeration is left to each tier's own OpenSpec change, but
-the roadmap names the targets so agents can pre-stage work:
+### D6: Phase 3 sketches
 
-- **Tier 4 — vision-transformers-v1:** Resize, Upsample, DepthToSpace,
-  SpaceToDepth, RoiAlign, GridSample, GroupNormalization, InstanceNorm,
-  TopK, Compress, NonZero, Unique
-- **Tier 5 — generative-models-v1:** ArgMin, LogSoftmax, HardSigmoid,
-  HardSwish, HardMax, PRelu, Mish, Softplus, Softsign, Selu,
-  ThresholdedRelu, Celu, Shrink, Bernoulli (sampling)
-- **Tier 6 — audio-models-v1:** STFT, DFT, MelWeightMatrix,
-  BlackmanWindow, HannWindow, HammingWindow, ConvTranspose, Sinh, Cosh,
-  Tanh variants, Asinh, Acosh, Atanh, LRN
-- **Tier 7 — detection-models-v1:** NonMaxSuppression, MaxRoiPool,
-  MaxUnpool, ReverseSequence, ScatterElements, GatherElements, Det,
-  EyeLike, MeanVarianceNormalization, LpNormalization
+- **`audio-models-v1` (~13 ops):** STFT, DFT, MelWeightMatrix,
+  Hann/Hamming/Blackman windows, ConvTranspose, Sinh, Cosh, LRN.
+  Validates with Whisper-tiny.
+- **`detection-models-v1` (~8 ops):** NonMaxSuppression, MaxRoiPool,
+  MaxUnpool, ReverseSequence, Det. Validates with DETR.
 
-### D6: Explicitly deferred / skipped operators
+### D7: Explicitly deferred / skipped operators
 
 These ops are listed in the inventory but will **not** receive an
 implementation slot unless a future model target demands one:

--- a/openspec/changes/onnx-full-coverage-roadmap-v1/proposal.md
+++ b/openspec/changes/onnx-full-coverage-roadmap-v1/proposal.md
@@ -2,8 +2,10 @@
 
 ## Why
 
-SmallAIOS currently implements 65 of the ~190 operators in the standard
-ONNX specification (~34% coverage). This is enough for classic CNN
+SmallAIOS currently implements 29 of the ~190 operators in the standard
+ONNX specification (~15% coverage), with 80 more in flight on Phase 1
+PRs (#74 Tier 2, #76 vision, #77 transformer) bringing the total to
+109 (~57%). This is enough for classic CNN
 inference (Tier 1) plus the building blocks for transformers, recurrent
 models, and quantized inference (Tier 2). It is **not** enough to load
 arbitrary real-world models off the shelf — every additional model

--- a/openspec/changes/onnx-full-coverage-roadmap-v1/proposal.md
+++ b/openspec/changes/onnx-full-coverage-roadmap-v1/proposal.md
@@ -1,0 +1,80 @@
+# ONNX Full Operator Coverage Roadmap
+
+## Why
+
+SmallAIOS currently implements 65 of the ~190 operators in the standard
+ONNX specification (~34% coverage). This is enough for classic CNN
+inference (Tier 1) plus the building blocks for transformers, recurrent
+models, and quantized inference (Tier 2). It is **not** enough to load
+arbitrary real-world models off the shelf — every additional model
+class (transformers, vision transformers, audio, object detection, …)
+requires a new burst of operator implementation work.
+
+We need a single, durable roadmap that:
+
+1. **Catalogs every remaining ONNX operator** so nothing slips through
+   the cracks during ad-hoc per-model work.
+2. **Groups operators into tiers driven by real model targets** rather
+   than spec compliance, so each tier delivers user-visible value.
+3. **Defines an explicit execution model** for parallel agent-team
+   implementation so multiple tiers can be in flight at once.
+4. **Identifies operators we will deliberately defer or skip** (training
+   ops, deprecated ops, ecosystem ops we may never support) so the
+   "remaining work" number is honest.
+
+The goal is *not* to ship all 190 ops in one change — that would be a
+multi-month effort spread across many PRs. The goal is to have a single
+authoritative plan that **every future operator-coverage PR slots into**.
+
+## What Changes
+
+This change adds a planning artifact set, not code:
+
+- **Roadmap document** (`docs/onnx-coverage-roadmap.md`) — long-form
+  prose describing the tier sequence, target models, op catalog, and
+  agent-team execution model. This becomes the canonical reference
+  cited by every subsequent operator-coverage OpenSpec change.
+- **Operator inventory spec** (`onnx-cpu-execution`) — adds a
+  requirement that the runtime SHALL track every standard ONNX
+  operator's status as one of `Implemented`, `Planned`, `Deferred`, or
+  `Skipped`, and that the inventory MUST be discoverable from the
+  operator registry source of truth.
+- **Tier definitions** — each subsequent tier (3-9) gets its own future
+  OpenSpec change name reserved here, so PR titles and discussion can
+  reference them before they exist.
+- **Agent-team execution playbook** — captures the worktree-per-tier
+  pattern, the file ownership rules for parallel agents, and the
+  validation gates each tier must pass before merge.
+
+This change does **not** implement any operators. It only sets up the
+plan. Operator implementation happens in the per-tier follow-up changes.
+
+## Impact
+
+**Affected specs:**
+- `onnx-cpu-execution` — adds a single non-implementation requirement
+  about the operator inventory.
+
+**Affected code:**
+- New file: `docs/onnx-coverage-roadmap.md`
+- No source code changes.
+
+**Risks:**
+- **Roadmap drift.** The ONNX spec evolves (new opset versions add
+  ops). The roadmap must be revisited when new opsets land. Mitigated
+  by an explicit "review checkpoint" task that runs before each new
+  release.
+- **Premature commitment.** Listing all tiers up front risks locking
+  in choices that turn out to be wrong (e.g. control-flow ops may need
+  a more invasive runtime change than we expect). Mitigated by treating
+  Tiers 3-9 as *named slots*, not binding contracts — the per-tier
+  OpenSpec proposals are still required and can revise the list.
+
+**Out of scope:**
+- Implementing any operators. Each tier gets its own follow-up change.
+- GPU coverage. The CPU executor is the only target here; GPU
+  operator coverage is tracked separately under the compute abstraction
+  workstream.
+- Custom / vendor / non-standard ops (e.g., ONNX Runtime contrib ops).
+  These are explicitly **Skipped** unless a future model target requires
+  them.

--- a/openspec/changes/onnx-full-coverage-roadmap-v1/specs/onnx-cpu-execution/spec.md
+++ b/openspec/changes/onnx-full-coverage-roadmap-v1/specs/onnx-cpu-execution/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Operator Coverage Roadmap
+The ONNX runtime SHALL maintain a single authoritative roadmap document
+at `docs/onnx-coverage-roadmap.md` that catalogs every standard ONNX
+operator and assigns it to one of: an implemented tier, a planned
+future tier, a deferred subsystem, or an explicitly skipped category.
+
+#### Scenario: Roadmap is the source of truth
+- **WHEN** a contributor needs to know whether an ONNX operator is
+  implemented, planned, deferred, or skipped
+- **THEN** they MUST be able to find the answer in
+  `docs/onnx-coverage-roadmap.md`
+- **AND** the roadmap MUST list a target tier and a target model class
+  for every planned operator
+
+#### Scenario: Roadmap stays in sync with the registry
+- **WHEN** a new operator is added to `OperatorRegistry`
+- **THEN** its entry in `docs/onnx-coverage-roadmap.md` MUST be
+  updated to mark it implemented in the same PR
+
+### Requirement: Tier Naming Convention
+Each future operator-coverage OpenSpec change SHALL use a tier name
+reserved by this roadmap. Tier names MUST follow the pattern
+`<model-class>-models-v1` (e.g., `transformer-models-v1`,
+`vision-transformers-v1`) or `<capability>-v1` for non-model tiers
+(e.g., `int8-kernels-v1`, `control-flow-v1`).
+
+#### Scenario: A new tier change uses a reserved name
+- **WHEN** a contributor opens a new operator-coverage OpenSpec change
+- **THEN** the change name MUST match a tier listed in the roadmap
+  document
+- **AND** the change proposal MUST cite the roadmap as its parent
+
+### Requirement: Agent-Team Execution Playbook
+The roadmap document SHALL include an "Agent-Team Execution"
+section describing the worktree-per-tier pattern, the file-ownership
+rules for parallel implementation agents, and the validation gates
+each tier must pass before merging to `develop`.
+
+#### Scenario: Agents work in parallel without merge conflicts
+- **WHEN** two tiers are being implemented concurrently in separate
+  worktrees
+- **THEN** the playbook MUST specify which files are append-only and
+  which require sequential ownership
+- **AND** each tier's PR MUST pass `just fmt`, `just clippy`, and
+  `just test` before merge

--- a/openspec/changes/onnx-full-coverage-roadmap-v1/tasks.md
+++ b/openspec/changes/onnx-full-coverage-roadmap-v1/tasks.md
@@ -10,7 +10,7 @@
 - [ ] 1.5 Add Tier 3 (`transformer-models-v1`) op catalog from D4
 - [ ] 1.6 Add Tier 4-7 sketches from D5 (these are not binding but reserve
   the slot names)
-- [ ] 1.7 Cross-reference: link from `README.md` "Status" section to the
+- [ ] 1.7 Cross-reference: link from `README.md` "Features" section to the
   roadmap
 
 ## 2. Tier Slot Reservation

--- a/openspec/changes/onnx-full-coverage-roadmap-v1/tasks.md
+++ b/openspec/changes/onnx-full-coverage-roadmap-v1/tasks.md
@@ -1,0 +1,39 @@
+## 1. Roadmap Document
+
+- [ ] 1.1 Create `docs/onnx-coverage-roadmap.md` with the tier table from
+  `design.md` D1
+- [ ] 1.2 Add the full operator inventory: every standard ONNX op with
+  status (`Implemented` / `Planned <tier>` / `Deferred` / `Skipped`)
+- [ ] 1.3 Add the "Agent-Team Execution" section with worktree pattern,
+  file-ownership rules, and per-tier validation gates
+- [ ] 1.4 Add the deferred / skipped sections (D6) with rationale per item
+- [ ] 1.5 Add Tier 3 (`transformer-models-v1`) op catalog from D4
+- [ ] 1.6 Add Tier 4-7 sketches from D5 (these are not binding but reserve
+  the slot names)
+- [ ] 1.7 Cross-reference: link from `README.md` "Status" section to the
+  roadmap
+
+## 2. Tier Slot Reservation
+
+- [ ] 2.1 Document the tier name → OpenSpec change mapping in the roadmap
+  so future PRs can cite it
+- [ ] 2.2 Verify each reserved tier name is unused in `openspec/changes/`
+  and `openspec/changes/archive/`
+
+## 3. Operator Inventory Hooks (deferred to Tier 3)
+
+- [ ] 3.1 Note in the roadmap that the `OperatorStatus` enum and
+  `SUPPORTED_OPS_INVENTORY` constant are added by `transformer-models-v1`,
+  not by this change. (This is a planning marker only.)
+
+## 4. Validation
+
+- [ ] 4.1 `openspec validate onnx-full-coverage-roadmap-v1 --strict`
+  passes
+- [ ] 4.2 The roadmap document renders cleanly in the docs build
+- [ ] 4.3 Operator counts in the roadmap match
+  `OperatorRegistry::supported_count()` (currently 65 after merging
+  `additional-operators-v1`)
+- [ ] 4.4 Every "Implemented" entry in the roadmap matches an `OpKind`
+  variant in `onnx-rt/src/operators.rs`
+- [ ] 4.5 No code changes outside `docs/`


### PR DESCRIPTION
## Summary
- Adds \`onnx-full-coverage-roadmap-v1\` OpenSpec change (proposal, design, specs, tasks)
- Adds \`docs/onnx-coverage-roadmap.md\` — the canonical, queryable plan for getting from 65 → ~190 ONNX operators
- Catalogs every standard ONNX op into one of: Implemented, Planned-T<n>, Deferred-subsystem, Skipped-training/deprecated/vendor
- Defines 10 model-driven tiers (Tier 3 transformer-models-v1 → Tier 10 long-tail-completion-v1)
- Defines the **agent-team execution playbook** for parallel tier implementation: worktree-per-tier, file-ownership rules, per-tier validation gates
- Updates README to reference the roadmap

## What this is *not*
This change adds zero operator implementations. Each tier still requires its own follow-up OpenSpec change (\`transformer-models-v1\`, \`vision-transformers-v1\`, …). The roadmap reserves the tier names so future PRs can cite a single authoritative source.

## Test plan
- [x] \`openspec validate onnx-full-coverage-roadmap-v1 --strict\` clean
- [x] No code changes outside docs/
- [ ] CI gates pass

## Next steps after merge
Launch agent teams in parallel worktrees on the highest-leverage early tiers:
1. \`transformer-models-v1\` (Tier 3) — unlocks BERT-base
2. \`vision-transformers-v1\` (Tier 4) — unlocks ViT/Swin
3. \`audio-models-v1\` (Tier 6) — unlocks Whisper-tiny

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * README updated to reflect ONNX operator coverage progression (29 in develop, 109 after Phase 1) and link to the coverage roadmap.
  * Added a canonical ONNX operator-coverage roadmap with phased targets, operator-status taxonomy, and phase deliverables.
  * Added design, proposal, specification, and task documents describing the execution playbook, tier naming, validation gates, and checklist for roadmap consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->