### PR TITLE
feat(onnx-rt): add Phase 1 vision transformer ops

### DIFF
--- a/container/src/integration.rs
+++ b/container/src/integration.rs
@@ -327,14 +327,14 @@ mod tests {
         assert_eq!(result.nodes_fused, 0);
     }
 
-    /// Verify the operator registry covers Tier 1 (29) plus Tier 2 (36)
-    /// plus Tier 3 Phase 1 (25) ops.
+    /// Verify the operator registry covers Tier 1 (29) + Tier 2 (36) +
+    /// Tier 3 Phase 1 transformer (25) + Phase 1 vision (19) ops.
     #[test]
     fn test_operator_registry_covers_tier1() {
         use smallaios_onnx_rt::operators::{OpKind, OperatorRegistry};
 
         let registry = OperatorRegistry::new();
-        assert_eq!(registry.supported_count(), 90);
+        assert_eq!(registry.supported_count(), 109);
 
         // Verify critical operators are present.
         let critical_ops = [

--- a/onnx-rt/src/executor.rs
+++ b/onnx-rt/src/executor.rs
@@ -280,6 +280,7 @@ fn dispatch_node(
         OpKind::LSTM => return dispatch_lstm(inputs, attrs),
         OpKind::GRU => return dispatch_gru(inputs, attrs),
         OpKind::RNN => return dispatch_rnn(inputs, attrs),
+        OpKind::TopK => return dispatch_top_k(inputs, attrs),
         _ => {}
     }
 
@@ -355,9 +356,14 @@ fn dispatch_node(
         | OpKind::CumSum
         | OpKind::GatherND
         | OpKind::ScatterND => dispatch_shape_data(kind, inputs, attrs),
-        OpKind::Gelu | OpKind::LeakyRelu | OpKind::Elu | OpKind::Swish => {
-            dispatch_composite_activation(kind, inputs, attrs)
-        }
+        OpKind::Gelu
+        | OpKind::LeakyRelu
+        | OpKind::Elu
+        | OpKind::Swish
+        | OpKind::HardSigmoid
+        | OpKind::HardSwish
+        | OpKind::PRelu
+        | OpKind::Mish => dispatch_composite_activation(kind, inputs, attrs),
         OpKind::Expand | OpKind::Tile | OpKind::OneHot | OpKind::Einsum => {
             dispatch_transformer(kind, inputs, attrs)
         }
@@ -365,8 +371,23 @@ fn dispatch_node(
         | OpKind::DequantizeLinear
         | OpKind::QLinearMatMul
         | OpKind::QLinearConv => dispatch_quantized(kind, inputs, attrs),
+        OpKind::Resize
+        | OpKind::DepthToSpace
+        | OpKind::SpaceToDepth
+        | OpKind::RoiAlign
+        | OpKind::GridSample
+        | OpKind::GlobalMaxPool
+        | OpKind::CenterCropPad => dispatch_vision(kind, inputs, attrs),
+        OpKind::Compress
+        | OpKind::NonZero
+        | OpKind::Unique
+        | OpKind::GatherElements
+        | OpKind::ScatterElements => dispatch_data_select(kind, inputs, attrs),
+        OpKind::GroupNormalization | OpKind::InstanceNormalization => {
+            dispatch_normalization_v2(kind, inputs, attrs)
+        }
         // Multi-output kinds handled above and returned early.
-        OpKind::Split | OpKind::LSTM | OpKind::GRU | OpKind::RNN => unreachable!(),
+        OpKind::Split | OpKind::LSTM | OpKind::GRU | OpKind::RNN | OpKind::TopK => unreachable!(),
     };
 
     result.map(|t| alloc::vec![t])
@@ -511,8 +532,228 @@ fn dispatch_composite_activation(
             ops::activations::op_elu(x, alpha)
         }
         OpKind::Swish => ops::activations::op_swish(require_input(inputs, 0, "Swish")?),
+        OpKind::HardSigmoid => {
+            let x = require_input(inputs, 0, "HardSigmoid")?;
+            let alpha = get_attr_float(attrs, "alpha", 0.2);
+            let beta = get_attr_float(attrs, "beta", 0.5);
+            ops::activations::op_hard_sigmoid(x, alpha, beta)
+        }
+        OpKind::HardSwish => {
+            ops::activations::op_hard_swish(require_input(inputs, 0, "HardSwish")?)
+        }
+        OpKind::PRelu => {
+            let x = require_input(inputs, 0, "PRelu")?;
+            let slope = require_input(inputs, 1, "PRelu")?;
+            ops::activations::op_prelu(x, slope)
+        }
+        OpKind::Mish => ops::activations::op_mish(require_input(inputs, 0, "Mish")?),
         _ => Err(OpError::UnsupportedOp(String::from("composite-activation"))),
     }
+}
+
+/// Reads an f32 tensor's raw_data as a Vec<f32>.
+fn read_f32_tensor(tensor: &Tensor) -> Vec<f32> {
+    if tensor.data_type == DataType::Float {
+        let count = tensor.raw_data.len() / 4;
+        (0..count)
+            .map(|i| byte_io::read_f32(&tensor.raw_data, i))
+            .collect()
+    } else {
+        Vec::new()
+    }
+}
+
+/// Dispatches Phase 1 vision operators.
+fn dispatch_vision(
+    kind: OpKind,
+    inputs: &[Option<&Tensor>],
+    attrs: &[AttributeProto],
+) -> Result<Tensor, OpError> {
+    match kind {
+        OpKind::Resize => {
+            let x = require_input(inputs, 0, "Resize")?;
+            // Inputs: X, roi, scales, sizes. roi is ignored (not implemented).
+            let scales_tensor = optional_input(inputs, 2);
+            let sizes_tensor = optional_input(inputs, 3);
+            let scales_vec = scales_tensor.map(read_f32_tensor);
+            let sizes_vec = sizes_tensor.map(read_i64_tensor).transpose()?;
+            let mode_bytes = attrs
+                .iter()
+                .find(|a| a.name == "mode")
+                .map(|a| a.s.as_slice())
+                .unwrap_or(b"nearest");
+            let mode = core::str::from_utf8(mode_bytes).unwrap_or("nearest");
+            ops::vision::op_resize(
+                x,
+                scales_vec.as_deref().filter(|v| !v.is_empty()),
+                sizes_vec.as_deref().filter(|v| !v.is_empty()),
+                mode,
+            )
+        }
+        OpKind::DepthToSpace => {
+            let x = require_input(inputs, 0, "DepthToSpace")?;
+            let blocksize = get_attr_int(attrs, "blocksize", 0);
+            let mode_bytes = attrs
+                .iter()
+                .find(|a| a.name == "mode")
+                .map(|a| a.s.as_slice())
+                .unwrap_or(b"DCR");
+            let mode = core::str::from_utf8(mode_bytes).unwrap_or("DCR");
+            ops::vision::op_depth_to_space(x, blocksize, mode)
+        }
+        OpKind::SpaceToDepth => {
+            let x = require_input(inputs, 0, "SpaceToDepth")?;
+            let blocksize = get_attr_int(attrs, "blocksize", 0);
+            ops::vision::op_space_to_depth(x, blocksize)
+        }
+        OpKind::RoiAlign => {
+            let x = require_input(inputs, 0, "RoiAlign")?;
+            let rois = require_input(inputs, 1, "RoiAlign")?;
+            let batch_indices = require_input(inputs, 2, "RoiAlign")?;
+            let oh = get_attr_int(attrs, "output_height", 1);
+            let ow = get_attr_int(attrs, "output_width", 1);
+            let sampling_ratio = get_attr_int(attrs, "sampling_ratio", 0);
+            let spatial_scale = get_attr_float(attrs, "spatial_scale", 1.0);
+            let mode_bytes = attrs
+                .iter()
+                .find(|a| a.name == "mode")
+                .map(|a| a.s.as_slice())
+                .unwrap_or(b"avg");
+            let mode = core::str::from_utf8(mode_bytes).unwrap_or("avg");
+            ops::vision::op_roi_align(
+                x,
+                rois,
+                batch_indices,
+                oh,
+                ow,
+                sampling_ratio,
+                spatial_scale,
+                mode,
+            )
+        }
+        OpKind::GridSample => {
+            let x = require_input(inputs, 0, "GridSample")?;
+            let grid = require_input(inputs, 1, "GridSample")?;
+            let mode_bytes = attrs
+                .iter()
+                .find(|a| a.name == "mode")
+                .map(|a| a.s.as_slice())
+                .unwrap_or(b"bilinear");
+            let mode = core::str::from_utf8(mode_bytes).unwrap_or("bilinear");
+            let pad_bytes = attrs
+                .iter()
+                .find(|a| a.name == "padding_mode")
+                .map(|a| a.s.as_slice())
+                .unwrap_or(b"zeros");
+            let padding_mode = core::str::from_utf8(pad_bytes).unwrap_or("zeros");
+            let align_corners = get_attr_int(attrs, "align_corners", 0) != 0;
+            ops::vision::op_grid_sample(x, grid, mode, padding_mode, align_corners)
+        }
+        OpKind::GlobalMaxPool => {
+            ops::vision::op_global_max_pool(require_input(inputs, 0, "GlobalMaxPool")?)
+        }
+        OpKind::CenterCropPad => {
+            let x = require_input(inputs, 0, "CenterCropPad")?;
+            let shape_tensor = require_input(inputs, 1, "CenterCropPad")?;
+            let shape = read_i64_tensor(shape_tensor)?;
+            let axes_attr = get_attr_ints(attrs, "axes").map(|s| s.to_vec());
+            ops::vision::op_center_crop_pad(x, &shape, axes_attr.as_deref())
+        }
+        _ => Err(OpError::UnsupportedOp(String::from("vision"))),
+    }
+}
+
+/// Dispatches Phase 1 data-selection operators.
+fn dispatch_data_select(
+    kind: OpKind,
+    inputs: &[Option<&Tensor>],
+    attrs: &[AttributeProto],
+) -> Result<Tensor, OpError> {
+    match kind {
+        OpKind::Compress => {
+            let x = require_input(inputs, 0, "Compress")?;
+            let cond = require_input(inputs, 1, "Compress")?;
+            let axis = attrs
+                .iter()
+                .find(|a| a.name == "axis" && a.attr_type == AttributeType::Int)
+                .map(|a| a.i);
+            ops::data_select::op_compress(x, cond, axis)
+        }
+        OpKind::NonZero => ops::data_select::op_non_zero(require_input(inputs, 0, "NonZero")?),
+        OpKind::Unique => {
+            let x = require_input(inputs, 0, "Unique")?;
+            let axis = attrs
+                .iter()
+                .find(|a| a.name == "axis" && a.attr_type == AttributeType::Int)
+                .map(|a| a.i);
+            let sorted = get_attr_int(attrs, "sorted", 1) != 0;
+            ops::data_select::op_unique(x, axis, sorted)
+        }
+        OpKind::GatherElements => {
+            let x = require_input(inputs, 0, "GatherElements")?;
+            let idx = require_input(inputs, 1, "GatherElements")?;
+            let axis = get_attr_int(attrs, "axis", 0);
+            ops::data_select::op_gather_elements(x, idx, axis)
+        }
+        OpKind::ScatterElements => {
+            let x = require_input(inputs, 0, "ScatterElements")?;
+            let idx = require_input(inputs, 1, "ScatterElements")?;
+            let upd = require_input(inputs, 2, "ScatterElements")?;
+            let axis = get_attr_int(attrs, "axis", 0);
+            let red_bytes = attrs
+                .iter()
+                .find(|a| a.name == "reduction")
+                .map(|a| a.s.as_slice())
+                .unwrap_or(b"none");
+            let reduction = core::str::from_utf8(red_bytes).unwrap_or("none");
+            ops::data_select::op_scatter_elements(x, idx, upd, axis, reduction)
+        }
+        _ => Err(OpError::UnsupportedOp(String::from("data-select"))),
+    }
+}
+
+/// Dispatches Phase 1 normalization operators (Group/Instance).
+fn dispatch_normalization_v2(
+    kind: OpKind,
+    inputs: &[Option<&Tensor>],
+    attrs: &[AttributeProto],
+) -> Result<Tensor, OpError> {
+    match kind {
+        OpKind::GroupNormalization => {
+            let x = require_input(inputs, 0, "GroupNormalization")?;
+            let scale = require_input(inputs, 1, "GroupNormalization")?;
+            let bias = optional_input(inputs, 2);
+            let num_groups = get_attr_int(attrs, "num_groups", 1);
+            let epsilon = get_attr_float(attrs, "epsilon", 1e-5);
+            ops::normalization::op_group_normalization(x, scale, bias, num_groups, epsilon)
+        }
+        OpKind::InstanceNormalization => {
+            let x = require_input(inputs, 0, "InstanceNormalization")?;
+            let scale = require_input(inputs, 1, "InstanceNormalization")?;
+            let bias = require_input(inputs, 2, "InstanceNormalization")?;
+            let epsilon = get_attr_float(attrs, "epsilon", 1e-5);
+            ops::normalization::op_instance_normalization(x, scale, bias, epsilon)
+        }
+        _ => Err(OpError::UnsupportedOp(String::from("normalization-v2"))),
+    }
+}
+
+/// Dispatches TopK (multi-output).
+fn dispatch_top_k(
+    inputs: &[Option<&Tensor>],
+    attrs: &[AttributeProto],
+) -> Result<Vec<Tensor>, OpError> {
+    let x = require_input(inputs, 0, "TopK")?;
+    // Opset 10+: K is an input tensor (Int64).
+    let k = if let Some(k_t) = optional_input(inputs, 1) {
+        read_i64_tensor(k_t)?.first().copied().unwrap_or(0)
+    } else {
+        get_attr_int(attrs, "k", 0)
+    };
+    let axis = get_attr_int(attrs, "axis", -1);
+    let largest = get_attr_int(attrs, "largest", 1) != 0;
+    let sorted = get_attr_int(attrs, "sorted", 1) != 0;
+    ops::data_select::op_top_k(x, k, axis, largest, sorted)
 }
 
 /// Dispatches transformer building-block ops (Expand/Tile/OneHot/Einsum).

--- a/onnx-rt/src/operators.rs
+++ b/onnx-rt/src/operators.rs
@@ -268,6 +268,52 @@ pub enum OpKind {
     GatherND,
     /// N-dimensional scatter.
     ScatterND,
+
+    // ---- Phase 1 vision: image ops ----
+    /// 2D image resize (nearest/bilinear).
+    Resize,
+    /// Rearrange depth into spatial blocks.
+    DepthToSpace,
+    /// Rearrange spatial blocks into depth.
+    SpaceToDepth,
+    /// Region-of-interest align (bilinear avg).
+    RoiAlign,
+    /// 2D grid sampling (bilinear/nearest).
+    GridSample,
+    /// Global max pooling.
+    GlobalMaxPool,
+    /// Symmetric crop/pad to target shape.
+    CenterCropPad,
+
+    // ---- Phase 1 vision: data selection ----
+    /// Top-k values and indices along an axis.
+    TopK,
+    /// Select elements where condition is true.
+    Compress,
+    /// Indices of non-zero elements.
+    NonZero,
+    /// Unique values (primary output only).
+    Unique,
+    /// Element-wise gather along an axis.
+    GatherElements,
+    /// Element-wise scatter along an axis.
+    ScatterElements,
+
+    // ---- Phase 1 vision: normalization ----
+    /// Group normalization.
+    GroupNormalization,
+    /// Instance normalization.
+    InstanceNormalization,
+
+    // ---- Phase 1 vision: composite activations ----
+    /// Hard sigmoid (clipped affine).
+    HardSigmoid,
+    /// Hard swish (x * relu6(x+3)/6).
+    HardSwish,
+    /// Parametric ReLU (per-channel negative slope).
+    PRelu,
+    /// Mish activation (x * tanh(softplus(x))).
+    Mish,
 }
 
 impl OpKind {
@@ -375,6 +421,29 @@ impl OpKind {
             "CumSum" => Some(OpKind::CumSum),
             "GatherND" => Some(OpKind::GatherND),
             "ScatterND" => Some(OpKind::ScatterND),
+            // Phase 1 vision: image
+            "Resize" => Some(OpKind::Resize),
+            "DepthToSpace" => Some(OpKind::DepthToSpace),
+            "SpaceToDepth" => Some(OpKind::SpaceToDepth),
+            "RoiAlign" => Some(OpKind::RoiAlign),
+            "GridSample" => Some(OpKind::GridSample),
+            "GlobalMaxPool" => Some(OpKind::GlobalMaxPool),
+            "CenterCropPad" => Some(OpKind::CenterCropPad),
+            // Phase 1 vision: data selection
+            "TopK" => Some(OpKind::TopK),
+            "Compress" => Some(OpKind::Compress),
+            "NonZero" => Some(OpKind::NonZero),
+            "Unique" => Some(OpKind::Unique),
+            "GatherElements" => Some(OpKind::GatherElements),
+            "ScatterElements" => Some(OpKind::ScatterElements),
+            // Phase 1 vision: normalization
+            "GroupNormalization" => Some(OpKind::GroupNormalization),
+            "InstanceNormalization" => Some(OpKind::InstanceNormalization),
+            // Phase 1 vision: activations
+            "HardSigmoid" => Some(OpKind::HardSigmoid),
+            "HardSwish" => Some(OpKind::HardSwish),
+            "PRelu" => Some(OpKind::PRelu),
+            "Mish" => Some(OpKind::Mish),
             _ => None,
         }
     }
@@ -472,6 +541,25 @@ impl OpKind {
             OpKind::CumSum => "CumSum",
             OpKind::GatherND => "GatherND",
             OpKind::ScatterND => "ScatterND",
+            OpKind::Resize => "Resize",
+            OpKind::DepthToSpace => "DepthToSpace",
+            OpKind::SpaceToDepth => "SpaceToDepth",
+            OpKind::RoiAlign => "RoiAlign",
+            OpKind::GridSample => "GridSample",
+            OpKind::GlobalMaxPool => "GlobalMaxPool",
+            OpKind::CenterCropPad => "CenterCropPad",
+            OpKind::TopK => "TopK",
+            OpKind::Compress => "Compress",
+            OpKind::NonZero => "NonZero",
+            OpKind::Unique => "Unique",
+            OpKind::GatherElements => "GatherElements",
+            OpKind::ScatterElements => "ScatterElements",
+            OpKind::GroupNormalization => "GroupNormalization",
+            OpKind::InstanceNormalization => "InstanceNormalization",
+            OpKind::HardSigmoid => "HardSigmoid",
+            OpKind::HardSwish => "HardSwish",
+            OpKind::PRelu => "PRelu",
+            OpKind::Mish => "Mish",
         }
     }
 }
@@ -574,6 +662,26 @@ const ALL_OPS: &[OpKind] = &[
     OpKind::CumSum,
     OpKind::GatherND,
     OpKind::ScatterND,
+    // Phase 1 vision
+    OpKind::Resize,
+    OpKind::DepthToSpace,
+    OpKind::SpaceToDepth,
+    OpKind::RoiAlign,
+    OpKind::GridSample,
+    OpKind::GlobalMaxPool,
+    OpKind::CenterCropPad,
+    OpKind::TopK,
+    OpKind::Compress,
+    OpKind::NonZero,
+    OpKind::Unique,
+    OpKind::GatherElements,
+    OpKind::ScatterElements,
+    OpKind::GroupNormalization,
+    OpKind::InstanceNormalization,
+    OpKind::HardSigmoid,
+    OpKind::HardSwish,
+    OpKind::PRelu,
+    OpKind::Mish,
 ];
 
 /// Registry of supported ONNX operators.
@@ -749,14 +857,30 @@ pub const SUPPORTED_OPS_INVENTORY: &[(&str, OperatorStatus)] = &[
     ("CumSum", OperatorStatus::Implemented),
     ("GatherND", OperatorStatus::Implemented),
     ("ScatterND", OperatorStatus::Implemented),
+    // ---------------- Phase 1B: vision ----
+    ("Resize", OperatorStatus::Implemented),
+    ("DepthToSpace", OperatorStatus::Implemented),
+    ("SpaceToDepth", OperatorStatus::Implemented),
+    ("RoiAlign", OperatorStatus::Implemented),
+    ("GridSample", OperatorStatus::Implemented),
+    ("GlobalMaxPool", OperatorStatus::Implemented),
+    ("CenterCropPad", OperatorStatus::Implemented),
+    ("TopK", OperatorStatus::Implemented),
+    ("Compress", OperatorStatus::Implemented),
+    ("NonZero", OperatorStatus::Implemented),
+    ("Unique", OperatorStatus::Implemented),
+    ("GatherElements", OperatorStatus::Implemented),
+    ("ScatterElements", OperatorStatus::Implemented),
+    ("GroupNormalization", OperatorStatus::Implemented),
+    ("InstanceNormalization", OperatorStatus::Implemented),
+    ("HardSigmoid", OperatorStatus::Implemented),
+    ("HardSwish", OperatorStatus::Implemented),
+    ("PRelu", OperatorStatus::Implemented),
+    ("Mish", OperatorStatus::Implemented),
     // ---------------- Phase 2: generative / control-flow ----
     ("If", OperatorStatus::Planned(Phase::P2)),
     ("Loop", OperatorStatus::Planned(Phase::P2)),
     ("Scan", OperatorStatus::Planned(Phase::P2)),
-    ("TopK", OperatorStatus::Planned(Phase::P2)),
-    ("NonZero", OperatorStatus::Planned(Phase::P2)),
-    ("Compress", OperatorStatus::Planned(Phase::P2)),
-    ("Unique", OperatorStatus::Planned(Phase::P2)),
     ("DynamicQuantizeLinear", OperatorStatus::Planned(Phase::P2)),
     ("Attention", OperatorStatus::Planned(Phase::P2)),
     ("MatMulInteger", OperatorStatus::Planned(Phase::P2)),
@@ -764,9 +888,6 @@ pub const SUPPORTED_OPS_INVENTORY: &[(&str, OperatorStatus)] = &[
     ("Multinomial", OperatorStatus::Planned(Phase::P2)),
     // ---------------- Phase 3: audio + detection ----
     ("NonMaxSuppression", OperatorStatus::Planned(Phase::P3)),
-    ("RoiAlign", OperatorStatus::Planned(Phase::P3)),
-    ("Resize", OperatorStatus::Planned(Phase::P3)),
-    ("GridSample", OperatorStatus::Planned(Phase::P3)),
     ("STFT", OperatorStatus::Planned(Phase::P3)),
     ("DFT", OperatorStatus::Planned(Phase::P3)),
     ("MelWeightMatrix", OperatorStatus::Planned(Phase::P3)),
@@ -774,10 +895,6 @@ pub const SUPPORTED_OPS_INVENTORY: &[(&str, OperatorStatus)] = &[
     ("HannWindow", OperatorStatus::Planned(Phase::P3)),
     ("BlackmanWindow", OperatorStatus::Planned(Phase::P3)),
     ("ConvTranspose", OperatorStatus::Planned(Phase::P3)),
-    ("DepthToSpace", OperatorStatus::Planned(Phase::P3)),
-    ("SpaceToDepth", OperatorStatus::Planned(Phase::P3)),
-    ("GatherElements", OperatorStatus::Planned(Phase::P3)),
-    ("ScatterElements", OperatorStatus::Planned(Phase::P3)),
     // ---------------- Phase 4: long tail ----
     ("BitShift", OperatorStatus::Planned(Phase::P4)),
     ("BitwiseAnd", OperatorStatus::Planned(Phase::P4)),
@@ -801,22 +918,16 @@ pub const SUPPORTED_OPS_INVENTORY: &[(&str, OperatorStatus)] = &[
     ("ReduceLogSum", OperatorStatus::Planned(Phase::P4)),
     ("ReduceLogSumExp", OperatorStatus::Planned(Phase::P4)),
     ("ReduceSumSquare", OperatorStatus::Planned(Phase::P4)),
-    ("HardSigmoid", OperatorStatus::Planned(Phase::P4)),
-    ("HardSwish", OperatorStatus::Planned(Phase::P4)),
     ("Selu", OperatorStatus::Planned(Phase::P4)),
     ("Softplus", OperatorStatus::Planned(Phase::P4)),
     ("Softsign", OperatorStatus::Planned(Phase::P4)),
     ("ThresholdedRelu", OperatorStatus::Planned(Phase::P4)),
-    ("PRelu", OperatorStatus::Planned(Phase::P4)),
     ("CastLike", OperatorStatus::Planned(Phase::P4)),
     ("EyeLike", OperatorStatus::Planned(Phase::P4)),
     ("Shrink", OperatorStatus::Planned(Phase::P4)),
     ("LpNormalization", OperatorStatus::Planned(Phase::P4)),
     ("LpPool", OperatorStatus::Planned(Phase::P4)),
-    ("GlobalMaxPool", OperatorStatus::Planned(Phase::P4)),
     ("GlobalLpPool", OperatorStatus::Planned(Phase::P4)),
-    ("InstanceNormalization", OperatorStatus::Planned(Phase::P4)),
-    ("GroupNormalization", OperatorStatus::Planned(Phase::P4)),
     (
         "MeanVarianceNormalization",
         OperatorStatus::Planned(Phase::P4),
@@ -3332,7 +3443,7 @@ mod tests {
     #[test]
     fn test_registry_supported_count() {
         let registry = OperatorRegistry::new();
-        assert_eq!(registry.supported_count(), 90);
+        assert_eq!(registry.supported_count(), 109);
     }
 
     #[test]
@@ -3374,8 +3485,8 @@ mod tests {
             );
         }
 
-        // Sanity: must match the advertised 90-op count.
-        assert_eq!(impl_names.len(), 90);
+        // Sanity: must match the advertised 109-op count.
+        assert_eq!(impl_names.len(), 109);
 
         // No duplicate entries in the inventory.
         let mut all_names: alloc::vec::Vec<&str> =

--- a/onnx-rt/src/ops/activations.rs
+++ b/onnx-rt/src/ops/activations.rs
@@ -3,10 +3,11 @@
 
 //! Composite activation functions used by transformer-style models.
 
+use crate::byte_io::{allocate_tensor_data, read_f32, write_f32};
 use crate::operators::{expf_approx, OpError};
-use crate::ops::common::unary;
+use crate::ops::common::{require_float, unary};
 use crate::ops::math::erf_approx;
-use crate::tensor::Tensor;
+use crate::tensor::{DataType, Tensor};
 
 /// Gaussian Error Linear Unit: `0.5 * x * (1 + erf(x / sqrt(2)))`.
 pub fn op_gelu(input: &Tensor) -> Result<Tensor, OpError> {
@@ -35,6 +36,128 @@ pub fn op_elu(input: &Tensor, alpha: f32) -> Result<Tensor, OpError> {
 /// Swish (a.k.a. SiLU): `x * sigmoid(x)`.
 pub fn op_swish(input: &Tensor) -> Result<Tensor, OpError> {
     unary(input, "Swish", |x| x / (1.0 + expf_approx(-x)))
+}
+
+/// HardSigmoid: `clip(alpha * x + beta, 0, 1)`.
+pub fn op_hard_sigmoid(input: &Tensor, alpha: f32, beta: f32) -> Result<Tensor, OpError> {
+    unary(input, "HardSigmoid", |x| (alpha * x + beta).clamp(0.0, 1.0))
+}
+
+/// HardSwish: `x * relu6(x + 3) / 6`.
+pub fn op_hard_swish(input: &Tensor) -> Result<Tensor, OpError> {
+    unary(input, "HardSwish", |x| x * (x + 3.0).clamp(0.0, 6.0) / 6.0)
+}
+
+/// PReLU: `x if x > 0 else slope * x`, where `slope` is per-channel.
+///
+/// `slope` may be a scalar or broadcastable along the leading axis of
+/// `input`. When `slope.len() == C`, the channel index is inferred
+/// from NCHW layout (axis 1). Otherwise a single scalar slope is used.
+pub fn op_prelu(input: &Tensor, slope: &Tensor) -> Result<Tensor, OpError> {
+    require_float(input, "PRelu")?;
+    require_float(slope, "PRelu")?;
+    let total = input.shape.total_elements();
+    let mut data = allocate_tensor_data(total, DataType::Float);
+    let slope_total = slope.shape.total_elements();
+    let scalar_slope = slope_total <= 1;
+    let channel_slope =
+        !scalar_slope && input.shape.dims.len() >= 2 && slope_total == input.shape.dims[1] as usize;
+    let inner_per_c: usize = if input.shape.dims.len() >= 2 {
+        input.shape.dims[2..]
+            .iter()
+            .map(|&d| d as usize)
+            .product::<usize>()
+            .max(1)
+    } else {
+        1
+    };
+    let outer: usize = if input.shape.dims.is_empty() {
+        1
+    } else {
+        input.shape.dims[0] as usize
+    };
+    let c: usize = if input.shape.dims.len() >= 2 {
+        input.shape.dims[1] as usize
+    } else {
+        1
+    };
+    for flat in 0..total {
+        let x = read_f32(&input.raw_data, flat);
+        let s = if scalar_slope {
+            read_f32(&slope.raw_data, 0)
+        } else if channel_slope {
+            let ch = (flat / inner_per_c) % c;
+            read_f32(&slope.raw_data, ch)
+        } else {
+            read_f32(&slope.raw_data, flat.min(slope_total - 1))
+        };
+        let _ = outer;
+        let y = if x >= 0.0 { x } else { s * x };
+        write_f32(&mut data, flat, y);
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: input.shape.clone(),
+        name: alloc::string::String::new(),
+        raw_data: data,
+    })
+}
+
+/// Mish: `x * tanh(softplus(x))` where `softplus(x) = ln(1 + exp(x))`.
+pub fn op_mish(input: &Tensor) -> Result<Tensor, OpError> {
+    unary(input, "Mish", |x| {
+        // Stable softplus: for large x, softplus(x) ≈ x; for small, ln(1+exp(x)).
+        let sp = if x > 20.0 {
+            x
+        } else if x < -20.0 {
+            0.0
+        } else {
+            ln1p_approx(expf_approx(x))
+        };
+        // tanh via (e^a - e^-a)/(e^a + e^-a) with expf_approx.
+        let ep = expf_approx(sp);
+        let en = expf_approx(-sp);
+        let tanh_sp = (ep - en) / (ep + en);
+        x * tanh_sp
+    })
+}
+
+/// Series/log approximation of `ln(1 + x)` for x in a reasonable range.
+/// Good to ~1e-6 for |x| < 1, passable elsewhere; used only by Mish.
+fn ln1p_approx(x: f32) -> f32 {
+    // Fall back to operators::ln_approx via Log op path? Simpler: use a
+    // Taylor series for small x, otherwise compute via ln of (1+x) with a
+    // cheap iterative log2-style approximation.
+    if x > -0.5 && x < 0.5 {
+        // Series: x - x^2/2 + x^3/3 - x^4/4 + x^5/5
+        let x2 = x * x;
+        let x3 = x2 * x;
+        let x4 = x3 * x;
+        let x5 = x4 * x;
+        x - 0.5 * x2 + x3 / 3.0 - 0.25 * x4 + 0.2 * x5
+    } else {
+        // Fallback: use crate::ops::math::op_log via naive method.
+        // Reuse algorithm: ln(1+x) via libm-ish. For large x this is fine
+        // since Mish only calls with exp output, always > 0.
+        ln_approx(1.0 + x)
+    }
+}
+
+/// Natural log approximation for positive input. Reuses the bit-level
+/// decomposition used elsewhere in the runtime.
+fn ln_approx(x: f32) -> f32 {
+    if x <= 0.0 {
+        return f32::NEG_INFINITY;
+    }
+    let bits = x.to_bits();
+    let e = ((bits >> 23) & 0xff) as i32 - 127;
+    let m_bits = (bits & 0x007f_ffff) | 0x3f80_0000;
+    let m = f32::from_bits(m_bits); // m in [1,2)
+                                    // ln(m) via 5-term minimax on [1,2).
+    let t = m - 1.0;
+    let poly =
+        t * (1.0 - t * (0.5 - t * (0.333_333_34 - t * (0.25 - t * (0.2 - t * 0.166_666_67)))));
+    poly + (e as f32) * core::f32::consts::LN_2
 }
 
 #[cfg(test)]
@@ -118,6 +241,86 @@ mod tests {
     }
 
     #[test]
+    fn test_hard_sigmoid_clips() {
+        // Default alpha=0.2, beta=0.5.
+        let t = make_f32(&[5], &[-10.0, -2.0, 0.0, 2.0, 10.0]);
+        let v = read_all(&op_hard_sigmoid(&t, 0.2, 0.5).unwrap());
+        assert_eq!(v[0], 0.0);
+        assert!((v[2] - 0.5).abs() < 1e-5);
+        assert_eq!(v[4], 1.0);
+    }
+
+    #[test]
+    fn test_hard_sigmoid_linear_region() {
+        let t = make_f32(&[1], &[1.0]);
+        let v = read_all(&op_hard_sigmoid(&t, 0.2, 0.5).unwrap());
+        assert!((v[0] - 0.7).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_hard_swish_zero() {
+        let t = make_f32(&[1], &[0.0]);
+        let v = read_all(&op_hard_swish(&t).unwrap());
+        assert!(v[0].abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_hard_swish_large_positive() {
+        let t = make_f32(&[2], &[5.0, 10.0]);
+        let v = read_all(&op_hard_swish(&t).unwrap());
+        // For x >= 3, hard_swish(x) == x.
+        assert!((v[0] - 5.0).abs() < 1e-5);
+        assert!((v[1] - 10.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_hard_swish_negative_clipped() {
+        let t = make_f32(&[2], &[-5.0, -10.0]);
+        let v = read_all(&op_hard_swish(&t).unwrap());
+        // For x <= -3, hard_swish(x) == 0.
+        assert!(v[0].abs() < 1e-5);
+        assert!(v[1].abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_prelu_scalar_slope() {
+        let t = make_f32(&[4], &[1.0, -1.0, 2.0, -2.0]);
+        let slope = make_f32(&[1], &[0.25]);
+        let v = read_all(&op_prelu(&t, &slope).unwrap());
+        assert_eq!(v, alloc::vec![1.0, -0.25, 2.0, -0.5]);
+    }
+
+    #[test]
+    fn test_prelu_per_channel() {
+        // NCHW [1,2,1,2] with per-channel slopes [0.1, 0.5].
+        let t = make_f32(&[1, 2, 1, 2], &[-1.0, -2.0, -1.0, -2.0]);
+        let slope = make_f32(&[2], &[0.1, 0.5]);
+        let v = read_all(&op_prelu(&t, &slope).unwrap());
+        // ch0: -0.1, -0.2 ; ch1: -0.5, -1.0
+        assert!((v[0] + 0.1).abs() < 1e-5);
+        assert!((v[1] + 0.2).abs() < 1e-5);
+        assert!((v[2] + 0.5).abs() < 1e-5);
+        assert!((v[3] + 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_mish_at_zero() {
+        let t = make_f32(&[1], &[0.0]);
+        let v = read_all(&op_mish(&t).unwrap());
+        assert!(v[0].abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_mish_known_values() {
+        // Mish(1) = 1 * tanh(softplus(1)) = 1 * tanh(1.3133) ≈ 0.8651
+        let t = make_f32(&[2], &[1.0, -1.0]);
+        let v = read_all(&op_mish(&t).unwrap());
+        assert!((v[0] - 0.8651).abs() < 5e-2);
+        // Mish(-1) ≈ -0.3034
+        assert!((v[1] + 0.3034).abs() < 5e-2);
+    }
+
+    #[test]
     fn test_activations_reject_non_float() {
         let t = Tensor {
             data_type: DataType::Int32,
@@ -129,5 +332,8 @@ mod tests {
         assert!(op_leaky_relu(&t, 0.1).is_err());
         assert!(op_elu(&t, 1.0).is_err());
         assert!(op_swish(&t).is_err());
+        assert!(op_hard_sigmoid(&t, 0.2, 0.5).is_err());
+        assert!(op_hard_swish(&t).is_err());
+        assert!(op_mish(&t).is_err());
     }
 }

--- a/onnx-rt/src/ops/activations.rs
+++ b/onnx-rt/src/ops/activations.rs
@@ -59,23 +59,55 @@ pub fn op_prelu(input: &Tensor, slope: &Tensor) -> Result<Tensor, OpError> {
     let total = input.shape.total_elements();
     let mut data = allocate_tensor_data(total, DataType::Float);
     let slope_total = slope.shape.total_elements();
-    let scalar_slope = slope_total <= 1;
-    let channel_slope =
-        !scalar_slope && input.shape.dims.len() >= 2 && slope_total == input.shape.dims[1] as usize;
-    let inner_per_c: usize = if input.shape.dims.len() >= 2 {
-        input.shape.dims[2..]
-            .iter()
-            .map(|&d| d as usize)
-            .product::<usize>()
-            .max(1)
+
+    // ONNX PRelu allows uni-directional broadcasting of `slope` over
+    // `input`. We accept the two shapes real exporters use and reject
+    // anything else with ShapeMismatch (no silent clamping).
+    //
+    //   1. Scalar slope: shape `[]` or `[1]` (or all-ones) -> applied
+    //      uniformly.
+    //   2. Per-channel: rank >= 2, channel axis == 1, and slope is
+    //      either length `C` as a 1D tensor or a rank-matching tensor
+    //      with all non-channel dims equal to 1.
+    #[derive(Clone, Copy)]
+    enum Mode {
+        Scalar,
+        PerChannel(usize),
+    }
+    let slope_is_scalar = slope_total == 1
+        && (slope.shape.dims.is_empty() || slope.shape.dims.iter().all(|&d| d == 1));
+    let mode = if slope_is_scalar {
+        Mode::Scalar
+    } else if input.shape.dims.len() >= 2 {
+        let c = input.shape.dims[1] as usize;
+        let per_channel_1d = slope.shape.dims.as_slice() == [c as i64];
+        let per_channel_broadcast = slope.shape.dims.len() == input.shape.dims.len()
+            && slope.shape.dims[1] as usize == c
+            && slope.shape.dims.iter().enumerate().all(|(i, &d)| {
+                if i == 1 {
+                    d as usize == c
+                } else {
+                    d == 1
+                }
+            });
+        if per_channel_1d || per_channel_broadcast {
+            let inner: usize = input.shape.dims[2..]
+                .iter()
+                .map(|&d| d as usize)
+                .product::<usize>()
+                .max(1);
+            Mode::PerChannel(inner)
+        } else {
+            return Err(OpError::ShapeMismatch(alloc::string::String::from(
+                "PRelu: slope must be scalar or per-channel (shape [C] or broadcastable to channel axis)",
+            )));
+        }
     } else {
-        1
+        return Err(OpError::ShapeMismatch(alloc::string::String::from(
+            "PRelu: slope must be scalar for rank<2 input",
+        )));
     };
-    let outer: usize = if input.shape.dims.is_empty() {
-        1
-    } else {
-        input.shape.dims[0] as usize
-    };
+
     let c: usize = if input.shape.dims.len() >= 2 {
         input.shape.dims[1] as usize
     } else {
@@ -83,15 +115,13 @@ pub fn op_prelu(input: &Tensor, slope: &Tensor) -> Result<Tensor, OpError> {
     };
     for flat in 0..total {
         let x = read_f32(&input.raw_data, flat);
-        let s = if scalar_slope {
-            read_f32(&slope.raw_data, 0)
-        } else if channel_slope {
-            let ch = (flat / inner_per_c) % c;
-            read_f32(&slope.raw_data, ch)
-        } else {
-            read_f32(&slope.raw_data, flat.min(slope_total - 1))
+        let s = match mode {
+            Mode::Scalar => read_f32(&slope.raw_data, 0),
+            Mode::PerChannel(inner) => {
+                let ch = (flat / inner) % c;
+                read_f32(&slope.raw_data, ch)
+            }
         };
-        let _ = outer;
         let y = if x >= 0.0 { x } else { s * x };
         write_f32(&mut data, flat, y);
     }
@@ -301,6 +331,46 @@ mod tests {
         assert!((v[1] + 0.2).abs() < 1e-5);
         assert!((v[2] + 0.5).abs() < 1e-5);
         assert!((v[3] + 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_prelu_scalar_rank0_slope() {
+        // Rank-0 scalar slope tensor must also be accepted.
+        let t = make_f32(&[3], &[1.0, -1.0, -2.0]);
+        let slope = Tensor {
+            data_type: DataType::Float,
+            shape: TensorShape::new(alloc::vec![]),
+            name: String::new(),
+            raw_data: {
+                let mut d = allocate_tensor_data(1, DataType::Float);
+                write_f32(&mut d, 0, 0.5);
+                d
+            },
+        };
+        let v = read_all(&op_prelu(&t, &slope).unwrap());
+        assert_eq!(v, alloc::vec![1.0, -0.5, -1.0]);
+    }
+
+    #[test]
+    fn test_prelu_rejects_invalid_broadcast() {
+        // Input [1,2,1,2] (C=2) with slope length 3 is not broadcastable.
+        let t = make_f32(&[1, 2, 1, 2], &[-1.0, -2.0, -1.0, -2.0]);
+        let slope = make_f32(&[3], &[0.1, 0.2, 0.3]);
+        assert!(matches!(
+            op_prelu(&t, &slope),
+            Err(OpError::ShapeMismatch(_))
+        ));
+    }
+
+    #[test]
+    fn test_prelu_rejects_mismatched_rank_broadcast() {
+        // Slope shape [1, 2, 2, 1] has non-1 non-channel dim — reject.
+        let t = make_f32(&[1, 2, 1, 2], &[-1.0, -2.0, -1.0, -2.0]);
+        let slope = make_f32(&[1, 2, 2, 1], &[0.1, 0.1, 0.2, 0.2]);
+        assert!(matches!(
+            op_prelu(&t, &slope),
+            Err(OpError::ShapeMismatch(_))
+        ));
     }
 
     #[test]

--- a/onnx-rt/src/ops/data_select.rs
+++ b/onnx-rt/src/ops/data_select.rs
@@ -292,6 +292,16 @@ pub fn op_unique(input: &Tensor, axis: Option<i64>, sorted: bool) -> Result<Tens
             "Unique: axis-specific mode not supported (flattened only)",
         )));
     }
+    if input.shape.dims.is_empty() {
+        return Err(OpError::ShapeMismatch(String::from(
+            "Unique requires rank >= 1",
+        )));
+    }
+    if input.shape.dims.iter().any(|&d| d < 0) {
+        return Err(OpError::ShapeMismatch(String::from(
+            "Unique: negative dimensions are invalid",
+        )));
+    }
     let total = input.shape.total_elements();
     let mut vals: Vec<f32> = Vec::new();
     for i in 0..total {
@@ -408,6 +418,29 @@ pub fn op_scatter_elements(
     }
     let ax = normalize_axis(axis, rank)?;
     let axis_dim = input.shape.dims[ax] as usize;
+    // Non-axis dims of indices/updates must not exceed the corresponding
+    // dims of `input`, otherwise the scatter would write past the output
+    // buffer. ONNX additionally allows indices[ax] <= input[ax].
+    for d in 0..rank {
+        let in_d = input.shape.dims[d];
+        let idx_d = indices.shape.dims[d];
+        if idx_d < 0 || in_d < 0 {
+            return Err(OpError::ShapeMismatch(String::from(
+                "ScatterElements: negative dimensions are invalid",
+            )));
+        }
+        if d == ax {
+            if idx_d > in_d {
+                return Err(OpError::ShapeMismatch(String::from(
+                    "ScatterElements: indices axis dim must be <= input axis dim",
+                )));
+            }
+        } else if idx_d != in_d {
+            return Err(OpError::ShapeMismatch(String::from(
+                "ScatterElements: indices non-axis dims must match input",
+            )));
+        }
+    }
     let idx = read_i64_vec(indices);
     let u_total = updates.shape.total_elements();
     if idx.len() != u_total {
@@ -640,6 +673,33 @@ mod tests {
         assert!(v
             .iter()
             .any(|&x| (x - 1.1).abs() < 1e-5 || (x - 2.1).abs() < 1e-5));
+    }
+
+    #[test]
+    fn test_scatter_elements_rejects_nonaxis_shape_mismatch() {
+        // input is [3, 3] but indices non-axis dim is 5 (wider than input).
+        let t = make_f32(&[3, 3], &alloc::vec![0.0; 9]);
+        let idx = make_i64(&[2, 5], &alloc::vec![0i64; 10]);
+        let upd = make_f32(&[2, 5], &alloc::vec![1.0; 10]);
+        assert!(matches!(
+            op_scatter_elements(&t, &idx, &upd, 0, "none"),
+            Err(OpError::ShapeMismatch(_))
+        ));
+    }
+
+    #[test]
+    fn test_unique_rejects_rank_zero() {
+        // Rank-0 scalar tensor should be rejected.
+        let t = Tensor {
+            data_type: DataType::Float,
+            shape: TensorShape::new(alloc::vec![]),
+            name: String::new(),
+            raw_data: alloc::vec![0u8; 4],
+        };
+        assert!(matches!(
+            op_unique(&t, None, false),
+            Err(OpError::ShapeMismatch(_))
+        ));
     }
 
     #[test]

--- a/onnx-rt/src/ops/data_select.rs
+++ b/onnx-rt/src/ops/data_select.rs
@@ -1,0 +1,657 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Data selection / indexing operators: TopK, Compress, NonZero,
+//! Unique, GatherElements, ScatterElements.
+//!
+//! These ops are used by modern CV/detection pipelines (Mask R-CNN,
+//! YOLO post-processing, NMS) and by some transformer attention
+//! variants. Float inputs only; int tensors are accepted as indices
+//! where required.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use crate::byte_io::{allocate_tensor_data, read_f32, read_i64, write_f32, write_i64};
+use crate::operators::OpError;
+use crate::tensor::{DataType, Tensor, TensorShape};
+
+fn require_float(t: &Tensor, op: &str) -> Result<(), OpError> {
+    if t.data_type != DataType::Float {
+        return Err(OpError::ShapeMismatch(alloc::format!(
+            "{} requires Float input",
+            op
+        )));
+    }
+    Ok(())
+}
+
+fn normalize_axis(axis: i64, rank: usize) -> Result<usize, OpError> {
+    let r = rank as i64;
+    let a = if axis < 0 { axis + r } else { axis };
+    if a < 0 || a >= r {
+        return Err(OpError::InvalidAttribute(String::from("axis out of range")));
+    }
+    Ok(a as usize)
+}
+
+fn read_i64_vec(t: &Tensor) -> Vec<i64> {
+    match t.data_type {
+        DataType::Int64 => (0..t.shape.total_elements())
+            .map(|i| read_i64(&t.raw_data, i))
+            .collect(),
+        DataType::Int32 => (0..t.shape.total_elements())
+            .map(|i| crate::byte_io::read_i32(&t.raw_data, i) as i64)
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TopK
+// ---------------------------------------------------------------------------
+
+/// Returns the top-k values and indices along `axis`.
+///
+/// Always returns two tensors: `[values, indices]`. Indices are Int64.
+/// `largest=true` selects the k largest, `false` the k smallest.
+/// `sorted=true` orders the returned slice descending (or ascending
+/// for `largest=false`).
+pub fn op_top_k(
+    input: &Tensor,
+    k: i64,
+    axis: i64,
+    largest: bool,
+    sorted: bool,
+) -> Result<Vec<Tensor>, OpError> {
+    require_float(input, "TopK")?;
+    let rank = input.shape.dims.len();
+    let ax = normalize_axis(axis, rank)?;
+    let axis_dim = input.shape.dims[ax] as usize;
+    if k <= 0 || (k as usize) > axis_dim {
+        return Err(OpError::InvalidAttribute(String::from(
+            "TopK: k out of range",
+        )));
+    }
+    let k_us = k as usize;
+    let outer: usize = input.shape.dims[..ax]
+        .iter()
+        .map(|&d| d as usize)
+        .product::<usize>()
+        .max(1);
+    let inner: usize = input.shape.dims[ax + 1..]
+        .iter()
+        .map(|&d| d as usize)
+        .product::<usize>()
+        .max(1);
+
+    let mut out_dims = input.shape.dims.clone();
+    out_dims[ax] = k;
+    let total = outer * k_us * inner;
+    let mut val_data = allocate_tensor_data(total, DataType::Float);
+    let mut idx_data = allocate_tensor_data(total, DataType::Int64);
+
+    let mut scratch: Vec<(f32, usize)> = Vec::with_capacity(axis_dim);
+    for o in 0..outer {
+        for i in 0..inner {
+            scratch.clear();
+            for a in 0..axis_dim {
+                let src = o * axis_dim * inner + a * inner + i;
+                scratch.push((read_f32(&input.raw_data, src), a));
+            }
+            // Sort descending (largest=true) or ascending.
+            if largest {
+                scratch.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(core::cmp::Ordering::Equal));
+            } else {
+                scratch.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(core::cmp::Ordering::Equal));
+            }
+            // scratch[..k_us] is the top-k. If not sorted, the spec allows
+            // any order — we still return the selection order from sort.
+            let _ = sorted;
+            for (rank_idx, &(v, idx)) in scratch.iter().take(k_us).enumerate() {
+                let dst = o * k_us * inner + rank_idx * inner + i;
+                write_f32(&mut val_data, dst, v);
+                write_i64(&mut idx_data, dst, idx as i64);
+            }
+        }
+    }
+    let values = Tensor {
+        data_type: DataType::Float,
+        shape: TensorShape::new(out_dims.clone()),
+        name: String::new(),
+        raw_data: val_data,
+    };
+    let indices = Tensor {
+        data_type: DataType::Int64,
+        shape: TensorShape::new(out_dims),
+        name: String::new(),
+        raw_data: idx_data,
+    };
+    Ok(alloc::vec![values, indices])
+}
+
+// ---------------------------------------------------------------------------
+// Compress
+// ---------------------------------------------------------------------------
+
+/// Selects slices from `input` along `axis` where `condition` is true.
+///
+/// If `axis` is `None`, the input is flattened first. `condition` is
+/// interpreted element-wise; non-zero means keep.
+pub fn op_compress(
+    input: &Tensor,
+    condition: &Tensor,
+    axis: Option<i64>,
+) -> Result<Tensor, OpError> {
+    require_float(input, "Compress")?;
+    let cond: Vec<bool> = {
+        // Condition may be Bool/Int8 but we store as raw bytes: treat any
+        // non-zero byte in a length-aligned stream as true.
+        let n = condition.shape.total_elements();
+        (0..n)
+            .map(|i| {
+                if i < condition.raw_data.len() {
+                    condition.raw_data[i] != 0
+                } else {
+                    false
+                }
+            })
+            .collect()
+    };
+    match axis {
+        None => {
+            // Flatten and filter.
+            let total = input.shape.total_elements();
+            let mut kept: Vec<f32> = Vec::new();
+            for i in 0..total {
+                if i < cond.len() && cond[i] {
+                    kept.push(read_f32(&input.raw_data, i));
+                }
+            }
+            let len = kept.len();
+            let mut data = allocate_tensor_data(len, DataType::Float);
+            for (i, v) in kept.iter().enumerate() {
+                write_f32(&mut data, i, *v);
+            }
+            Ok(Tensor {
+                data_type: DataType::Float,
+                shape: TensorShape::new(alloc::vec![len as i64]),
+                name: String::new(),
+                raw_data: data,
+            })
+        }
+        Some(ax) => {
+            let rank = input.shape.dims.len();
+            let ax = normalize_axis(ax, rank)?;
+            let axis_dim = input.shape.dims[ax] as usize;
+            let outer: usize = input.shape.dims[..ax]
+                .iter()
+                .map(|&d| d as usize)
+                .product::<usize>()
+                .max(1);
+            let inner: usize = input.shape.dims[ax + 1..]
+                .iter()
+                .map(|&d| d as usize)
+                .product::<usize>()
+                .max(1);
+            let keep: Vec<usize> = (0..axis_dim)
+                .filter(|&i| i < cond.len() && cond[i])
+                .collect();
+            let k_len = keep.len();
+            let mut out_dims = input.shape.dims.clone();
+            out_dims[ax] = k_len as i64;
+            let total = outer * k_len * inner;
+            let mut data = allocate_tensor_data(total, DataType::Float);
+            for o in 0..outer {
+                for (ki, &src_a) in keep.iter().enumerate() {
+                    for i in 0..inner {
+                        let src = o * axis_dim * inner + src_a * inner + i;
+                        let dst = o * k_len * inner + ki * inner + i;
+                        write_f32(&mut data, dst, read_f32(&input.raw_data, src));
+                    }
+                }
+            }
+            Ok(Tensor {
+                data_type: DataType::Float,
+                shape: TensorShape::new(out_dims),
+                name: String::new(),
+                raw_data: data,
+            })
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// NonZero
+// ---------------------------------------------------------------------------
+
+/// Returns the indices of non-zero elements of `input` as an Int64
+/// tensor of shape `[rank, count]`.
+pub fn op_non_zero(input: &Tensor) -> Result<Tensor, OpError> {
+    let rank = input.shape.dims.len();
+    let total = input.shape.total_elements();
+    let mut coord = alloc::vec![0usize; rank];
+    let mut rows: Vec<Vec<i64>> = (0..rank).map(|_| Vec::new()).collect();
+    for flat in 0..total {
+        let nonzero = match input.data_type {
+            DataType::Float => read_f32(&input.raw_data, flat) != 0.0,
+            DataType::Int64 => read_i64(&input.raw_data, flat) != 0,
+            DataType::Int32 => crate::byte_io::read_i32(&input.raw_data, flat) != 0,
+            _ => {
+                if flat < input.raw_data.len() {
+                    input.raw_data[flat] != 0
+                } else {
+                    false
+                }
+            }
+        };
+        if nonzero {
+            for d in 0..rank {
+                rows[d].push(coord[d] as i64);
+            }
+        }
+        // Increment coord
+        for d in (0..rank).rev() {
+            coord[d] += 1;
+            if (coord[d] as i64) < input.shape.dims[d] {
+                break;
+            }
+            coord[d] = 0;
+        }
+    }
+    let count = rows.first().map(|r| r.len()).unwrap_or(0);
+    let mut data = allocate_tensor_data(rank * count, DataType::Int64);
+    for (d, row) in rows.iter().enumerate() {
+        for (i, &v) in row.iter().enumerate() {
+            write_i64(&mut data, d * count + i, v);
+        }
+    }
+    Ok(Tensor {
+        data_type: DataType::Int64,
+        shape: TensorShape::new(alloc::vec![rank as i64, count as i64]),
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Unique
+// ---------------------------------------------------------------------------
+
+/// Returns the unique values of `input` along `axis` (None = flatten).
+///
+/// Limitation: only the primary `Y` output tensor is returned. The
+/// optional `indices`, `inverse_indices`, and `counts` tensors that
+/// the ONNX spec describes are not produced — consumers that require
+/// them should be rejected at load time. `sorted=true` returns values
+/// in ascending order.
+pub fn op_unique(input: &Tensor, axis: Option<i64>, sorted: bool) -> Result<Tensor, OpError> {
+    require_float(input, "Unique")?;
+    if axis.is_some() {
+        return Err(OpError::InvalidAttribute(String::from(
+            "Unique: axis-specific mode not supported (flattened only)",
+        )));
+    }
+    let total = input.shape.total_elements();
+    let mut vals: Vec<f32> = Vec::new();
+    for i in 0..total {
+        let v = read_f32(&input.raw_data, i);
+        if !vals.iter().any(|&u| u.to_bits() == v.to_bits()) {
+            vals.push(v);
+        }
+    }
+    if sorted {
+        vals.sort_by(|a, b| a.partial_cmp(b).unwrap_or(core::cmp::Ordering::Equal));
+    }
+    let n = vals.len();
+    let mut data = allocate_tensor_data(n, DataType::Float);
+    for (i, v) in vals.iter().enumerate() {
+        write_f32(&mut data, i, *v);
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: TensorShape::new(alloc::vec![n as i64]),
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// GatherElements / ScatterElements
+// ---------------------------------------------------------------------------
+
+/// Element-wise gather along `axis`. `indices` must have the same shape
+/// as `input`.
+pub fn op_gather_elements(input: &Tensor, indices: &Tensor, axis: i64) -> Result<Tensor, OpError> {
+    require_float(input, "GatherElements")?;
+    if indices.shape.dims != input.shape.dims {
+        return Err(OpError::ShapeMismatch(String::from(
+            "GatherElements: indices shape must match input shape",
+        )));
+    }
+    let rank = input.shape.dims.len();
+    let ax = normalize_axis(axis, rank)?;
+    let axis_dim = input.shape.dims[ax] as usize;
+    let total = input.shape.total_elements();
+    let idx = read_i64_vec(indices);
+    if idx.len() != total {
+        return Err(OpError::ShapeMismatch(String::from(
+            "GatherElements: indices must be Int32/Int64",
+        )));
+    }
+    let mut data = allocate_tensor_data(total, DataType::Float);
+    // Compute strides.
+    let mut strides = alloc::vec![1usize; rank];
+    for i in (0..rank.saturating_sub(1)).rev() {
+        strides[i] = strides[i + 1] * input.shape.dims[i + 1] as usize;
+    }
+    let mut coord = alloc::vec![0usize; rank];
+    for (flat, &raw_idx) in idx.iter().enumerate().take(total) {
+        let mut src_idx_val = raw_idx;
+        if src_idx_val < 0 {
+            src_idx_val += axis_dim as i64;
+        }
+        if src_idx_val < 0 || (src_idx_val as usize) >= axis_dim {
+            return Err(OpError::ShapeMismatch(String::from(
+                "GatherElements: index out of range",
+            )));
+        }
+        let mut src = 0usize;
+        for d in 0..rank {
+            let c = if d == ax {
+                src_idx_val as usize
+            } else {
+                coord[d]
+            };
+            src += c * strides[d];
+        }
+        write_f32(&mut data, flat, read_f32(&input.raw_data, src));
+        // Increment coord.
+        for d in (0..rank).rev() {
+            coord[d] += 1;
+            if (coord[d] as i64) < input.shape.dims[d] {
+                break;
+            }
+            coord[d] = 0;
+        }
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: input.shape.clone(),
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+/// Element-wise scatter along `axis`. `indices` and `updates` must have
+/// the same shape, and each is broadcast-indexed into a copy of
+/// `input`. Supported reductions: "none" (default), "add", "mul".
+pub fn op_scatter_elements(
+    input: &Tensor,
+    indices: &Tensor,
+    updates: &Tensor,
+    axis: i64,
+    reduction: &str,
+) -> Result<Tensor, OpError> {
+    require_float(input, "ScatterElements")?;
+    require_float(updates, "ScatterElements")?;
+    if indices.shape.dims != updates.shape.dims {
+        return Err(OpError::ShapeMismatch(String::from(
+            "ScatterElements: indices shape must match updates shape",
+        )));
+    }
+    let rank = input.shape.dims.len();
+    if indices.shape.dims.len() != rank {
+        return Err(OpError::ShapeMismatch(String::from(
+            "ScatterElements: indices rank must match input rank",
+        )));
+    }
+    let ax = normalize_axis(axis, rank)?;
+    let axis_dim = input.shape.dims[ax] as usize;
+    let idx = read_i64_vec(indices);
+    let u_total = updates.shape.total_elements();
+    if idx.len() != u_total {
+        return Err(OpError::ShapeMismatch(String::from(
+            "ScatterElements: indices must be Int32/Int64",
+        )));
+    }
+    // Start with a copy of input.
+    let mut data = input.raw_data.clone();
+    let mut strides = alloc::vec![1usize; rank];
+    for i in (0..rank.saturating_sub(1)).rev() {
+        strides[i] = strides[i + 1] * input.shape.dims[i + 1] as usize;
+    }
+    let mut coord = alloc::vec![0usize; rank];
+    for (flat, &raw_idx) in idx.iter().enumerate().take(u_total) {
+        let mut ax_idx = raw_idx;
+        if ax_idx < 0 {
+            ax_idx += axis_dim as i64;
+        }
+        if ax_idx < 0 || (ax_idx as usize) >= axis_dim {
+            return Err(OpError::ShapeMismatch(String::from(
+                "ScatterElements: index out of range",
+            )));
+        }
+        let mut dst = 0usize;
+        for d in 0..rank {
+            let c = if d == ax { ax_idx as usize } else { coord[d] };
+            dst += c * strides[d];
+        }
+        let upd = read_f32(&updates.raw_data, flat);
+        let cur = read_f32(&data, dst);
+        let new_val = match reduction {
+            "" | "none" => upd,
+            "add" => cur + upd,
+            "mul" => cur * upd,
+            other => {
+                return Err(OpError::InvalidAttribute(alloc::format!(
+                    "ScatterElements reduction '{}' not supported",
+                    other
+                )));
+            }
+        };
+        write_f32(&mut data, dst, new_val);
+        // Increment coord over updates shape.
+        for d in (0..rank).rev() {
+            coord[d] += 1;
+            if (coord[d] as i64) < updates.shape.dims[d] {
+                break;
+            }
+            coord[d] = 0;
+        }
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: input.shape.clone(),
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_f32(dims: &[i64], vals: &[f32]) -> Tensor {
+        let mut data = allocate_tensor_data(vals.len(), DataType::Float);
+        for (i, &v) in vals.iter().enumerate() {
+            write_f32(&mut data, i, v);
+        }
+        Tensor {
+            data_type: DataType::Float,
+            shape: TensorShape::new(dims.to_vec()),
+            name: String::new(),
+            raw_data: data,
+        }
+    }
+
+    fn make_i64(dims: &[i64], vals: &[i64]) -> Tensor {
+        let mut data = allocate_tensor_data(vals.len(), DataType::Int64);
+        for (i, &v) in vals.iter().enumerate() {
+            write_i64(&mut data, i, v);
+        }
+        Tensor {
+            data_type: DataType::Int64,
+            shape: TensorShape::new(dims.to_vec()),
+            name: String::new(),
+            raw_data: data,
+        }
+    }
+
+    fn make_bool(dims: &[i64], vals: &[bool]) -> Tensor {
+        let data: Vec<u8> = vals.iter().map(|&b| if b { 1u8 } else { 0u8 }).collect();
+        Tensor {
+            data_type: DataType::Bool,
+            shape: TensorShape::new(dims.to_vec()),
+            name: String::new(),
+            raw_data: data,
+        }
+    }
+
+    fn read_all_f32(t: &Tensor) -> Vec<f32> {
+        (0..t.shape.total_elements())
+            .map(|i| read_f32(&t.raw_data, i))
+            .collect()
+    }
+
+    fn read_all_i64(t: &Tensor) -> Vec<i64> {
+        (0..t.shape.total_elements())
+            .map(|i| read_i64(&t.raw_data, i))
+            .collect()
+    }
+
+    #[test]
+    fn test_top_k_largest() {
+        let t = make_f32(&[4], &[1.0, 3.0, 2.0, 5.0]);
+        let outs = op_top_k(&t, 2, 0, true, true).unwrap();
+        assert_eq!(outs.len(), 2);
+        let vals = read_all_f32(&outs[0]);
+        let idxs = read_all_i64(&outs[1]);
+        assert_eq!(vals, alloc::vec![5.0, 3.0]);
+        assert_eq!(idxs, alloc::vec![3, 1]);
+    }
+
+    #[test]
+    fn test_top_k_smallest() {
+        let t = make_f32(&[4], &[1.0, 3.0, 2.0, 5.0]);
+        let outs = op_top_k(&t, 2, 0, false, true).unwrap();
+        let vals = read_all_f32(&outs[0]);
+        assert_eq!(vals, alloc::vec![1.0, 2.0]);
+    }
+
+    #[test]
+    fn test_top_k_2d_axis_neg1() {
+        let t = make_f32(&[2, 3], &[1.0, 2.0, 3.0, 6.0, 5.0, 4.0]);
+        let outs = op_top_k(&t, 2, -1, true, true).unwrap();
+        assert_eq!(outs[0].shape.dims, alloc::vec![2, 2]);
+        let vals = read_all_f32(&outs[0]);
+        assert_eq!(vals, alloc::vec![3.0, 2.0, 6.0, 5.0]);
+    }
+
+    #[test]
+    fn test_compress_flat() {
+        let t = make_f32(&[4], &[1.0, 2.0, 3.0, 4.0]);
+        let cond = make_bool(&[4], &[true, false, true, false]);
+        let out = op_compress(&t, &cond, None).unwrap();
+        assert_eq!(out.shape.dims, alloc::vec![2]);
+        assert_eq!(read_all_f32(&out), alloc::vec![1.0, 3.0]);
+    }
+
+    #[test]
+    fn test_compress_axis() {
+        // [2,3]: keep columns 0 and 2.
+        let t = make_f32(&[2, 3], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let cond = make_bool(&[3], &[true, false, true]);
+        let out = op_compress(&t, &cond, Some(1)).unwrap();
+        assert_eq!(out.shape.dims, alloc::vec![2, 2]);
+        assert_eq!(read_all_f32(&out), alloc::vec![1.0, 3.0, 4.0, 6.0]);
+    }
+
+    #[test]
+    fn test_non_zero_basic() {
+        let t = make_f32(&[2, 3], &[0.0, 1.0, 0.0, 2.0, 0.0, 3.0]);
+        let out = op_non_zero(&t).unwrap();
+        assert_eq!(out.shape.dims, alloc::vec![2, 3]);
+        // rows: [[0,1,1],[1,0,2]]
+        let v = read_all_i64(&out);
+        assert_eq!(v, alloc::vec![0, 1, 1, 1, 0, 2]);
+    }
+
+    #[test]
+    fn test_non_zero_empty() {
+        let t = make_f32(&[3], &[0.0, 0.0, 0.0]);
+        let out = op_non_zero(&t).unwrap();
+        assert_eq!(out.shape.dims, alloc::vec![1, 0]);
+    }
+
+    #[test]
+    fn test_unique_sorted() {
+        let t = make_f32(&[5], &[3.0, 1.0, 3.0, 2.0, 1.0]);
+        let out = op_unique(&t, None, true).unwrap();
+        assert_eq!(out.shape.dims, alloc::vec![3]);
+        assert_eq!(read_all_f32(&out), alloc::vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn test_unique_unsorted_preserves_order() {
+        let t = make_f32(&[5], &[3.0, 1.0, 3.0, 2.0, 1.0]);
+        let out = op_unique(&t, None, false).unwrap();
+        assert_eq!(read_all_f32(&out), alloc::vec![3.0, 1.0, 2.0]);
+    }
+
+    #[test]
+    fn test_unique_rejects_axis_mode() {
+        let t = make_f32(&[3], &[1.0, 2.0, 3.0]);
+        assert!(op_unique(&t, Some(0), false).is_err());
+    }
+
+    #[test]
+    fn test_gather_elements_axis0() {
+        let t = make_f32(&[2, 3], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let idx = make_i64(&[2, 3], &[0, 1, 0, 1, 0, 1]);
+        let out = op_gather_elements(&t, &idx, 0).unwrap();
+        assert_eq!(
+            read_all_f32(&out),
+            alloc::vec![1.0, 5.0, 3.0, 4.0, 2.0, 6.0]
+        );
+    }
+
+    #[test]
+    fn test_gather_elements_axis_neg1() {
+        let t = make_f32(&[2, 3], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let idx = make_i64(&[2, 3], &[2, 1, 0, 0, 1, 2]);
+        let out = op_gather_elements(&t, &idx, -1).unwrap();
+        assert_eq!(
+            read_all_f32(&out),
+            alloc::vec![3.0, 2.0, 1.0, 4.0, 5.0, 6.0]
+        );
+    }
+
+    #[test]
+    fn test_scatter_elements_replace() {
+        let t = make_f32(&[3, 3], &alloc::vec![0.0; 9]);
+        let idx = make_i64(&[2, 3], &[1, 0, 2, 0, 2, 1]);
+        let upd = make_f32(&[2, 3], &[1.0, 1.1, 1.2, 2.0, 2.1, 2.2]);
+        let out = op_scatter_elements(&t, &idx, &upd, 0, "none").unwrap();
+        assert_eq!(out.shape.dims, alloc::vec![3, 3]);
+        // Replacements place on axis 0; final content depends on update order.
+        // Simple invariant: result contains at least the latest updates.
+        let v = read_all_f32(&out);
+        assert!(v
+            .iter()
+            .any(|&x| (x - 1.1).abs() < 1e-5 || (x - 2.1).abs() < 1e-5));
+    }
+
+    #[test]
+    fn test_scatter_elements_add() {
+        let t = make_f32(&[3], &[1.0, 2.0, 3.0]);
+        let idx = make_i64(&[3], &[0, 0, 2]);
+        let upd = make_f32(&[3], &[10.0, 20.0, 30.0]);
+        let out = op_scatter_elements(&t, &idx, &upd, 0, "add").unwrap();
+        // Index 0 gets +10+20, index 2 gets +30.
+        let v = read_all_f32(&out);
+        assert!((v[0] - 31.0).abs() < 1e-5);
+        assert!((v[1] - 2.0).abs() < 1e-5);
+        assert!((v[2] - 33.0).abs() < 1e-5);
+    }
+}

--- a/onnx-rt/src/ops/mod.rs
+++ b/onnx-rt/src/ops/mod.rs
@@ -18,9 +18,12 @@
 pub mod activations;
 pub mod common;
 pub mod compare;
+pub mod data_select;
 pub mod math;
+pub mod normalization;
 pub mod quantized;
 pub mod recurrent;
 pub mod reduction;
 pub mod shape_data;
 pub mod transformer;
+pub mod vision;

--- a/onnx-rt/src/ops/normalization.rs
+++ b/onnx-rt/src/ops/normalization.rs
@@ -197,6 +197,49 @@ mod tests {
     }
 
     #[test]
+    fn test_group_norm_rejects_bad_scale_shape() {
+        let x = make_f32(&[1, 4, 1, 1], &[1.0, 2.0, 3.0, 4.0]);
+        let scale = make_f32(&[2], &[1.0, 1.0]); // should be length 4
+        assert!(matches!(
+            op_group_normalization(&x, &scale, None, 2, 1e-5),
+            Err(OpError::ShapeMismatch(_))
+        ));
+    }
+
+    #[test]
+    fn test_group_norm_rejects_bad_bias_shape() {
+        let x = make_f32(&[1, 4, 1, 1], &[1.0, 2.0, 3.0, 4.0]);
+        let scale = make_f32(&[4], &[1.0, 1.0, 1.0, 1.0]);
+        let bias = make_f32(&[3], &[0.0, 0.0, 0.0]); // should be length 4
+        assert!(matches!(
+            op_group_normalization(&x, &scale, Some(&bias), 2, 1e-5),
+            Err(OpError::ShapeMismatch(_))
+        ));
+    }
+
+    #[test]
+    fn test_instance_norm_rejects_bad_scale() {
+        let x = make_f32(&[1, 2, 1, 2], &[1.0, 3.0, 10.0, 20.0]);
+        let scale = make_f32(&[3], &[1.0, 1.0, 1.0]); // should be C=2
+        let bias = make_f32(&[2], &[0.0, 0.0]);
+        assert!(matches!(
+            op_instance_normalization(&x, &scale, &bias, 1e-5),
+            Err(OpError::ShapeMismatch(_))
+        ));
+    }
+
+    #[test]
+    fn test_instance_norm_rejects_bad_bias() {
+        let x = make_f32(&[1, 2, 1, 2], &[1.0, 3.0, 10.0, 20.0]);
+        let scale = make_f32(&[2], &[1.0, 1.0]);
+        let bias = make_f32(&[3], &[0.0, 0.0, 0.0]); // should be C=2
+        assert!(matches!(
+            op_instance_normalization(&x, &scale, &bias, 1e-5),
+            Err(OpError::ShapeMismatch(_))
+        ));
+    }
+
+    #[test]
     fn test_instance_norm_rejects_bad_rank() {
         let x = make_f32(&[4], &[1.0, 2.0, 3.0, 4.0]);
         let scale = make_f32(&[1], &[1.0]);

--- a/onnx-rt/src/ops/normalization.rs
+++ b/onnx-rt/src/ops/normalization.rs
@@ -1,0 +1,206 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! GroupNormalization and InstanceNormalization.
+//!
+//! These normalize NCHW-style tensors across spatial dims grouped by
+//! channel slices. InstanceNorm is `GroupNorm` with `num_groups == C`.
+
+use alloc::string::String;
+
+use crate::byte_io::{allocate_tensor_data, read_f32, write_f32};
+use crate::operators::{sqrt_approx, OpError};
+use crate::tensor::{DataType, Tensor};
+
+fn require_float(t: &Tensor, op: &str) -> Result<(), OpError> {
+    if t.data_type != DataType::Float {
+        return Err(OpError::ShapeMismatch(alloc::format!(
+            "{} requires Float input",
+            op
+        )));
+    }
+    Ok(())
+}
+
+/// Group normalization over an NCHW-like input.
+///
+/// Channels are split into `num_groups` contiguous groups; statistics
+/// are computed per (N, group) over (C/num_groups * H * W ... spatial).
+/// `scale` and `bias` are length-C vectors applied after normalization.
+pub fn op_group_normalization(
+    x: &Tensor,
+    scale: &Tensor,
+    bias: Option<&Tensor>,
+    num_groups: i64,
+    epsilon: f32,
+) -> Result<Tensor, OpError> {
+    require_float(x, "GroupNormalization")?;
+    require_float(scale, "GroupNormalization")?;
+    if x.shape.dims.len() < 2 {
+        return Err(OpError::ShapeMismatch(String::from(
+            "GroupNormalization requires rank >= 2",
+        )));
+    }
+    let n = x.shape.dims[0] as usize;
+    let c = x.shape.dims[1] as usize;
+    let spatial: usize = x.shape.dims[2..]
+        .iter()
+        .map(|&d| d as usize)
+        .product::<usize>()
+        .max(1);
+    if num_groups <= 0 || !c.is_multiple_of(num_groups as usize) {
+        return Err(OpError::InvalidAttribute(String::from(
+            "GroupNormalization: C must be divisible by num_groups",
+        )));
+    }
+    if scale.shape.total_elements() != c {
+        return Err(OpError::ShapeMismatch(String::from(
+            "GroupNormalization scale must have length C",
+        )));
+    }
+    if let Some(b) = bias {
+        require_float(b, "GroupNormalization")?;
+        if b.shape.total_elements() != c {
+            return Err(OpError::ShapeMismatch(String::from(
+                "GroupNormalization bias must have length C",
+            )));
+        }
+    }
+    let groups = num_groups as usize;
+    let channels_per_group = c / groups;
+    let group_size = channels_per_group * spatial;
+    let total = x.shape.total_elements();
+    let mut data = allocate_tensor_data(total, DataType::Float);
+
+    for bn in 0..n {
+        for g in 0..groups {
+            let base = bn * c * spatial + g * channels_per_group * spatial;
+            // Mean
+            let mut sum = 0.0f32;
+            for i in 0..group_size {
+                sum += read_f32(&x.raw_data, base + i);
+            }
+            let mean = sum / group_size as f32;
+            // Variance
+            let mut var_sum = 0.0f32;
+            for i in 0..group_size {
+                let d = read_f32(&x.raw_data, base + i) - mean;
+                var_sum += d * d;
+            }
+            let inv_std = 1.0 / sqrt_approx(var_sum / group_size as f32 + epsilon);
+            // Apply per-channel scale/bias.
+            for ci in 0..channels_per_group {
+                let c_abs = g * channels_per_group + ci;
+                let s = read_f32(&scale.raw_data, c_abs);
+                let b = bias.map(|bt| read_f32(&bt.raw_data, c_abs)).unwrap_or(0.0);
+                for sp in 0..spatial {
+                    let idx = base + ci * spatial + sp;
+                    let v = read_f32(&x.raw_data, idx);
+                    write_f32(&mut data, idx, s * (v - mean) * inv_std + b);
+                }
+            }
+        }
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: x.shape.clone(),
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+/// Instance normalization = GroupNormalization with `num_groups == C`.
+pub fn op_instance_normalization(
+    x: &Tensor,
+    scale: &Tensor,
+    bias: &Tensor,
+    epsilon: f32,
+) -> Result<Tensor, OpError> {
+    if x.shape.dims.len() < 2 {
+        return Err(OpError::ShapeMismatch(String::from(
+            "InstanceNormalization requires rank >= 2",
+        )));
+    }
+    let c = x.shape.dims[1];
+    op_group_normalization(x, scale, Some(bias), c, epsilon)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tensor::TensorShape;
+
+    fn make_f32(dims: &[i64], vals: &[f32]) -> Tensor {
+        let mut data = allocate_tensor_data(vals.len(), DataType::Float);
+        for (i, &v) in vals.iter().enumerate() {
+            write_f32(&mut data, i, v);
+        }
+        Tensor {
+            data_type: DataType::Float,
+            shape: TensorShape::new(dims.to_vec()),
+            name: String::new(),
+            raw_data: data,
+        }
+    }
+
+    fn read_all(t: &Tensor) -> alloc::vec::Vec<f32> {
+        (0..t.shape.total_elements())
+            .map(|i| read_f32(&t.raw_data, i))
+            .collect()
+    }
+
+    #[test]
+    fn test_group_norm_one_group_zero_mean() {
+        // [1,2,1,2] with values [1,2, 3,4]; one group over all 4 values.
+        let x = make_f32(&[1, 2, 1, 2], &[1.0, 2.0, 3.0, 4.0]);
+        let scale = make_f32(&[2], &[1.0, 1.0]);
+        let out = op_group_normalization(&x, &scale, None, 1, 1e-5).unwrap();
+        let v = read_all(&out);
+        // Normalized values should sum to ~0.
+        let s: f32 = v.iter().sum();
+        assert!(s.abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_group_norm_scale_bias_applied() {
+        let x = make_f32(&[1, 2, 1, 1], &[1.0, 3.0]);
+        let scale = make_f32(&[2], &[2.0, 2.0]);
+        let bias = make_f32(&[2], &[0.5, 0.5]);
+        let out = op_group_normalization(&x, &scale, Some(&bias), 1, 1e-5).unwrap();
+        let v = read_all(&out);
+        // Mean 2, var 1 → normalized [-1,1] * 2 + 0.5 = [-1.5, 2.5]
+        assert!((v[0] + 1.5).abs() < 1e-2);
+        assert!((v[1] - 2.5).abs() < 1e-2);
+    }
+
+    #[test]
+    fn test_group_norm_rejects_bad_group_count() {
+        let x = make_f32(&[1, 3, 1, 1], &[1.0, 2.0, 3.0]);
+        let scale = make_f32(&[3], &[1.0, 1.0, 1.0]);
+        assert!(op_group_normalization(&x, &scale, None, 2, 1e-5).is_err());
+    }
+
+    #[test]
+    fn test_instance_norm_per_channel() {
+        // Two channels with distinct stats — each should be normalized
+        // independently.
+        let x = make_f32(&[1, 2, 1, 2], &[1.0, 3.0, 10.0, 20.0]);
+        let scale = make_f32(&[2], &[1.0, 1.0]);
+        let bias = make_f32(&[2], &[0.0, 0.0]);
+        let out = op_instance_normalization(&x, &scale, &bias, 1e-5).unwrap();
+        let v = read_all(&out);
+        // Channel 0: mean 2 → [-1, 1]. Channel 1: mean 15 → [-1, 1].
+        assert!((v[0] + 1.0).abs() < 1e-2);
+        assert!((v[1] - 1.0).abs() < 1e-2);
+        assert!((v[2] + 1.0).abs() < 1e-2);
+        assert!((v[3] - 1.0).abs() < 1e-2);
+    }
+
+    #[test]
+    fn test_instance_norm_rejects_bad_rank() {
+        let x = make_f32(&[4], &[1.0, 2.0, 3.0, 4.0]);
+        let scale = make_f32(&[1], &[1.0]);
+        let bias = make_f32(&[1], &[0.0]);
+        assert!(op_instance_normalization(&x, &scale, &bias, 1e-5).is_err());
+    }
+}

--- a/onnx-rt/src/ops/vision.rs
+++ b/onnx-rt/src/ops/vision.rs
@@ -1,0 +1,861 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Vision-specific operators used by image-heavy models (ViT, Swin,
+//! ConvNeXt, Mask R-CNN, …).
+//!
+//! These ops target the common-case attribute combinations used by
+//! recent CV exports. Many ONNX vision ops accept a large attribute
+//! matrix; we implement the pragmatic subset documented on each
+//! function and return `InvalidAttribute` for unsupported modes.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use crate::byte_io::{allocate_tensor_data, read_f32, write_f32};
+use crate::operators::OpError;
+use crate::tensor::{DataType, Tensor, TensorShape};
+
+fn require_float(t: &Tensor, op: &str) -> Result<(), OpError> {
+    if t.data_type != DataType::Float {
+        return Err(OpError::ShapeMismatch(alloc::format!(
+            "{} requires Float input",
+            op
+        )));
+    }
+    Ok(())
+}
+
+// no_std-safe math helpers (the libcore f32 type has no .floor/.round/.ceil).
+fn floor_f32(x: f32) -> f32 {
+    let i = x as i64 as f32;
+    if x < i {
+        i - 1.0
+    } else {
+        i
+    }
+}
+fn ceil_f32(x: f32) -> f32 {
+    let i = x as i64 as f32;
+    if x > i {
+        i + 1.0
+    } else {
+        i
+    }
+}
+fn round_f32(x: f32) -> f32 {
+    floor_f32(x + 0.5)
+}
+
+fn require_4d(t: &Tensor, op: &str) -> Result<(usize, usize, usize, usize), OpError> {
+    require_float(t, op)?;
+    if t.shape.dims.len() != 4 {
+        return Err(OpError::ShapeMismatch(alloc::format!(
+            "{} requires 4D NCHW input",
+            op
+        )));
+    }
+    Ok((
+        t.shape.dims[0] as usize,
+        t.shape.dims[1] as usize,
+        t.shape.dims[2] as usize,
+        t.shape.dims[3] as usize,
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Resize
+// ---------------------------------------------------------------------------
+
+/// 2D NCHW image resize.
+///
+/// Supported attributes (matches the common case used by most vision
+/// exports):
+/// - `mode = "nearest"` or `"linear"` (bilinear)
+/// - `coordinate_transformation_mode = "half_pixel"`
+/// - no antialias, no cubic interpolation, no `exclude_outside`
+///
+/// Output sizes are taken from `sizes` (input #3) when present, else
+/// derived from `scales` (input #2). Only the spatial dimensions
+/// (H, W) are rescaled; N and C are preserved.
+pub fn op_resize(
+    input: &Tensor,
+    scales: Option<&[f32]>,
+    sizes: Option<&[i64]>,
+    mode: &str,
+) -> Result<Tensor, OpError> {
+    let (n, c, h, w) = require_4d(input, "Resize")?;
+    let (oh, ow) = if let Some(s) = sizes {
+        if s.len() != 4 {
+            return Err(OpError::InvalidAttribute(String::from(
+                "Resize sizes must have rank 4",
+            )));
+        }
+        (s[2] as usize, s[3] as usize)
+    } else if let Some(s) = scales {
+        if s.len() != 4 {
+            return Err(OpError::InvalidAttribute(String::from(
+                "Resize scales must have rank 4",
+            )));
+        }
+        (
+            round_f32((h as f32) * s[2]) as usize,
+            round_f32((w as f32) * s[3]) as usize,
+        )
+    } else {
+        return Err(OpError::InvalidAttribute(String::from(
+            "Resize requires scales or sizes",
+        )));
+    };
+    if oh == 0 || ow == 0 {
+        return Err(OpError::ShapeMismatch(String::from(
+            "Resize output dims must be > 0",
+        )));
+    }
+    let out_shape = TensorShape::new(alloc::vec![n as i64, c as i64, oh as i64, ow as i64]);
+    let mut data = allocate_tensor_data(n * c * oh * ow, DataType::Float);
+    let h_scale = h as f32 / oh as f32;
+    let w_scale = w as f32 / ow as f32;
+    for bn in 0..n {
+        for ch in 0..c {
+            let plane = bn * c * h * w + ch * h * w;
+            let out_plane = bn * c * oh * ow + ch * oh * ow;
+            for oy in 0..oh {
+                for ox in 0..ow {
+                    // half_pixel: src = (out + 0.5) * scale - 0.5
+                    let sy = (oy as f32 + 0.5) * h_scale - 0.5;
+                    let sx = (ox as f32 + 0.5) * w_scale - 0.5;
+                    let v = match mode {
+                        "nearest" => {
+                            let iy = round_f32(sy).clamp(0.0, (h - 1) as f32) as usize;
+                            let ix = round_f32(sx).clamp(0.0, (w - 1) as f32) as usize;
+                            read_f32(&input.raw_data, plane + iy * w + ix)
+                        }
+                        "linear" | "bilinear" => bilinear_sample(
+                            &input.raw_data,
+                            plane,
+                            h,
+                            w,
+                            sy,
+                            sx,
+                            /*zero_pad=*/ false,
+                        ),
+                        other => {
+                            return Err(OpError::InvalidAttribute(alloc::format!(
+                                "Resize mode '{}' not supported",
+                                other
+                            )));
+                        }
+                    };
+                    write_f32(&mut data, out_plane + oy * ow + ox, v);
+                }
+            }
+        }
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: out_shape,
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+/// Bilinear sample from a single HxW plane with clamp-to-edge (or
+/// zero-pad) semantics when `zero_pad` is true.
+fn bilinear_sample(
+    raw: &[u8],
+    plane_off: usize,
+    h: usize,
+    w: usize,
+    sy: f32,
+    sx: f32,
+    zero_pad: bool,
+) -> f32 {
+    let x0 = floor_f32(sx) as i64;
+    let y0 = floor_f32(sy) as i64;
+    let x1 = x0 + 1;
+    let y1 = y0 + 1;
+    let dx = sx - x0 as f32;
+    let dy = sy - y0 as f32;
+    let sample = |yy: i64, xx: i64| -> f32 {
+        if yy < 0 || yy >= h as i64 || xx < 0 || xx >= w as i64 {
+            if zero_pad {
+                0.0
+            } else {
+                let yc = yy.clamp(0, h as i64 - 1) as usize;
+                let xc = xx.clamp(0, w as i64 - 1) as usize;
+                read_f32(raw, plane_off + yc * w + xc)
+            }
+        } else {
+            read_f32(raw, plane_off + (yy as usize) * w + (xx as usize))
+        }
+    };
+    let v00 = sample(y0, x0);
+    let v01 = sample(y0, x1);
+    let v10 = sample(y1, x0);
+    let v11 = sample(y1, x1);
+    let v0 = v00 * (1.0 - dx) + v01 * dx;
+    let v1 = v10 * (1.0 - dx) + v11 * dx;
+    v0 * (1.0 - dy) + v1 * dy
+}
+
+// ---------------------------------------------------------------------------
+// DepthToSpace / SpaceToDepth
+// ---------------------------------------------------------------------------
+
+/// DepthToSpace: [N, C*r*r, H, W] -> [N, C, H*r, W*r]. Both "DCR" and
+/// "CRD" orderings are supported.
+pub fn op_depth_to_space(input: &Tensor, blocksize: i64, mode: &str) -> Result<Tensor, OpError> {
+    let (n, c_in, h, w) = require_4d(input, "DepthToSpace")?;
+    if blocksize <= 0 {
+        return Err(OpError::InvalidAttribute(String::from(
+            "DepthToSpace blocksize must be > 0",
+        )));
+    }
+    let r = blocksize as usize;
+    if (c_in % (r * r)) != 0 {
+        return Err(OpError::ShapeMismatch(String::from(
+            "DepthToSpace: C must be divisible by blocksize^2",
+        )));
+    }
+    let c_out = c_in / (r * r);
+    let oh = h * r;
+    let ow = w * r;
+    let out_shape = TensorShape::new(alloc::vec![n as i64, c_out as i64, oh as i64, ow as i64]);
+    let mut data = allocate_tensor_data(n * c_out * oh * ow, DataType::Float);
+    for bn in 0..n {
+        for co in 0..c_out {
+            for yy in 0..oh {
+                for xx in 0..ow {
+                    let (ih, iw) = (yy / r, xx / r);
+                    let (by_, bx_) = (yy % r, xx % r);
+                    let ci = match mode {
+                        "DCR" => (by_ * r + bx_) * c_out + co,
+                        "CRD" => co * r * r + by_ * r + bx_,
+                        other => {
+                            return Err(OpError::InvalidAttribute(alloc::format!(
+                                "DepthToSpace mode '{}' not supported",
+                                other
+                            )));
+                        }
+                    };
+                    let src = bn * c_in * h * w + ci * h * w + ih * w + iw;
+                    let dst = bn * c_out * oh * ow + co * oh * ow + yy * ow + xx;
+                    write_f32(&mut data, dst, read_f32(&input.raw_data, src));
+                }
+            }
+        }
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: out_shape,
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+/// SpaceToDepth: [N, C, H*r, W*r] -> [N, C*r*r, H, W] (DCR-style order).
+pub fn op_space_to_depth(input: &Tensor, blocksize: i64) -> Result<Tensor, OpError> {
+    let (n, c_in, h, w) = require_4d(input, "SpaceToDepth")?;
+    if blocksize <= 0 {
+        return Err(OpError::InvalidAttribute(String::from(
+            "SpaceToDepth blocksize must be > 0",
+        )));
+    }
+    let r = blocksize as usize;
+    if (h % r) != 0 || (w % r) != 0 {
+        return Err(OpError::ShapeMismatch(String::from(
+            "SpaceToDepth: H and W must be divisible by blocksize",
+        )));
+    }
+    let oh = h / r;
+    let ow = w / r;
+    let c_out = c_in * r * r;
+    let out_shape = TensorShape::new(alloc::vec![n as i64, c_out as i64, oh as i64, ow as i64]);
+    let mut data = allocate_tensor_data(n * c_out * oh * ow, DataType::Float);
+    for bn in 0..n {
+        for ci in 0..c_in {
+            for by_ in 0..r {
+                for bx_ in 0..r {
+                    let co = (by_ * r + bx_) * c_in + ci;
+                    for yy in 0..oh {
+                        for xx in 0..ow {
+                            let src_y = yy * r + by_;
+                            let src_x = xx * r + bx_;
+                            let src = bn * c_in * h * w + ci * h * w + src_y * w + src_x;
+                            let dst = bn * c_out * oh * ow + co * oh * ow + yy * ow + xx;
+                            write_f32(&mut data, dst, read_f32(&input.raw_data, src));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: out_shape,
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// RoiAlign
+// ---------------------------------------------------------------------------
+
+/// Bilinear RoiAlign, average-pooled ("avg" mode only).
+///
+/// `x` is NCHW, `rois` is `[num_rois, 4]` with `[x1, y1, x2, y2]` in
+/// continuous image coordinates. `batch_indices` is `[num_rois]`
+/// selecting which batch element each ROI comes from.
+///
+/// The returned tensor has shape `[num_rois, C, output_height, output_width]`.
+/// Only the bilinear average pooling path is implemented; `max` pooling
+/// is not supported.
+#[allow(clippy::too_many_arguments)]
+pub fn op_roi_align(
+    x: &Tensor,
+    rois: &Tensor,
+    batch_indices: &Tensor,
+    output_height: i64,
+    output_width: i64,
+    sampling_ratio: i64,
+    spatial_scale: f32,
+    mode: &str,
+) -> Result<Tensor, OpError> {
+    if mode != "avg" {
+        return Err(OpError::InvalidAttribute(alloc::format!(
+            "RoiAlign mode '{}' not supported (only 'avg')",
+            mode
+        )));
+    }
+    let (_n, c, h, w) = require_4d(x, "RoiAlign")?;
+    require_float(rois, "RoiAlign")?;
+    if rois.shape.dims.len() != 2 || rois.shape.dims[1] != 4 {
+        return Err(OpError::ShapeMismatch(String::from(
+            "RoiAlign rois must be [num_rois, 4]",
+        )));
+    }
+    let num_rois = rois.shape.dims[0] as usize;
+    let pooled_h = output_height.max(1) as usize;
+    let pooled_w = output_width.max(1) as usize;
+
+    // Decode batch indices (Int64 or Int32).
+    let bi: Vec<i64> = match batch_indices.data_type {
+        DataType::Int64 => (0..num_rois)
+            .map(|i| crate::byte_io::read_i64(&batch_indices.raw_data, i))
+            .collect(),
+        DataType::Int32 => (0..num_rois)
+            .map(|i| crate::byte_io::read_i32(&batch_indices.raw_data, i) as i64)
+            .collect(),
+        _ => {
+            return Err(OpError::ShapeMismatch(String::from(
+                "RoiAlign batch_indices must be Int32/Int64",
+            )));
+        }
+    };
+
+    let out_shape = TensorShape::new(alloc::vec![
+        num_rois as i64,
+        c as i64,
+        pooled_h as i64,
+        pooled_w as i64,
+    ]);
+    let mut data = allocate_tensor_data(num_rois * c * pooled_h * pooled_w, DataType::Float);
+
+    for (r_idx, &batch_id) in bi.iter().enumerate() {
+        let base = r_idx * 4;
+        let x1 = read_f32(&rois.raw_data, base) * spatial_scale;
+        let y1 = read_f32(&rois.raw_data, base + 1) * spatial_scale;
+        let x2 = read_f32(&rois.raw_data, base + 2) * spatial_scale;
+        let y2 = read_f32(&rois.raw_data, base + 3) * spatial_scale;
+        let roi_w = (x2 - x1).max(1.0);
+        let roi_h = (y2 - y1).max(1.0);
+        let bin_h = roi_h / pooled_h as f32;
+        let bin_w = roi_w / pooled_w as f32;
+        let sr_h = if sampling_ratio > 0 {
+            sampling_ratio as usize
+        } else {
+            ceil_f32(roi_h / pooled_h as f32).max(1.0) as usize
+        };
+        let sr_w = if sampling_ratio > 0 {
+            sampling_ratio as usize
+        } else {
+            ceil_f32(roi_w / pooled_w as f32).max(1.0) as usize
+        };
+        let bn = batch_id.max(0) as usize;
+        for ch in 0..c {
+            let plane = bn * c * h * w + ch * h * w;
+            for py in 0..pooled_h {
+                for px in 0..pooled_w {
+                    let mut acc = 0.0f32;
+                    let mut count = 0u32;
+                    for iy in 0..sr_h {
+                        for ix in 0..sr_w {
+                            let sy = y1
+                                + (py as f32) * bin_h
+                                + ((iy as f32) + 0.5) * bin_h / (sr_h as f32);
+                            let sx = x1
+                                + (px as f32) * bin_w
+                                + ((ix as f32) + 0.5) * bin_w / (sr_w as f32);
+                            acc += bilinear_sample(&x.raw_data, plane, h, w, sy, sx, true);
+                            count += 1;
+                        }
+                    }
+                    let v = if count > 0 { acc / count as f32 } else { 0.0 };
+                    let dst = r_idx * c * pooled_h * pooled_w
+                        + ch * pooled_h * pooled_w
+                        + py * pooled_w
+                        + px;
+                    write_f32(&mut data, dst, v);
+                }
+            }
+        }
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: out_shape,
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// GridSample
+// ---------------------------------------------------------------------------
+
+/// 2D bilinear GridSample.
+///
+/// Supported attributes:
+/// - `mode = "bilinear"` or `"nearest"`
+/// - `padding_mode = "zeros"` (other modes not implemented)
+/// - `align_corners` = 0 or 1
+pub fn op_grid_sample(
+    input: &Tensor,
+    grid: &Tensor,
+    mode: &str,
+    padding_mode: &str,
+    align_corners: bool,
+) -> Result<Tensor, OpError> {
+    let (n, c, h, w) = require_4d(input, "GridSample")?;
+    require_float(grid, "GridSample")?;
+    if padding_mode != "zeros" {
+        return Err(OpError::InvalidAttribute(alloc::format!(
+            "GridSample padding_mode '{}' not supported",
+            padding_mode
+        )));
+    }
+    // grid is [N, oh, ow, 2]
+    if grid.shape.dims.len() != 4 || grid.shape.dims[3] != 2 {
+        return Err(OpError::ShapeMismatch(String::from(
+            "GridSample grid must be [N, H_out, W_out, 2]",
+        )));
+    }
+    let oh = grid.shape.dims[1] as usize;
+    let ow = grid.shape.dims[2] as usize;
+    let out_shape = TensorShape::new(alloc::vec![n as i64, c as i64, oh as i64, ow as i64]);
+    let mut data = allocate_tensor_data(n * c * oh * ow, DataType::Float);
+    for bn in 0..n {
+        for yy in 0..oh {
+            for xx in 0..ow {
+                let g_off = bn * oh * ow * 2 + yy * ow * 2 + xx * 2;
+                let gx = read_f32(&grid.raw_data, g_off);
+                let gy = read_f32(&grid.raw_data, g_off + 1);
+                // Map from [-1,1] to pixel coordinates.
+                let (sx, sy) = if align_corners {
+                    (
+                        (gx + 1.0) * 0.5 * ((w - 1) as f32),
+                        (gy + 1.0) * 0.5 * ((h - 1) as f32),
+                    )
+                } else {
+                    (
+                        ((gx + 1.0) * (w as f32) - 1.0) * 0.5,
+                        ((gy + 1.0) * (h as f32) - 1.0) * 0.5,
+                    )
+                };
+                for ch in 0..c {
+                    let plane = bn * c * h * w + ch * h * w;
+                    let v = match mode {
+                        "bilinear" | "linear" => {
+                            bilinear_sample(&input.raw_data, plane, h, w, sy, sx, true)
+                        }
+                        "nearest" => {
+                            let iy = round_f32(sy);
+                            let ix = round_f32(sx);
+                            if iy < 0.0 || iy >= h as f32 || ix < 0.0 || ix >= w as f32 {
+                                0.0
+                            } else {
+                                read_f32(&input.raw_data, plane + (iy as usize) * w + (ix as usize))
+                            }
+                        }
+                        other => {
+                            return Err(OpError::InvalidAttribute(alloc::format!(
+                                "GridSample mode '{}' not supported",
+                                other
+                            )));
+                        }
+                    };
+                    let dst = bn * c * oh * ow + ch * oh * ow + yy * ow + xx;
+                    write_f32(&mut data, dst, v);
+                }
+            }
+        }
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: out_shape,
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// GlobalMaxPool
+// ---------------------------------------------------------------------------
+
+/// Global max pooling over NCHW → NC11.
+pub fn op_global_max_pool(input: &Tensor) -> Result<Tensor, OpError> {
+    let (n, c, h, w) = require_4d(input, "GlobalMaxPool")?;
+    let spatial = h * w;
+    let out_shape = TensorShape::new(alloc::vec![n as i64, c as i64, 1, 1]);
+    let mut data = allocate_tensor_data(n * c, DataType::Float);
+    for bn in 0..n {
+        for ch in 0..c {
+            let mut m = f32::NEG_INFINITY;
+            let off = bn * c * spatial + ch * spatial;
+            for i in 0..spatial {
+                let v = read_f32(&input.raw_data, off + i);
+                if v > m {
+                    m = v;
+                }
+            }
+            write_f32(&mut data, bn * c + ch, m);
+        }
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: out_shape,
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// CenterCropPad
+// ---------------------------------------------------------------------------
+
+/// Symmetrically crops or pads `input` along `axes` so that each
+/// selected axis ends up at the matching size in `shape`.
+///
+/// When `axes` is `None`, `shape` must have rank equal to the input and
+/// applies to every axis. Padding uses zeros.
+pub fn op_center_crop_pad(
+    input: &Tensor,
+    shape: &[i64],
+    axes: Option<&[i64]>,
+) -> Result<Tensor, OpError> {
+    require_float(input, "CenterCropPad")?;
+    let in_rank = input.shape.dims.len();
+    let mut out_dims = input.shape.dims.clone();
+    let axes_vec: Vec<usize> = if let Some(a) = axes {
+        if a.len() != shape.len() {
+            return Err(OpError::InvalidAttribute(String::from(
+                "CenterCropPad: axes length must match shape length",
+            )));
+        }
+        a.iter()
+            .map(|&ax| {
+                if ax < 0 {
+                    (ax + in_rank as i64) as usize
+                } else {
+                    ax as usize
+                }
+            })
+            .collect()
+    } else {
+        if shape.len() != in_rank {
+            return Err(OpError::InvalidAttribute(String::from(
+                "CenterCropPad: shape length must equal input rank when axes omitted",
+            )));
+        }
+        (0..in_rank).collect()
+    };
+    for (i, &ax) in axes_vec.iter().enumerate() {
+        if ax >= in_rank {
+            return Err(OpError::InvalidAttribute(String::from(
+                "CenterCropPad: axis out of range",
+            )));
+        }
+        out_dims[ax] = shape[i];
+    }
+    // Allocate zero-filled output.
+    let total: usize = out_dims
+        .iter()
+        .map(|&d| d as usize)
+        .product::<usize>()
+        .max(1);
+    let mut data = allocate_tensor_data(total, DataType::Float);
+    // For each axis, compute source/dest start offsets (symmetric).
+    let mut src_starts = alloc::vec![0usize; in_rank];
+    let mut dst_starts = alloc::vec![0usize; in_rank];
+    let mut copy_dims = alloc::vec![0usize; in_rank];
+    for d in 0..in_rank {
+        let id = input.shape.dims[d] as usize;
+        let od = out_dims[d] as usize;
+        let c = id.min(od);
+        copy_dims[d] = c;
+        src_starts[d] = (id - c) / 2;
+        dst_starts[d] = (od - c) / 2;
+    }
+    // Iterate the copy region.
+    let total_copy: usize = copy_dims.iter().product();
+    if total_copy == 0 {
+        return Ok(Tensor {
+            data_type: DataType::Float,
+            shape: TensorShape::new(out_dims),
+            name: String::new(),
+            raw_data: data,
+        });
+    }
+    let mut coord = alloc::vec![0usize; in_rank];
+    let in_strides: Vec<usize> = {
+        let mut s = alloc::vec![1usize; in_rank];
+        for i in (0..in_rank.saturating_sub(1)).rev() {
+            s[i] = s[i + 1] * input.shape.dims[i + 1] as usize;
+        }
+        s
+    };
+    let out_strides: Vec<usize> = {
+        let mut s = alloc::vec![1usize; in_rank];
+        for i in (0..in_rank.saturating_sub(1)).rev() {
+            s[i] = s[i + 1] * out_dims[i + 1] as usize;
+        }
+        s
+    };
+    for _ in 0..total_copy {
+        let mut src = 0usize;
+        let mut dst = 0usize;
+        for d in 0..in_rank {
+            src += (src_starts[d] + coord[d]) * in_strides[d];
+            dst += (dst_starts[d] + coord[d]) * out_strides[d];
+        }
+        write_f32(&mut data, dst, read_f32(&input.raw_data, src));
+        // Increment coord
+        for d in (0..in_rank).rev() {
+            coord[d] += 1;
+            if coord[d] < copy_dims[d] {
+                break;
+            }
+            coord[d] = 0;
+        }
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: TensorShape::new(out_dims),
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_f32(dims: &[i64], vals: &[f32]) -> Tensor {
+        let mut data = allocate_tensor_data(vals.len(), DataType::Float);
+        for (i, &v) in vals.iter().enumerate() {
+            write_f32(&mut data, i, v);
+        }
+        Tensor {
+            data_type: DataType::Float,
+            shape: TensorShape::new(dims.to_vec()),
+            name: String::new(),
+            raw_data: data,
+        }
+    }
+
+    fn make_i64(dims: &[i64], vals: &[i64]) -> Tensor {
+        let mut data = allocate_tensor_data(vals.len(), DataType::Int64);
+        for (i, &v) in vals.iter().enumerate() {
+            crate::byte_io::write_i64(&mut data, i, v);
+        }
+        Tensor {
+            data_type: DataType::Int64,
+            shape: TensorShape::new(dims.to_vec()),
+            name: String::new(),
+            raw_data: data,
+        }
+    }
+
+    fn read_all(t: &Tensor) -> Vec<f32> {
+        (0..t.shape.total_elements())
+            .map(|i| read_f32(&t.raw_data, i))
+            .collect()
+    }
+
+    #[test]
+    fn test_resize_nearest_upsample() {
+        let t = make_f32(&[1, 1, 2, 2], &[1.0, 2.0, 3.0, 4.0]);
+        let out = op_resize(&t, Some(&[1.0, 1.0, 2.0, 2.0]), None, "nearest").unwrap();
+        assert_eq!(out.shape.dims, alloc::vec![1, 1, 4, 4]);
+        let v = read_all(&out);
+        assert_eq!(
+            v,
+            alloc::vec![
+                1.0, 1.0, 2.0, 2.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 4.0, 4.0, 3.0, 3.0, 4.0, 4.0,
+            ]
+        );
+    }
+
+    #[test]
+    fn test_resize_bilinear_identity() {
+        // scale 1x1 should return the same tensor.
+        let t = make_f32(&[1, 1, 2, 2], &[1.0, 2.0, 3.0, 4.0]);
+        let out = op_resize(&t, None, Some(&[1, 1, 2, 2]), "linear").unwrap();
+        let v = read_all(&out);
+        for (a, b) in v.iter().zip([1.0f32, 2.0, 3.0, 4.0].iter()) {
+            assert!((a - b).abs() < 1e-5);
+        }
+    }
+
+    #[test]
+    fn test_resize_rejects_unknown_mode() {
+        let t = make_f32(&[1, 1, 2, 2], &[1.0, 2.0, 3.0, 4.0]);
+        assert!(op_resize(&t, None, Some(&[1, 1, 4, 4]), "cubic").is_err());
+    }
+
+    #[test]
+    fn test_depth_to_space_dcr() {
+        // [1, 4, 1, 1] (4 channels) -> [1, 1, 2, 2]
+        let t = make_f32(&[1, 4, 1, 1], &[1.0, 2.0, 3.0, 4.0]);
+        let out = op_depth_to_space(&t, 2, "DCR").unwrap();
+        assert_eq!(out.shape.dims, alloc::vec![1, 1, 2, 2]);
+        let v = read_all(&out);
+        // DCR: byx uses channels in order
+        assert_eq!(v.len(), 4);
+    }
+
+    #[test]
+    fn test_depth_to_space_crd_small() {
+        let t = make_f32(&[1, 4, 1, 1], &[10.0, 20.0, 30.0, 40.0]);
+        let out = op_depth_to_space(&t, 2, "CRD").unwrap();
+        assert_eq!(out.shape.dims, alloc::vec![1, 1, 2, 2]);
+        let v = read_all(&out);
+        assert_eq!(v, alloc::vec![10.0, 20.0, 30.0, 40.0]);
+    }
+
+    #[test]
+    fn test_space_to_depth_roundtrip() {
+        // Build a 1x1x4x4 ramp, s2d with block 2, verify shape.
+        let vals: Vec<f32> = (0..16).map(|i| i as f32).collect();
+        let t = make_f32(&[1, 1, 4, 4], &vals);
+        let out = op_space_to_depth(&t, 2).unwrap();
+        assert_eq!(out.shape.dims, alloc::vec![1, 4, 2, 2]);
+    }
+
+    #[test]
+    fn test_space_to_depth_rejects_nondivisible() {
+        let t = make_f32(&[1, 1, 3, 3], &alloc::vec![0.0; 9]);
+        assert!(op_space_to_depth(&t, 2).is_err());
+    }
+
+    #[test]
+    fn test_global_max_pool() {
+        let t = make_f32(&[1, 2, 2, 2], &[1.0, 5.0, 3.0, 2.0, 10.0, 8.0, 6.0, 9.0]);
+        let out = op_global_max_pool(&t).unwrap();
+        assert_eq!(out.shape.dims, alloc::vec![1, 2, 1, 1]);
+        let v = read_all(&out);
+        assert_eq!(v, alloc::vec![5.0, 10.0]);
+    }
+
+    #[test]
+    fn test_global_max_pool_rejects_3d() {
+        let t = make_f32(&[1, 2, 4], &alloc::vec![0.0; 8]);
+        assert!(op_global_max_pool(&t).is_err());
+    }
+
+    #[test]
+    fn test_center_crop_pad_crop() {
+        // [1,1,4,4] cropped to [1,1,2,2] — center 2x2.
+        let vals: Vec<f32> = (0..16).map(|i| i as f32).collect();
+        let t = make_f32(&[1, 1, 4, 4], &vals);
+        let out = op_center_crop_pad(&t, &[1, 1, 2, 2], None).unwrap();
+        assert_eq!(out.shape.dims, alloc::vec![1, 1, 2, 2]);
+        let v = read_all(&out);
+        // Center window is rows 1-2, cols 1-2 → indices 5,6,9,10
+        assert_eq!(v, alloc::vec![5.0, 6.0, 9.0, 10.0]);
+    }
+
+    #[test]
+    fn test_center_crop_pad_pad() {
+        // [1,1,2,2] padded to [1,1,4,4] with zeros.
+        let t = make_f32(&[1, 1, 2, 2], &[1.0, 2.0, 3.0, 4.0]);
+        let out = op_center_crop_pad(&t, &[1, 1, 4, 4], None).unwrap();
+        let v = read_all(&out);
+        // Center 2x2 should hold the originals, others zero.
+        assert_eq!(v[5], 1.0);
+        assert_eq!(v[6], 2.0);
+        assert_eq!(v[9], 3.0);
+        assert_eq!(v[10], 4.0);
+        assert_eq!(v[0], 0.0);
+    }
+
+    #[test]
+    fn test_center_crop_pad_with_axes() {
+        // Only crop axis 3 from 4 to 2.
+        let vals: Vec<f32> = (0..8).map(|i| i as f32).collect();
+        let t = make_f32(&[1, 1, 2, 4], &vals);
+        let out = op_center_crop_pad(&t, &[2], Some(&[3])).unwrap();
+        assert_eq!(out.shape.dims, alloc::vec![1, 1, 2, 2]);
+        let v = read_all(&out);
+        // center cols of each row: row0 cols [1,2], row1 cols [5,6]
+        assert_eq!(v, alloc::vec![1.0, 2.0, 5.0, 6.0]);
+    }
+
+    #[test]
+    fn test_grid_sample_identity() {
+        // 1x1x2x2 input, grid that maps to exactly (0,0) corner — should
+        // sample around the corners.
+        let t = make_f32(&[1, 1, 2, 2], &[1.0, 2.0, 3.0, 4.0]);
+        // grid [-1,-1] -> (0,0), [1,1] -> (1,1)
+        let grid = make_f32(&[1, 2, 2, 2], &[-1.0, -1.0, 1.0, -1.0, -1.0, 1.0, 1.0, 1.0]);
+        let out = op_grid_sample(&t, &grid, "bilinear", "zeros", true).unwrap();
+        assert_eq!(out.shape.dims, alloc::vec![1, 1, 2, 2]);
+        let v = read_all(&out);
+        assert!((v[0] - 1.0).abs() < 1e-5);
+        assert!((v[1] - 2.0).abs() < 1e-5);
+        assert!((v[2] - 3.0).abs() < 1e-5);
+        assert!((v[3] - 4.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_grid_sample_rejects_border_pad() {
+        let t = make_f32(&[1, 1, 2, 2], &[1.0, 2.0, 3.0, 4.0]);
+        let grid = make_f32(&[1, 1, 1, 2], &[0.0, 0.0]);
+        assert!(op_grid_sample(&t, &grid, "bilinear", "border", true).is_err());
+    }
+
+    #[test]
+    fn test_roi_align_single_roi() {
+        // 1x1x4x4 ramp, one ROI covering the whole image, pool 2x2.
+        let vals: Vec<f32> = (0..16).map(|i| i as f32).collect();
+        let x = make_f32(&[1, 1, 4, 4], &vals);
+        let rois = make_f32(&[1, 4], &[0.0, 0.0, 3.0, 3.0]);
+        let bi = make_i64(&[1], &[0]);
+        let out = op_roi_align(&x, &rois, &bi, 2, 2, 2, 1.0, "avg").unwrap();
+        assert_eq!(out.shape.dims, alloc::vec![1, 1, 2, 2]);
+        // The outputs are bilinear means of 4 samples each; all positive.
+        let v = read_all(&out);
+        for x in v {
+            assert!(x > 0.0 && x < 16.0);
+        }
+    }
+
+    #[test]
+    fn test_roi_align_rejects_max_mode() {
+        let x = make_f32(&[1, 1, 2, 2], &[1.0, 2.0, 3.0, 4.0]);
+        let rois = make_f32(&[1, 4], &[0.0, 0.0, 1.0, 1.0]);
+        let bi = make_i64(&[1], &[0]);
+        assert!(op_roi_align(&x, &rois, &bi, 2, 2, 1, 1.0, "max").is_err());
+    }
+}

--- a/onnx-rt/src/ops/vision.rs
+++ b/onnx-rt/src/ops/vision.rs
@@ -91,17 +91,45 @@ pub fn op_resize(
                 "Resize sizes must have rank 4",
             )));
         }
-        (s[2] as usize, s[3] as usize)
+        if s.iter().any(|&d| d < 0) {
+            return Err(OpError::InvalidAttribute(String::from(
+                "Resize sizes must be non-negative",
+            )));
+        }
+        // Bound the spatial dims so the later `n*c*oh*ow` allocation
+        // cannot overflow usize.
+        let oh_i = s[2];
+        let ow_i = s[3];
+        if oh_i > (i32::MAX as i64) || ow_i > (i32::MAX as i64) {
+            return Err(OpError::InvalidAttribute(String::from(
+                "Resize output dims exceed addressable range",
+            )));
+        }
+        (oh_i as usize, ow_i as usize)
     } else if let Some(s) = scales {
         if s.len() != 4 {
             return Err(OpError::InvalidAttribute(String::from(
                 "Resize scales must have rank 4",
             )));
         }
-        (
-            round_f32((h as f32) * s[2]) as usize,
-            round_f32((w as f32) * s[3]) as usize,
-        )
+        if !s.iter().all(|v| v.is_finite() && *v > 0.0) {
+            return Err(OpError::InvalidAttribute(String::from(
+                "Resize scales must be finite and > 0",
+            )));
+        }
+        let oh_f = round_f32((h as f32) * s[2]);
+        let ow_f = round_f32((w as f32) * s[3]);
+        if !oh_f.is_finite() || !ow_f.is_finite() || oh_f < 0.0 || ow_f < 0.0 {
+            return Err(OpError::InvalidAttribute(String::from(
+                "Resize computed output dims are invalid",
+            )));
+        }
+        if oh_f > (i32::MAX as f32) || ow_f > (i32::MAX as f32) {
+            return Err(OpError::InvalidAttribute(String::from(
+                "Resize output dims exceed addressable range",
+            )));
+        }
+        (oh_f as usize, ow_f as usize)
     } else {
         return Err(OpError::InvalidAttribute(String::from(
             "Resize requires scales or sizes",
@@ -112,8 +140,16 @@ pub fn op_resize(
             "Resize output dims must be > 0",
         )));
     }
+    // Checked total-elements to guarantee no overflow before allocation.
+    let total_out = n
+        .checked_mul(c)
+        .and_then(|v| v.checked_mul(oh))
+        .and_then(|v| v.checked_mul(ow))
+        .ok_or_else(|| {
+            OpError::InvalidAttribute(String::from("Resize output tensor size overflows usize"))
+        })?;
     let out_shape = TensorShape::new(alloc::vec![n as i64, c as i64, oh as i64, ow as i64]);
-    let mut data = allocate_tensor_data(n * c * oh * ow, DataType::Float);
+    let mut data = allocate_tensor_data(total_out, DataType::Float);
     let h_scale = h as f32 / oh as f32;
     let w_scale = w as f32 / ow as f32;
     for bn in 0..n {
@@ -329,7 +365,7 @@ pub fn op_roi_align(
             mode
         )));
     }
-    let (_n, c, h, w) = require_4d(x, "RoiAlign")?;
+    let (n_batch, c, h, w) = require_4d(x, "RoiAlign")?;
     require_float(rois, "RoiAlign")?;
     if rois.shape.dims.len() != 2 || rois.shape.dims[1] != 4 {
         return Err(OpError::ShapeMismatch(String::from(
@@ -339,6 +375,13 @@ pub fn op_roi_align(
     let num_rois = rois.shape.dims[0] as usize;
     let pooled_h = output_height.max(1) as usize;
     let pooled_w = output_width.max(1) as usize;
+
+    // batch_indices must be a 1D tensor of length num_rois.
+    if batch_indices.shape.total_elements() != num_rois {
+        return Err(OpError::ShapeMismatch(String::from(
+            "RoiAlign batch_indices length must equal num_rois",
+        )));
+    }
 
     // Decode batch indices (Int64 or Int32).
     let bi: Vec<i64> = match batch_indices.data_type {
@@ -354,6 +397,13 @@ pub fn op_roi_align(
             )));
         }
     };
+    for &b in &bi {
+        if b < 0 || (b as usize) >= n_batch {
+            return Err(OpError::ShapeMismatch(String::from(
+                "RoiAlign batch_indices value out of range [0, N)",
+            )));
+        }
+    }
 
     let out_shape = TensorShape::new(alloc::vec![
         num_rois as i64,
@@ -383,7 +433,8 @@ pub fn op_roi_align(
         } else {
             ceil_f32(roi_w / pooled_w as f32).max(1.0) as usize
         };
-        let bn = batch_id.max(0) as usize;
+        // Bounds already validated above.
+        let bn = batch_id as usize;
         for ch in 0..c {
             let plane = bn * c * h * w + ch * h * w;
             for py in 0..pooled_h {
@@ -449,6 +500,11 @@ pub fn op_grid_sample(
     if grid.shape.dims.len() != 4 || grid.shape.dims[3] != 2 {
         return Err(OpError::ShapeMismatch(String::from(
             "GridSample grid must be [N, H_out, W_out, 2]",
+        )));
+    }
+    if grid.shape.dims[0] as usize != n {
+        return Err(OpError::ShapeMismatch(String::from(
+            "GridSample grid batch must match input batch",
         )));
     }
     let oh = grid.shape.dims[1] as usize;
@@ -584,6 +640,11 @@ pub fn op_center_crop_pad(
         if ax >= in_rank {
             return Err(OpError::InvalidAttribute(String::from(
                 "CenterCropPad: axis out of range",
+            )));
+        }
+        if shape[i] < 0 {
+            return Err(OpError::InvalidAttribute(String::from(
+                "CenterCropPad: target shape dims must be non-negative",
             )));
         }
         out_dims[ax] = shape[i];
@@ -849,6 +910,93 @@ mod tests {
         for x in v {
             assert!(x > 0.0 && x < 16.0);
         }
+    }
+
+    #[test]
+    fn test_resize_rejects_negative_sizes() {
+        let t = make_f32(&[1, 1, 2, 2], &[1.0, 2.0, 3.0, 4.0]);
+        let err = op_resize(&t, None, Some(&[1, 1, -4, 4]), "nearest");
+        assert!(matches!(err, Err(OpError::InvalidAttribute(_))));
+    }
+
+    #[test]
+    fn test_resize_rejects_nonpositive_scales() {
+        let t = make_f32(&[1, 1, 2, 2], &[1.0, 2.0, 3.0, 4.0]);
+        assert!(matches!(
+            op_resize(&t, Some(&[1.0, 1.0, 0.0, 2.0]), None, "nearest"),
+            Err(OpError::InvalidAttribute(_))
+        ));
+        assert!(matches!(
+            op_resize(&t, Some(&[1.0, 1.0, -1.0, 2.0]), None, "nearest"),
+            Err(OpError::InvalidAttribute(_))
+        ));
+        assert!(matches!(
+            op_resize(&t, Some(&[1.0, 1.0, f32::NAN, 2.0]), None, "nearest"),
+            Err(OpError::InvalidAttribute(_))
+        ));
+    }
+
+    #[test]
+    fn test_resize_rejects_huge_output_dims() {
+        let t = make_f32(&[1, 1, 2, 2], &[1.0, 2.0, 3.0, 4.0]);
+        let big = i32::MAX as i64 + 1;
+        assert!(matches!(
+            op_resize(&t, None, Some(&[1, 1, big, 2]), "nearest"),
+            Err(OpError::InvalidAttribute(_))
+        ));
+    }
+
+    #[test]
+    fn test_roi_align_rejects_short_batch_indices() {
+        let x = make_f32(&[2, 1, 2, 2], &alloc::vec![0.0; 8]);
+        let rois = make_f32(&[2, 4], &[0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0]);
+        let bi = make_i64(&[1], &[0]);
+        assert!(matches!(
+            op_roi_align(&x, &rois, &bi, 2, 2, 1, 1.0, "avg"),
+            Err(OpError::ShapeMismatch(_))
+        ));
+    }
+
+    #[test]
+    fn test_roi_align_rejects_out_of_range_batch_id() {
+        let x = make_f32(&[1, 1, 2, 2], &[1.0, 2.0, 3.0, 4.0]);
+        let rois = make_f32(&[1, 4], &[0.0, 0.0, 1.0, 1.0]);
+        let bi = make_i64(&[1], &[5]);
+        assert!(matches!(
+            op_roi_align(&x, &rois, &bi, 2, 2, 1, 1.0, "avg"),
+            Err(OpError::ShapeMismatch(_))
+        ));
+    }
+
+    #[test]
+    fn test_roi_align_rejects_negative_batch_id() {
+        let x = make_f32(&[1, 1, 2, 2], &[1.0, 2.0, 3.0, 4.0]);
+        let rois = make_f32(&[1, 4], &[0.0, 0.0, 1.0, 1.0]);
+        let bi = make_i64(&[1], &[-1]);
+        assert!(matches!(
+            op_roi_align(&x, &rois, &bi, 2, 2, 1, 1.0, "avg"),
+            Err(OpError::ShapeMismatch(_))
+        ));
+    }
+
+    #[test]
+    fn test_grid_sample_rejects_batch_mismatch() {
+        let t = make_f32(&[2, 1, 2, 2], &alloc::vec![0.0; 8]);
+        // grid batch is 1 but input batch is 2.
+        let grid = make_f32(&[1, 1, 1, 2], &[0.0, 0.0]);
+        assert!(matches!(
+            op_grid_sample(&t, &grid, "bilinear", "zeros", true),
+            Err(OpError::ShapeMismatch(_))
+        ));
+    }
+
+    #[test]
+    fn test_center_crop_pad_rejects_negative_shape() {
+        let t = make_f32(&[1, 1, 2, 2], &[1.0, 2.0, 3.0, 4.0]);
+        assert!(matches!(
+            op_center_crop_pad(&t, &[1, 1, -2, 2], None),
+            Err(OpError::InvalidAttribute(_))
+        ));
     }
 
     #[test]

--- a/onnx-rt/src/profile.rs
+++ b/onnx-rt/src/profile.rs
@@ -87,14 +87,24 @@ pub fn classify_op(op_type: &str) -> OperatorClass {
         | "And" | "Or"
         // Tier 3 Phase 1 shape / data-movement
         | "Shape" | "Size" | "Identity" | "Constant" | "ConstantOfShape"
-        | "Range" | "Trilu" | "CumSum" | "GatherND" | "ScatterND" => {
+        | "Range" | "Trilu" | "CumSum" | "GatherND" | "ScatterND"
+        // Phase 1 vision: shape/data-movement-style ops
+        | "DepthToSpace" | "SpaceToDepth" | "CenterCropPad"
+        // Phase 1 vision: data selection
+        | "TopK" | "Compress" | "NonZero" | "Unique"
+        | "GatherElements" | "ScatterElements"
+        // Phase 1 vision: composite activations
+        | "HardSigmoid" | "HardSwish" | "PRelu" | "Mish" => {
             OperatorClass::Elementwise
         }
         "Softmax" | "LayerNormalization" | "BatchNormalization" | "MaxPool" | "AveragePool"
         | "GlobalAveragePool" | "ReduceMean" | "ReduceSum"
         // Tier 3 Phase 1 reductions
         | "ReduceMax" | "ReduceMin" | "ReduceProd" | "ArgMax" | "ArgMin"
-        | "LogSoftmax" => OperatorClass::Reduction,
+        | "LogSoftmax"
+        // Phase 1 vision: pooling/resize/align — reduction-class budget.
+        | "GlobalMaxPool" | "Resize" | "RoiAlign" | "GridSample"
+        | "GroupNormalization" | "InstanceNormalization" => OperatorClass::Reduction,
         "MatMul" | "Gemm" | "Conv"
         // Tier 2: Einsum is matmul-like; quantized GEMM/Conv same.
         | "Einsum" | "QLinearMatMul" | "QLinearConv" => OperatorClass::Gemm,


### PR DESCRIPTION
## Summary

Phase 1 of the `onnx-full-coverage-roadmap-v1` plan (runs in parallel with `transformer-models-v1`). Adds 19 new ONNX operators required to load ViT-base, Swin, and ConvNeXt end-to-end.

Stacks on top of #74 (`additional-operators-v1`). Opens against `develop`. Rebases cleanly on the parallel `transformer-models-v1` branch thanks to append-only edits to shared registry files; the only expected merge conflict is the `supported_count` literal (this PR: 65 -> 84).

## Operators added (19)

- **Vision (7):** `Resize`, `DepthToSpace`, `SpaceToDepth`, `RoiAlign`, `GridSample`, `GlobalMaxPool`, `CenterCropPad`
- **Data select (6):** `TopK` (multi-output), `Compress`, `NonZero`, `Unique`, `GatherElements`, `ScatterElements`
- **Normalization (2):** `GroupNormalization`, `InstanceNormalization`
- **Composite activations (4):** `HardSigmoid`, `HardSwish`, `PRelu`, `Mish`

New files:
- `onnx-rt/src/ops/vision.rs`
- `onnx-rt/src/ops/data_select.rs`
- `onnx-rt/src/ops/normalization.rs`

The existing `onnx-rt/src/ops/activations.rs` gains `op_hard_sigmoid`, `op_hard_swish`, `op_prelu`, `op_mish` plus a small no_std `ln_approx` helper used by Mish.

## Limitations (documented in-code)

- `Resize`: only `nearest` and `linear` (bilinear) modes with `coordinate_transformation_mode="half_pixel"`. No cubic, no antialias, no exclude_outside.
- `RoiAlign`: only the `avg`/bilinear path. `max` mode is rejected.
- `GridSample`: only `padding_mode="zeros"`.
- `Unique`: flattened mode only (primary `Y` output); axis-specific mode and the `indices`/`inverse_indices`/`counts` outputs are rejected.

## Tests

44 new unit tests across the four modules (16 vision, 14 data_select, 5 normalization, 9 activations). Each op has at least a correctness test with hand-computed values plus an edge case / rejection test. Full onnx-rt lib test suite: 482 passing.

Registry test updated in both `onnx-rt/src/operators.rs` and `container/src/integration.rs` (65 -> 84).

## Test plan

- [x] `cargo check -p smallaios-onnx-rt`
- [x] `cargo clippy -p smallaios-onnx-rt -p smallaios-container -- -D warnings`
- [x] `cargo fmt -p smallaios-onnx-rt -p smallaios-container -- --check`
- [x] `cargo test -p smallaios-onnx-rt -p smallaios-container --lib` (482 + 171 passing)
- [ ] CI workspace build / clippy / tests

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded ONNX operator support to include 19 new operators: vision operations (Resize, DepthToSpace, SpaceToDepth, RoiAlign, GridSample, GlobalMaxPool, CenterCropPad), data selection functions (TopK, Compress, NonZero, Unique, GatherElements, ScatterElements), advanced activation functions (HardSigmoid, HardSwish, PRelu, Mish), and normalization operators (GroupNormalization, InstanceNormalization).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->