### PR TITLE
feat(tools): add ONNX model coverage probe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,6 +773,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallaios-coverage-probe"
+version = "0.2.1"
+dependencies = [
+ "serde",
+ "serde_json",
+ "smallaios-onnx-rt",
+]
+
+[[package]]
 name = "smallaios-ipc"
 version = "0.2.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "sdr",
     "bench",
     "sched-types",
+    "tools/coverage-probe",
 ]
 
 [workspace.package]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -4,6 +4,12 @@
 [cargo-vet]
 version = "0.10"
 
+# The coverage-probe is a developer / CI tool that ships only as a host
+# binary. It does not run inside the unikernel or container image, so its
+# transitive deps only need safe-to-run audits, not safe-to-deploy.
+[policy."smallaios-coverage-probe"]
+criteria = "safe-to-run"
+
 [[exemptions.aho-corasick]]
 version = "1.1.4"
 criteria = "safe-to-run"

--- a/tools/coverage-probe/Cargo.toml
+++ b/tools/coverage-probe/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "smallaios-coverage-probe"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "ONNX model operator coverage probe against the SmallAIOS roadmap"
+publish = false
+
+[dependencies]
+smallaios-onnx-rt = { path = "../../onnx-rt" }
+serde = { version = "1", features = ["derive"], optional = true }
+serde_json = { version = "1", optional = true }
+
+[features]
+default = ["json"]
+json = ["dep:serde", "dep:serde_json"]
+
+[[bin]]
+name = "smallaios-coverage-probe"
+path = "src/main.rs"

--- a/tools/coverage-probe/README.md
+++ b/tools/coverage-probe/README.md
@@ -1,0 +1,103 @@
+# smallaios-coverage-probe
+
+Structural coverage analysis for ONNX models against the SmallAIOS
+runtime roadmap.
+
+## What it does
+
+Given an ONNX model file, this tool:
+
+1. Parses the `ModelProto` using the in-tree `smallaios-onnx-rt`
+   protobuf parser (no external ONNX dependency).
+2. Tallies every op kind in the graph.
+3. Cross-references each op against two sources of truth:
+   - the live `OperatorRegistry` from `smallaios-onnx-rt` — what the
+     runtime *actually* supports today,
+   - `docs/onnx-coverage-roadmap.md` — what we plan to support, and
+     when.
+4. Emits a Markdown (default), text, or JSON report showing which ops
+   are implemented, which are planned in each phase, which are deferred
+   or skipped, and which are unrecognized entirely.
+
+The tool is used to **empirically validate** that Phase 1 actually
+covers BERT / ViT and that Phase 2 actually covers GPT-2 / Llama
+**before** spending implementation effort on those phases.
+
+## Build
+
+```bash
+cargo build -p smallaios-coverage-probe
+cargo test  -p smallaios-coverage-probe
+```
+
+## Usage
+
+```bash
+smallaios-coverage-probe model.onnx
+smallaios-coverage-probe --json model.onnx
+smallaios-coverage-probe --detailed model.onnx
+smallaios-coverage-probe --strict model.onnx       # CI gate
+smallaios-coverage-probe --inventory path/to/roadmap.md model.onnx
+```
+
+### Flags
+
+| Flag | Purpose |
+|---|---|
+| `--json` | Emit JSON instead of Markdown/text |
+| `--detailed` | Include per-node attribute-level concerns (Resize cubic, RoiAlign max, …) |
+| `--quiet` | Summary only, no per-op breakdown |
+| `--strict` | Exit with code 2 if any op is unrecognized or otherwise unsupported |
+| `--inventory <path>` | Override the default roadmap-doc location |
+| `-h`, `--help` | Print help |
+
+### Example output
+
+```
+Coverage report: bert-like.onnx
+
+Total nodes:        6
+Distinct op kinds:  5
+
+Implemented in develop:      4
+Planned Phase 1:             1
+Planned Phase 2:             0
+Planned Phase 3:             0
+Planned Phase 4:             0
+Deferred subsystem:          0
+Skipped (training/deprecated/vendor): 0
+Unrecognized:                0
+
+Verdict: Model becomes loadable after Phase 1 PRs merge.
+
+Per-op breakdown:
+  MatMul                        2 nodes   Implemented
+  Add                           1 nodes   Implemented
+  Gelu                          1 nodes   Planned-P1
+  LayerNormalization            1 nodes   Implemented
+  Softmax                       1 nodes   Implemented
+```
+
+## Adding new attribute concerns
+
+Attribute-level limitations live in `src/walker.rs` under
+`attribute_concerns_for`. To add a new one, match on the op type and
+push a human-readable concern string for any unsupported attribute
+combination. See the existing `Resize`, `RoiAlign`, `GridSample`,
+`Unique`, and `ScatterND` entries for examples.
+
+## Doc drift detection
+
+If the roadmap doc claims an op is `Planned-P1` (or any non-Implemented
+status) but the live `OperatorRegistry` already supports it, the probe
+records a `doc_drifts` entry. The effective status is always the
+registry's — the drift is surfaced as a warning so roadmap authors can
+keep the doc honest.
+
+## CI integration
+
+Future: a CI job will run the probe against
+`tests/fixtures/onnx-models/*.onnx` under `--strict` and fail if any
+model regresses from `loadable_today` (or `loadable_after_phase<N>`) to
+a less-loadable state. That ensures operator-coverage PRs cannot
+accidentally break the baseline models.

--- a/tools/coverage-probe/src/inventory.rs
+++ b/tools/coverage-probe/src/inventory.rs
@@ -1,0 +1,525 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Parses `docs/onnx-coverage-roadmap.md` into an operator status map and
+//! cross-references entries against the live `OperatorRegistry` from
+//! `smallaios-onnx-rt`.
+//!
+//! The roadmap contains Markdown tables with rows of the form:
+//!
+//! ```text
+//! | Sin | Planned-P1 | Sinusoidal positional embeddings |
+//! ```
+//!
+//! We recognize the following status tokens (case-insensitive, hyphens
+//! or underscores accepted):
+//!
+//! - `Planned-P1`, `Planned-P2`, `Planned-P3`, `Planned-P4`
+//! - `Deferred-subsystem` (optionally `Deferred-subsystem:<name>`)
+//! - `Skipped-training`, `Skipped-deprecated`, `Skipped-vendor`
+//!
+//! Any op not named in the roadmap but recognized by the registry is
+//! treated as [`OperatorStatus::Implemented`]. Any op neither in the
+//! registry nor the roadmap is [`OperatorStatus::Unrecognized`].
+
+use smallaios_onnx_rt::operators::OperatorRegistry;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+/// Roadmap phase identifiers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Phase {
+    /// Phase 1 (transformers baseline: BERT / ViT).
+    P1,
+    /// Phase 2 (generative LLMs: GPT-2 / Llama).
+    P2,
+    /// Phase 3 (audio / advanced vision).
+    P3,
+    /// Phase 4 (long-tail completion).
+    P4,
+}
+
+impl Phase {
+    /// Short display label, e.g. "P1".
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Phase::P1 => "P1",
+            Phase::P2 => "P2",
+            Phase::P3 => "P3",
+            Phase::P4 => "P4",
+        }
+    }
+}
+
+/// Status of an ONNX operator relative to the SmallAIOS roadmap.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OperatorStatus {
+    /// Present in the live `OperatorRegistry` — loadable today.
+    Implemented,
+    /// Planned in one of the roadmap phases.
+    Planned(Phase),
+    /// Deferred pending a subsystem (sequence, optional, control-flow,
+    /// string, ml, …).
+    DeferredSubsystem(String),
+    /// Explicitly skipped: training-only op.
+    SkippedTraining,
+    /// Explicitly skipped: deprecated and rewritten by converters.
+    SkippedDeprecated,
+    /// Explicitly skipped: vendor-specific (`com.microsoft`, …).
+    SkippedVendor,
+    /// Not mentioned in the roadmap and not implemented.
+    Unrecognized,
+}
+
+impl OperatorStatus {
+    /// Human-readable label used in Markdown and CLI output.
+    pub fn label(&self) -> String {
+        match self {
+            OperatorStatus::Implemented => "Implemented".to_string(),
+            OperatorStatus::Planned(p) => format!("Planned-{}", p.as_str()),
+            OperatorStatus::DeferredSubsystem(s) if s.is_empty() => {
+                "Deferred-subsystem".to_string()
+            }
+            OperatorStatus::DeferredSubsystem(s) => format!("Deferred-subsystem:{s}"),
+            OperatorStatus::SkippedTraining => "Skipped-training".to_string(),
+            OperatorStatus::SkippedDeprecated => "Skipped-deprecated".to_string(),
+            OperatorStatus::SkippedVendor => "Skipped-vendor".to_string(),
+            OperatorStatus::Unrecognized => "Unrecognized".to_string(),
+        }
+    }
+}
+
+/// A case where the roadmap claims a status incompatible with the
+/// current `OperatorRegistry` — e.g. the doc says `Implemented` but the
+/// registry does not recognize the op, or (more commonly) the doc marks
+/// an op `Planned-P1` when the registry already supports it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocDrift {
+    /// Operator name as written in the roadmap.
+    pub op: String,
+    /// Status listed in the roadmap.
+    pub doc_status: OperatorStatus,
+    /// Short explanation.
+    pub note: String,
+}
+
+/// Parsed roadmap plus the set of registry-supported ops.
+#[derive(Debug, Clone)]
+pub struct Inventory {
+    /// Map from op type name to its roadmap-declared status, with
+    /// registry overrides applied (registry always wins for
+    /// `Implemented`).
+    statuses: BTreeMap<String, OperatorStatus>,
+    /// Ops detected as both "Implemented in registry" and "Planned in
+    /// roadmap" — surfaces doc drift without blocking anything.
+    drifts: Vec<DocDrift>,
+    /// Names of ops the registry currently recognizes.
+    registered: Vec<String>,
+}
+
+impl Inventory {
+    /// Build an inventory from the roadmap file at `path`.
+    pub fn from_roadmap_file<P: AsRef<Path>>(path: P) -> Result<Self, std::io::Error> {
+        let src = fs::read_to_string(path)?;
+        Ok(Self::from_roadmap_str(&src))
+    }
+
+    /// Build an inventory from raw roadmap Markdown plus the live
+    /// operator registry. The registry is consulted via
+    /// `OperatorRegistry::new()`.
+    pub fn from_roadmap_str(src: &str) -> Self {
+        let registered = all_registered_op_names();
+        let mut statuses: BTreeMap<String, OperatorStatus> = BTreeMap::new();
+        let mut drifts: Vec<DocDrift> = Vec::new();
+
+        // Seed from the registry.
+        for name in &registered {
+            statuses.insert(name.clone(), OperatorStatus::Implemented);
+        }
+
+        // Parse roadmap rows.
+        for row in parse_status_rows(src) {
+            let (op, status) = row;
+            // Registry wins for `Implemented`, but we record the drift.
+            if registered.iter().any(|n| n == &op) {
+                if !matches!(status, OperatorStatus::Implemented) {
+                    drifts.push(DocDrift {
+                        op: op.clone(),
+                        doc_status: status.clone(),
+                        note: format!(
+                            "registry already implements `{op}` but roadmap lists `{}`",
+                            status.label()
+                        ),
+                    });
+                }
+                continue;
+            }
+            // Otherwise, record the roadmap status. Later duplicate
+            // rows overwrite earlier ones (unlikely in practice).
+            statuses.insert(op, status);
+        }
+
+        Inventory {
+            statuses,
+            drifts,
+            registered,
+        }
+    }
+
+    /// Look up the status of an op by type name. Returns
+    /// [`OperatorStatus::Unrecognized`] when the op is neither
+    /// registered nor in the roadmap.
+    pub fn status_of(&self, op_type: &str) -> OperatorStatus {
+        self.statuses
+            .get(op_type)
+            .cloned()
+            .unwrap_or(OperatorStatus::Unrecognized)
+    }
+
+    /// Names of the ops the live registry recognizes.
+    pub fn registered_ops(&self) -> &[String] {
+        &self.registered
+    }
+
+    /// Doc-drift entries detected during parsing.
+    pub fn drifts(&self) -> &[DocDrift] {
+        &self.drifts
+    }
+
+    /// All roadmap-listed ops (including implemented).
+    pub fn len(&self) -> usize {
+        self.statuses.len()
+    }
+
+    /// Whether the inventory is empty (only meaningful for tests).
+    pub fn is_empty(&self) -> bool {
+        self.statuses.is_empty()
+    }
+}
+
+/// Collects the canonical names of every op in `OperatorRegistry::new()`.
+///
+/// Instead of re-deriving the list from `OpKind`, we probe the registry
+/// for every ONNX op we know the name of. This keeps the probe working
+/// even as the registry grows — it just needs the probing list to stay
+/// reasonably comprehensive (expanded when new ops are added).
+fn all_registered_op_names() -> Vec<String> {
+    let reg = OperatorRegistry::new();
+    // Baseline candidate set. When new ops are added to `OpKind` in
+    // `smallaios-onnx-rt`, they should be added here as well. This list
+    // is intentionally a superset of the current `OpKind` enum.
+    const CANDIDATES: &[&str] = &[
+        // Arithmetic / elementwise
+        "Add",
+        "Sub",
+        "Mul",
+        "Div",
+        "MatMul",
+        "Mod",
+        "Pow",
+        "Neg",
+        "Abs",
+        "Reciprocal",
+        "Sqrt",
+        "Sign",
+        "Sum",
+        "Mean",
+        "Max",
+        "Min",
+        "And",
+        "Or",
+        "Xor",
+        "Not",
+        "Equal",
+        "Greater",
+        "Less",
+        "GreaterOrEqual",
+        "LessOrEqual",
+        // Trig / exponential
+        "Exp",
+        "Log",
+        "Sin",
+        "Cos",
+        "Tan",
+        "Sinh",
+        "Cosh",
+        "Tanh",
+        "Asin",
+        "Acos",
+        "Atan",
+        "Asinh",
+        "Acosh",
+        "Atanh",
+        "Erf",
+        // Activations
+        "Relu",
+        "Sigmoid",
+        "Softmax",
+        "LogSoftmax",
+        "PRelu",
+        "LeakyRelu",
+        "Elu",
+        "Gelu",
+        "HardSigmoid",
+        "HardSwish",
+        "Selu",
+        "Celu",
+        "Softplus",
+        "Softsign",
+        "ThresholdedRelu",
+        // Convolution / pooling
+        "Conv",
+        "ConvTranspose",
+        "MaxPool",
+        "AveragePool",
+        "GlobalAveragePool",
+        "GlobalMaxPool",
+        "BatchNormalization",
+        "InstanceNormalization",
+        "GroupNormalization",
+        // Shape manipulation
+        "Reshape",
+        "Transpose",
+        "Flatten",
+        "Squeeze",
+        "Unsqueeze",
+        "Expand",
+        "Tile",
+        "Identity",
+        "Shape",
+        "Size",
+        // Data movement
+        "Concat",
+        "Gather",
+        "GatherElements",
+        "GatherND",
+        "Scatter",
+        "ScatterElements",
+        "ScatterND",
+        "Slice",
+        "Pad",
+        "Where",
+        "Split",
+        // Linear algebra / normalization
+        "Gemm",
+        "LayerNormalization",
+        "LpNormalization",
+        "MeanVarianceNormalization",
+        // Type / reduction
+        "Cast",
+        "Clip",
+        "ReduceMean",
+        "ReduceSum",
+        "ReduceMax",
+        "ReduceMin",
+        "ReduceProd",
+        "ArgMax",
+        "ArgMin",
+        "TopK",
+        // Random / constants
+        "Constant",
+        "ConstantOfShape",
+        "Range",
+        // Quantization
+        "DequantizeLinear",
+        "QuantizeLinear",
+    ];
+    CANDIDATES
+        .iter()
+        .filter(|name| reg.is_supported(name))
+        .map(|n| (*n).to_string())
+        .collect()
+}
+
+/// Extract `(op_name, status)` pairs from the roadmap Markdown source.
+///
+/// Only rows whose second column matches a known status token are
+/// retained. Table headers like `| Op | Status | Rationale |` are
+/// filtered out because `Status` is not a status token.
+fn parse_status_rows(src: &str) -> Vec<(String, OperatorStatus)> {
+    let mut rows = Vec::new();
+    for line in src.lines() {
+        let line = line.trim();
+        if !line.starts_with('|') {
+            continue;
+        }
+        let cells: Vec<&str> = line
+            .trim_matches('|')
+            .split('|')
+            .map(|c| c.trim())
+            .collect();
+        if cells.len() < 2 {
+            continue;
+        }
+        let op = cells[0];
+        let status_cell = cells[1];
+        // Skip header / separator rows.
+        if op.is_empty() || op.chars().next().is_some_and(|c| !c.is_ascii_alphabetic()) {
+            continue;
+        }
+        if !is_likely_op_name(op) {
+            continue;
+        }
+        if let Some(status) = parse_status_token(status_cell) {
+            rows.push((op.to_string(), status));
+        }
+    }
+    rows
+}
+
+/// Heuristic: ONNX op names are CamelCase identifiers of up to a few
+/// words (no spaces, no punctuation). This filters out prose like
+/// "Phase" or "Op count".
+fn is_likely_op_name(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    if !s.chars().next().is_some_and(|c| c.is_ascii_uppercase()) {
+        return false;
+    }
+    if s.chars().any(|c| c.is_whitespace()) {
+        return false;
+    }
+    // Reject known non-op header labels.
+    !matches!(s, "Op" | "Bucket" | "Phase" | "Tier" | "Group")
+        && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Parse a status cell into [`OperatorStatus`]. Returns `None` for
+/// unrecognized tokens so that prose rows (e.g. the header) are
+/// silently dropped.
+fn parse_status_token(cell: &str) -> Option<OperatorStatus> {
+    let normalized = cell.replace('_', "-").to_ascii_lowercase();
+    let normalized = normalized.trim();
+    match normalized {
+        "planned-p1" => Some(OperatorStatus::Planned(Phase::P1)),
+        "planned-p2" => Some(OperatorStatus::Planned(Phase::P2)),
+        "planned-p3" => Some(OperatorStatus::Planned(Phase::P3)),
+        "planned-p4" => Some(OperatorStatus::Planned(Phase::P4)),
+        "skipped-training" => Some(OperatorStatus::SkippedTraining),
+        "skipped-deprecated" => Some(OperatorStatus::SkippedDeprecated),
+        "skipped-vendor" => Some(OperatorStatus::SkippedVendor),
+        "implemented" => Some(OperatorStatus::Implemented),
+        s if s.starts_with("deferred-subsystem") => {
+            let detail = s
+                .strip_prefix("deferred-subsystem")
+                .and_then(|rest| rest.strip_prefix(':'))
+                .unwrap_or("")
+                .to_string();
+            Some(OperatorStatus::DeferredSubsystem(detail))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_simple_planned_row() {
+        let src = "| Sin | Planned-P1 | Sinusoidal positional embeddings |";
+        let rows = parse_status_rows(src);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].0, "Sin");
+        assert_eq!(rows[0].1, OperatorStatus::Planned(Phase::P1));
+    }
+
+    #[test]
+    fn parses_multiple_phases() {
+        let src = "\
+| Sin | Planned-P1 | trig |
+| Softplus | Planned-P2 | smooth relu |
+| Sinh | Planned-P3 | hyperbolic |
+| Tan | Planned-P4 | rare |
+";
+        let rows = parse_status_rows(src);
+        assert_eq!(rows.len(), 4);
+        assert_eq!(rows[3].1, OperatorStatus::Planned(Phase::P4));
+    }
+
+    #[test]
+    fn parses_deferred_and_skipped() {
+        let src = "\
+| SplitToSequence | Deferred-subsystem | Sequence type required |
+| Affine | Skipped-deprecated | Replaced by Mul+Add |
+| QLinearConv | Skipped-vendor | com.microsoft |
+";
+        let rows = parse_status_rows(src);
+        assert_eq!(rows.len(), 3);
+        assert!(matches!(rows[0].1, OperatorStatus::DeferredSubsystem(_)));
+        assert_eq!(rows[1].1, OperatorStatus::SkippedDeprecated);
+        assert_eq!(rows[2].1, OperatorStatus::SkippedVendor);
+    }
+
+    #[test]
+    fn header_rows_are_filtered() {
+        let src = "\
+| Op | Status | Rationale |
+|----|--------|-----------|
+| Sin | Planned-P1 | trig |
+";
+        let rows = parse_status_rows(src);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].0, "Sin");
+    }
+
+    #[test]
+    fn inventory_marks_matmul_as_implemented_via_registry() {
+        let inv = Inventory::from_roadmap_str("");
+        assert_eq!(inv.status_of("MatMul"), OperatorStatus::Implemented);
+        assert_eq!(inv.status_of("Add"), OperatorStatus::Implemented);
+    }
+
+    #[test]
+    fn inventory_returns_unrecognized_for_unknown_ops() {
+        let inv = Inventory::from_roadmap_str("");
+        assert_eq!(
+            inv.status_of("FrobnicateTheGizmo"),
+            OperatorStatus::Unrecognized
+        );
+    }
+
+    #[test]
+    fn inventory_records_doc_drift_when_registry_beats_roadmap() {
+        // Roadmap claims Add is Planned-P1, but the registry already
+        // implements it. This should be recorded as a drift and the
+        // effective status should remain Implemented.
+        let src = "| Add | Planned-P1 | bogus |";
+        let inv = Inventory::from_roadmap_str(src);
+        assert_eq!(inv.status_of("Add"), OperatorStatus::Implemented);
+        assert_eq!(inv.drifts().len(), 1);
+        assert_eq!(inv.drifts()[0].op, "Add");
+    }
+
+    #[test]
+    fn inventory_records_planned_op_not_in_registry() {
+        let src = "| Gelu | Planned-P1 | transformer activation |";
+        let inv = Inventory::from_roadmap_str(src);
+        // Gelu is not in the develop registry (29 ops).
+        // The walker will see it as Planned(P1).
+        assert_eq!(inv.status_of("Gelu"), OperatorStatus::Planned(Phase::P1));
+    }
+
+    #[test]
+    fn parses_real_roadmap_file() {
+        // Test that the actual roadmap file parses without panicking
+        // and produces a non-trivial inventory.
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../docs/onnx-coverage-roadmap.md"
+        );
+        let inv = Inventory::from_roadmap_file(path).expect("roadmap file should exist");
+        assert!(
+            inv.len() > 30,
+            "expected roadmap to contribute >30 ops, got {}",
+            inv.len()
+        );
+        // Known Phase 1 planned ops.
+        assert_eq!(inv.status_of("Sin"), OperatorStatus::Planned(Phase::P1));
+        assert_eq!(inv.status_of("Cos"), OperatorStatus::Planned(Phase::P1));
+        // Known deprecated skip.
+        assert_eq!(inv.status_of("Affine"), OperatorStatus::SkippedDeprecated);
+    }
+}

--- a/tools/coverage-probe/src/lib.rs
+++ b/tools/coverage-probe/src/lib.rs
@@ -1,0 +1,37 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! SmallAIOS ONNX coverage probe.
+//!
+//! Walks an ONNX [`ModelProto`](smallaios_onnx_rt::onnx_types::ModelProto),
+//! tallies each op kind, and cross-references it against two sources of
+//! truth:
+//!
+//! 1. The live [`OperatorRegistry`](smallaios_onnx_rt::operators::OperatorRegistry)
+//!    in `smallaios-onnx-rt` (what the runtime *actually* supports today).
+//! 2. The roadmap document `docs/onnx-coverage-roadmap.md` (what we plan
+//!    to support, and when).
+//!
+//! The result is a [`CoverageReport`] which the CLI renders as Markdown
+//! or JSON. This crate is used to empirically validate that upcoming
+//! OpenSpec phases cover the target model families before spending the
+//! implementation effort.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use smallaios_coverage_probe::{Inventory, walk_bytes};
+//!
+//! let bytes = std::fs::read("model.onnx").unwrap();
+//! let inventory = Inventory::from_roadmap_file("docs/onnx-coverage-roadmap.md").unwrap();
+//! let report = walk_bytes(&bytes, "model.onnx", &inventory).unwrap();
+//! println!("{}", report.to_markdown(false));
+//! ```
+
+pub mod inventory;
+pub mod report;
+pub mod walker;
+
+pub use inventory::{DocDrift, Inventory, OperatorStatus, Phase};
+pub use report::{CoverageReport, NodeSummary, StatusCounts, Verdict};
+pub use walker::{walk_bytes, walk_model, WalkError};

--- a/tools/coverage-probe/src/main.rs
+++ b/tools/coverage-probe/src/main.rs
@@ -1,0 +1,227 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! CLI entry point for the SmallAIOS ONNX coverage probe.
+
+use smallaios_coverage_probe::{walk_bytes, Inventory, Verdict};
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+#[derive(Debug, Default)]
+struct Args {
+    model: Option<PathBuf>,
+    inventory: Option<PathBuf>,
+    json: bool,
+    detailed: bool,
+    quiet: bool,
+    strict: bool,
+    show_help: bool,
+}
+
+fn parse_args(argv: Vec<String>) -> Result<Args, String> {
+    let mut args = Args::default();
+    let mut iter = argv.into_iter().skip(1);
+    while let Some(a) = iter.next() {
+        match a.as_str() {
+            "--json" => args.json = true,
+            "--detailed" => args.detailed = true,
+            "--quiet" => args.quiet = true,
+            "--strict" => args.strict = true,
+            "-h" | "--help" => args.show_help = true,
+            "--inventory" => {
+                let v = iter
+                    .next()
+                    .ok_or_else(|| "--inventory requires a path argument".to_string())?;
+                args.inventory = Some(PathBuf::from(v));
+            }
+            s if s.starts_with("--") => {
+                return Err(format!("unknown flag: {s}"));
+            }
+            _ => {
+                if args.model.is_some() {
+                    return Err(format!("unexpected positional argument: {a}"));
+                }
+                args.model = Some(PathBuf::from(a));
+            }
+        }
+    }
+    Ok(args)
+}
+
+const HELP: &str = "\
+smallaios-coverage-probe — ONNX model operator coverage probe
+
+USAGE:
+    smallaios-coverage-probe [FLAGS] <model.onnx>
+
+FLAGS:
+    --json                 Emit JSON instead of Markdown/text
+    --detailed             Show per-node attribute concerns
+    --quiet                Only summary, no per-op breakdown
+    --strict               Exit nonzero if any op is unrecognized or
+                           otherwise unsupported
+    --inventory <path>     Override the roadmap file location
+                           (default: docs/onnx-coverage-roadmap.md)
+    -h, --help             Print this help
+
+EXIT CODES:
+    0   success
+    1   CLI or IO error
+    2   --strict and at least one unrecognized or unsupported op
+";
+
+fn main() -> ExitCode {
+    let argv: Vec<String> = std::env::args().collect();
+    let args = match parse_args(argv) {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("error: {e}\n");
+            eprintln!("{HELP}");
+            return ExitCode::from(1);
+        }
+    };
+    if args.show_help {
+        println!("{HELP}");
+        return ExitCode::SUCCESS;
+    }
+    let model_path = match &args.model {
+        Some(p) => p.clone(),
+        None => {
+            eprintln!("error: missing model path\n\n{HELP}");
+            return ExitCode::from(1);
+        }
+    };
+
+    // Locate inventory.
+    let inventory_path = args
+        .inventory
+        .clone()
+        .unwrap_or_else(default_inventory_path);
+    let inventory = match Inventory::from_roadmap_file(&inventory_path) {
+        Ok(inv) => inv,
+        Err(e) => {
+            eprintln!(
+                "warning: could not read inventory at {}: {e}. \
+                 Falling back to registry-only mode.",
+                inventory_path.display()
+            );
+            Inventory::from_roadmap_str("")
+        }
+    };
+
+    // Read model bytes.
+    let bytes = match std::fs::read(&model_path) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("error: could not read model {}: {e}", model_path.display());
+            return ExitCode::from(1);
+        }
+    };
+    let label = model_path.display().to_string();
+    let report = match walk_bytes(&bytes, &label, &inventory) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::from(1);
+        }
+    };
+
+    if args.json {
+        #[cfg(feature = "json")]
+        {
+            println!("{}", report.to_json());
+        }
+        #[cfg(not(feature = "json"))]
+        {
+            eprintln!("error: --json requires building with the `json` feature");
+            return ExitCode::from(1);
+        }
+    } else if args.quiet || !args.detailed {
+        print!("{}", report.to_text_summary(args.quiet));
+        if args.detailed {
+            // Detailed concerns: emit after summary.
+            let concerns: Vec<&String> = report
+                .per_op
+                .iter()
+                .flat_map(|op| op.attribute_concerns.iter())
+                .collect();
+            if !concerns.is_empty() {
+                println!("\nAttribute concerns:");
+                for c in concerns {
+                    println!("  - {c}");
+                }
+            }
+        }
+    } else {
+        // Full Markdown output.
+        print!("{}", report.to_markdown(args.detailed));
+    }
+
+    if args.strict {
+        match report.verdict {
+            Verdict::LoadableToday => ExitCode::SUCCESS,
+            Verdict::HasUnrecognizedOps | Verdict::NotLoadable => ExitCode::from(2),
+            _ => ExitCode::from(2),
+        }
+    } else {
+        ExitCode::SUCCESS
+    }
+}
+
+fn default_inventory_path() -> PathBuf {
+    // Walk upwards from CWD looking for docs/onnx-coverage-roadmap.md.
+    if let Ok(cwd) = std::env::current_dir() {
+        let mut here = cwd.as_path();
+        loop {
+            let candidate = here.join("docs").join("onnx-coverage-roadmap.md");
+            if candidate.exists() {
+                return candidate;
+            }
+            match here.parent() {
+                Some(p) => here = p,
+                None => break,
+            }
+        }
+    }
+    PathBuf::from("docs/onnx-coverage-roadmap.md")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_basic_args() {
+        let a = parse_args(vec!["probe".into(), "model.onnx".into()]).unwrap();
+        assert_eq!(a.model.as_deref(), Some(std::path::Path::new("model.onnx")));
+        assert!(!a.json);
+        assert!(!a.strict);
+    }
+
+    #[test]
+    fn parses_flags() {
+        let a = parse_args(vec![
+            "probe".into(),
+            "--json".into(),
+            "--detailed".into(),
+            "--strict".into(),
+            "m.onnx".into(),
+        ])
+        .unwrap();
+        assert!(a.json);
+        assert!(a.detailed);
+        assert!(a.strict);
+    }
+
+    #[test]
+    fn rejects_unknown_flag() {
+        let e = parse_args(vec!["probe".into(), "--frobnicate".into()]).unwrap_err();
+        assert!(e.contains("unknown flag"));
+    }
+
+    #[test]
+    fn inventory_override_requires_value() {
+        let e = parse_args(vec!["probe".into(), "--inventory".into()]).unwrap_err();
+        assert!(e.contains("--inventory"));
+    }
+}

--- a/tools/coverage-probe/src/report.rs
+++ b/tools/coverage-probe/src/report.rs
@@ -1,0 +1,385 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Report rendering: Markdown and JSON serialization of a coverage walk.
+
+use crate::inventory::{DocDrift, OperatorStatus};
+use std::fmt::Write;
+
+/// Per-op entry in a [`CoverageReport`].
+#[derive(Debug, Clone)]
+pub struct NodeSummary {
+    /// ONNX operator type string (e.g. "MatMul").
+    pub op_type: String,
+    /// Number of nodes with this op type in the model.
+    pub count: usize,
+    /// Effective status after registry + roadmap reconciliation.
+    pub status: OperatorStatus,
+    /// Human-readable per-node attribute warnings (detailed mode).
+    pub attribute_concerns: Vec<String>,
+}
+
+/// Status-bucket counts, used for summary tables.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StatusCounts {
+    /// Ops already implemented in the live `OperatorRegistry`.
+    pub implemented: usize,
+    /// Ops planned in Phase 1.
+    pub planned_p1: usize,
+    /// Ops planned in Phase 2.
+    pub planned_p2: usize,
+    /// Ops planned in Phase 3.
+    pub planned_p3: usize,
+    /// Ops planned in Phase 4.
+    pub planned_p4: usize,
+    /// Ops deferred pending a subsystem.
+    pub deferred: usize,
+    /// Ops explicitly skipped (training, deprecated, vendor).
+    pub skipped: usize,
+    /// Ops not recognized at all.
+    pub unrecognized: usize,
+}
+
+impl StatusCounts {
+    /// Sum across all buckets — equals the number of distinct ops.
+    pub fn total(&self) -> usize {
+        self.implemented
+            + self.planned_p1
+            + self.planned_p2
+            + self.planned_p3
+            + self.planned_p4
+            + self.deferred
+            + self.skipped
+            + self.unrecognized
+    }
+}
+
+/// Aggregate verdict for whether the runtime can execute the model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict {
+    /// All ops already implemented — loadable on the current `develop`.
+    LoadableToday,
+    /// Loadable once Phase 1 PRs land.
+    LoadableAfterPhase1,
+    /// Loadable once Phase 2 PRs land.
+    LoadableAfterPhase2,
+    /// Loadable once Phase 3 PRs land.
+    LoadableAfterPhase3,
+    /// Loadable once Phase 4 PRs land.
+    LoadableAfterPhase4,
+    /// Model uses at least one op the roadmap does not plan.
+    NotLoadable,
+    /// Model uses at least one op we do not recognize at all.
+    HasUnrecognizedOps,
+}
+
+impl Verdict {
+    /// Short machine-readable string, used in JSON output and tests.
+    pub fn as_tag(&self) -> &'static str {
+        match self {
+            Verdict::LoadableToday => "loadable_today",
+            Verdict::LoadableAfterPhase1 => "loadable_after_phase1",
+            Verdict::LoadableAfterPhase2 => "loadable_after_phase2",
+            Verdict::LoadableAfterPhase3 => "loadable_after_phase3",
+            Verdict::LoadableAfterPhase4 => "loadable_after_phase4",
+            Verdict::NotLoadable => "not_loadable",
+            Verdict::HasUnrecognizedOps => "has_unrecognized_ops",
+        }
+    }
+
+    /// Human-readable sentence for Markdown output.
+    pub fn explain(&self) -> &'static str {
+        match self {
+            Verdict::LoadableToday => "Model is loadable on the current `develop` branch.",
+            Verdict::LoadableAfterPhase1 => "Model becomes loadable after Phase 1 PRs merge.",
+            Verdict::LoadableAfterPhase2 => "Model becomes loadable after Phase 2 PRs merge.",
+            Verdict::LoadableAfterPhase3 => "Model becomes loadable after Phase 3 PRs merge.",
+            Verdict::LoadableAfterPhase4 => "Model becomes loadable after Phase 4 PRs merge.",
+            Verdict::NotLoadable => {
+                "Model uses ops the roadmap has deferred or skipped; not loadable."
+            }
+            Verdict::HasUnrecognizedOps => {
+                "Model uses ops neither implemented nor listed on the roadmap."
+            }
+        }
+    }
+}
+
+/// The full structural analysis of one model file.
+#[derive(Debug, Clone)]
+pub struct CoverageReport {
+    /// Label for the model, typically the file path.
+    pub model_label: String,
+    /// Total node count in the graph.
+    pub total_nodes: usize,
+    /// Distinct op-type count.
+    pub distinct_ops: usize,
+    /// Per-op breakdown sorted by count desc.
+    pub per_op: Vec<NodeSummary>,
+    /// Aggregate status counts.
+    pub counts: StatusCounts,
+    /// Overall verdict.
+    pub verdict: Verdict,
+    /// Doc-drift entries from the inventory (not filtered by model).
+    pub doc_drifts: Vec<DocDrift>,
+}
+
+impl CoverageReport {
+    /// Render as Markdown.
+    pub fn to_markdown(&self, detailed: bool) -> String {
+        let mut out = String::new();
+        let _ = writeln!(out, "# ONNX Coverage Report");
+        let _ = writeln!(out);
+        let _ = writeln!(out, "**Model:** `{}`", self.model_label);
+        let _ = writeln!(out, "**Total nodes:** {}", self.total_nodes);
+        let _ = writeln!(out, "**Distinct op kinds:** {}", self.distinct_ops);
+        let _ = writeln!(out);
+        let _ = writeln!(out, "## Summary");
+        let _ = writeln!(out);
+        let _ = writeln!(out, "| Status | Count | Percentage |");
+        let _ = writeln!(out, "|---|---|---|");
+        let total = self.distinct_ops.max(1);
+        let pct = |n: usize| -> String { format!("{}%", (n * 100) / total) };
+        let c = &self.counts;
+        let _ = writeln!(
+            out,
+            "| Implemented in develop | {} | {} |",
+            c.implemented,
+            pct(c.implemented)
+        );
+        let _ = writeln!(
+            out,
+            "| Planned Phase 1 | {} | {} |",
+            c.planned_p1,
+            pct(c.planned_p1)
+        );
+        let _ = writeln!(
+            out,
+            "| Planned Phase 2 | {} | {} |",
+            c.planned_p2,
+            pct(c.planned_p2)
+        );
+        let _ = writeln!(
+            out,
+            "| Planned Phase 3 | {} | {} |",
+            c.planned_p3,
+            pct(c.planned_p3)
+        );
+        let _ = writeln!(
+            out,
+            "| Planned Phase 4 | {} | {} |",
+            c.planned_p4,
+            pct(c.planned_p4)
+        );
+        let _ = writeln!(
+            out,
+            "| Deferred subsystem | {} | {} |",
+            c.deferred,
+            pct(c.deferred)
+        );
+        let _ = writeln!(out, "| Skipped | {} | {} |", c.skipped, pct(c.skipped));
+        let _ = writeln!(
+            out,
+            "| Unrecognized | {} | {} |",
+            c.unrecognized,
+            pct(c.unrecognized)
+        );
+        let _ = writeln!(out);
+        let _ = writeln!(out, "**Verdict:** {}", self.verdict.explain());
+        let _ = writeln!(out);
+
+        let _ = writeln!(out, "## Per-op breakdown");
+        let _ = writeln!(out);
+        let _ = writeln!(out, "| Op | Count | Status |");
+        let _ = writeln!(out, "|---|---|---|");
+        for op in &self.per_op {
+            let _ = writeln!(
+                out,
+                "| {} | {} | {} |",
+                op.op_type,
+                op.count,
+                op.status.label()
+            );
+        }
+        let _ = writeln!(out);
+
+        if detailed {
+            let all_concerns: Vec<&String> = self
+                .per_op
+                .iter()
+                .flat_map(|op| op.attribute_concerns.iter())
+                .collect();
+            if !all_concerns.is_empty() {
+                let _ = writeln!(out, "## Attribute concerns");
+                let _ = writeln!(out);
+                for concern in all_concerns {
+                    let _ = writeln!(out, "- {concern}");
+                }
+                let _ = writeln!(out);
+            }
+        }
+
+        if !self.doc_drifts.is_empty() {
+            let _ = writeln!(out, "## Doc drift warnings");
+            let _ = writeln!(out);
+            for d in &self.doc_drifts {
+                let _ = writeln!(out, "- {}", d.note);
+            }
+            let _ = writeln!(out);
+        }
+
+        out
+    }
+
+    /// Render as JSON.
+    #[cfg(feature = "json")]
+    pub fn to_json(&self) -> String {
+        use serde_json::json;
+        let per_op: Vec<_> = self
+            .per_op
+            .iter()
+            .map(|op| {
+                json!({
+                    "op": op.op_type,
+                    "count": op.count,
+                    "status": op.status.label(),
+                    "attribute_concerns": op.attribute_concerns,
+                })
+            })
+            .collect();
+        let drifts: Vec<_> = self
+            .doc_drifts
+            .iter()
+            .map(|d| {
+                json!({
+                    "op": d.op,
+                    "doc_status": d.doc_status.label(),
+                    "note": d.note,
+                })
+            })
+            .collect();
+        let v = json!({
+            "model": self.model_label,
+            "total_nodes": self.total_nodes,
+            "distinct_ops": self.distinct_ops,
+            "summary": {
+                "implemented_in_develop": self.counts.implemented,
+                "planned_p1": self.counts.planned_p1,
+                "planned_p2": self.counts.planned_p2,
+                "planned_p3": self.counts.planned_p3,
+                "planned_p4": self.counts.planned_p4,
+                "deferred": self.counts.deferred,
+                "skipped": self.counts.skipped,
+                "unrecognized": self.counts.unrecognized,
+            },
+            "per_op": per_op,
+            "doc_drifts": drifts,
+            "verdict": self.verdict.as_tag(),
+        });
+        serde_json::to_string_pretty(&v).expect("json serialization should not fail")
+    }
+
+    /// Render as a short plain-text summary for the default CLI mode.
+    pub fn to_text_summary(&self, quiet: bool) -> String {
+        let mut out = String::new();
+        let _ = writeln!(out, "Coverage report: {}", self.model_label);
+        let _ = writeln!(out);
+        let _ = writeln!(out, "Total nodes:        {}", self.total_nodes);
+        let _ = writeln!(out, "Distinct op kinds:  {}", self.distinct_ops);
+        let _ = writeln!(out);
+        let c = &self.counts;
+        let _ = writeln!(out, "Implemented in develop:      {}", c.implemented);
+        let _ = writeln!(out, "Planned Phase 1:             {}", c.planned_p1);
+        let _ = writeln!(out, "Planned Phase 2:             {}", c.planned_p2);
+        let _ = writeln!(out, "Planned Phase 3:             {}", c.planned_p3);
+        let _ = writeln!(out, "Planned Phase 4:             {}", c.planned_p4);
+        let _ = writeln!(out, "Deferred subsystem:          {}", c.deferred);
+        let _ = writeln!(out, "Skipped (training/deprecated/vendor): {}", c.skipped);
+        let _ = writeln!(out, "Unrecognized:                {}", c.unrecognized);
+        let _ = writeln!(out);
+        let _ = writeln!(out, "Verdict: {}", self.verdict.explain());
+        let _ = writeln!(out);
+
+        if !quiet {
+            let _ = writeln!(out, "Per-op breakdown:");
+            for op in &self.per_op {
+                let _ = writeln!(
+                    out,
+                    "  {:<24} {:>6} nodes   {}",
+                    op.op_type,
+                    op.count,
+                    op.status.label()
+                );
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inventory::{Inventory, Phase};
+    use crate::walker::walk_model;
+    use smallaios_onnx_rt::onnx_types::{GraphProto, ModelProto, NodeProto};
+
+    fn model_with_ops(ops: &[&str]) -> ModelProto {
+        ModelProto {
+            graph: Some(GraphProto {
+                node: ops
+                    .iter()
+                    .map(|o| NodeProto {
+                        op_type: (*o).to_string(),
+                        ..Default::default()
+                    })
+                    .collect(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn markdown_contains_verdict_and_breakdown() {
+        let inv = Inventory::from_roadmap_str("| Gelu | Planned-P1 | x |");
+        let m = model_with_ops(&["MatMul", "Gelu"]);
+        let report = walk_model(&m, "m.onnx", &inv).unwrap();
+        let md = report.to_markdown(false);
+        assert!(md.contains("# ONNX Coverage Report"));
+        assert!(md.contains("MatMul"));
+        assert!(md.contains("Gelu"));
+        assert!(md.contains("Phase 1"));
+    }
+
+    #[cfg(feature = "json")]
+    #[test]
+    fn json_round_trip_contains_verdict_tag() {
+        let inv = Inventory::from_roadmap_str("| Gelu | Planned-P1 | x |");
+        let m = model_with_ops(&["MatMul", "Gelu"]);
+        let report = walk_model(&m, "m.onnx", &inv).unwrap();
+        let json = report.to_json();
+        assert!(json.contains("\"verdict\""));
+        assert!(json.contains("loadable_after_phase1"));
+    }
+
+    #[test]
+    fn status_counts_verdict_precedence() {
+        // P2 beats P1; unrecognized beats everything.
+        let inv = Inventory::from_roadmap_str("| Gelu | Planned-P1 | |\n| Loop | Planned-P2 | |");
+        let m = model_with_ops(&["MatMul", "Gelu", "Loop"]);
+        let r = walk_model(&m, "m.onnx", &inv).unwrap();
+        assert_eq!(r.verdict, Verdict::LoadableAfterPhase2);
+        assert_eq!(r.counts.planned_p1, 1);
+        assert_eq!(r.counts.planned_p2, 1);
+
+        let m2 = model_with_ops(&["MatMul", "FooBar"]);
+        let r2 = walk_model(&m2, "m.onnx", &inv).unwrap();
+        assert_eq!(r2.verdict, Verdict::HasUnrecognizedOps);
+    }
+
+    #[test]
+    fn planned_phase_parsing_smoke() {
+        assert_eq!(Phase::P1.as_str(), "P1");
+        assert_eq!(Phase::P4.as_str(), "P4");
+    }
+}

--- a/tools/coverage-probe/src/walker.rs
+++ b/tools/coverage-probe/src/walker.rs
@@ -1,0 +1,390 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! ONNX model walker: consumes a `ModelProto`, tallies op kinds, and
+//! optionally flags known attribute-level limitations.
+
+use crate::inventory::{Inventory, OperatorStatus};
+use crate::report::{CoverageReport, NodeSummary, StatusCounts, Verdict};
+use smallaios_onnx_rt::onnx_types::{AttributeProto, AttributeType, ModelProto, NodeProto};
+use smallaios_onnx_rt::protobuf::{decode_model, ProtoError};
+use std::collections::BTreeMap;
+
+/// Error type returned by [`walk_bytes`].
+#[derive(Debug)]
+pub enum WalkError {
+    /// Protobuf decode failed.
+    Decode(ProtoError),
+    /// The model has no graph.
+    EmptyModel,
+}
+
+impl std::fmt::Display for WalkError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WalkError::Decode(e) => write!(f, "protobuf decode error: {e:?}"),
+            WalkError::EmptyModel => write!(f, "model has no graph"),
+        }
+    }
+}
+
+impl std::error::Error for WalkError {}
+
+/// Parse a raw ONNX model buffer and walk it, producing a full report.
+pub fn walk_bytes(
+    bytes: &[u8],
+    model_label: &str,
+    inventory: &Inventory,
+) -> Result<CoverageReport, WalkError> {
+    let model = decode_model(bytes).map_err(WalkError::Decode)?;
+    walk_model(&model, model_label, inventory)
+}
+
+/// Walk an already-decoded [`ModelProto`].
+pub fn walk_model(
+    model: &ModelProto,
+    model_label: &str,
+    inventory: &Inventory,
+) -> Result<CoverageReport, WalkError> {
+    let graph = model.graph.as_ref().ok_or(WalkError::EmptyModel)?;
+
+    // Tally op kinds.
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    let mut concerns_by_op: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    let total_nodes = graph.node.len();
+
+    for node in &graph.node {
+        *counts.entry(node.op_type.clone()).or_insert(0) += 1;
+        for concern in attribute_concerns_for(node) {
+            concerns_by_op
+                .entry(node.op_type.clone())
+                .or_default()
+                .push(concern);
+        }
+    }
+
+    // Build per-op summaries.
+    let mut per_op: Vec<NodeSummary> = counts
+        .into_iter()
+        .map(|(op, count)| {
+            let status = inventory.status_of(&op);
+            let attribute_concerns = concerns_by_op.remove(&op).unwrap_or_default();
+            NodeSummary {
+                op_type: op,
+                count,
+                status,
+                attribute_concerns,
+            }
+        })
+        .collect();
+    // Sort by count descending, then op name ascending.
+    per_op.sort_by(|a, b| {
+        b.count
+            .cmp(&a.count)
+            .then_with(|| a.op_type.cmp(&b.op_type))
+    });
+
+    // Tally statuses.
+    let mut counts = StatusCounts::default();
+    for op in &per_op {
+        match &op.status {
+            OperatorStatus::Implemented => counts.implemented += 1,
+            OperatorStatus::Planned(p) => match p {
+                crate::inventory::Phase::P1 => counts.planned_p1 += 1,
+                crate::inventory::Phase::P2 => counts.planned_p2 += 1,
+                crate::inventory::Phase::P3 => counts.planned_p3 += 1,
+                crate::inventory::Phase::P4 => counts.planned_p4 += 1,
+            },
+            OperatorStatus::DeferredSubsystem(_) => counts.deferred += 1,
+            OperatorStatus::SkippedTraining
+            | OperatorStatus::SkippedDeprecated
+            | OperatorStatus::SkippedVendor => counts.skipped += 1,
+            OperatorStatus::Unrecognized => counts.unrecognized += 1,
+        }
+    }
+
+    let verdict = compute_verdict(&counts);
+
+    Ok(CoverageReport {
+        model_label: model_label.to_string(),
+        total_nodes,
+        distinct_ops: per_op.len(),
+        per_op,
+        counts,
+        verdict,
+        doc_drifts: inventory.drifts().to_vec(),
+    })
+}
+
+/// Compute the overall verdict from aggregate status counts.
+fn compute_verdict(c: &StatusCounts) -> Verdict {
+    if c.unrecognized > 0 {
+        return Verdict::HasUnrecognizedOps;
+    }
+    if c.deferred > 0 || c.skipped > 0 {
+        // These are effectively unsupported for this model.
+        return Verdict::NotLoadable;
+    }
+    if c.planned_p4 > 0 {
+        return Verdict::LoadableAfterPhase4;
+    }
+    if c.planned_p3 > 0 {
+        return Verdict::LoadableAfterPhase3;
+    }
+    if c.planned_p2 > 0 {
+        return Verdict::LoadableAfterPhase2;
+    }
+    if c.planned_p1 > 0 {
+        return Verdict::LoadableAfterPhase1;
+    }
+    Verdict::LoadableToday
+}
+
+/// Flag known attribute-level limitations seeded from the
+/// `onnx-rt/src/ops/*` comments. This is a best-effort list — the goal
+/// is to surface "your Resize node uses cubic mode, which is not
+/// supported" kinds of gotchas before the user runs the model and gets
+/// a cryptic error.
+///
+/// Returns a list of human-readable concern strings.
+pub fn attribute_concerns_for(node: &NodeProto) -> Vec<String> {
+    let mut concerns = Vec::new();
+    match node.op_type.as_str() {
+        "Resize" => {
+            if let Some(s) = string_attr(node, "mode") {
+                if s != "linear" && s != "nearest" {
+                    concerns.push(format!(
+                        "Resize node `{}` uses mode={s}; only linear and nearest are supported",
+                        node.name
+                    ));
+                }
+            }
+            if let Some(s) = string_attr(node, "coordinate_transformation_mode") {
+                if s != "half_pixel" {
+                    concerns.push(format!(
+                        "Resize node `{}` uses coordinate_transformation_mode={s}; only half_pixel is supported",
+                        node.name
+                    ));
+                }
+            }
+            if let Some(f) = float_attr(node, "cubic_coeff_a") {
+                if (f - -0.75).abs() > 1e-6 {
+                    concerns.push(format!(
+                        "Resize node `{}` uses cubic_coeff_a={f}; only -0.75 is supported",
+                        node.name
+                    ));
+                }
+            }
+            if let Some(i) = int_attr(node, "exclude_outside") {
+                if i != 0 {
+                    concerns.push(format!(
+                        "Resize node `{}` uses exclude_outside={i}; only 0 is supported",
+                        node.name
+                    ));
+                }
+            }
+            if let Some(f) = float_attr(node, "extrapolation_value") {
+                if f != 0.0 {
+                    concerns.push(format!(
+                        "Resize node `{}` uses extrapolation_value={f}; only 0 is supported",
+                        node.name
+                    ));
+                }
+            }
+        }
+        "RoiAlign" => {
+            if let Some(s) = string_attr(node, "mode") {
+                if s != "avg" {
+                    concerns.push(format!(
+                        "RoiAlign node `{}` uses mode={s}; only avg is supported",
+                        node.name
+                    ));
+                }
+            }
+        }
+        "GridSample" => {
+            if let Some(s) = string_attr(node, "padding_mode") {
+                if s != "zeros" {
+                    concerns.push(format!(
+                        "GridSample node `{}` uses padding_mode={s}; only zeros is supported",
+                        node.name
+                    ));
+                }
+            }
+        }
+        "Unique" => {
+            // Non-flattened mode = axis attribute present.
+            if int_attr(node, "axis").is_some() {
+                concerns.push(format!(
+                    "Unique node `{}` uses axis mode; only flattened (no axis) is supported",
+                    node.name
+                ));
+            }
+        }
+        "ScatterND" => {
+            if let Some(s) = string_attr(node, "reduction") {
+                if s != "none" && !s.is_empty() {
+                    concerns.push(format!(
+                        "ScatterND node `{}` uses reduction={s}; only none is supported",
+                        node.name
+                    ));
+                }
+            }
+        }
+        _ => {}
+    }
+    concerns
+}
+
+fn find_attr<'a>(node: &'a NodeProto, name: &str) -> Option<&'a AttributeProto> {
+    node.attribute.iter().find(|a| a.name == name)
+}
+
+fn string_attr(node: &NodeProto, name: &str) -> Option<String> {
+    let a = find_attr(node, name)?;
+    if a.attr_type != AttributeType::String {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&a.s).into_owned())
+}
+
+fn int_attr(node: &NodeProto, name: &str) -> Option<i64> {
+    let a = find_attr(node, name)?;
+    if a.attr_type != AttributeType::Int {
+        return None;
+    }
+    Some(a.i)
+}
+
+fn float_attr(node: &NodeProto, name: &str) -> Option<f32> {
+    let a = find_attr(node, name)?;
+    if a.attr_type != AttributeType::Float {
+        return None;
+    }
+    Some(a.f)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use smallaios_onnx_rt::onnx_types::{GraphProto, ModelProto, NodeProto};
+
+    fn node(op: &str) -> NodeProto {
+        NodeProto {
+            op_type: op.to_string(),
+            name: format!("{op}_0"),
+            ..Default::default()
+        }
+    }
+
+    fn model_with_ops(ops: &[&str]) -> ModelProto {
+        let nodes = ops.iter().map(|o| node(o)).collect();
+        ModelProto {
+            graph: Some(GraphProto {
+                node: nodes,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn empty_model_is_loadable_today() {
+        let inv = Inventory::from_roadmap_str("");
+        let m = model_with_ops(&[]);
+        let report = walk_model(&m, "empty.onnx", &inv).unwrap();
+        assert_eq!(report.total_nodes, 0);
+        assert_eq!(report.distinct_ops, 0);
+        assert_eq!(report.verdict, Verdict::LoadableToday);
+    }
+
+    #[test]
+    fn single_supported_op_is_loadable_today() {
+        let inv = Inventory::from_roadmap_str("");
+        let m = model_with_ops(&["MatMul"]);
+        let report = walk_model(&m, "m.onnx", &inv).unwrap();
+        assert_eq!(report.total_nodes, 1);
+        assert_eq!(report.distinct_ops, 1);
+        assert_eq!(report.per_op[0].status, OperatorStatus::Implemented);
+        assert_eq!(report.verdict, Verdict::LoadableToday);
+    }
+
+    #[test]
+    fn multi_op_model_tallies_correctly() {
+        let inv = Inventory::from_roadmap_str("");
+        let m = model_with_ops(&["MatMul", "Add", "MatMul", "Relu", "MatMul"]);
+        let report = walk_model(&m, "m.onnx", &inv).unwrap();
+        assert_eq!(report.total_nodes, 5);
+        assert_eq!(report.distinct_ops, 3);
+        // Should be sorted by count desc.
+        assert_eq!(report.per_op[0].op_type, "MatMul");
+        assert_eq!(report.per_op[0].count, 3);
+    }
+
+    #[test]
+    fn unknown_op_is_unrecognized_and_marks_verdict() {
+        let inv = Inventory::from_roadmap_str("");
+        let m = model_with_ops(&["MatMul", "FrobnicateTheGizmo"]);
+        let report = walk_model(&m, "m.onnx", &inv).unwrap();
+        assert_eq!(report.counts.unrecognized, 1);
+        assert_eq!(report.verdict, Verdict::HasUnrecognizedOps);
+    }
+
+    #[test]
+    fn planned_p1_op_marks_phase1_verdict() {
+        let src = "| Gelu | Planned-P1 | transformer activation |";
+        let inv = Inventory::from_roadmap_str(src);
+        let m = model_with_ops(&["MatMul", "Gelu"]);
+        let report = walk_model(&m, "bert-ish.onnx", &inv).unwrap();
+        assert_eq!(report.counts.planned_p1, 1);
+        assert_eq!(report.counts.implemented, 1);
+        assert_eq!(report.verdict, Verdict::LoadableAfterPhase1);
+    }
+
+    #[test]
+    fn resize_cubic_mode_is_flagged() {
+        let mut n = node("Resize");
+        n.attribute.push(AttributeProto {
+            name: "mode".to_string(),
+            attr_type: AttributeType::String,
+            s: b"cubic".to_vec(),
+            ..Default::default()
+        });
+        let concerns = attribute_concerns_for(&n);
+        assert_eq!(concerns.len(), 1);
+        assert!(concerns[0].contains("cubic"));
+    }
+
+    #[test]
+    fn resize_linear_mode_is_not_flagged() {
+        let mut n = node("Resize");
+        n.attribute.push(AttributeProto {
+            name: "mode".to_string(),
+            attr_type: AttributeType::String,
+            s: b"linear".to_vec(),
+            ..Default::default()
+        });
+        assert!(attribute_concerns_for(&n).is_empty());
+    }
+
+    #[test]
+    fn empty_model_proto_without_graph_errors() {
+        let inv = Inventory::from_roadmap_str("");
+        let m = ModelProto::default();
+        let err = walk_model(&m, "m.onnx", &inv).unwrap_err();
+        assert!(matches!(err, WalkError::EmptyModel));
+    }
+
+    #[test]
+    fn roialign_max_mode_is_flagged() {
+        let mut n = node("RoiAlign");
+        n.attribute.push(AttributeProto {
+            name: "mode".to_string(),
+            attr_type: AttributeType::String,
+            s: b"max".to_vec(),
+            ..Default::default()
+        });
+        let c = attribute_concerns_for(&n);
+        assert_eq!(c.len(), 1);
+    }
+}

--- a/tools/coverage-probe/tests/fixtures.rs
+++ b/tools/coverage-probe/tests/fixtures.rs
@@ -1,0 +1,61 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for `smallaios-coverage-probe`.
+//!
+//! Synthesizes small in-memory `ModelProto` values and walks them end
+//! to end.
+
+use smallaios_coverage_probe::{walk_model, Inventory, Verdict};
+use smallaios_onnx_rt::onnx_types::{GraphProto, ModelProto, NodeProto};
+
+fn model(ops: &[&str]) -> ModelProto {
+    ModelProto {
+        graph: Some(GraphProto {
+            node: ops
+                .iter()
+                .map(|o| NodeProto {
+                    op_type: (*o).to_string(),
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn end_to_end_bert_like_model_is_loadable_after_phase1() {
+    // A very rough BERT-shaped op set: most are implemented in
+    // develop, but `Sin` (for positional encoding) is Planned-P1 in
+    // the real roadmap.
+    let m = model(&[
+        "MatMul",
+        "Add",
+        "LayerNormalization",
+        "Sin",
+        "MatMul",
+        "Softmax",
+    ]);
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../docs/onnx-coverage-roadmap.md"
+    );
+    let inv = Inventory::from_roadmap_file(path).expect("roadmap should parse");
+    let report = walk_model(&m, "bert-like.onnx", &inv).unwrap();
+    assert_eq!(report.total_nodes, 6);
+    assert_eq!(report.distinct_ops, 5);
+    // `Sin` is Planned-P1 in the real roadmap.
+    assert!(report.counts.planned_p1 >= 1);
+    assert_eq!(report.verdict, Verdict::LoadableAfterPhase1);
+}
+
+#[test]
+fn end_to_end_purely_implemented_model() {
+    let m = model(&["MatMul", "Add", "Relu"]);
+    let inv = Inventory::from_roadmap_str("");
+    let report = walk_model(&m, "basic.onnx", &inv).unwrap();
+    assert_eq!(report.verdict, Verdict::LoadableToday);
+    assert_eq!(report.counts.implemented, 3);
+}


### PR DESCRIPTION
## Summary
- New `tools/coverage-probe/` CLI tool that walks an ONNX `ModelProto`, tallies op kinds, and cross-references against `OperatorRegistry` and `docs/onnx-coverage-roadmap.md`
- Emits text (default), Markdown, or JSON (`--json`) reports
- `--detailed` flag flags known attribute limitations (Resize cubic, RoiAlign max, GridSample border, Unique with axis, ScatterND with reduction)
- `--strict` flag exits nonzero on unrecognized/unsupported ops (for CI gating)
- Reuses the existing `smallaios-onnx-rt` protobuf parser, so no new external dependencies
- Detects doc drift (registry implements an op but roadmap still lists it as planned)

## Why
We need empirical validation that Phase 1 actually covers BERT/ViT and Phase 2 covers GPT-2/Llama-3.2 before launching expensive implementation work. Today the only way to know is to try to run the model and watch it crash. The probe gives a structural answer in milliseconds. It is also permanent CI infrastructure: any future operator-coverage PR can point the probe at a fixture to validate the coverage delta.

## Test plan
- [x] `cargo test -p smallaios-coverage-probe` - 29 tests (22 unit + 4 CLI + 2 integration + 1 doctest)
- [x] `cargo clippy -p smallaios-coverage-probe --all-targets -- -D warnings` clean
- [x] Workspace `just clippy` still clean after adding the new member
- [x] `just fmt` clean
- [x] Smoke-ran the release binary against a synthetic ONNX model and confirmed summary / JSON / per-op breakdown output

## Future work
- Wire into CI as a gate: any PR that regresses a fixture from `loadable_today`/`loadable_after_phaseN` to a worse state fails
- Auto-update the roadmap doc inventory from probe output (vs manual maintenance)
- Sub-graph walking for If/Loop/Scan nodes (Phase 2 dependent)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI tool to analyze ONNX operator coverage versus runtime support and a roadmap, outputting Markdown, text, or JSON and supporting strict/detailed/quiet/inventory flags.

* **Documentation**
  * Included a README describing workflow, CLI usage, output formats, doc-drift behavior, and CI integration suggestions.

* **Tests**
  * Added integration fixtures and end-to-end tests validating report verdicts and behaviors.

* **Chores**
  * Registered the new tool in the workspace and added a supply-chain policy entry marking it safe-to-run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->