### PR TITLE
fix(onnx-rt): support tensor-valued AttributeProto for Constant ops

### DIFF
--- a/onnx-rt/src/executor.rs
+++ b/onnx-rt/src/executor.rs
@@ -226,6 +226,15 @@ fn get_attr_ints<'a>(attrs: &'a [AttributeProto], name: &str) -> Option<&'a [i64
         .map(|a| a.ints.as_slice())
 }
 
+/// Extracts a tensor attribute by name. Returns `None` if absent or if the
+/// attribute's declared type is not `Tensor`.
+fn get_attr_tensor<'a>(attrs: &'a [AttributeProto], name: &str) -> Option<&'a TensorProto> {
+    attrs
+        .iter()
+        .find(|a| a.name == name && a.attr_type == AttributeType::Tensor)
+        .and_then(|a| a.t.as_deref())
+}
+
 // ---------------------------------------------------------------------------
 // Operator dispatch
 // ---------------------------------------------------------------------------
@@ -1210,15 +1219,21 @@ fn dispatch_shape_data(
         OpKind::Size => ops::shape_data::op_size(require_input(inputs, 0, "Size")?),
         OpKind::Identity => ops::shape_data::op_identity(require_input(inputs, 0, "Identity")?),
         OpKind::Constant => {
-            // ONNX Constant carries its payload in a 'value' attribute
-            // (TensorProto). SmallAIOS's AttributeProto does not model
-            // tensor attributes yet, so at runtime we fall back to
-            // either an explicit input tensor (treating Constant as an
-            // Identity pass-through of a graph initializer) or a single
-            // float / int scalar decoded from the float / int attribute
-            // fields. Scalar attributes produce a true 0-D tensor.
+            // ONNX Constant most commonly carries its payload in a
+            // 'value' attribute of type TensorProto. We also accept an
+            // explicit input tensor (initializer pass-through) or the
+            // scalar 'value_float' / 'value_int' variants emitted by
+            // some exporters. Scalar attributes produce a true 0-D
+            // tensor.
             if let Some(t) = optional_input(inputs, 0) {
                 return ops::shape_data::op_identity(t);
+            }
+            if let Some(proto) = get_attr_tensor(attrs, "value") {
+                return tensor_from_proto(proto).ok_or_else(|| {
+                    OpError::InvalidAttribute(String::from(
+                        "Constant 'value' tensor has unsupported data_type",
+                    ))
+                });
             }
             if let Some(a) = attrs
                 .iter()
@@ -1240,17 +1255,25 @@ fn dispatch_shape_data(
         OpKind::ConstantOfShape => {
             let shape_tensor = require_input(inputs, 0, "ConstantOfShape")?;
             let shape = read_i64_tensor(shape_tensor)?;
-            // SmallAIOS can't yet decode tensor-typed attributes, so we
-            // accept a scalar fill via 'value_float' / 'value_int' or
-            // default to 0.0.
-            let value = attrs
-                .iter()
-                .find_map(|a| match (a.name.as_str(), a.attr_type) {
-                    ("value_float", AttributeType::Float) => Some(a.f),
-                    ("value_int", AttributeType::Int) => Some(a.i as f32),
-                    _ => None,
-                })
-                .unwrap_or(0.0);
+            // Prefer the tensor-typed 'value' attribute (standard ONNX
+            // export). Fall back to 'value_float' / 'value_int' or 0.0.
+            let value = if let Some(proto) = get_attr_tensor(attrs, "value") {
+                let fill_tensor = tensor_from_proto(proto).ok_or_else(|| {
+                    OpError::InvalidAttribute(String::from(
+                        "ConstantOfShape 'value' tensor has unsupported data_type",
+                    ))
+                })?;
+                read_scalar_f32(&fill_tensor)?
+            } else {
+                attrs
+                    .iter()
+                    .find_map(|a| match (a.name.as_str(), a.attr_type) {
+                        ("value_float", AttributeType::Float) => Some(a.f),
+                        ("value_int", AttributeType::Int) => Some(a.i as f32),
+                        _ => None,
+                    })
+                    .unwrap_or(0.0)
+            };
             ops::shape_data::op_constant_of_shape(&shape, value)
         }
         OpKind::Range => {
@@ -2423,5 +2446,103 @@ mod tests {
         let inputs: [Option<&Tensor>; 0] = [];
         let r = dispatch_shape(OpKind::Concat, &inputs, &[]);
         assert!(r.is_err());
+    }
+
+    // ---- Tensor-valued 'value' attribute for Constant / ConstantOfShape ----
+
+    fn make_value_tensor_attr(proto: TensorProto) -> AttributeProto {
+        AttributeProto {
+            name: String::from("value"),
+            attr_type: AttributeType::Tensor,
+            t: Some(alloc::boxed::Box::new(proto)),
+            ..AttributeProto::default()
+        }
+    }
+
+    #[test]
+    fn test_get_attr_tensor_finds_tensor() {
+        let proto = TensorProto {
+            dims: vec![2],
+            data_type: 1,
+            float_data: vec![1.0, 2.0],
+            ..TensorProto::default()
+        };
+        let attrs = vec![make_value_tensor_attr(proto)];
+        let t = get_attr_tensor(&attrs, "value").expect("tensor attr present");
+        assert_eq!(t.dims, vec![2i64]);
+        assert!(get_attr_tensor(&attrs, "missing").is_none());
+    }
+
+    #[test]
+    fn test_dispatch_constant_with_tensor_value_attr() {
+        let proto = TensorProto {
+            dims: vec![3],
+            data_type: 1, // FLOAT
+            float_data: vec![10.0, 20.0, 30.0],
+            ..TensorProto::default()
+        };
+        let attrs = vec![make_value_tensor_attr(proto)];
+        let inputs: [Option<&Tensor>; 0] = [];
+        let out = dispatch_shape_data(OpKind::Constant, &inputs, &attrs).unwrap();
+        assert_eq!(out.data_type, DataType::Float);
+        assert_eq!(out.shape.dims, vec![3i64]);
+        assert_eq!(out.raw_data.len(), 12);
+        assert!((byte_io::read_f32(&out.raw_data, 0) - 10.0).abs() < f32::EPSILON);
+        assert!((byte_io::read_f32(&out.raw_data, 1) - 20.0).abs() < f32::EPSILON);
+        assert!((byte_io::read_f32(&out.raw_data, 2) - 30.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_dispatch_constant_prefers_tensor_over_value_float() {
+        // Both 'value' (tensor) and 'value_float' are provided; the
+        // tensor attribute should win.
+        let proto = TensorProto {
+            dims: vec![1],
+            data_type: 1,
+            float_data: vec![99.0],
+            ..TensorProto::default()
+        };
+        let attrs = vec![
+            make_value_tensor_attr(proto),
+            AttributeProto {
+                name: String::from("value_float"),
+                attr_type: AttributeType::Float,
+                f: 0.5,
+                ..AttributeProto::default()
+            },
+        ];
+        let inputs: [Option<&Tensor>; 0] = [];
+        let out = dispatch_shape_data(OpKind::Constant, &inputs, &attrs).unwrap();
+        assert!((byte_io::read_f32(&out.raw_data, 0) - 99.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_dispatch_constant_of_shape_with_tensor_value_attr() {
+        // Fill value tensor: scalar float 7.0.
+        let fill_proto = TensorProto {
+            dims: vec![1],
+            data_type: 1,
+            float_data: vec![7.0],
+            ..TensorProto::default()
+        };
+        let attrs = vec![make_value_tensor_attr(fill_proto)];
+
+        // Input shape tensor: Int64 [2, 3].
+        let mut shape_raw = alloc::vec![0u8; 2 * I64_SIZE];
+        byte_io::write_i64(&mut shape_raw, 0, 2);
+        byte_io::write_i64(&mut shape_raw, 1, 3);
+        let shape_tensor = Tensor {
+            data_type: DataType::Int64,
+            shape: TensorShape::new(vec![2]),
+            name: String::from("shape"),
+            raw_data: shape_raw,
+        };
+        let inputs = [Some(&shape_tensor)];
+        let out = dispatch_shape_data(OpKind::ConstantOfShape, &inputs, &attrs).unwrap();
+        assert_eq!(out.shape.dims, vec![2i64, 3]);
+        assert_eq!(out.data_type, DataType::Float);
+        for i in 0..6 {
+            assert!((byte_io::read_f32(&out.raw_data, i) - 7.0).abs() < f32::EPSILON);
+        }
     }
 }

--- a/onnx-rt/src/onnx_types.rs
+++ b/onnx-rt/src/onnx_types.rs
@@ -87,6 +87,9 @@ pub struct AttributeProto {
     pub ints: Vec<i64>,
     /// Byte string list (when `attr_type == Strings`).
     pub strings: Vec<Vec<u8>>,
+    /// Tensor value (when `attr_type == Tensor`). Boxed to keep
+    /// `AttributeProto` small when the common scalar case applies.
+    pub t: Option<alloc::boxed::Box<TensorProto>>,
 }
 
 impl Default for AttributeProto {
@@ -100,6 +103,7 @@ impl Default for AttributeProto {
             floats: Vec::new(),
             ints: Vec::new(),
             strings: Vec::new(),
+            t: None,
         }
     }
 }
@@ -259,6 +263,7 @@ mod tests {
         assert!(attr.floats.is_empty());
         assert!(attr.ints.is_empty());
         assert!(attr.strings.is_empty());
+        assert!(attr.t.is_none());
     }
 
     #[test]

--- a/onnx-rt/src/ops/shape_data.rs
+++ b/onnx-rt/src/ops/shape_data.rs
@@ -99,9 +99,10 @@ pub fn op_constant(value: &Tensor) -> Result<Tensor, OpError> {
 }
 
 /// ConstantOfShape: produce a tensor of the given shape filled with a
-/// scalar value. The current runtime stores float32 fills; if the
-/// fill-value tensor is Int64 we emit a Float32 with the integer
-/// converted to float (good enough for BERT-style integer masks).
+/// scalar value. The current runtime stores float32 fills; the executor
+/// dispatcher accepts the standard tensor-typed `value` attribute as well
+/// as the `value_float` / `value_int` scalar shortcuts and projects the
+/// fill down to f32 before invoking this function.
 pub fn op_constant_of_shape(shape: &[i64], value: f32) -> Result<Tensor, OpError> {
     // Reject negative dims rather than silently absorbing them.
     if shape.iter().any(|&d| d < 0) {

--- a/onnx-rt/src/protobuf.rs
+++ b/onnx-rt/src/protobuf.rs
@@ -425,10 +425,13 @@ pub fn decode_attribute(data: &[u8]) -> Result<AttributeProto, ProtoError> {
                 attr.s = bytes.to_vec();
             }
             5 => {
-                // t (TensorProto) — content not yet stored, but flip
-                // `attr_type` to Tensor so downstream consumers don't
-                // see an Undefined attribute when field 20 is absent.
-                decoder.skip_field(header.wire_type)?;
+                // t (TensorProto) — length-delimited nested message.
+                // Decode and store the tensor; also flip `attr_type` to
+                // Tensor so downstream consumers don't see an Undefined
+                // attribute when field 20 is absent.
+                let tensor_data = decoder.read_length_delimited()?;
+                let tensor = decode_tensor(tensor_data)?;
+                attr.t = Some(alloc::boxed::Box::new(tensor));
                 if attr.attr_type == AttributeType::Undefined {
                     attr.attr_type = AttributeType::Tensor;
                 }
@@ -1457,6 +1460,72 @@ mod tests {
         let attr = decode_attribute(&data).unwrap();
         assert_eq!(attr.ints, alloc::vec![3i64, 3]);
         assert_eq!(attr.attr_type, AttributeType::Ints);
+    }
+
+    #[test]
+    fn decode_attribute_tensor_value() {
+        // Build an inner TensorProto: dims=[3], data_type=FLOAT,
+        // float_data=[1.0, 2.0, 3.0].
+        let mut tensor_bytes = Vec::new();
+        let mut dims_bytes = Vec::new();
+        dims_bytes.extend(encode_varint(3));
+        tensor_bytes.extend(encode_length_delimited(1, &dims_bytes));
+        tensor_bytes.extend(encode_varint_field(2, 1));
+        let mut float_bytes = Vec::new();
+        for v in [1.0f32, 2.0, 3.0] {
+            float_bytes.extend(v.to_le_bytes());
+        }
+        tensor_bytes.extend(encode_length_delimited(4, &float_bytes));
+
+        // Wrap in an AttributeProto: name="value", t=<tensor>, type=Tensor(4).
+        let mut data = Vec::new();
+        data.extend(encode_length_delimited(1, b"value"));
+        data.extend(encode_length_delimited(5, &tensor_bytes));
+        data.extend(encode_varint_field(20, 4));
+
+        let attr = decode_attribute(&data).unwrap();
+        assert_eq!(attr.name, "value");
+        assert_eq!(attr.attr_type, AttributeType::Tensor);
+        let t = attr.t.as_ref().expect("tensor should be populated");
+        assert_eq!(t.dims, alloc::vec![3i64]);
+        assert_eq!(t.data_type, 1);
+        assert_eq!(t.float_data.len(), 3);
+        assert!((t.float_data[2] - 3.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn decode_attribute_tensor_with_mixed_fields() {
+        // An AttributeProto that sets t, f, and i simultaneously, but
+        // declares attr_type = Tensor. The parser should populate every
+        // raw field it decoded, but downstream lookups via
+        // `get_attr_tensor` should only match the declared type.
+        let mut tensor_bytes = Vec::new();
+        let mut dims_bytes = Vec::new();
+        dims_bytes.extend(encode_varint(1));
+        tensor_bytes.extend(encode_length_delimited(1, &dims_bytes));
+        tensor_bytes.extend(encode_varint_field(2, 1));
+        let mut float_bytes = Vec::new();
+        float_bytes.extend(7.5f32.to_le_bytes());
+        tensor_bytes.extend(encode_length_delimited(4, &float_bytes));
+
+        let mut data = Vec::new();
+        data.extend(encode_length_delimited(1, b"value"));
+        // f = 0.5 (irrelevant — attr_type is Tensor)
+        data.extend(encode_fixed32_field(2, 0.5f32.to_bits()));
+        // i = 42 (irrelevant — attr_type is Tensor)
+        data.extend(encode_varint_field(3, 42));
+        // t = <tensor>
+        data.extend(encode_length_delimited(5, &tensor_bytes));
+        data.extend(encode_varint_field(20, 4));
+
+        let attr = decode_attribute(&data).unwrap();
+        assert_eq!(attr.attr_type, AttributeType::Tensor);
+        assert!((attr.f - 0.5).abs() < f32::EPSILON);
+        assert_eq!(attr.i, 42);
+        let t = attr.t.as_ref().expect("tensor should be populated");
+        assert_eq!(t.dims, alloc::vec![1i64]);
+        assert_eq!(t.float_data.len(), 1);
+        assert!((t.float_data[0] - 7.5).abs() < f32::EPSILON);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Small, focused fix that extends `AttributeProto` with a `t: Option<Box<TensorProto>>` field so the ONNX runtime can accept the standard `value` tensor attribute on `Constant` / `ConstantOfShape`. Previously these ops only accepted the `value_float` / `value_int` scalar shortcuts, which most exporters do not emit.

- Stacks on #77 (transformer-models-v1 / Phase 1 transformer ops).
- Resolves the `Constant` / `ConstantOfShape` limitation called out in #78.
- Protobuf decoder now handles tag 5 of `AttributeProto` as a length-delimited `TensorProto`.
- New `get_attr_tensor` helper in `executor.rs` mirrors the existing `get_attr_int` / `get_attr_float` / `get_attr_ints` pattern.
- `dispatch_shape_data` prefers the tensor-typed `value` attribute, then falls back to `value_float` / `value_int` (Constant) or 0.0 (ConstantOfShape).
- Dropped the stale "we can't decode tensor attrs" comment in `ops/shape_data.rs`.

## Files touched

- `onnx-rt/src/onnx_types.rs` — add `t: Option<Box<TensorProto>>` field + `Default` wiring
- `onnx-rt/src/protobuf.rs` — decode tag 5 via `decode_tensor`, plus two new unit tests
- `onnx-rt/src/executor.rs` — `get_attr_tensor` helper, `Constant` / `ConstantOfShape` wiring, four new unit tests
- `onnx-rt/src/ops/shape_data.rs` — update the stale limitation comment

## Test plan

- [x] `just fmt`
- [x] `just clippy` (warnings-as-errors)
- [x] `just test` — full workspace (all suites green, 6 new tests added)
- [x] New tests cover: tensor attribute round-trip through protobuf; `AttributeProto` with mixed `t` / `f` / `i` fields; `get_attr_tensor` lookup; `Constant` with tensor `value` attr; tensor attr preferred over `value_float`; `ConstantOfShape` filled from tensor `value` attr.

Refs #78

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced support for tensor-typed attributes in constant operations with proper validation and improved error reporting for unsupported data types.
  * Improved attribute processing to support both tensor-valued and scalar-based formats with correct precedence handling.

* **Tests**
  * Added comprehensive test coverage for tensor attribute handling, value conversion, and attribute format precedence in constant operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->