### PR TITLE
docs(openspec): draft microsoft-fused-ops-v1 (Llama/Gemma/DeepSeek unblock)

### DIFF
--- a/openspec/changes/microsoft-fused-ops-v1/design.md
+++ b/openspec/changes/microsoft-fused-ops-v1/design.md
@@ -1,0 +1,657 @@
+# Design — Microsoft Fused Ops for Llama / Gemma / DeepSeek
+
+## Context
+
+The empirical coverage probe (`tools/coverage-probe/REPORT.md`) walked
+the canonical HuggingFace ONNX exports of three modern decoder-only
+LLM families — `meta-llama/Llama-3.2-1B`, `google/gemma-3-1b-it`, and
+`deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B` — counting node frequencies
+by op name and domain. Every standard-domain ONNX op in all three
+models is already implemented by Phase 1 + Phase 2. The only unknown
+ops all live in the `com.microsoft` domain, and together they form
+exactly five distinct op names:
+
+| Op | Llama-3.2-1B | Gemma 3 1b | DeepSeek-R1-Distill-Qwen-1.5B |
+|---|:---:|:---:|:---:|
+| `SimplifiedLayerNormalization` | ✅ | ✅ | ✅ (1 use) |
+| `SkipSimplifiedLayerNormalization` | ✅ | ❌ | ✅ |
+| `GroupQueryAttention` | ✅ | ✅ | ❌ |
+| `MultiHeadAttention` | ❌ | ❌ | ✅ |
+| `RotaryEmbedding` | ❌ (inside GQA) | ❌ (inside GQA) | ✅ |
+
+The union is irreducible: no op can be removed without breaking at
+least one family. Gemma uses a plain `Add` residual where Llama uses
+`SkipSimplifiedLayerNormalization`, and DeepSeek replaces
+`GroupQueryAttention` + fused RoPE with the older
+`MultiHeadAttention` + a standalone `RotaryEmbedding` node.
+
+The original `onnx-full-coverage-roadmap-v1` change (now archived)
+classified every `com.microsoft` op as *Skipped-vendor* on the
+assumption that they were ORT-specific optimizations. The coverage
+probe shows that assumption was wrong: these ops are not optional
+optimizations, they are the output of the HuggingFace
+`optimum-cli export onnx` pipeline, which runs the ORT transformer
+optimizer by default. Without these five ops, SmallAIOS cannot load
+any of the three mainstream 1B-class open-weights decoder LLMs off
+the shelf.
+
+This change reverses the Skipped-vendor decision for these five
+specific ops while leaving the rest of the `com.microsoft` op tail
+Skipped. If a future model target requires another one, a future
+change will add it.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Load `Llama-3.2-1B`, `Gemma 3 1b`, and
+  `DeepSeek-R1-Distill-Qwen-1.5B` from their canonical HF ONNX exports
+  via `Session::new_from_file()` and complete a 1-token generation.
+- Add the 5 operators as first-class, domain-namespaced entries in
+  `OperatorRegistry` so provenance is preserved (Standard ONNX vs
+  Microsoft fusion).
+- Maintain `#![no_std]` compatibility. No new external dependencies.
+- Reuse the Phase 2 RMSNorm kernel (`op_rms_normalization`) and the
+  Phase 2 sub-graph executor with *no* changes to either. All KV-cache
+  interactions are handled by how the outer graph passes in values,
+  not by changes to the sub-graph executor itself.
+
+**Non-Goals:**
+- GPU dispatch. CPU only.
+- Other `com.microsoft` ops (`QLinear*` fused activations,
+  `QAttention`, `EmbedLayerNormalization` variants, `MatMulNBits`,
+  `GatherBlockQuantized`, etc.). Stay Skipped-vendor.
+- FP16 / BF16 specialized kernels. Accept these dtypes via existing
+  type-promotion shims, nothing more.
+- Rewriting or extending the sub-graph executor. D8 documents the
+  constraint KV-cache tensors impose; it does not change executor code.
+- Implementing flash-attention or paged-attention fast paths. The
+  first implementation uses a straightforward tiled masked SDPA. If
+  performance becomes a gate, a follow-up change adds those.
+
+## Decisions
+
+### D1: Treat `com.microsoft` as a first-class but namespaced domain
+
+**Decision.** Add a `Domain` enum to `onnx-rt/src/operators.rs`:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Domain {
+    StandardOnnx,
+    MicrosoftFused,
+}
+```
+
+Every `OpKind` variant records its domain (for existing standard ops
+this is always `Domain::StandardOnnx`). `OperatorRegistry` gets a
+`fn lookup_by_domain_and_name(domain: &str, name: &str) -> Option<OpKind>`
+helper that routes `"com.microsoft"` to the MicrosoftFused table and
+`""` (the default domain) or `"ai.onnx"` to the StandardOnnx table.
+
+The node dispatcher in `executor.rs` currently ignores `NodeProto.domain`.
+That field is now read and forwarded to `lookup_by_domain_and_name`.
+Two nodes named `"MultiHeadAttention"` in different domains will resolve
+to different `OpKind` values (and dispatch to different code paths,
+even if only one is implemented today).
+
+**Rationale.** We want provenance. Treating Microsoft ops as if they
+were standard ONNX ops (by aliasing them into the StandardOnnx
+namespace) would collapse the distinction and prevent future
+cross-vendor support — imagine an `ai.amd` or `ai.nvidia` contrib op
+with the same name but different semantics. Collapsing domains would
+also confuse tooling: a coverage probe should be able to say "we
+implement 131 standard-domain ops and 5 microsoft-domain ops", not
+"we implement 136 ops of uncertain origin".
+
+The runtime cost of the enum check is one branch on a cold path
+(graph compilation time, not per-op dispatch); it does not affect
+steady-state inference performance.
+
+**Alternative considered.** Alias each Microsoft op into the
+StandardOnnx namespace under its natural name (e.g.,
+`SimplifiedLayerNormalization` becomes an alias for
+`RMSNormalization`). Rejected. It loses provenance, it breaks the
+principle that our `OpKind` enum reflects what the model says it
+needs, and it creates surprising-by-distance behavior when a future
+standard ONNX opset adds a genuinely-different operator under one of
+these names.
+
+### D2: `SimplifiedLayerNormalization` is a thin alias for `RMSNormalization`
+
+**Decision.** `op_simplified_layer_normalization` is ~20 LOC; it
+delegates to the Phase 2 `op_rms_normalization` kernel.
+
+**Math.** `SimplifiedLayerNormalization` computes
+`y = x / sqrt(mean(x^2) + epsilon) * scale` with an optional bias
+add. Critically, there is **no mean subtraction**. This is identical
+to the math of RMSNorm as defined by Zhang & Sennrich (2019) and
+identical to the Phase 2 `op_rms_normalization` implementation.
+
+**Attributes (per ORT contrib op spec):**
+- `epsilon` (float, default 1e-5) — numerical stability term inside
+  the square root. Same semantics as RMSNorm `epsilon`.
+- `axis` (int, default -1) — axis to normalize over. Always the last
+  axis for the HF LLM exports we care about. Phase 2 RMSNorm already
+  supports arbitrary negative axes.
+- `stash_type` (int, default 1 = f32) — intermediate accumulator
+  dtype. We always use f32 regardless of input dtype.
+
+**Outputs.** `SimplifiedLayerNormalization` has an optional second
+output (`inv_std_dev`) used by the backward pass. We only produce the
+first output; if the second is requested by a model, we error out
+cleanly (no legitimate inference graph asks for it).
+
+**Implementation shape:**
+
+```rust
+pub fn op_simplified_layer_normalization(
+    inputs: &[Tensor],
+    attrs: &[AttributeProto],
+) -> Result<Vec<Tensor>, OperatorError> {
+    let epsilon = attr_float(attrs, "epsilon").unwrap_or(1e-5);
+    let axis = attr_int(attrs, "axis").unwrap_or(-1);
+    // Delegate to the Phase 2 RMSNorm kernel, which already handles
+    // axis normalization and the optional bias.
+    super::generative::op_rms_normalization_raw(
+        &inputs[0], &inputs[1], inputs.get(2), epsilon, axis,
+    ).map(|t| alloc::vec![t])
+}
+```
+
+**Rationale.** The ops are mathematically identical. The only reason
+this is not literally a direct reuse is the namespacing from D1 — the
+dispatcher needs a handle to call for the Microsoft-domain name. A
+thin wrapper preserves both the mathematical identity and the
+registry provenance.
+
+### D3: `SkipSimplifiedLayerNormalization` fuses RMSNorm + residual Add
+
+**Decision.** `op_skip_simplified_layer_normalization` is ~50 LOC.
+It reads three inputs (`x`, `skip`, `scale`) plus an optional bias,
+and computes:
+
+```
+pre_layernorm = x + skip + bias  // element-wise
+y             = pre_layernorm / sqrt(mean(pre_layernorm^2) + epsilon) * scale
+```
+
+It produces two outputs: the normalized `y` and the pre-layernorm sum
+`pre_layernorm` (which is re-used as the input to the next layer's
+skip connection in the transformer block, so ORT emits it to avoid a
+redundant add in the next block).
+
+**Why ORT fuses this.** In the transformer residual stream, every
+layer reads `hidden + residual`, normalizes, computes attention/FFN,
+and writes a new `hidden + residual`. The sum is both the output of
+layer N and the skip input of layer N+1. A non-fused export would
+read the residual stream twice (once for the normalize, once for the
+next add), doubling the memory bandwidth on the residual path. The
+fused op reads once and produces both outputs.
+
+**Gemma does not use this op.** The coverage probe confirms Gemma 3
+emits plain `Add` + `SimplifiedLayerNormalization` nodes in sequence
+where Llama emits a single `SkipSimplifiedLayerNormalization`. This
+is a legitimate exporter choice (Gemma's export was produced with
+ORT transformer optimizations partially disabled), and it means
+`op_skip_simplified_layer_normalization` is required *only* by Llama
+and DeepSeek. We still implement it unconditionally — there is no
+conditional-compile reason not to, and future Gemma exports may
+enable the fusion.
+
+**Implementation.** Sum the three (or two) input tensors into a
+contiguous buffer, call `op_rms_normalization_raw` on that buffer
+with the provided scale, and return both tensors. The sum buffer is
+the `pre_layernorm` output; the normalized tensor is `y`. ~50 LOC
+total.
+
+### D4: `GroupQueryAttention` is the substantial piece
+
+**Decision.** `op_group_query_attention` is the largest single
+operator in this tier — approximately 600-800 LOC. It fuses RoPE,
+KV-cache concatenation, grouped-query dispatch, scaled dot-product
+attention, and causal masking into one op.
+
+**Algorithm.**
+
+1. **Parse inputs.** The ORT contrib op spec defines the following
+   inputs (with exact indices):
+   - `query` (B, Sq, hidden) — where `hidden = num_heads * head_dim`
+   - `key` (B, Sq, kv_hidden) — where `kv_hidden = num_kv_heads * head_dim`
+   - `value` (B, Sq, kv_hidden)
+   - `past_key` (B, num_kv_heads, past_Sk, head_dim) — the KV-cache
+     from previous Loop iterations
+   - `past_value` (B, num_kv_heads, past_Sk, head_dim)
+   - `seqlens_k` (B,) — int32 vector giving the *current* key-sequence
+     length (per batch) including all past tokens
+   - `total_sequence_length` (scalar int32) — max key-sequence length
+     across the batch, used to size the working tensors
+   - `cos_cache` (max_seq_len, head_dim / 2)
+   - `sin_cache` (max_seq_len, head_dim / 2)
+
+2. **Attributes.**
+   - `num_heads` (int, required)
+   - `kv_num_heads` (int, required, `num_heads % kv_num_heads == 0`)
+   - `scale` (float, optional; defaults to `1/sqrt(head_dim)`)
+   - `local_window_size` (int, default -1, meaning no sliding window;
+     we support `-1` only in this tier — sliding-window attention is
+     not required by Llama or Gemma, and if a future model needs it
+     we add it as a new change)
+   - `do_rotary` (int, default 1 — meaning RoPE is applied inside GQA;
+     if 0, RoPE was already applied in a separate `RotaryEmbedding`
+     node upstream and we skip step 4)
+   - `rotary_interleaved` (int, default 0)
+
+3. **Reshape Q, K, V** from `(B, Sq, num_heads * head_dim)` into
+   `(B, num_heads, Sq, head_dim)` for Q and
+   `(B, kv_num_heads, Sq, head_dim)` for K and V.
+
+4. **Apply RoPE in-place to Q and K** (skipped if `do_rotary == 0`)
+   using the shared `apply_rope_in_place` helper (see D6). Position
+   IDs for the RoPE are computed on-the-fly as
+   `position = past_Sk + i` for `i in 0..Sq`, per batch.
+
+5. **Concatenate K, V with the past KV-cache** along the sequence
+   axis to produce full keys `K_full` of shape
+   `(B, kv_num_heads, past_Sk + Sq, head_dim)` and similarly `V_full`.
+   The concatenation is an in-place append into the `past_key` /
+   `past_value` tensors — see D8 on why those tensors must live in
+   the outer scope. The *output* `present_key` / `present_value` are
+   views into the updated past tensors.
+
+6. **Grouped attention dispatch.** Since `num_heads >= kv_num_heads`,
+   each KV head is shared across `num_heads / kv_num_heads` query
+   heads. Rather than materialize a `num_heads`-sized K tensor by
+   tiling, we compute the attention per KV group: for each of the
+   `kv_num_heads` groups, run the shared SDPA helper over the
+   `num_heads / kv_num_heads` query heads with that group's K and V.
+
+7. **Call the shared SDPA helper** (see below and D5):
+   ```text
+   attn_out = scaled_dot_product_attention(
+       q_group,      // (B, group_size, Sq, head_dim)
+       k_group,      // (B, 1,          Sk, head_dim)
+       v_group,      // (B, 1,          Sk, head_dim)
+       causal_mask,  // on-the-fly, see step 8
+       scale,        // attribute or default
+   )
+   ```
+   The helper broadcasts `k_group` / `v_group` across the `group_size`
+   query heads internally.
+
+8. **Causal mask handling.** ORT exposes two mask modes: model-supplied
+   (where an earlier node in the graph pre-computes a
+   `(B, 1, Sq, Sk)` additive mask) and on-the-fly. SmallAIOS implements
+   on-the-fly only: the SDPA helper walks the output tile and, for
+   each `(q_idx, k_idx)` pair where `k_idx > q_idx + past_Sk`, writes
+   `-inf` into the attention-score accumulator before the softmax.
+   This costs one branch per element of the attention score tile,
+   which is free next to the matmul itself.
+
+9. **Reshape output** from `(B, num_heads, Sq, head_dim)` back to
+   `(B, Sq, hidden)` and return it alongside the updated
+   `present_key` / `present_value` (which are the same tensors as the
+   input `past_key` / `past_value`, mutated in place).
+
+**Internal helpers.**
+- `scaled_dot_product_attention(q, k, v, scale, causal_mask_fn)` —
+  shared with `MultiHeadAttention` (D5). Computes
+  `softmax(Q @ K^T * scale + mask) @ V` per head with online-softmax
+  numerics (max-stabilized to avoid fp32 overflow on long sequences).
+  Takes a *function* for the mask rather than a tensor, so the caller
+  can compute the mask on the fly without materializing it.
+- `apply_rope_in_place(tensor, cos_cache, sin_cache, positions,
+  interleaved)` — shared with standalone `RotaryEmbedding` (D6).
+  Mutates the input tensor; returns nothing. The `positions`
+  parameter is a `&[i64]` slice of length `Sq`, one entry per query
+  position.
+
+**KV-cache memory ownership.** The `past_key` / `past_value` tensors
+are mutated in place. This requires two runtime guarantees:
+
+1. The outer-graph executor must NOT alias the `past_key` /
+   `past_value` tensor names — that is, no two live nodes in the
+   current iteration may hold references to the same underlying
+   buffer. This is already true in the Phase 2 `execute_graph`
+   because tensors are looked up by name out of a `BTreeMap`, and
+   GQA is the only writer to its own KV-cache names.
+2. The tensors must be declared in the *outer* value map (the
+   `Session`'s main scope), not in a sub-graph's inner value map.
+   See D8 for why.
+
+The mutation is safe because the Rust borrow checker sees the
+in-place update as `&mut Tensor`, and `dispatch_node` in the executor
+already holds an `&mut BTreeMap<String, Tensor>` for the duration of
+a single node's execution.
+
+### D5: `MultiHeadAttention` is the older, simpler fusion
+
+**Decision.** `op_multi_head_attention` is approximately 250 LOC. It
+reuses the `scaled_dot_product_attention` helper from D4.
+
+**Differences from GroupQueryAttention:**
+- No grouping. `num_heads == kv_num_heads` (implicit). Every query
+  head has its own KV head.
+- RoPE is *not* applied inside. DeepSeek-R1 factors RoPE out as a
+  separate `RotaryEmbedding` node upstream of MHA, so the MHA op
+  receives already-rotated Q and K.
+- KV-cache handling is still supported (`past_key` / `past_value`
+  inputs, same in-place concat semantics as D4).
+- Supports both "packed QKV" (single input of shape
+  `(B, Sq, 3*hidden)` that gets split) and "unpacked" (three separate
+  inputs). DeepSeek uses unpacked.
+
+**Inputs (per ORT contrib op spec).** See the ORT docs for the exact
+list; the two important variants are the 3-input unpacked form (Q, K, V)
+and the 1-input packed form. Both are implemented by the same function
+with a branch at the top reading input count.
+
+**Algorithm.** Identical to GroupQueryAttention steps 6-9 with
+`group_size = 1`. The only difference is that the dispatcher does not
+need the grouping loop — each query head has its own KV head, and
+the shared SDPA helper is called once per head (or once with the
+`num_heads` axis left intact and handled internally).
+
+**Rationale for reuse.** The SDPA helper is the hot loop. Factoring
+it out means GQA and MHA share the same optimized implementation,
+the same cache-blocking strategy, and the same numerical behavior.
+If we later add a flash-attention-style fast path, it lives in the
+helper and both ops get it for free.
+
+### D6: `RotaryEmbedding` standalone op
+
+**Decision.** `op_rotary_embedding` is approximately 150 LOC. It
+wraps the shared `apply_rope_in_place` helper with input/output
+marshalling.
+
+**Inputs (per ORT contrib op spec):**
+- `input` — shape `(B, Sq, hidden)` or
+  `(B, num_heads, Sq, head_dim)`. Both are valid; the op infers the
+  layout from rank.
+- `position_ids` — shape `(B, Sq)` or `(1, Sq)` (broadcast). Integer
+  positions into the `cos_cache` / `sin_cache`.
+- `cos_cache` — shape `(max_seq_len, head_dim/2)`
+- `sin_cache` — shape `(max_seq_len, head_dim/2)`
+
+**Attributes:**
+- `interleaved` (int, default 0)
+- `rotary_embedding_dim` (int, default 0 = full `head_dim`)
+- `num_heads` (int, used only when input is rank-3 to reshape into
+  rank-4 internally)
+- `scale` (float, default 1.0 — for some exporter variants that
+  pre-scale cos/sin)
+
+**Interleaved vs non-interleaved.** The critical attribute. HuggingFace
+and Llama use **non-interleaved** rotation: given a head of dim D,
+the first D/2 elements pair with the second D/2 elements, and the
+rotation is `(x[i], x[i+D/2]) → (cos*x[i] - sin*x[i+D/2], sin*x[i] + cos*x[i+D/2])`.
+DeepSeek uses **interleaved** rotation: the pairing is
+`(x[0], x[1]), (x[2], x[3]), ...` and the rotation applies to each
+adjacent pair with the same cos/sin but a different indexing pattern:
+`(x[2i], x[2i+1]) → (cos*x[2i] - sin*x[2i+1], sin*x[2i] + cos*x[2i+1])`.
+
+Both must be supported. The shared `apply_rope_in_place` helper
+takes the `interleaved` flag and branches on it in the hot loop.
+
+**Output.** Same shape as input, with RoPE applied.
+
+**Rationale.** DeepSeek's export pipeline produces a standalone
+`RotaryEmbedding` node ahead of `MultiHeadAttention`. Llama and Gemma
+fuse RoPE inside `GroupQueryAttention` (controlled by the `do_rotary`
+attribute). Both styles must work. Factoring `apply_rope_in_place`
+out as a shared helper from D4 means this op is almost trivial —
+reshape, call helper, reshape back.
+
+### D7: Op grouping and file layout
+
+**Decision.** All five operators plus the two shared helpers go into
+a single new file: `onnx-rt/src/ops/microsoft.rs`.
+
+```text
+onnx-rt/src/ops/
+├── mod.rs                          # registers microsoft module
+├── activations.rs
+├── generative.rs                   # Phase 2 RMSNorm etc. (unchanged)
+├── microsoft.rs                    # NEW — this change
+│   ├── op_simplified_layer_normalization
+│   ├── op_skip_simplified_layer_normalization
+│   ├── op_group_query_attention
+│   ├── op_multi_head_attention
+│   ├── op_rotary_embedding
+│   ├── scaled_dot_product_attention      (internal helper)
+│   └── apply_rope_in_place               (internal helper)
+└── ...
+```
+
+The dispatcher gets a new `dispatch_microsoft_fused(op_kind, inputs,
+attrs)` helper in `onnx-rt/src/executor.rs` that matches on the
+`MicrosoftFused` subset of `OpKind` and calls the corresponding
+function from `ops::microsoft`.
+
+**Rationale.** All five ops share the SDPA and RoPE helpers. Splitting
+them across multiple files would require duplicating the helpers or
+exposing them publicly across modules. A single `microsoft.rs` keeps
+the helpers `pub(super)` and avoids indirection. The file will be
+large (~1500 LOC with tests co-located) but it is the natural unit.
+
+If `microsoft.rs` grows unwieldy in a future tier, it can be split
+into a sub-directory `ops/microsoft/{mod.rs, attention.rs, norm.rs,
+rotary.rs}` without breaking the public API.
+
+### D8: KV-cache lifecycle interaction with the sub-graph executor
+
+**Background.** Phase 2's sub-graph executor (`onnx-rt/src/sub_executor.rs`)
+evaluates `Loop` bodies by allocating a fresh inner `BTreeMap<String,
+Tensor>` value map each time the `Loop` is invoked at graph level. Per
+the Phase 2 design document Q1 decision, the inner map is *reused and
+cleared* between iterations rather than reallocated, but all tensor
+entries living in that inner map are invalidated between iterations.
+The only tensors that survive iteration-to-iteration are:
+
+1. Loop-carried values (declared as `v_initial`/`v_final` by the ONNX
+   Loop node)
+2. Outer-referenced values (the `outer_refs` list, passed in by name
+   from the outer scope at the start of each iteration)
+
+**The problem.** A GroupQueryAttention node inside a `Loop` body
+wants to mutate its `past_key` / `past_value` in place so that the
+next iteration sees the extended KV-cache. If the cache tensors live
+in the inner value map, they are invalidated at the end of each
+iteration and the mutation is lost. The next iteration sees an empty
+past cache and the model produces garbage.
+
+**Decision.** KV-cache tensors MUST live in the outer-graph scope,
+not in the inner sub-graph scope. They are passed into the `Loop`
+body via the `outer_refs` mechanism (by name reference, not by
+value-copy), and GQA mutates them in place through that outer
+reference. The inner value map never owns a KV-cache tensor — it
+only borrows one from the outer scope.
+
+Concretely, this means the ONNX model graph structure looks like:
+
+```text
+outer_graph:
+  Constant → past_key_init                 (zero tensor, (B, num_kv_heads, 0, head_dim))
+  Constant → past_value_init
+  Loop(M, cond, past_key_init, past_value_init, ...) ──┐
+    └── body (inner_graph):                            │
+          inputs:                                      │
+            iter_num       (loop var)                  │
+            cond_in        (loop var)                  │
+            past_key       (loop-carried from outer)   │
+            past_value     (loop-carried from outer)   │
+          nodes:                                       │
+            GroupQueryAttention(...,                   │
+              past_key, past_value,                    │  ← mutates in-place
+              ...)                                     │
+          outputs:                                     │
+            cond_out                                   │
+            present_key  = past_key     (same buffer)  │
+            present_value = past_value  (same buffer)  │
+  outputs of Loop: final_past_key, final_past_value ───┘
+```
+
+The `past_key` / `past_value` names are **loop-carried values**, not
+outer refs — meaning the sub-graph executor explicitly rotates them
+iteration-to-iteration (iteration N's `present_key` becomes iteration
+N+1's `past_key`). Loop-carried values are the one class of inner
+tensor that is *not* cleared between iterations (see Phase 2 design
+D3 on scope and value passing).
+
+**Constraint on exporters.** This is already how ORT-exported Llama
+and Gemma write their graphs: KV-cache tensors are always loop-carried,
+never inner-local. SmallAIOS relies on this. If a future exporter
+produced a graph where the KV-cache tensor lived in a pure inner
+scope, the model would produce incorrect output on iteration 2+.
+We do not detect this case at load time; we treat it as the
+exporter's responsibility (consistent with how ORT treats it).
+
+**Non-change to the sub-graph executor.** This decision requires zero
+code changes to `onnx-rt/src/sub_executor.rs`. The loop-carried
+value mechanism already works. We are documenting a contract, not
+extending the executor.
+
+**Implication for tests.** The end-to-end model-loading tests in
+tasks section 10 validate this path by loading the canonical HF
+exports (which use loop-carried KV-caches) and checking that iteration
+2 sees the mutation from iteration 1. The unit tests for GQA in
+tasks section 8 test the in-place mutation directly by calling
+`op_group_query_attention` twice against the same `past_key` /
+`past_value` buffers and asserting the second call sees the first
+call's writes.
+
+### D9: Validation — numerical match against Python ORT reference
+
+**Decision.** The end-to-end tests in tasks section 10 load each of
+the three model families via `Session::new_from_file()`, run a
+single-token generation (or for DeepSeek f32, a single forward pass),
+and compare the output against a Python `onnxruntime` reference
+captured as golden data.
+
+**Bounds.**
+- **Llama-3.2-1B** — the canonical HF export is int4-weight-quantized
+  but with int8 activations and f32 accumulators. The output logits
+  are f32. Bound: top-1 token must match; max absolute error on the
+  top-5 logits ≤ 1e-2.
+- **Gemma 3 1b** — same as Llama. Bound: same as Llama.
+- **DeepSeek-R1-Distill-Qwen-1.5B** — canonical HF export is f32
+  end-to-end. Bound: max absolute error on the output hidden states
+  ≤ 1e-3.
+
+**Golden data.** The Python reference outputs are captured once,
+committed to `onnx-rt/tests/fixtures/microsoft_fused_ops/` as raw
+binary files (one per model), and loaded from disk in the test. The
+capture script (`tools/capture-ort-reference.py`) is not part of this
+change; it is checked in as an unversioned tool with a README in the
+fixtures directory explaining how to regenerate the files against a
+specific HF mirror checksum.
+
+**Rationale.** Numerical matching against a reference implementation
+is the only way to validate a vendor contrib op whose specification
+is "the C++ source code of onnxruntime". Matching top-1 token on a
+1-token generation exercises the full attention + norm + RoPE path
+and is sensitive to any subtle bug in any of the five ops.
+
+**Test performance.** Loading a 1B-parameter model from disk, even
+for a 1-token generation, is expensive (seconds of wall clock). The
+end-to-end tests are gated behind the `--ignored` test flag by
+default and run in a separate CI job (`real-model-tests`) that is
+advisory-only initially and promoted to a gate once it is stable.
+The per-op unit tests in sections 3-8 stay in the default test suite
+and cover correctness on small hand-crafted tensors.
+
+## Alternatives Considered
+
+### A1: Implement only GQA + the two norm ops, skip MHA and RotaryEmbedding
+
+Skip DeepSeek. Ship support for Llama and Gemma only. MHA and
+standalone RoPE are not needed.
+
+**Rejected.** DeepSeek-R1-Distill-Qwen-1.5B is the single most
+popular open-weight reasoning model in the 1.5B class and a reference
+target for agent work. Leaving it out means the first LLM tier
+shipping in SmallAIOS cannot load the one model that users would most
+likely want to benchmark against. The marginal cost of MHA (~250
+LOC reusing the SDPA helper) and standalone RoPE (~150 LOC reusing
+`apply_rope_in_place`) is small because both reuse helpers that GQA
+needs anyway.
+
+### A2: Alias Microsoft ops into the StandardOnnx namespace
+
+Rather than add a `Domain` enum, pretend these ops live in the
+standard domain. `SimplifiedLayerNormalization` becomes just another
+name for RMSNorm, etc.
+
+**Rejected.** Loses provenance (see D1). Confuses tooling (the
+coverage probe cannot distinguish "we support the standard ONNX op
+set fully" from "we support an ORT-optimized flavor"). Fails on the
+day a future standard ONNX opset adds a genuine
+`SimplifiedLayerNormalization` with slightly different semantics.
+
+### A3: Skip RoPE and rely on pre-rotated tensors being passed in
+
+Some ONNX exports produce RoPE as a chain of standard ops
+(`Cos`/`Sin`/`Concat`/`Mul`/`Add`). Force the HF exporter to emit
+that path instead of the fused `RotaryEmbedding` op.
+
+**Rejected.** This is a user-facing support burden (every user has
+to learn and configure a non-default export flag), and the HF
+`optimum-cli export onnx` default uses the fused path for a reason —
+it is an order of magnitude fewer nodes in the graph and avoids
+materializing the intermediate cos/sin broadcasts. Meeting users
+where they are means supporting the fused op.
+
+### A4: Implement a model-surgery pass at load time that rewrites Microsoft ops into standard ops
+
+At `Session::new_from_file()` time, walk the graph and replace each
+Microsoft op with an equivalent sub-graph of standard ops (e.g.,
+`GroupQueryAttention` → `Transpose`+`MatMul`+`Softmax`+`MatMul`+
+`Reshape`+...).
+
+**Rejected.** This rewrites the graph structure invisibly, making
+the profile output lie (the user sees "MatMul" rows for operators
+that were actually GQA nodes in the source graph). It also adds a
+new failure mode (the rewriter may produce an incorrect decomposition
+for edge-case attribute combinations). The straightforward
+implementation — a real fused op with real math — is clearer and
+easier to debug.
+
+## Open Questions
+
+### Q1: Do we need `local_window_size` for sliding-window attention?
+
+Gemma 3 uses sliding-window attention (window=4096) in some layers.
+The coverage probe confirmed the 1b model works without SWA (either
+the 1b variant uses dense attention throughout, or the ORT exporter
+did not set `local_window_size`). If a larger Gemma variant is later
+added, we need to support `local_window_size > -1` in GQA.
+
+**Leaning.** Implement in a follow-up change if required. Document
+in the GQA code that `local_window_size != -1` currently returns
+`UnsupportedAttribute`. The coverage probe should be re-run against
+Gemma 3 4b before claiming support for that model.
+
+### Q2: Does int4 weight-quantization work through the existing int8 MatMul kernels?
+
+Llama-3.2-1B and Gemma 3 1b use int4 weight quantization in practice
+(the HF export is `awq`-style with int4 weights and int8
+activations). The standard ONNX ops the model contains are the int8
+variants we already support, so loading *should* work, but runtime
+performance on the int4 weight tensors is untested.
+
+**Leaning.** The end-to-end tests (task 10.1 and 10.2) answer this
+empirically. If they pass, the int4 → int8 path works. If they fail,
+we open a separate change for int4 kernel support and mark these
+two models as deferred until that change lands.
+
+### Q3: How big should the attention score working buffer be?
+
+SDPA computes `Q @ K^T` into a `(B, num_heads, Sq, Sk)` buffer
+before applying softmax. For `B=1, num_heads=32, Sq=1, Sk=4096` (a
+typical decoding step on Llama-3.2-1B), this is 128 KB of f32 per
+step. That is fine. For `B=1, num_heads=32, Sq=1024, Sk=4096`
+(prefill), it is 128 MB. That is not fine for a 15 MB container.
+
+**Leaning.** Tile the SDPA helper in the `Sq` dimension at 64 rows
+per tile. This keeps the working buffer at <10 MB at all times. The
+tile size is a compile-time constant initially; tunable in a
+follow-up if profiling shows a hot spot.

--- a/openspec/changes/microsoft-fused-ops-v1/proposal.md
+++ b/openspec/changes/microsoft-fused-ops-v1/proposal.md
@@ -1,0 +1,170 @@
+# Microsoft Fused Ops for Llama / Gemma / DeepSeek
+
+## Why
+
+Phase 1 (`transformer-models-v1`, `vision-transformers-v1`) and Phase 2
+(`generative-llm-v1`) are complete. Together they took the CPU ONNX
+runtime from 29 to 131 operators and added a sub-graph executor that
+makes in-graph `Loop`-driven autoregressive generation feasible. The
+empirical coverage probe that just landed (PR #88, see
+`tools/coverage-probe/REPORT.md`) confirms that BERT, ViT, and GPT-2
+now load end-to-end from their canonical HuggingFace ONNX exports.
+
+The same probe also shows the uncomfortable truth about modern LLMs:
+**the canonical HF ONNX exports of Llama 3.2, Gemma 3, and DeepSeek-R1
+all fail to load today**, and in every case the failure is one or
+more unknown operators from the `com.microsoft` domain. The union of
+the ops required across the three model families is exactly five:
+
+| `com.microsoft` op | Llama-3.2-1B | Gemma 3 1b | DeepSeek-R1-Distill-Qwen-1.5B |
+|---|:---:|:---:|:---:|
+| `SimplifiedLayerNormalization` | ✅ | ✅ | ✅ (1 use) |
+| `SkipSimplifiedLayerNormalization` | ✅ | ❌ (plain Add) | ✅ |
+| `GroupQueryAttention` | ✅ | ✅ | ❌ |
+| `MultiHeadAttention` | ❌ | ❌ | ✅ |
+| `RotaryEmbedding` | ❌ (fused in GQA) | ❌ (fused in GQA) | ✅ (standalone) |
+
+No single op can be dropped from this union without breaking one of the
+three families. Gemma uses a plain `Add` residual instead of the fused
+`SkipSimplifiedLayerNormalization`; DeepSeek factors RoPE out as a
+standalone op instead of fusing it into attention. The set is
+irreducible.
+
+The original `onnx-full-coverage-roadmap-v1` (now archived under
+`openspec/changes/archive/`) classified every `com.microsoft` op as
+**Skipped-vendor** on the assumption that they were optional
+optimization tricks specific to Microsoft's ONNX Runtime. That decision
+was wrong. These are not optional optimizations — they are how
+HuggingFace's `optimum-cli export onnx --task text-generation`
+pipeline writes every modern decoder-only LLM, because that pipeline
+uses the ORT transformer optimizer by default. Without these five ops,
+SmallAIOS cannot load **any** LLM from the canonical HF export path.
+
+This change reverses that Skipped-vendor decision for these five
+specific ops while leaving the long tail of other `com.microsoft` ops
+(QLinear* fused activations, EmbedLayerNormalization variants,
+QAttention, etc.) Skipped. We implement exactly what the empirical
+probe says we need — no more, no less.
+
+## What Changes
+
+- **Add a `Domain` enum on `OpKind`** (`StandardOnnx | MicrosoftFused`)
+  so the registry can differentiate standard ONNX operators from
+  namespaced vendor fusions. The dispatcher checks the node's `domain`
+  field (currently ignored) to route to the correct handler.
+- **Add 5 new `OpKind` variants** for the Microsoft-domain fused ops:
+  - `SimplifiedLayerNormalization` (all three families)
+  - `SkipSimplifiedLayerNormalization` (Llama + DeepSeek; Gemma uses
+    plain `Add` residual and does not need this op)
+  - `GroupQueryAttention` (Llama + Gemma; the substantial one)
+  - `MultiHeadAttention` (DeepSeek; older non-GQA fusion)
+  - `RotaryEmbedding` (DeepSeek; standalone RoPE, interleaved and
+    non-interleaved variants)
+- **Extend `OperatorRegistry`** to list the 5 new variants with
+  `Domain::MicrosoftFused`, and extend `classify_op` in
+  `onnx-rt/src/profile.rs` so each gets a WCET budget class
+  (`Attention` for GQA/MHA, `Elementwise` for the norm variants,
+  `Elementwise` for `RotaryEmbedding`).
+- **New file `onnx-rt/src/ops/microsoft.rs`** containing all 5 operator
+  functions plus two shared internal helpers:
+  - `scaled_dot_product_attention(q, k, v, mask, scale)` — shared by
+    `GroupQueryAttention` and `MultiHeadAttention`.
+  - `apply_rope_in_place(tensor, cos_cache, sin_cache, position_ids,
+    interleaved)` — shared by `GroupQueryAttention` (RoPE is fused
+    inside), and by the standalone `RotaryEmbedding` op.
+- **New dispatcher hook** `dispatch_microsoft_fused` in
+  `onnx-rt/src/executor.rs` that routes nodes with
+  `domain == "com.microsoft"` to the Microsoft op table.
+- **Inventory update** (`SUPPORTED_OPS_INVENTORY`): flip each of the 5
+  ops from `Skipped` to `Implemented`. Flip the roadmap document at
+  `docs/onnx-coverage-roadmap.md` in the same PR.
+- **End-to-end validation tests**: load `Llama-3.2-1B`, `Gemma 3 1b`,
+  and `DeepSeek-R1-Distill-Qwen-1.5B` from their canonical HF ONNX
+  exports via `Session::new_from_file()` and run a 1-token generation
+  (or for DeepSeek f32, an f32 forward pass).
+
+## Impact
+
+**Affected specs:**
+- `onnx-cpu-execution` — adds 5 operator requirements and 2
+  cross-cutting requirements (domain-aware OpKind, empirical model
+  loading).
+
+**Affected code:**
+- New file: `onnx-rt/src/ops/microsoft.rs` (~1200-1500 LOC estimated).
+- `onnx-rt/src/operators.rs` — 5 new `OpKind` variants, `Domain` enum,
+  `OperatorRegistry` entries.
+- `onnx-rt/src/executor.rs` — `dispatch_microsoft_fused` hook.
+- `onnx-rt/src/profile.rs` — `classify_op` extension.
+- `onnx-rt/src/ops/mod.rs` — register new module.
+- `onnx-rt/tests/microsoft_fused_ops.rs` — per-op unit tests.
+- `onnx-rt/tests/real_model_loading.rs` — end-to-end loading tests for
+  the three LLM families.
+- `docs/onnx-coverage-roadmap.md` — flip entries Skipped → Implemented.
+
+**Size estimate.** `GroupQueryAttention` is the large piece:
+approximately 600-800 LOC including KV-cache concatenation, RoPE
+integration, grouped attention dispatch, and the causal mask. The
+other four ops are smaller: `MultiHeadAttention` ~250 LOC (heavy reuse
+of the SDPA helper), `RotaryEmbedding` ~150 LOC, the two norm variants
+~50 LOC each, and the two shared helpers add ~200 LOC of their own.
+Tests roughly double the implementation LOC.
+
+**Out of scope:**
+- Other `com.microsoft` ops not used by Llama, Gemma, or DeepSeek. The
+  long tail (`QLinearAdd`, `QLinearSoftmax`, `QLinearSigmoid`,
+  `QLinearLeakyRelu`, `QAttention`, `QEmbedLayerNormalization`,
+  `GatherBlockQuantized`, `MatMulNBits`, `DequantizeLinear` with
+  `axis`, etc.) stays classified as Skipped-vendor. If a future model
+  target requires one, a new OpenSpec change will add it.
+- GPU dispatch of any of these ops. CPU only for this tier.
+- FP16 or BF16 fast paths. The ops accept fp16/bf16 inputs via the
+  existing type-promotion shims but do not add specialized kernels.
+- Llama / Gemma / DeepSeek training or fine-tuning. Inference only.
+
+**Risks:**
+- **`GroupQueryAttention` is not formally specified by ONNX.** It is a
+  vendor contrib op. The canonical reference is the ORT contrib op
+  implementation in the `onnxruntime` C++ source tree plus the
+  Microsoft documentation page at
+  <https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#com.microsoft.GroupQueryAttention>.
+  Our implementation reads from both. Mitigated by the end-to-end
+  validation test (D9): the output must match a Python ORT reference
+  within ±1 in the quantized integer domain.
+- **KV-cache state management interacts with the sub-graph executor.**
+  The Phase 2 sub-graph executor clears its inner `value_map` between
+  `Loop` iterations. KV-cache tensors cannot live in that inner map —
+  they must live in the outer scope and be passed in by outer-ref.
+  This is already how ORT-exported Llama / Gemma write their graphs,
+  but we must document the constraint so that future graph
+  optimizations do not accidentally localize a KV-cache tensor.
+  Mitigated by D8 in the design doc.
+- **Interleaved vs non-interleaved RoPE.** HuggingFace / Llama use
+  non-interleaved rotation (the second half rotates against the first
+  half). DeepSeek uses interleaved rotation (alternating elements
+  rotate pairwise). Both must be supported via the `interleaved` bool
+  attribute. Mitigated by per-variant unit tests in tasks section 3.
+- **Roadmap drift.** Flipping five Skipped entries to Implemented must
+  happen in the same PR as the implementation, not a follow-up. An
+  explicit task (11.2) enforces this.
+
+## References
+
+- `tools/coverage-probe/REPORT.md` — the empirical findings that
+  motivate this change. The coverage probe walks every node of each
+  HF ONNX export and reports unknown operators by domain. This is
+  where the irreducible-union table in the Why section comes from.
+- `openspec/changes/archive/<date>-onnx-full-coverage-roadmap-v1/` —
+  the original roadmap that classified these five ops as Skipped-vendor.
+  This change reverses that decision for these five specific ops only.
+- `openspec/changes/archive/<date>-generative-llm-v1/` — Phase 2. The
+  RMSNorm kernel this change reuses lives in `onnx-rt/src/ops/generative.rs`,
+  added by that change. The sub-graph executor whose KV-cache
+  lifecycle is discussed in D8 lives in `onnx-rt/src/sub_executor.rs`,
+  also added there.
+- `docs/sub-graph-executor-design.md` — the detailed spec for the
+  sub-graph executor. Section on outer-ref value passing is the
+  contract that KV-cache tensors rely on.
+- <https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md> —
+  the ORT contrib op documentation, canonical reference for all five
+  operators.

--- a/openspec/changes/microsoft-fused-ops-v1/specs/onnx-cpu-execution/spec.md
+++ b/openspec/changes/microsoft-fused-ops-v1/specs/onnx-cpu-execution/spec.md
@@ -1,0 +1,109 @@
+## ADDED Requirements
+
+### Requirement: Domain-Aware OpKind
+The ONNX runtime SHALL distinguish operator provenance by domain, so that operators from the `com.microsoft` contrib op set are tracked separately from standard ONNX operators and dispatched through a separate handler table.
+
+#### Scenario: Standard and Microsoft ops with the same name resolve differently
+- **WHEN** the graph builder encounters a node with `op_type = "MultiHeadAttention"` and `domain = "com.microsoft"`
+- **THEN** the registry MUST resolve the node to the `OpKind::MultiHeadAttention` variant tagged `Domain::MicrosoftFused`
+- **AND** the dispatcher MUST route the node to `ops::microsoft::op_multi_head_attention`
+- **AND** a future node with the same `op_type` but `domain = ""` or `domain = "ai.onnx"` MUST resolve to a different `OpKind` value (or fail with `UnsupportedOperator` if no standard-domain op of that name exists)
+
+#### Scenario: Operator registry reports domain per entry
+- **WHEN** a contributor queries `OperatorRegistry` for the status of `"GroupQueryAttention"` in the `com.microsoft` domain
+- **THEN** the registry MUST return `OperatorStatus::Implemented` with `Domain::MicrosoftFused`
+- **AND** the same query in the standard domain MUST return `UnsupportedOperator`
+
+### Requirement: SimplifiedLayerNormalization Operator
+The ONNX runtime SHALL implement the `com.microsoft.SimplifiedLayerNormalization` operator, mathematically equivalent to RMS normalization over the specified axis, with optional bias and configurable epsilon.
+
+#### Scenario: Matches RMSNorm on a last-axis input
+- **WHEN** `op_simplified_layer_normalization` is called with an input of shape `(2, 4, 8)`, a scale vector of length 8, `axis = -1`, and `epsilon = 1e-5`
+- **THEN** the output MUST be element-wise equal (within 1e-6 absolute error) to the result of the existing `op_rms_normalization` with the same arguments
+
+#### Scenario: Optional bias is added after normalization
+- **WHEN** the operator is called with three inputs (`x`, `scale`, `bias`)
+- **THEN** the output MUST equal `(x / rms(x)) * scale + bias`
+- **AND** the bias MUST be broadcast along the non-normalized axes
+
+### Requirement: SkipSimplifiedLayerNormalization Operator
+The ONNX runtime SHALL implement the `com.microsoft.SkipSimplifiedLayerNormalization` operator, which fuses a residual-stream element-wise add with RMS normalization, producing both the normalized output and the pre-normalization sum.
+
+#### Scenario: Fused residual add and normalization
+- **WHEN** the operator is called with `input`, `skip`, `scale`, and `bias` tensors
+- **THEN** the first output MUST equal `rms_normalize(input + skip + bias) * scale`
+- **AND** the second output MUST equal `input + skip + bias` (the pre-normalization sum)
+
+#### Scenario: Bias is optional
+- **WHEN** the operator is called with only `input`, `skip`, and `scale` (no bias)
+- **THEN** the sum MUST be `input + skip`
+- **AND** the first output MUST equal `rms_normalize(input + skip) * scale`
+
+### Requirement: GroupQueryAttention Operator
+The ONNX runtime SHALL implement the `com.microsoft.GroupQueryAttention` operator, which fuses rotary positional embedding, past-KV-cache concatenation, grouped-query attention dispatch, scaled dot-product attention, and causal masking into a single op.
+
+#### Scenario: Matches Python ORT reference on a small hand-crafted model
+- **WHEN** `op_group_query_attention` is called with `num_heads = 4`, `kv_num_heads = 2`, `head_dim = 8`, a batch-1 query of shape `(1, 3, 32)`, empty past-KV tensors of shape `(1, 2, 0, 8)`, and cos/sin caches sized `(16, 4)`
+- **THEN** the output MUST match a Python `onnxruntime.InferenceSession` reference within 1e-5 absolute error
+- **AND** the returned `present_key` and `present_value` MUST have shape `(1, 2, 3, 8)` and contain the post-RoPE key and value projections
+
+#### Scenario: KV-cache is mutated in place across two calls
+- **WHEN** the operator is called twice against the same `past_key` and `past_value` buffers, first with `Sq = 3` and then with `Sq = 1`
+- **THEN** the second call MUST see the first call's key/value writes in the past cache
+- **AND** the second call's output attention MUST attend over all four total key positions (3 from call 1 + 1 from call 2)
+
+#### Scenario: do_rotary = 0 skips the internal RoPE step
+- **WHEN** the operator is called with attribute `do_rotary = 0` and a query tensor that is already rotary-embedded
+- **THEN** the internal `apply_rope_in_place` MUST NOT be called
+- **AND** the query passed into the SDPA helper MUST be bit-identical to the input query
+
+#### Scenario: Causal mask is applied on the fly
+- **WHEN** the operator is called with `Sq = 4` and `past_Sk = 0`
+- **THEN** position `(q=0, k=1)`, `(q=0, k=2)`, `(q=0, k=3)`, `(q=1, k=2)`, `(q=1, k=3)`, `(q=2, k=3)` MUST all receive `-inf` masking in the attention scores
+- **AND** the softmax output at those positions MUST be exactly zero
+
+### Requirement: MultiHeadAttention Operator
+The ONNX runtime SHALL implement the `com.microsoft.MultiHeadAttention` operator as a non-grouped attention fusion that reuses the same scaled-dot-product-attention helper as `GroupQueryAttention`.
+
+#### Scenario: Unpacked Q, K, V inputs with past KV-cache
+- **WHEN** `op_multi_head_attention` is called with three separate Q, K, V inputs of shape `(1, 4, 64)` with `num_heads = 8`, plus `past_key` and `past_value` tensors of shape `(1, 8, 2, 8)`
+- **THEN** the output MUST match a Python `onnxruntime.InferenceSession` reference within 1e-5 absolute error
+- **AND** the `present_key` / `present_value` MUST have shape `(1, 8, 6, 8)` (2 past + 4 new)
+
+#### Scenario: No internal RoPE (DeepSeek style)
+- **WHEN** the operator is called on inputs that were already rotary-embedded upstream by a standalone `RotaryEmbedding` node
+- **THEN** the operator MUST NOT apply RoPE internally (it has no cos/sin cache inputs)
+- **AND** the output MUST equal the SDPA helper's result on the unrotated call's rotated inputs
+
+### Requirement: RotaryEmbedding Operator
+The ONNX runtime SHALL implement the `com.microsoft.RotaryEmbedding` operator in both interleaved and non-interleaved variants, sharing the `apply_rope_in_place` helper with `GroupQueryAttention`.
+
+#### Scenario: Non-interleaved rotation matches HuggingFace layout
+- **WHEN** `op_rotary_embedding` is called with `interleaved = 0` on an input of shape `(1, 2, 64)` (one head, two positions, head_dim=64), with `position_ids = [0, 1]` and matching cos/sin caches
+- **THEN** the output at position 0 MUST equal the input (rotation by angle 0)
+- **AND** the output at position 1 MUST equal the non-interleaved rotation of the input (elements `[0..32]` paired with `[32..64]`)
+
+#### Scenario: Interleaved rotation matches DeepSeek layout
+- **WHEN** the same operator is called with `interleaved = 1`
+- **THEN** the output at position 1 MUST equal the interleaved rotation (adjacent element pairs `[0,1]`, `[2,3]`, ... each rotated)
+- **AND** the output MUST NOT equal the non-interleaved result (confirming the two variants are distinct)
+
+### Requirement: Canonical LLM Model Loading
+The ONNX runtime SHALL load the canonical HuggingFace ONNX exports of `meta-llama/Llama-3.2-1B`, `google/gemma-3-1b-it`, and `deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B` end-to-end via `Session::new_from_file()` and produce numerically-correct output for at least one generation step.
+
+#### Scenario: Llama-3.2-1B single-token generation matches Python ORT
+- **WHEN** the canonical HF export of `Llama-3.2-1B` (ONNX format, int4-weight / int8-activation quantization) is loaded via `Session::new_from_file()` and a single-token generation is run
+- **THEN** the session MUST load without `UnsupportedOperator` errors
+- **AND** the top-1 output token MUST match a Python `onnxruntime` reference on the same input
+- **AND** the top-5 output logits MUST match the reference within 1e-2 absolute error
+
+#### Scenario: Gemma 3 1b single-token generation matches Python ORT
+- **WHEN** the canonical HF export of `google/gemma-3-1b-it` is loaded and a single-token generation is run
+- **THEN** the session MUST load without errors
+- **AND** the top-1 output token MUST match a Python `onnxruntime` reference
+- **AND** the top-5 output logits MUST match the reference within 1e-2 absolute error
+
+#### Scenario: DeepSeek-R1-Distill-Qwen-1.5B forward pass matches Python ORT
+- **WHEN** the canonical HF export of `DeepSeek-R1-Distill-Qwen-1.5B` (ONNX, f32) is loaded and a single forward pass is run
+- **THEN** the session MUST load without errors
+- **AND** the output hidden states MUST match a Python `onnxruntime` reference within 1e-3 absolute error

--- a/openspec/changes/microsoft-fused-ops-v1/tasks.md
+++ b/openspec/changes/microsoft-fused-ops-v1/tasks.md
@@ -1,0 +1,140 @@
+## 1. Domain-aware OpKind machinery
+
+- [ ] 1.1 Add `Domain` enum (`StandardOnnx`, `MicrosoftFused`) to
+  `onnx-rt/src/operators.rs`
+- [ ] 1.2 Extend `OpKind` so each variant records its domain; add
+  helper `fn domain(&self) -> Domain`
+- [ ] 1.3 Add `OperatorRegistry::lookup_by_domain_and_name(&str, &str)
+  -> Option<OpKind>` and route `"com.microsoft"` / `""` / `"ai.onnx"`
+- [ ] 1.4 Update the graph builder in `onnx-rt/src/graph.rs` to read
+  `NodeProto.domain` and pass it through `lookup_by_domain_and_name`
+
+## 2. Shared `scaled_dot_product_attention` helper
+
+- [ ] 2.1 Write the SDPA helper signature in `ops/microsoft.rs`:
+  `fn scaled_dot_product_attention(q, k, v, scale, causal_mask_fn)`
+- [ ] 2.2 Implement online-softmax (max-stabilized) SDPA with tiling
+  in the `Sq` dimension at 64 rows per tile (see design Q3)
+- [ ] 2.3 Add unit test: SDPA on `B=1, heads=2, Sq=3, Sk=4, hd=8`
+  against a hand-computed reference
+- [ ] 2.4 Add unit test: SDPA with causal mask, verify zero probability
+  mass at masked positions
+- [ ] 2.5 Add unit test: SDPA broadcasting a single KV head across
+  multiple query heads (GQA group-size test)
+
+## 3. Shared `apply_rope_in_place` helper
+
+- [ ] 3.1 Write the helper signature in `ops/microsoft.rs`:
+  `fn apply_rope_in_place(tensor, cos_cache, sin_cache, positions, interleaved)`
+- [ ] 3.2 Implement non-interleaved rotation (HF / Llama layout)
+- [ ] 3.3 Implement interleaved rotation (DeepSeek layout), branched
+  on the `interleaved` flag in the hot loop
+- [ ] 3.4 Add unit test: non-interleaved rotation against a Python
+  reference on a small `(1, 2, 64)` tensor
+- [ ] 3.5 Add unit test: interleaved rotation, confirming the result
+  differs from non-interleaved on the same input
+
+## 4. `SimplifiedLayerNormalization`
+
+- [ ] 4.1 Add `op_simplified_layer_normalization` in
+  `ops/microsoft.rs` as a ~20 LOC wrapper over
+  `op_rms_normalization_raw`
+- [ ] 4.2 Unit test: matches `op_rms_normalization` output on
+  `(2, 4, 8)` input within 1e-6 absolute
+- [ ] 4.3 Unit test: optional bias input is added after normalization
+
+## 5. `SkipSimplifiedLayerNormalization`
+
+- [ ] 5.1 Add `op_skip_simplified_layer_normalization` in
+  `ops/microsoft.rs` (~50 LOC)
+- [ ] 5.2 Unit test: three-input form (`x`, `skip`, `scale`) produces
+  correct normalized output and pre-layernorm sum
+- [ ] 5.3 Unit test: four-input form with bias
+- [ ] 5.4 Unit test: second output (pre-layernorm sum) equals
+  `x + skip + bias` exactly
+
+## 6. Standalone `RotaryEmbedding`
+
+- [ ] 6.1 Add `op_rotary_embedding` in `ops/microsoft.rs` (~150 LOC)
+- [ ] 6.2 Handle both rank-3 (`(B, Sq, hidden)`) and rank-4
+  (`(B, num_heads, Sq, head_dim)`) inputs via shape inference on
+  `rank` + `num_heads` attribute
+- [ ] 6.3 Unit test: rank-3 non-interleaved matches HF reference
+- [ ] 6.4 Unit test: rank-4 interleaved matches DeepSeek reference
+- [ ] 6.5 Unit test: `position_ids` broadcast from `(1, Sq)` to
+  `(B, Sq)`
+
+## 7. `MultiHeadAttention`
+
+- [ ] 7.1 Add `op_multi_head_attention` in `ops/microsoft.rs` (~250 LOC)
+- [ ] 7.2 Implement input parsing for unpacked Q/K/V form
+- [ ] 7.3 Implement input parsing for packed QKV form (single input
+  split along the last axis)
+- [ ] 7.4 Wire in-place past KV-cache concat (same mechanism as GQA,
+  without grouping)
+- [ ] 7.5 Unit test: unpacked Q/K/V on `(1, 4, 64)` with `num_heads = 8`
+- [ ] 7.6 Unit test: packed QKV form
+- [ ] 7.7 Unit test: with past KV-cache (`past_key` and `past_value`
+  supplied)
+- [ ] 7.8 Unit test: no internal RoPE — confirm the op does not
+  mutate Q or K along the rotary dimension
+
+## 8. `GroupQueryAttention`
+
+- [ ] 8.1 Add `op_group_query_attention` in `ops/microsoft.rs`
+  (~600-800 LOC)
+- [ ] 8.2 Input parsing: required 9-input form (Q, K, V, past_K,
+  past_V, seqlens_k, total_sequence_length, cos_cache, sin_cache)
+- [ ] 8.3 Attribute parsing: `num_heads`, `kv_num_heads`, `scale`,
+  `local_window_size`, `do_rotary`, `rotary_interleaved`
+- [ ] 8.4 Return `UnsupportedAttribute` if `local_window_size != -1`
+- [ ] 8.5 Reshape Q, K, V to rank-4 `(B, heads, Sq, head_dim)`
+- [ ] 8.6 Apply RoPE to Q and K in place using the shared helper
+  (skip if `do_rotary == 0`)
+- [ ] 8.7 Concatenate K, V with past-KV in place
+- [ ] 8.8 Grouped attention dispatch: outer loop over the
+  `kv_num_heads` groups, inner call to the shared SDPA helper
+- [ ] 8.9 Reshape output back to `(B, Sq, hidden)` and return it
+  alongside `present_key` / `present_value`
+- [ ] 8.10 Unit test: hand-crafted 4-head / 2-kv-head / head_dim-8
+  case against Python ORT reference within 1e-5 absolute
+- [ ] 8.11 Unit test: KV-cache in-place mutation across two calls
+- [ ] 8.12 Unit test: `do_rotary = 0` path (query is not rotated
+  inside the op)
+
+## 9. Dispatcher wiring + `classify_op`
+
+- [ ] 9.1 Add `dispatch_microsoft_fused` in `onnx-rt/src/executor.rs`
+  matching on the Microsoft subset of `OpKind`
+- [ ] 9.2 Extend `classify_op` in `onnx-rt/src/profile.rs`: GQA and
+  MHA → `OperatorClass::Attention`; the two norm variants and
+  RotaryEmbedding → `OperatorClass::Elementwise`
+- [ ] 9.3 Register the `microsoft` module in `onnx-rt/src/ops/mod.rs`
+
+## 10. End-to-end model loading tests
+
+- [ ] 10.1 Add `onnx-rt/tests/real_model_loading.rs` — load
+  `Llama-3.2-1B` from `SMALLAIOS_MODEL_DIR/llama-3.2-1b.onnx`, run a
+  single-token generation, assert top-1 token matches the golden
+  reference in `onnx-rt/tests/fixtures/microsoft_fused_ops/llama.bin`
+- [ ] 10.2 Extend with `Gemma 3 1b`, same fixture scheme
+- [ ] 10.3 Extend with `DeepSeek-R1-Distill-Qwen-1.5B` f32 forward
+  pass, assert output hidden states within 1e-3 absolute
+
+## 11. Inventory updates + roadmap doc flip
+
+- [ ] 11.1 Flip all 5 entries in
+  `SUPPORTED_OPS_INVENTORY` from `Skipped` to `Implemented`
+- [ ] 11.2 Flip the corresponding rows in
+  `docs/onnx-coverage-roadmap.md` from `Skipped-vendor` to
+  `Implemented (microsoft-fused-ops-v1)` in the same PR as the
+  implementation
+
+## 12. Validation
+
+- [ ] 12.1 `just fmt`, `just clippy`, `just test` all pass
+- [ ] 12.2 `openspec validate microsoft-fused-ops-v1 --strict` passes
+- [ ] 12.3 Re-run `tools/coverage-probe` against `Llama-3.2-1B`,
+  `Gemma 3 1b`, and `DeepSeek-R1-Distill-Qwen-1.5B`; REPORT.md MUST
+  show zero unknown operators for all three model families after
+  this change lands


### PR DESCRIPTION
## Summary
Plan-only OpenSpec change for the 5 com.microsoft-domain fused ops needed to load Llama, Gemma, and DeepSeek end-to-end from canonical HF ONNX exports.

## Empirical motivation
The coverage probe (PR #88) showed that the union of com.microsoft ops needed across the three families is exactly:

| Op | Llama | Gemma 3 | DeepSeek |
|---|:---:|:---:|:---:|
| SimplifiedLayerNormalization | Y | Y | Y |
| SkipSimplifiedLayerNormalization | Y | N | Y |
| GroupQueryAttention | Y | Y | N |
| MultiHeadAttention | N | N | Y |
| RotaryEmbedding | N | N | Y |

No single op can be dropped without breaking at least one family.

## What this is *not*
This PR adds zero operator implementations. The implementation will happen in a follow-up after spec review.

## Test plan
- [x] `openspec validate microsoft-fused-ops-v1 --strict` clean
- [x] No code changes outside openspec/

## After merge
A follow-up implementation PR (or agent run) will add the actual operators in `onnx-rt/src/ops/microsoft.rs` plus the shared SDPA + RoPE helpers, with end-to-end model-loading tests against the public ONNX mirrors of Llama-3.2-1B, Gemma 3 1b, and DeepSeek-R1-Distill-Qwen-1.5B.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive specification for Microsoft fused operators supporting HuggingFace-exported large language models (Llama-3.2-1B, Gemma 3 1b, DeepSeek-R1-Distill-Qwen-1.5B).
  * Defined design for five new operators enabling optimized inference with 1-token generation capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->