### PR TITLE
docs(openspec): draft graph-attr-parser-v1 (on-disk If/Loop/Scan)

### DIFF
--- a/openspec/changes/graph-attr-parser-v1/design.md
+++ b/openspec/changes/graph-attr-parser-v1/design.md
@@ -1,0 +1,237 @@
+# Design: graph-attr-parser-v1
+
+## Context
+
+Phase 2 (`generative-llm-v1`, PR #89) shipped the sub-graph executor (`onnx-rt/src/sub_executor.rs`) and the three control-flow operators (`If`/`Loop`/`Scan` in `onnx-rt/src/ops/control_flow.rs`) with full unit-test coverage. Both use synthetic, in-memory `ExecutionGraph` bodies constructed by test-only `_with_body` helpers. The protobuf parser side of that story was explicitly deferred.
+
+Today:
+
+```rust
+// onnx-rt/src/protobuf.rs, inside decode_attribute()
+6 => {
+    // g (GraphProto) — skip for now
+    decoder.skip_field(header.wire_type)?;
+}
+```
+
+and:
+
+```rust
+// onnx-rt/src/onnx_types.rs
+pub struct AttributeProto {
+    pub name: String,
+    pub attr_type: AttributeType,
+    pub f: f32,
+    pub i: i64,
+    pub s: Vec<u8>,
+    pub floats: Vec<f32>,
+    pub ints: Vec<i64>,
+    pub strings: Vec<Vec<u8>>,
+    pub t: Option<Box<TensorProto>>,
+    // no `g` field
+}
+```
+
+This change closes that gap with minimum surface area.
+
+## Goals
+
+- Decode `AttributeProto.g` (field 6) on-disk so `Session::new_from_file()` can load models with embedded `If`/`Loop`/`Scan` bodies.
+- Wire the compiled inner graph into the existing sub-graph executor without changing its public behaviour.
+- Delete the test-only `_with_body` shims — after this change, the production parser path is the only path, and the existing Phase 2 tests still cover the executor logic because they can now build an `AttributeProto { g: Some(...) }` directly instead of calling a special constructor.
+
+## Non-Goals
+
+- Decoding other unimplemented `AttributeType` variants (`SparseTensor`, `TypeProto`, plural `Graphs`, etc.).
+- Adding operator-set overrides at the sub-graph level (no consumer uses them).
+- Redesigning the sub-graph executor's value-scope semantics — those stay as Phase 2 shipped them.
+
+## Decisions
+
+### D1: `AttributeProto` field layout
+
+ONNX `AttributeProto` field 6 is `g: GraphProto` (a single nested message, not repeated). Add a corresponding Rust field:
+
+```rust
+pub struct AttributeProto {
+    // ... existing fields ...
+    pub t: Option<Box<TensorProto>>,
+    pub g: Option<Box<GraphProto>>,  // NEW
+}
+```
+
+Boxed because `GraphProto` is significantly larger than the other scalar fields and the common case (`attr_type` in `{Float, Int, Ints, Floats, Tensor}`) should not pay for the inline memory. Matches the existing treatment of `t: Option<Box<TensorProto>>`. Update `Default for AttributeProto` to set `g: None`.
+
+### D2: Recursive parser entry point
+
+The protobuf decoder already has a `decode_graph` function used by `decode_model` for the top-level `ModelProto.graph` (field 2). Reuse it in `decode_attribute` field 6:
+
+```rust
+6 => {
+    // g (GraphProto) — recursive parse of nested body graph.
+    let graph_data = decoder.read_length_delimited()?;
+    let nested = decode_graph_with_depth(graph_data, depth + 1)?;
+    attr.g = Some(alloc::boxed::Box::new(nested));
+    if attr.attr_type == AttributeType::Undefined {
+        attr.attr_type = AttributeType::Graph;
+    }
+}
+```
+
+Recursion is bounded by the graph nesting depth in the ONNX file — typically 1 (body of a `Loop` containing standard ops), occasionally 2 (`Loop` body containing an `If`). We add an explicit guard:
+
+```rust
+const MAX_GRAPH_NESTING_DEPTH: usize = 16;
+```
+
+returning `ProtoError::NestingTooDeep` if exceeded. The public `decode_graph` / `decode_attribute` entry points keep their existing signatures; the depth counter threads through private helpers `decode_graph_with_depth` / `decode_attribute_with_depth`. The public entrypoints just start at depth 0.
+
+### D3: When does the inner `GraphProto` become an `ExecutionGraph`?
+
+Two options:
+
+- **(a) At parse time** — `decode_attribute` returns an already-compiled `ExecutionGraph`, never a raw `GraphProto`. Pro: errors caught at load. Con: the protobuf layer would need to depend on the graph-builder layer, inverting the current parser → graph → executor flow. Con: every parsed model pays compilation cost even for attributes it ignores.
+- **(b) At graph-build time** — parser stores the raw `GraphProto`; the graph builder compiles it during `build_execution_graph`. Pro: compilation is one explicit step the graph builder is already responsible for. Pro: preserves layering (protobuf layer stays pure data, graph layer owns "now executable").
+
+**Decision: (b).** The graph builder is the single source of truth for "this is now executable", and the compilation cost should be visible at the call site that traverses nodes. The parser stays a dumb deserializer.
+
+### D4: Storage on `ExecutionNode`
+
+Add a new field to `ExecutionNode`:
+
+```rust
+pub struct ExecutionNode {
+    // ... existing fields ...
+    pub attributes: Vec<AttributeProto>,
+    pub inner_graphs: BTreeMap<String, ExecutionGraph>,  // NEW
+}
+```
+
+Keyed by attribute name because `If` uses *two* inner graphs (`then_branch` and `else_branch`) and `Loop`/`Scan` use one (`body`). A `BTreeMap<String, _>` is deterministic-order (important for debug output) and small (≤ 2 entries in practice). `BTreeMap` rather than `Vec<(String, _)>` for readable lookup at dispatch time.
+
+The graph builder populates this map inside `create_execution_nodes`:
+
+```rust
+fn create_execution_nodes(graph: &GraphProto) -> Result<Vec<ExecutionNode>, GraphError> {
+    let mut out = Vec::with_capacity(graph.node.len());
+    for (i, node_proto) in graph.node.iter().enumerate() {
+        let mut inner_graphs = BTreeMap::new();
+        for attr in &node_proto.attribute {
+            if let Some(inner_proto) = &attr.g {
+                let inner_exec = build_execution_graph_with_depth(inner_proto, depth + 1)?;
+                inner_graphs.insert(attr.name.clone(), inner_exec);
+            }
+        }
+        out.push(ExecutionNode {
+            node_index: NodeIndex::new(i),
+            op_type: node_proto.op_type.clone(),
+            name: node_proto.name.clone(),
+            inputs: node_proto.input.clone(),
+            outputs: node_proto.output.clone(),
+            dependencies: Vec::new(),
+            attributes: node_proto.attribute.clone(),
+            inner_graphs,
+        });
+    }
+    Ok(out)
+}
+```
+
+`create_execution_nodes` changes from infallible to `Result<..., GraphError>` (it can now propagate inner-graph compilation failures). `build_execution_graph` itself threads depth through a new private helper `build_execution_graph_with_depth`, matching the parser's depth-threading pattern. `GraphError::NestingTooDeep` is added alongside `CyclicGraph`/`MissingInput`.
+
+**Outer-referenced names.** Inside an `If`/`Loop` body, a node may reference a tensor defined in the *outer* graph (captured values and loop-carried inputs). The current `resolve_dependencies` raises `GraphError::MissingInput` for any unresolved name. To stay layering-clean, the inner `build_execution_graph` call must *not* treat outer names as errors. We handle this by:
+
+1. Passing the outer graph's known-names set as an allow-list into the recursive call, OR
+2. Deferring the check: treat any unresolved name in an inner graph as an implicit outer reference (the sub-graph executor already seeds these at runtime from its parent scope).
+
+**Decision: option 2.** The sub-graph executor already owns the value-resolution semantics (it explicitly merges outer scope at entry). The graph builder's only job for inner graphs is to produce a topologically ordered list of nodes; unresolved names are left to the runtime to satisfy. We add a new `build_execution_graph_inner` variant that skips the `MissingInput` check for names absent from *both* input_names and the producer map. Cycles are still errors; missing inputs become runtime `SubExecutorError::UnresolvedOuterRef` if they are never supplied.
+
+### D5: Sub-graph executor integration
+
+Phase 2 shipped the executor with three test-only constructors:
+
+```rust
+// onnx-rt/src/sub_executor.rs (Phase 2)
+#[doc(hidden)]
+pub fn op_if_with_body(
+    cond: &Tensor,
+    then_body: &ExecutionGraph,
+    else_body: &ExecutionGraph,
+    ctx: &mut SubExecCtx,
+) -> Result<Vec<Tensor>, SubExecError> { ... }
+
+#[doc(hidden)]
+pub fn op_loop_with_body(...) -> Result<_, _> { ... }
+
+#[doc(hidden)]
+pub fn op_scan_with_body(...) -> Result<_, _> { ... }
+```
+
+After this change, `executor.rs::dispatch_node` calls `sub_executor::run_sub_graph` directly, reading the body from `node.inner_graphs`:
+
+```rust
+OpKind::If => {
+    let cond = values.get_required(&node.inputs[0])?;
+    let then_body = node.inner_graphs.get("then_branch")
+        .ok_or(ExecutionError::MissingInnerGraph("then_branch"))?;
+    let else_body = node.inner_graphs.get("else_branch")
+        .ok_or(ExecutionError::MissingInnerGraph("else_branch"))?;
+    let selected = if cond_is_true(cond)? { then_body } else { else_body };
+    sub_executor::run_sub_graph(selected, /* captured outer values */, ctx)?
+}
+OpKind::Loop => {
+    let body = node.inner_graphs.get("body")
+        .ok_or(ExecutionError::MissingInnerGraph("body"))?;
+    sub_executor::run_loop(body, /* M, cond, v_initial */, ctx)?
+}
+OpKind::Scan => {
+    let body = node.inner_graphs.get("body")
+        .ok_or(ExecutionError::MissingInnerGraph("body"))?;
+    sub_executor::run_scan(body, /* inputs, axes */, ctx)?
+}
+```
+
+The three `_with_body` helpers are deleted. Phase 2's unit tests that currently call them are updated (straightforward mechanical change: build an `AttributeProto { name: "body".into(), attr_type: AttributeType::Graph, g: Some(Box::new(inner_proto)), ..Default::default() }`, push it into a `NodeProto.attribute`, let the graph builder compile it).
+
+### D6: Validation
+
+Three layers of validation:
+
+1. **Protobuf round-trip unit tests** (`protobuf.rs` tests module): encode a minimal `AttributeProto` whose `g` field contains a hand-built `GraphProto` with one `Add` node; decode; assert the round-tripped `AttributeProto.g` has the expected node count, inputs, outputs. Plus a negative test: decode a maliciously-nested 17-deep graph and expect `ProtoError::NestingTooDeep`.
+
+2. **Graph builder unit tests** (`graph.rs` tests module): construct an in-memory `GraphProto` whose top-level contains a `Loop` node with an `AttributeProto { g: Some(inner), .. }`. Call `build_execution_graph`. Assert the returned `ExecutionGraph.nodes[0].inner_graphs["body"]` has the expected node count and topological order. Plus negative tests for nesting-depth overflow and inner-graph cycles.
+
+3. **End-to-end fixture test** (feature-gated, in `onnx-rt/tests/` or the existing `tests/fixtures/` mechanism): a small synthetic ONNX file — a 2-input `Loop` wrapping a `MatMul + Add` body — exported from a scripted PyTorch builder (`tests/fixtures/scripts/build_loop_fixture.py`, not checked into the main test shard). The test loads the file via `Session::new_from_file()`, runs it, and compares against a reference value. Gated behind an `onnx-fixtures` cargo feature so it only runs when the fixture is present, matching the pattern used by the existing `bert-tiny` / `vit-tiny` fixture tests.
+
+## Alternatives Considered
+
+### Alt 1: Explicit `Graph` IR layer between parser and executor
+
+Introduce a new `ir::Graph` type that sits between `GraphProto` and `ExecutionGraph`, with its own recursion/validation logic, and have the graph builder consume `ir::Graph` instead of `GraphProto`.
+
+**Rejected** because (a) it duplicates work `ExecutionGraph` already does (topological sort, dependency resolution, name tables), (b) it adds a layer that no other part of the runtime needs, and (c) the recursion bound is cheap enough that threading a depth counter through two existing functions is strictly less code than adding a new IR.
+
+### Alt 2: Compile inner graphs lazily at first dispatch
+
+Store raw `GraphProto` on `ExecutionNode` and compile it the first time `dispatch_node` hits the parent op. Pro: cheaper load for models that have `If` branches they never take.
+
+**Rejected** because (a) the savings are negligible — inner graphs are small by construction, and (b) we prefer "load-time errors" so a malformed model fails fast at `Session::new()` rather than mid-inference during a deadline-critical call. Consistent with the project's DO-178C-oriented design stance.
+
+### Alt 3: Flatten all inner graphs into the outer graph at parse time
+
+Inline `If`/`Loop`/`Scan` bodies into the parent graph with gated execution, eliminating the need for a sub-graph executor entirely.
+
+**Rejected** because (a) Phase 2 already shipped the sub-graph executor and extensively tested it — throwing it away now is a pure loss, (b) `Loop` has dynamic iteration counts that cannot be flattened at compile time, and (c) flattening `If` duplicates the dead branch's work because `dispatch_node` would still visit both paths in topological order.
+
+## Open Questions
+
+None at planning time. The sub-graph executor's scope-management semantics (Phase 2) are already settled, and the parser extension is mechanically simple once field 6 is wired up.
+
+## Success Criteria
+
+- `decode_attribute` round-trips `AttributeProto.g` losslessly for up to 16 levels of nesting; depth 17 returns `ProtoError::NestingTooDeep`.
+- `build_execution_graph` populates `inner_graphs` for every node whose `NodeProto` has graph-valued attributes, with correct topological order on each inner graph.
+- `executor::dispatch_node` handles `OpKind::If`/`Loop`/`Scan` entirely from `ExecutionNode.inner_graphs` — `grep -n '_with_body' onnx-rt/src/` returns zero hits outside `#[cfg(test)]` blocks (or zero hits total if the helpers are fully deleted).
+- End-to-end: a synthetic on-disk `loop.onnx` file loads via `Session::new_from_file()` and runs to completion, producing the expected output tensor, with zero test-only helper calls in the runtime path.
+- `cargo fmt`, `cargo clippy -D warnings`, and `cargo test --workspace` all pass.
+- Estimated ~300 LOC of production code, ~400 LOC of tests.

--- a/openspec/changes/graph-attr-parser-v1/proposal.md
+++ b/openspec/changes/graph-attr-parser-v1/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+Phase 2 of the ONNX coverage roadmap (`generative-llm-v1`, PR #89) ships the sub-graph executor (`onnx-rt/src/sub_executor.rs`) and the three control-flow operators (`If`, `Loop`, `Scan` in `onnx-rt/src/ops/control_flow.rs`). Both landed with full unit-test coverage using synthetic, in-memory `ExecutionGraph` bodies constructed by test-only `_with_body` helpers (`op_loop_with_body`, `op_if_with_body`, `op_scan_with_body`).
+
+What Phase 2 **deferred** — and what this change closes — is the protobuf parser side of that story. Today `onnx-rt/src/protobuf.rs::decode_attribute` explicitly skips field 6 of `AttributeProto`:
+
+```rust
+6 => {
+    // g (GraphProto) — skip for now
+    decoder.skip_field(header.wire_type)?;
+}
+```
+
+That means when a *real* on-disk ONNX file contains an `If`/`Loop`/`Scan` node, the body `GraphProto` is silently dropped during parsing. The dispatcher then has no inner graph to execute and must bail out. The control-flow operators are effectively only reachable through unit tests, not through `Session::new_from_file()`.
+
+Closing this gap unlocks **single-call in-graph autoregressive generation** for any decoder-only model exported via `optimum --use-cache`-style tooling. Those are the models the entire Phase 2 sub-graph executor was built to run. Without this parser change, they still require an external host-side token loop.
+
+The deferral was intentional: Agent L, who implemented Phase 2, scoped the parser extension out as a "focused follow-up" because (a) the sub-graph executor itself is the large, risky piece and deserved its own change, and (b) graph-attribute parsing is mechanically simple once the executor is in place. See the `generative-llm-v1` archived change and the PR #89 description for the original rationale.
+
+## What Changes
+
+- **Extend `AttributeProto`** (`onnx-rt/src/onnx_types.rs`) with a new field `pub g: Option<Box<GraphProto>>`. Boxed because `GraphProto` is large and the common case (scalar attributes) should not pay for it.
+- **Decode field 6 of `AttributeProto`** in `protobuf.rs::decode_attribute`. Replace the `skip_field` stub with a recursive call to `decode_graph` (which already exists for parsing top-level `ModelProto.graph`). Flip `attr_type` to `AttributeType::Graph` when the field is encountered without an explicit field 20 type tag.
+- **Extend `ExecutionNode`** (`onnx-rt/src/graph.rs`) with a new field `pub inner_graphs: BTreeMap<String, ExecutionGraph>`, keyed by attribute name (`body`, `then_branch`, `else_branch`).
+- **Recursive graph compilation**. Extend `build_execution_graph` to walk each created `ExecutionNode`'s attributes, and for every attribute with a non-`None` `g` field, compile the inner `GraphProto` into its own `ExecutionGraph` via a recursive call, storing the result on the parent node's `inner_graphs` map.
+- **Dispatcher integration**. Update `executor.rs::dispatch_node` so that `OpKind::If`/`Loop`/`Scan` read the body graph from `node.inner_graphs` and hand it to `sub_executor::run_sub_graph` directly. Delete (or `#[cfg(test)]`-gate and `#[doc(hidden)]`) the test-only `op_loop_with_body` / `op_if_with_body` / `op_scan_with_body` shim helpers.
+- **End-to-end test**. Add a fixture-based integration test that loads a small synthetic ONNX file containing an embedded `Loop` body and runs it to completion via the public `Session` API, proving the path works without any test-only helpers. Feature-gated like the existing fixture tests so it does not need to run in every CI shard.
+
+### Modified Capabilities
+
+- `onnx-cpu-execution`: Add three requirements covering graph-attribute parsing, inner-graph compilation, and dispatcher wiring.
+
+## Impact
+
+- **Code:**
+  - `onnx-rt/src/onnx_types.rs` — add `AttributeProto.g` field and update `Default`.
+  - `onnx-rt/src/protobuf.rs` — decode field 6 of `AttributeProto` via recursive `decode_graph`; add `MAX_GRAPH_NESTING_DEPTH` safety net and `ProtoError::NestingTooDeep` variant.
+  - `onnx-rt/src/graph.rs` — add `ExecutionNode.inner_graphs` field; extend `build_execution_graph` to compile inner graphs recursively.
+  - `onnx-rt/src/executor.rs` — route `OpKind::If`/`Loop`/`Scan` dispatch through `node.inner_graphs`.
+  - `onnx-rt/src/sub_executor.rs` — drop the three `_with_body` test shims (or gate them behind `#[cfg(test)]` + `#[doc(hidden)]`).
+  - Tests: ~8 new unit tests covering field-6 decoding round-trips, nested-graph depth limiting, inner-graph compilation, and recursive topological sort; 1 end-to-end fixture test with a real on-disk ONNX `Loop`.
+- **APIs:** No breaking changes to the public `Session` API. `AttributeProto` gains a new public field (additive); `ExecutionNode` gains a new public field (additive). `cargo-semver-checks` will flag these as minor bumps; conventional commit is `feat(onnx-rt)`.
+- **Estimated size:** ~300 LOC of production code plus ~400 LOC of tests. Small and focused.
+- **Risk:** The graph builder has so far only been called on the top-level `GraphProto`. Recursive compilation must not rely on any module-level state (it currently does not — `build_execution_graph` is a pure function over its `GraphProto` argument), and must not accidentally treat inner graph inputs as missing when they reference outer-graph values. The design note D4 addresses this: outer-referenced names are intentionally left as `MissingInput`-safe (handled by the sub-graph executor at runtime, not at build time) because the same mechanism already exists for loop-carried values.
+
+## Out of Scope
+
+- **Full `Scan` axis handling.** `Scan` uses the same field-6 machinery to carry its body, so the parser change automatically unblocks it. However, `Scan` has additional `scan_input_axes` / `scan_output_axes` / `scan_input_directions` / `scan_output_directions` attributes that control iteration order and output stacking. Those are already decoded by Phase 2 as integer-list attributes; this change does not touch them. If the Phase 2 sub-graph executor fully consumes those attributes (it should — see `op_scan_with_body` in `sub_executor.rs`), `Scan` lights up for free. If not, a small follow-up will be needed.
+- **Other deferred `AttributeType` variants** (`SparseTensor`, `TypeProto`, `Graphs` plural, `SparseTensors`, `TypeProtos`). These are not used by any operator in the Phase 1 or Phase 2 inventory. This change is deliberately narrow to field 6 only.
+- **Graph-attribute support for operator-set-dependent opset version checks.** Inner graphs inherit the outer graph's opset; per-subgraph opset overrides are an ONNX feature no one in our inventory uses.
+
+## Risks
+
+- **Recursive `build_execution_graph` stack depth.** The ONNX schema permits arbitrary nesting, but in practice all models we care about have nesting depth ≤ 3 (typical: a `Loop` containing a body with a few MatMul/Add ops). We add a `MAX_GRAPH_NESTING_DEPTH = 16` safety net returning `GraphError::NestingTooDeep` on overflow. This is cheaper and more predictable than letting the host stack blow up.
+- **Dead test helpers becoming stale.** The sub-graph executor currently exposes three test-only constructors that build inner graphs by hand. Once the real parser path lands, those helpers should be deleted, not left around, so Phase 2's tests prove the same code path the production parser exercises. The dispatcher wiring step in this change includes that deletion (or at minimum `#[cfg(test)]`-gating).
+- **Ordering with `generative-llm-v1` merge.** This change is logically a follow-up to PR #89 and cannot be implemented until #89 merges. The OpenSpec artifacts in this folder can be reviewed independently; implementation is gated on #89 landing in develop.

--- a/openspec/changes/graph-attr-parser-v1/specs/onnx-cpu-execution/spec.md
+++ b/openspec/changes/graph-attr-parser-v1/specs/onnx-cpu-execution/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Graph Attribute Parsing
+The ONNX runtime SHALL decode `AttributeProto.g` (field 6, a single nested `GraphProto`) into an owned `Option<Box<GraphProto>>` value when parsing model files. The parser SHALL enforce a maximum graph nesting depth of 16 and return `ProtoError::NestingTooDeep` for deeper inputs.
+
+#### Scenario: Loop body GraphProto round-trips losslessly
+- **WHEN** a model file contains a `Loop` node whose `body` attribute (`AttributeProto`, field 6) wraps a `GraphProto` with two nodes (`MatMul`, `Add`)
+- **THEN** `decode_attribute` MUST return an `AttributeProto` with `g = Some(Box::new(...))`
+- **AND** the returned inner `GraphProto` MUST contain exactly two `NodeProto` entries with `op_type = "MatMul"` and `op_type = "Add"` in that order
+- **AND** `attr_type` MUST be set to `AttributeType::Graph` even when the original bytes omit field 20
+
+#### Scenario: Nested graph depth limit
+- **WHEN** a maliciously constructed model nests `AttributeProto.g` values 17 levels deep
+- **THEN** `decode_attribute` MUST return `ProtoError::NestingTooDeep`
+- **AND** MUST NOT recurse into the 17th level
+- **AND** MUST NOT blow the host stack
+
+#### Scenario: Non-graph attribute unchanged
+- **WHEN** a model file contains a scalar `Float` attribute with no `g` field set
+- **THEN** `decode_attribute` MUST return `g = None`
+- **AND** the parser behavior for all other `AttributeType` variants MUST be unchanged from the pre-change baseline
+
+### Requirement: Inner Graph Compilation
+The graph builder SHALL compile every `AttributeProto.g` value reached during `build_execution_graph` into its own standalone `ExecutionGraph` and store it on the parent `ExecutionNode.inner_graphs`, keyed by the attribute's name.
+
+#### Scenario: Loop body compiled and cached on parent node
+- **WHEN** `build_execution_graph` is called on a `GraphProto` whose top-level contains a `Loop` node with a `body` graph attribute
+- **THEN** the returned `ExecutionGraph.nodes[loop_index].inner_graphs` MUST contain a single entry with key `"body"`
+- **AND** the inner `ExecutionGraph` MUST have its own populated `topological_order` with `node_count > 0`
+- **AND** the parent `ExecutionNode.attributes` MUST still contain the original `AttributeProto` (attribute cloning is not replaced by the inner-graph map)
+
+#### Scenario: If node compiles both branches
+- **WHEN** `build_execution_graph` is called on a graph containing an `If` node with both `then_branch` and `else_branch` attributes
+- **THEN** the parent `ExecutionNode.inner_graphs` MUST contain two entries with keys `"then_branch"` and `"else_branch"`
+- **AND** each inner `ExecutionGraph` MUST have its own topological order
+
+#### Scenario: Inner graph outer-referenced names are not rejected
+- **WHEN** an inner graph references a tensor name defined by the outer graph (captured value or loop-carried input) rather than produced by a sibling node inside the inner graph
+- **THEN** the recursive `build_execution_graph_inner` call MUST NOT return `GraphError::MissingInput` for that name
+- **AND** MUST leave resolution to the sub-graph executor at runtime
+
+#### Scenario: Inner graph nesting depth overflow
+- **WHEN** `build_execution_graph` encounters a chain of nested inner graphs deeper than 16 levels
+- **THEN** the builder MUST return `GraphError::NestingTooDeep`
+
+### Requirement: Sub-Graph Dispatch From Inner Graphs
+The dispatcher SHALL execute `If`, `Loop`, and `Scan` operators by reading the compiled inner graph from `ExecutionNode.inner_graphs`, without relying on any test-only constructors or externally passed body parameters.
+
+#### Scenario: On-disk Loop model runs end-to-end
+- **WHEN** a `Session` is created from a model file whose top-level graph contains a `Loop` wrapping a body of `MatMul + Add` and `Session::run()` is called with valid inputs
+- **THEN** the dispatcher MUST retrieve `node.inner_graphs["body"]` at dispatch time
+- **AND** MUST pass it directly to `sub_executor::run_loop`
+- **AND** MUST NOT invoke any function whose name contains `_with_body`
+- **AND** the final output tensors MUST match a hand-computed reference within `f32::EPSILON * 16.0`
+
+#### Scenario: On-disk If model selects a branch
+- **WHEN** a model file contains an `If` node and the runtime condition evaluates to `true`
+- **THEN** the dispatcher MUST execute `node.inner_graphs["then_branch"]` via `sub_executor::run_sub_graph`
+- **AND** MUST NOT execute the `else_branch`
+
+#### Scenario: Missing inner graph surfaces a clear error
+- **WHEN** a malformed model presents an `If` node whose `then_branch` attribute has `g = None`
+- **THEN** the dispatcher MUST return `ExecutionError::MissingInnerGraph("then_branch")`
+- **AND** MUST NOT panic

--- a/openspec/changes/graph-attr-parser-v1/tasks.md
+++ b/openspec/changes/graph-attr-parser-v1/tasks.md
@@ -1,0 +1,50 @@
+# Tasks: graph-attr-parser-v1
+
+> Implementation gated on `generative-llm-v1` (PR #89) landing in develop.
+> These tasks assume `onnx-rt/src/sub_executor.rs` and `onnx-rt/src/ops/control_flow.rs` already exist.
+
+## 1. AttributeProto extension
+
+- [ ] 1.1 Add `pub g: Option<alloc::boxed::Box<GraphProto>>` field to `AttributeProto` in `onnx-rt/src/onnx_types.rs`.
+- [ ] 1.2 Update `impl Default for AttributeProto` to initialize `g: None`.
+- [ ] 1.3 Update the existing `AttributeProto` unit tests (`onnx_types.rs` tests module) to include a case asserting `g == None` on default, and one case constructing a graph-valued attribute by hand.
+
+## 2. Protobuf decoder field 6
+
+- [ ] 2.1 Add `ProtoError::NestingTooDeep` variant and `const MAX_GRAPH_NESTING_DEPTH: usize = 16` in `onnx-rt/src/protobuf.rs`.
+- [ ] 2.2 Introduce private helpers `decode_graph_with_depth(bytes, depth)` and `decode_attribute_with_depth(bytes, depth)`; keep the public `decode_graph` / `decode_attribute` as thin wrappers calling at `depth = 0`.
+- [ ] 2.3 Replace the `6 => decoder.skip_field(...)` stub in `decode_attribute_with_depth` with a length-delimited read + recursive `decode_graph_with_depth(..., depth + 1)`. Set `attr.g = Some(Box::new(...))` and flip `attr_type` to `AttributeType::Graph` when currently `Undefined`.
+- [ ] 2.4 Add `protobuf.rs` unit tests: (a) round-trip a `Loop` body with one `Add` node through `decode_attribute`; (b) reject a 17-level nested graph with `ProtoError::NestingTooDeep`; (c) assert that a scalar attribute still round-trips with `g = None`; (d) assert `attr_type` auto-flips to `Graph` when field 20 is omitted.
+
+## 3. Graph builder recursive compilation
+
+- [ ] 3.1 Add `GraphError::NestingTooDeep` variant in `onnx-rt/src/graph.rs`.
+- [ ] 3.2 Introduce private helper `build_execution_graph_with_depth(graph, depth)` and `build_execution_graph_inner(graph, depth)` (the latter relaxes `MissingInput` for names unknown in the inner scope). Public `build_execution_graph` becomes a thin wrapper at `depth = 0`.
+- [ ] 3.3 Change `create_execution_nodes` signature to `fn create_execution_nodes(graph: &GraphProto, depth: usize) -> Result<Vec<ExecutionNode>, GraphError>`; for each attribute with `g.is_some()`, recursively call `build_execution_graph_inner(inner, depth + 1)` and insert into the node's `inner_graphs`.
+- [ ] 3.4 Thread the new `Result` return through `build_execution_graph` (currently calls `create_execution_nodes` infallibly — now it must `?`).
+- [ ] 3.5 Add graph builder unit tests: (a) top-level Loop with inner MatMul+Add compiles and populates `inner_graphs["body"]`; (b) If with both branches populates two entries; (c) nesting depth 17 returns `GraphError::NestingTooDeep`; (d) inner graph referencing an outer-defined tensor name does NOT return `MissingInput`.
+
+## 4. ExecutionNode.inner_graphs field
+
+- [ ] 4.1 Add `pub inner_graphs: alloc::collections::BTreeMap<String, ExecutionGraph>` field to `ExecutionNode` in `onnx-rt/src/graph.rs`.
+- [ ] 4.2 Initialize to empty in any `ExecutionNode` construction site outside `create_execution_nodes` (search with `grep -rn 'ExecutionNode {' onnx-rt/`); typically only test helpers need updating.
+- [ ] 4.3 Make sure `ExecutionNode` still derives `Debug, Clone`; verify `BTreeMap<String, ExecutionGraph>` satisfies both.
+
+## 5. Dispatcher integration + delete test-only helpers
+
+- [ ] 5.1 In `onnx-rt/src/executor.rs::dispatch_node`, handle `OpKind::If` by looking up `node.inner_graphs["then_branch"]` and `node.inner_graphs["else_branch"]`, then calling `sub_executor::run_sub_graph` directly with the selected branch. Surface `ExecutionError::MissingInnerGraph(&'static str)` on a `None` lookup.
+- [ ] 5.2 Handle `OpKind::Loop` by looking up `node.inner_graphs["body"]` and calling `sub_executor::run_loop(...)`. Likewise for `OpKind::Scan` → `sub_executor::run_scan(...)`.
+- [ ] 5.3 Delete `op_if_with_body`, `op_loop_with_body`, `op_scan_with_body` from `onnx-rt/src/sub_executor.rs` (or gate them behind `#[cfg(test)] #[doc(hidden)]` if a handful of Phase 2 tests still need them as a transition step — prefer deletion, update the tests to go through the parser/builder path).
+- [ ] 5.4 Update any Phase 2 unit tests that currently call `_with_body` helpers: rewrite them to construct an `AttributeProto { name: "body".into(), g: Some(Box::new(inner_proto)), attr_type: AttributeType::Graph, .. }` and let the graph builder compile it. Grep for `_with_body` in `onnx-rt/` and confirm zero hits post-change.
+
+## 6. End-to-end test with synthetic Loop ONNX file
+
+- [ ] 6.1 Add a Python fixture builder script `onnx-rt/tests/fixtures/scripts/build_loop_fixture.py` that uses the `onnx` library (not torch — keep it minimal) to construct a `ModelProto` with a `Loop` wrapping `MatMul + Add`, running for a fixed `M = 4` iterations. Write the result to `onnx-rt/tests/fixtures/loop_matmul_add.onnx`. Document prerequisites (`pip install onnx`) in a top-of-file comment.
+- [ ] 6.2 Add an integration test in `onnx-rt/tests/` (or the existing fixture-test module) gated behind the `onnx-fixtures` cargo feature. The test loads `loop_matmul_add.onnx` via `Session::new_from_file()`, runs it with known inputs, and asserts the output matches a hand-computed reference within `f32::EPSILON * 16.0`.
+- [ ] 6.3 Verify `grep -n '_with_body' onnx-rt/src/` returns zero hits outside `#[cfg(test)]` (or zero hits total).
+
+## 7. Validation: fmt / clippy / test
+
+- [ ] 7.1 `just fmt-check` (or `cargo fmt -- --check`) passes.
+- [ ] 7.2 `just clippy` (or `cargo clippy --workspace -- -D warnings`) passes.
+- [ ] 7.3 `just test` passes (all existing 4,143+ tests plus the new unit + fixture tests). Confirm `cargo-semver-checks` flags the change as `minor` (new public fields on `AttributeProto` and `ExecutionNode`) and that the PR title is `feat(onnx-rt): decode AttributeProto.g for on-disk If/Loop/Scan`.


### PR DESCRIPTION
## Summary

Plan-only OpenSpec change extending the protobuf parser to decode `AttributeProto.g` (field 6, `GraphProto`) so on-disk ONNX models containing `If`/`Loop`/`Scan` operators can be loaded end-to-end.

Phase 2 (`generative-llm-v1`, #89) shipped the sub-graph executor (`onnx-rt/src/sub_executor.rs`) and control-flow ops with synthetic in-memory body graphs via test-only `_with_body` helpers. The protobuf decoder currently skips field 6:

```rust
6 => {
    // g (GraphProto) — skip for now
    decoder.skip_field(header.wire_type)?;
}
```

This change closes that gap so models exported via `optimum --use-cache`-style tooling with embedded control flow load via `Session::new_from_file()` without test-only helpers.

## Artifacts

- `openspec/changes/graph-attr-parser-v1/proposal.md` — Why/What/Impact/Risks
- `openspec/changes/graph-attr-parser-v1/design.md` — D1-D6 decisions plus three rejected alternatives
- `openspec/changes/graph-attr-parser-v1/specs/onnx-cpu-execution/spec.md` — three ADDED requirements (Graph Attribute Parsing, Inner Graph Compilation, Sub-Graph Dispatch)
- `openspec/changes/graph-attr-parser-v1/tasks.md` — 25 tasks across 7 buckets

## Scope

- **In scope:** `AttributeProto.g` decoding, recursive `build_execution_graph` compilation, `ExecutionNode.inner_graphs` storage, dispatcher wiring, deletion of `_with_body` shims, end-to-end fixture test.
- **Out of scope:** other unimplemented `AttributeType` variants (`SparseTensor`, `TypeProto`, plural `Graphs`), per-subgraph opset overrides, `Scan` axis semantics beyond what Phase 2 already handles.

Estimated ~300 LOC production + ~400 LOC tests. Implementation gated on #89 merging.

## Validation

- [x] `openspec validate graph-attr-parser-v1 --strict` passes
- [ ] Implementation (deferred — plan only)

## Test plan

- [ ] Spec review
- [ ] After #89 merges, a follow-up PR implements this change per the tasks.md checklist
- [ ] The follow-up must end with `grep -n '_with_body' onnx-rt/src/` returning zero hits outside `#[cfg(test)]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design specifications for nested graph attribute parsing support.
  * Documented implementation plan for control-flow operations (If, Loop, Scan).
  * Specified safety mechanisms including maximum nesting depth limits to prevent stack overflow.
  * Added end-to-end execution requirements and test scenarios for complex ONNX models with embedded graph structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->