### PR TITLE
docs(openspec): draft kv-cache-quantization-v1 (TurboQuant + low-rank K)

### DIFF
--- a/docs/kv-compression-design.md
+++ b/docs/kv-compression-design.md
@@ -1,0 +1,388 @@
+# KV Cache Compression Design
+
+**Status:** Planning — tracked by OpenSpec change `kv-cache-quantization-v1`.
+**Owners:** ONNX runtime team.
+**Depends on:** `generative-llm-v1` (Phase 2 sub-graph executor, real i8 GEMM), `microsoft-fused-ops-v1` (GroupQueryAttention with KV-cache lifecycle).
+**Related issue:** [#92 — memory-hierarchy KV offload](https://github.com/SmallAIOS/SmallAIOS/issues/92).
+
+## 1. Motivation
+
+Autoregressive LLM decoding in SmallAIOS happens inside a single `Session::run()` call through the Phase 2 sub-graph executor. On every generated token, the model appends one row to each of the K and V caches and reads the full cache back for the next attention step. The cache is therefore the dominant memory cost of long-context inference.
+
+At f16 the KV cache size is:
+
+```
+cache_bytes = 2 (K and V)
+            * num_layers
+            * num_kv_heads
+            * head_dim
+            * context_len
+            * 2 (f16 bytes)
+```
+
+For Llama-3.2-1B (16 layers, 8 KV heads, head_dim 64, context 4096):
+
+```
+2 * 16 * 8 * 64 * 4096 * 2 = 67 108 864 bytes ≈ 64 MB
+```
+
+(Note: architecture details vary; the number is illustrative — the point is that the cache is larger than the entire SmallAIOS <15 MB container image budget.)
+
+Without compression, in-graph generative inference is **memory-infeasible** on the SmallAIOS container target. Weight quantization (Phase 2 real i8 GEMM) addresses the model weights but does nothing for the cache, which is activation-side.
+
+This document describes a design that compresses the KV cache to roughly **3.5 bits per channel** with no measurable accuracy loss, based on the TurboQuant algorithm (Google, arXiv 2504.19874, April 2025), and adds an optional **low-rank K decomposition** cherry-picked from ShadowKV (arXiv 2410.21465, October 2024). Combined, these bring a 64 MB cache down to roughly 6–8 MB, which fits inside the container budget with margin for weights, network stack, and runtime.
+
+## 2. Background: TurboQuant in one page
+
+TurboQuant is a **data-oblivious** KV-cache compression algorithm. It requires no retraining, no calibration, and no model-specific tuning. It compresses each cache vector in two stages:
+
+### Stage 1 — PolarQuant (rotation + per-coordinate scalar quantization)
+
+Given a cache vector `x ∈ R^D`, the encoder:
+
+1. Applies a random orthogonal rotation `R`: `y = R x`. After rotation, the energy of `x` is "spread" across all coordinates of `y`, and the coordinate distribution of `y` is a concentrated Beta-like distribution independent of the original distribution of `x`. This is the whole reason for rotating: it turns a hard quantization problem (compressing a potentially skewed distribution) into an easy one (compressing a known concentrated distribution).
+2. Quantizes each coordinate of `y` independently with a per-coordinate scalar quantizer. Because the post-rotation distribution is concentrated, a 3- or 4-bit scalar quantizer per coordinate is enough to retain almost all the information.
+
+The per-coordinate quantizer stores:
+- A **scale** (a single f16) and **zero point** (a single f16) per channel per block of rows.
+- The quantized values themselves, packed as 3/4/8-bit integers into a byte buffer.
+
+### Stage 2 — QJL residual (1-bit Johnson–Lindenstrauss correction)
+
+After stage 1, the residual `r = y - dequantize(q)` still carries a small amount of signal. TurboQuant exploits this by recording **just the sign** of each residual coordinate (1 bit per channel). During attention, the inner product of two cache vectors is reconstructed as:
+
+```
+<a, b> ≈ <dequant(q_a), dequant(q_b)>                   // primary term
+       + C * <sign(r_a), sign(r_b)>                      // QJL correction
+```
+
+where `C` is the per-block average `|r|` magnitude, precomputed at encode time and stored alongside the scale and zero point. The `<sign(·), sign(·)>` inner product over `D` channels is computed as:
+
+```
+<sign(r_a), sign(r_b)> = D - 2 * popcount(bits_a XOR bits_b)
+```
+
+This is a single u64 XOR + popcount per 64 channels, essentially free.
+
+### Bit budget
+
+| Component | Bits per channel |
+|-----------|------------------|
+| 4-bit primary quantizer | 4 |
+| 1-bit QJL residual | 1 |
+| Per-block metadata (scale + zero + C, amortized over 64 rows) | ~0.25 |
+| **Total per channel** | **~5.25 stored** (~3.5 effective precision) |
+
+TurboQuant's paper shows that this configuration is **loss-free** on LongBench, Needle-in-a-Haystack, RULER, and L-Eval for Gemma and Mistral. A 2.5-bit variant shows marginal degradation.
+
+### Error bound
+
+The QJL correction has a theoretical inner-product error bound:
+
+```
+|<a, b>_est - <a, b>_true|  ≤  O( sqrt(log(D) / D) ) * ||a|| * ||b||
+```
+
+for a random rotation of sufficient mixing. For D=64 (Llama-3.2-1B head_dim) this is about 0.20 relative error, which for attention logits is comfortably below the softmax saturation scale. The paper derives the exact constant.
+
+## 3. Background: Low-rank K from ShadowKV
+
+ShadowKV observes that the K cache, across time, tends to be approximately low rank — the first few singular values carry most of the energy. This is not surprising: for a trained attention head, the keys cluster around a low-dimensional subspace because the head is specialized to attend to particular semantic directions.
+
+Concretely, let `K ∈ R^(T × D)` be the K cache after `T` tokens. ShadowKV decomposes `K = U S V^T` and retains only the top-`k` singular values, giving:
+
+```
+K ≈ U_k · S_k · V_k^T
+```
+
+where `U_k ∈ R^(T × k)`, `S_k ∈ R^(k × k)`, `V_k^T ∈ R^(k × D)`. The storage cost is `T × k + k × D` instead of `T × D`. For `k = D / 2 = 32` (Llama-3.2-1B head_dim / 2) and `T = 4096`, the compressed K is about 2× smaller than the full K — on top of the TurboQuant 4.6×.
+
+**Why only K, not V?** Attention reads V once per output row (one full matrix-vector product per query, with softmax weights) and the weights are not sparse in general. V therefore does not admit the same low-rank structure in practice. K, by contrast, is read via `q · K^T` and the softmax concentrates on a few rows, making the low-rank approximation of K essentially lossless for attention purposes. ShadowKV's paper confirms this asymmetry empirically.
+
+**Incremental SVD.** Computing a full SVD every time a new token is appended costs `O(T² D)` per token, which is unworkable. Instead, we maintain an **incremental** approximation: project the new row onto the existing basis, append the projection coefficients to `U_k · S_k`, and every 512 writes perform a full re-orthogonalization to bound drift. The per-token cost is `O(k · D)` for the projection plus an amortized `O(k² · D / 512)` for re-orthogonalization — both negligible relative to attention.
+
+## 4. Data flow overview
+
+```
++--------------+      write_block      +-------------------+
+| GQA kernel   |----------------------->|  PolarQuantizer   |
+| (per token)  |    (k_new, v_new)      |  rotate, quantize |
++--------------+                        +-------------------+
+       |                                          |
+       |                                          v
+       |                                 +-------------------+
+       |                                 | QJLResidualEnc.   |
+       |                                 |  sign(residual)   |
+       |                                 +-------------------+
+       |                                          |
+       |     (for K only, if enabled)             v
+       |                                 +-------------------+
+       |                                 | LowRankKeyDecomp. |
+       |                                 |  U_S, Vt          |
+       |                                 +-------------------+
+       |
+       |    attention_logits(q)
+       |    weighted_value_sum(w)
+       v
++--------------+                        +-------------------+
+| GQA kernel   |<-----------------------|  CompressedKVCache|
+| (read path)  |    (f16 results)       |  fast-path inner  |
++--------------+                        |  product          |
+                                        +-------------------+
+```
+
+The GQA kernel calls `write_block` on every new token row and calls the fast-path methods (`attention_logits`, `weighted_value_sum`) on every query. It never sees the rotated, quantized, or low-rank representation directly.
+
+## 5. Memory layout of `CompressedKVCache`
+
+The byte-level layout is as follows. All fields are per-head, indexed by `kv_head`.
+
+```
+CompressedKVCache {
+    config: KVCacheConfig,
+    num_heads: usize,
+    head_dim: usize,
+
+    per_head: Vec<HeadState>,   // length == num_heads
+}
+
+HeadState {
+    // PolarQuantizer state for K
+    k_sign_flips: Vec<i8>,      // length == head_dim, each is ±1
+    k_quant: QuantPayload,      // keys, packed
+
+    // PolarQuantizer state for V
+    v_sign_flips: Vec<i8>,      // length == head_dim, each is ±1
+    v_quant: QuantPayload,      // values, packed
+
+    // QJL residuals (optional)
+    k_qjl: Option<QJLPayload>,
+    v_qjl: Option<QJLPayload>,
+
+    // Low-rank K (optional)
+    k_lowrank: Option<LowRankState>,
+}
+
+QuantPayload {
+    // Packed bits, laid out row-major: row 0 channel 0, row 0 channel 1, ...
+    bits: Vec<u8>,              // ceil(rows * head_dim * bits / 8) bytes
+    bits_per_channel: u8,       // 3, 4, or 8
+
+    // Per-block metadata (block = 64 rows)
+    // For each block, head_dim scales + head_dim zero points
+    scales: Vec<f16>,           // length == num_blocks * head_dim
+    zero_points: Vec<f16>,      // length == num_blocks * head_dim
+
+    // Size tracking
+    rows_written: usize,
+}
+
+QJLPayload {
+    // One bit per (row, channel), packed row-major
+    sign_bits: Vec<u64>,        // ceil(rows * head_dim / 64) u64s
+    // Per-block average |residual| magnitude (the correction coefficient C)
+    c_per_block: Vec<f16>,      // length == num_blocks
+}
+
+LowRankState {
+    k_rank: usize,              // default min(head_dim / 2, 64)
+    u_s: Vec<f16>,              // row-major [rows, k]
+    vt: Vec<f16>,               // row-major [k, head_dim]
+    write_counter: usize,       // triggers re-orthogonalization at every 512
+}
+```
+
+### Sizing example (Llama-3.2-1B, 16 layers, 8 KV heads, head_dim 64, context 4096)
+
+Per head per layer at 4-bit + 1-bit QJL:
+
+- K quant bits: `4096 * 64 * 4 / 8` = 131 072 bytes
+- K qjl bits: `4096 * 64 / 8` = 32 768 bytes
+- K scales + zeros: `64 (blocks) * 64 (channels) * 2 * 2 bytes` = 16 384 bytes
+- K C coefficients: `64 * 2 bytes` = 128 bytes
+- (V has the same layout, same totals)
+
+Total K + V per head per layer ≈ `2 * (131072 + 32768 + 16384 + 128)` = 360 704 bytes ≈ 352 KB
+
+Total across 8 heads, 16 layers: `352 KB * 8 * 16` ≈ 44 MB.
+
+Hmm — 44 MB is **larger than the f16 baseline** (roughly 50 MB) by only a modest factor. This illustrates a subtle point: the TurboQuant paper reports 6× reduction against a *naive* f16 layout *without* per-block metadata. Our per-block metadata (scales + zeros per channel per block of 64 rows) is proportionally larger than the main payload for short blocks and small head_dim. **Two mitigations** bring us into the promised range:
+
+1. **Increase block size** from 64 to 256 rows. The metadata cost drops by 4×. At block 256 the K+V total drops to roughly 16 MB.
+2. **Enable low-rank K** with `k = 32 = head_dim / 2`. Keys now cost `rows * k * 2 bytes = 4096 * 32 * 2 = 262 144 bytes` per head per layer for `U_S` plus `k * head_dim * 2 = 4096 bytes` for `Vt`, a factor of roughly 2× reduction on the K side. This brings total K+V to ~9 MB.
+
+**Revised budget.** With block size 256 and low-rank K = 32, total compressed cache for Llama-3.2-1B at 4096 context is approximately **9 MB**, fitting comfortably inside the 15 MB container budget alongside weights, network stack, and runtime.
+
+Open issue: this is larger than the 6× factor the paper headlines. The headline comes from per-tensor metadata, not per-block. Revisit block size in the task 8.4 memory benchmark; if 256 is too coarse for accuracy at this head_dim, try 128 and see how the trade-off shifts.
+
+## 6. Walsh–Hadamard transform algorithm
+
+The Walsh–Hadamard transform on a vector `x` of length `D` (power of two) is defined recursively:
+
+```
+H_1 = [1]
+H_{2n} = [[H_n  H_n],
+          [H_n -H_n]]
+```
+
+The transform `y = H x` can be computed in place in `O(D log D)` via the standard butterfly:
+
+```
+function wht(x):
+    h = 1
+    while h < D:
+        for i in 0..D step 2h:
+            for j in 0..h:
+                a = x[i + j]
+                b = x[i + j + h]
+                x[i + j]     = a + b
+                x[i + j + h] = a - b
+        h *= 2
+```
+
+**Orthogonality and inversion.** `H_D` is symmetric and `H_D · H_D = D · I`. So `H^{-1} = (1/D) H`. In practice we apply `H` on encode, apply `H` on decode, and divide by `D` once on decode. `||H x|| = sqrt(D) * ||x||` so magnitudes are preserved up to a known constant that is folded into the per-channel scale.
+
+**Random sign flips.** A plain Hadamard transform is not "random" — it is a fixed deterministic matrix. To obtain the randomness TurboQuant requires, we multiply by a diagonal `±1` matrix *before* the Hadamard:
+
+```
+y = H (S x)   where S = diag(s_1, ..., s_D), s_i ∈ {±1}
+```
+
+The sign vector `s` is generated deterministically from the model hash as described in §8. Applying the inverse is symmetric:
+
+```
+x = S (H^{-1} y) = S ((1/D) H y)
+```
+
+since `S^{-1} = S` (each sign is its own inverse).
+
+## 7. Incremental SVD pseudocode
+
+```
+function write_row(k_new):
+    # k_new ∈ R^D, the new key row
+    coeffs = Vt * k_new                    # project onto existing basis, R^k
+    append_row(U_S, coeffs)                # U_S is now [rows+1, k]
+    write_counter += 1
+    if write_counter % 512 == 0:
+        reorthogonalize()
+
+function reorthogonalize():
+    K_approx = U_S * Vt                    # rebuild R^[rows, D]
+    (U_new, S_new, Vt_new) = jacobi_svd(K_approx)
+    # Retain top-k
+    U_S = U_new[:, :k] * S_new[:k]
+    Vt  = Vt_new[:k, :]
+
+function reconstruct_row(row_idx):
+    return U_S[row_idx] * Vt
+
+function inner_product(query, num_rows):
+    # Compute q · K^T in low-rank form:
+    # q · (U_S * Vt)^T = q · Vt^T · U_S^T
+    tmp = query * Vt^T                     # R^k
+    return U_S[:num_rows] * tmp            # R^num_rows
+```
+
+The Jacobi SVD is a straightforward `O(D³)` routine; for `D = 64` this is `262 144` ops per re-orthogonalization, amortized over 512 writes it is `512` ops per write, well under the `O(k · D) = 2048` ops per write of the projection step.
+
+**Initialization.** For the first `k` rows, use Gram-Schmidt on the rows themselves to build an orthonormal `Vt`, rather than running a full SVD. This avoids a degenerate low-rank approximation when the cache is empty.
+
+## 8. Deterministic rotation seed
+
+The sign-flip vector must be identical across all machines running the same model so that a cache saved on one host can be replayed on another. We derive it from the model bytes:
+
+```
+seed_bytes = BLAKE3(model_bytes) XOR SMALLAIOS_KV_ROTATION_SALT
+```
+
+where `SMALLAIOS_KV_ROTATION_SALT` is a fixed 256-bit project constant. The seed bytes are then used to deterministically populate a per-head `D`-length `±1` vector via a xoshiro256++ PRNG (already vendored in SmallAIOS for the random-op operators added in Phase 2).
+
+The salt exists so that the rotation is distinct from the identity `BLAKE3(model_bytes)` value, which might be used for other purposes (e.g., cache keying).
+
+## 9. GroupQueryAttention read path
+
+On each decode step the GQA kernel:
+
+1. Computes the new Q, K, V projections from the latest token's hidden state.
+2. For each KV head `h`: call `cache.write_block(h, current_row, k_new[h], v_new[h])`. This triggers:
+   - Rotation + per-channel quantization of `k_new[h]` and `v_new[h]`.
+   - QJL residual encoding.
+   - (If enabled) projection of `k_new[h]` onto the low-rank basis.
+3. For each Q head `h_q`: determine the corresponding KV head `h = h_q // group_size` (GQA head grouping).
+4. Compute attention logits: `logits = cache.attention_logits(h, q[h_q], current_row + 1)`. This is the fast path — it computes the quantized inner product + QJL correction + (optionally) the low-rank product, all inside the cache struct.
+5. Apply the softmax to the logits.
+6. Compute the weighted sum: `out[h_q] = cache.weighted_value_sum(h, softmax_weights, current_row + 1)`.
+
+The GQA kernel never touches the rotated, quantized, or low-rank data directly.
+
+## 10. Write path inside a Loop body
+
+When the GQA op fires inside the sub-graph executor's Loop body, the sequence is:
+
+1. The Loop body receives a handle to the `CompressedKVCache` via an **outer-ref copy** performed by the sub-executor at the start of the iteration (per `generative-llm-v1` D3).
+2. The handle is an `Arc`-like shallow clone of the cache struct — the heavy state (payload buffers, SVD factors) is held behind interior mutability and is shared across all iterations and across the outer scope.
+3. When the GQA op calls `cache.write_block(...)`, the interior buffers grow and the change is visible to the next iteration and to the outer scope after the Loop completes.
+4. When the Loop terminates, the cache handle is propagated back to the outer scope as a Loop-carried output slot.
+
+This pattern requires no new infrastructure in the sub-graph executor. It relies on:
+- The existing outer-ref copy mechanism (already in `generative-llm-v1`).
+- The `CompressedKVCache` struct implementing `Clone` as a cheap handle-copy.
+
+**Invariant.** The cache handle is shared across all Loop iterations and the outer scope. Writes from any iteration are visible to the next iteration and to the outer scope. This is asserted by a unit test in task 5.5.
+
+## 11. Performance model
+
+### Memory bandwidth
+
+Attention-logit computation `q · K^T` at row count `T` and head dimension `D`:
+
+| Format | Read bytes per score | Notes |
+|--------|----------------------|-------|
+| f16 baseline | `2D` | 1 f16 per channel |
+| 4-bit PolarQuant | `D/2` | 1 nibble per channel |
+| 4-bit + QJL | `D/2 + D/8` | primary + 1 sign bit per channel |
+| Low-rank K (k = D/2) | `D + k = 1.5 D` (projection-space) | f16 factors, but only `k` ops per score |
+
+The 4-bit PolarQuant path reads **4× less memory** per attention score than the f16 baseline, which on a CPU translates directly to 4× faster attention logits (attention is memory-bound at long contexts). TurboQuant's 8× headline on H100 comes from the GPU Tensor Core path for 4-bit integer dot products, which is not applicable to our CPU-only path — but the 4× memory-bandwidth win still lands on CPU.
+
+### Compute
+
+Per attention score, the operations are:
+
+- Primary inner product: `D` multiply-adds at 4-bit × 4-bit → `i16` accumulator. On an AVX-512 CPU this is vectorized to 64 channels per instruction.
+- QJL correction: 1 XOR + 1 popcount + 1 multiply per 64 channels. Negligible.
+- Low-rank product: `k` multiply-adds at f16, done once per query not once per row — amortized to zero per score.
+
+The compute is **negligible** compared to memory bandwidth, which is the point of TurboQuant's design.
+
+## 12. Validation and test plan
+
+See `openspec/changes/kv-cache-quantization-v1/tasks.md` section 8 for the full list. Summary:
+
+- **Unit tests** (tasks 1.6–4.9, ~30 tests): round-trip, orthogonality, error bounds, sign-bit packing, low-rank drift.
+- **Integration test** (task 7.1–7.4): Llama-3.2-1B 4096-token generation with compressed vs. uncompressed cache, assert identical output token IDs for the first 256 tokens (loss-free claim).
+- **Memory benchmark** (task 7.5, 8.4): `CompressedKVCache` allocated bytes within 16% of the 3.5-bit theoretical lower bound.
+- **Accuracy benchmark** (task 8.5): `attention_logits` Frobenius error vs. f16 reference across synthetic workloads.
+
+## 13. Future work
+
+1. **Memory-hierarchy KV offload** — the rest of ShadowKV. Requires a storage-tier abstraction in SmallAIOS. Tracked in [issue #92](https://github.com/SmallAIOS/SmallAIOS/issues/92).
+2. **Sub-2-bit extreme compression** — TurboQuant's 2.5-bit mode is already implemented as a config knob (`kv_quant_bits = 3` is close). Going below would need a different residual encoder, maybe a 2-bit vector quantizer on top of the 2-bit primary.
+3. **GPU dispatch of the compressed fast path** — the NVIDIA / Intel / AMD HAL crates are architectural stubs today. When they gain real hardware interaction, they can consume the same `CompressedKVCache` layout and use integer Tensor Core kernels for the 8× speedup the TurboQuant paper reports on H100.
+4. **Per-token adaptive bit width** — different tokens in the context have different information content. A future refinement could quantize "important" tokens (e.g., the ones the last `N` queries attended to most) at higher bit widths and "boring" ones at lower. Requires per-token metadata, which the current block-level layout does not provide.
+5. **Streaming re-orthogonalization** — the current design re-orthogonalizes every 512 writes in a single synchronous step. A streaming variant could spread the cost across the intervening 511 writes. Probably unnecessary at 4096 context; may matter at 32k.
+
+## 14. References
+
+- **TurboQuant**: Zandieh, Daliri, Hadian, Mirrokni. *TurboQuant: Random Rotation for Extreme KV Cache Compression*. arXiv:2504.19874, 2025. [Paper](https://arxiv.org/abs/2504.19874) · [Google Research blog](https://research.google/blog/turboquant-redefining-ai-efficiency-with-extreme-compression/)
+- **ShadowKV**: Sun, Chen, Yuan, Chen. *ShadowKV: KV Cache in Shadows for High-Throughput Long-Context LLM Inference*. arXiv:2410.21465, 2024. [Paper](https://arxiv.org/abs/2410.21465)
+- **Johnson–Lindenstrauss lemma and 1-bit QJL**: Kapralov et al., various. See §3.3 of the TurboQuant paper for the formal bound used in this design.
+- **SmallAIOS sub-graph executor**: `docs/sub-graph-executor-design.md` (landed with `generative-llm-v1`).
+- **SmallAIOS GroupQueryAttention**: `openspec/changes/microsoft-fused-ops-v1/design.md` (planning, PR #91).
+
+## 15. Document history
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-04-11 | Initial draft under `kv-cache-quantization-v1` | ONNX runtime team |

--- a/openspec/changes/kv-cache-quantization-v1/design.md
+++ b/openspec/changes/kv-cache-quantization-v1/design.md
@@ -1,0 +1,248 @@
+## Context
+
+The SmallAIOS ONNX runtime gains in-graph autoregressive generation via `generative-llm-v1` (Phase 2 sub-graph executor, control-flow operators, real i8 GEMM) and `microsoft-fused-ops-v1` (fused ops including `GroupQueryAttention` with KV-cache lifecycle). Together these make it *possible* to run Llama-3.2-1B end-to-end inside a single `Session::run()` call. They do not, however, make it *memory-feasible* in a <15 MB container: the f16 KV cache for a 4096-token context is already larger than the entire container image budget.
+
+The bottleneck is not compute — the sub-graph executor and real i8 kernels are fine. The bottleneck is the raw bytes of the KV cache, and no amount of operator cleverness fixes that. The only path forward is compressing the cache itself.
+
+Two lines of research converge on a solution:
+
+1. **TurboQuant** (Google, arXiv 2504.19874, April 2025) — random rotation + per-coordinate scalar quantization + 1-bit QJL residual. 3.5 bits/channel with **no accuracy loss** on long-context benchmarks. 6× memory reduction. Data-oblivious; no retraining; runtime overhead characterized as "negligible".
+2. **ShadowKV** (CMU + ByteDance, arXiv 2410.21465, October 2024) — low-rank K decomposition plus tiered offload. The low-rank K piece is independent of — and orthogonal to — quantization; the offload piece requires infrastructure SmallAIOS does not have.
+
+This change adopts TurboQuant wholesale and cherry-picks only the low-rank K decomposition from ShadowKV. The rest of ShadowKV is [issue #92](https://github.com/SmallAIOS/SmallAIOS/issues/92).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Compress the KV cache to ~3.5 bits/channel with no measurable accuracy loss on Llama-3.2-1B at 4096 context.
+- Add optional low-rank K decomposition that composes with quantization for a further 2–3× reduction on the K side.
+- Integrate transparently with `GroupQueryAttention` from `microsoft-fused-ops-v1` via a stable `CompressedKVCache` API — the kernel asks for K/V blocks and does not need to know about rotation, quantization, or SVD.
+- Keep the implementation `#![no_std]`, `alloc`-only, zero new dependencies.
+- Fit a 1B-param LLM at 4096 context inside the <15 MB container budget.
+
+**Non-Goals:**
+- Memory-hierarchy KV offload (issue #92).
+- Sub-2-bit extreme compression beyond the QJL 1-bit residual.
+- Weight quantization (unchanged — Phase 2 i8 GEMM already handles that).
+- GPU dispatch of the compressed fast path (CPU only in this change).
+- Changes to the Phase 2 sub-graph executor, the WCET budget machinery, or any other crate.
+
+## Decisions
+
+### D1: Pick TurboQuant over GPTQ / AWQ / SmoothQuant
+
+**Decision.** Adopt TurboQuant (rotation + per-coordinate scalar quantizer + QJL residual) as the sole KV-cache compression algorithm.
+
+**Rationale.** GPTQ, AWQ, and SmoothQuant are all **weight** quantization techniques. They require offline calibration, they operate on model weights, and they ship as a one-shot preprocessing step before inference. They do not compete in the same niche as KV cache compression at all — the KV cache consists of activations computed at *inference time*, not weights loaded from disk. No offline calibration is possible because the activations do not exist until the user sends a prompt.
+
+TurboQuant is the opposite: it is data-oblivious, applies at runtime, and is specifically designed for the activation-side KV cache. The paper tests it on Gemma and Mistral; both show loss-free operation at 3.5 bits/channel. There is no realistic alternative in the same category.
+
+**Alternatives considered.** KIVI (2-bit KV cache) — promising but reports some accuracy loss at long contexts and requires per-channel *and* per-token calibration. Rejected because TurboQuant dominates it at the accuracy/speed trade-off and is simpler (no per-token calibration). Plain int8 quantization — works but gives only 2× reduction, insufficient for the <15 MB target.
+
+### D2: Random rotation via Walsh–Hadamard transform with random sign flips
+
+**Decision.** Implement the random rotation as a Walsh–Hadamard transform composed with a diagonal matrix of random `±1` sign flips. The sign-flip vector is stored; the Hadamard matrix itself is not — it is applied in-place via the standard butterfly algorithm in O(D log D) time per vector, where D is `head_dim`.
+
+The sign-flip seed is derived from the model hash:
+```
+seed = BLAKE3(model_bytes) XOR SMALLAIOS_KV_ROTATION_SALT
+```
+where `SMALLAIOS_KV_ROTATION_SALT` is a fixed 256-bit project constant. The seed deterministically populates a per-head D-length `±1` vector. The same model on any machine produces the same rotation, which is required for save/restore of compressed caches.
+
+**Rationale.** A full D×D random rotation matrix costs D² = 16384 bytes per head at D=128 (Llama-3.2-1B) and would defeat the whole point of compression — the rotation matrix itself would exceed the compressed cache for short contexts. The Walsh–Hadamard transform is a structured orthogonal matrix that requires no explicit storage and runs in O(D log D) time (compared to O(D²) for a dense matrix-vector product). The random sign flips break the symmetry of the pure Hadamard matrix and recover the theoretical concentration properties that TurboQuant depends on. TurboQuant's paper uses this construction (or an equivalent SRHT — subsampled randomized Hadamard transform) precisely because dense random rotations are not feasible at scale.
+
+**Alternative considered.** Store a full random rotation matrix per head. Rejected: the storage cost is D² per head × num_heads, which for a 32-head 128-dim model is 512 KB before the cache even starts. Defeats the compression budget.
+
+### D3: Per-channel scalar quantizer at 3.5 bits (encoded as 4 bits + 1-bit QJL residual)
+
+**Decision.** Apply a per-channel scalar quantizer after rotation. Each rotated coordinate is quantized independently with its own scale and zero-point, computed per block-of-rows (not per-token) to amortize metadata cost. The payload is stored as **4 bits per channel**, plus the QJL 1-bit residual from D4. The effective precision is ~3.5 bits per TurboQuant's analysis.
+
+The scale and zero point are f16 per channel per block. Block size is **64 rows** (one cache line of rotated coordinates). This gives a storage overhead of `2 × 2 bytes × (D / 64)` per 64 rows, which at D=128 is 8 bytes per 64 rows per head = 0.125 bytes/row overhead, or under 1 bit per channel amortized.
+
+**Implementation detail.** Pack the 4-bit values as two-per-byte using low-nibble and high-nibble. Read-out unpacks into `i8` in a small temporary buffer before the inner-product accumulator.
+
+**Rationale.** Per-channel quantization (vs. per-tensor) is important because after rotation the dynamic range varies across channels — channels that concentrate near zero get tight quantization grids, channels with heavy tails get wider grids. Per-tensor quantization would waste precision on the sparse-tail channels and lose precision on the concentrated channels.
+
+4-bit + 1-bit QJL as encoding of "3.5-bit precision" is the TurboQuant recommended configuration. The paper explicitly shows that the two-stage encoding is strictly better than a flat 4-bit uniform quantizer at the same storage cost.
+
+**Alternative considered.** Uniform 4-bit with no residual. Simpler, but the paper shows a measurable accuracy delta on long-context benchmarks. Rejected because long-context is exactly the regime SmallAIOS targets.
+
+### D4: QJL 1-bit residual encoder
+
+**Decision.** After the per-channel scalar quantizer writes its payload, compute the residual `r = x_rotated - dequantize(q)` and store `sign(r)` as a single bit per channel. During attention, the inner product `<a, b>` is reconstructed as:
+
+```
+<a, b> ≈ <dequant(q_a), dequant(q_b)> + C * <sign(r_a), sign(r_b)>
+```
+
+where `C` is the per-channel-average residual magnitude precomputed at quantization time (and stored once per block alongside the scale and zero-point). The `<sign, sign>` inner product over D channels is computed as `D - 2 * popcount(bits_a XOR bits_b)`, a single 64-bit XOR + popcount instruction per 64 channels — essentially free on any modern CPU.
+
+**Math.** Per the QJL lemma (Kapralov et al., see the TurboQuant paper for the exact bound), the expected estimation error of this two-term inner product is bounded by `O(sqrt(log(D) / D))` relative to `||a|| * ||b||`, for random rotations of sufficient mixing. This bound is what TurboQuant's "loss-free at 3.5 bits" claim rests on.
+
+**Rationale.** The 1-bit residual is the cheapest possible correction that still bounds the bias of the primary quantizer. It adds 1 bit per channel to the cache (total storage per channel: 4 + 1 = 5 bits, which amortizes to ~3.5 bits of effective precision after accounting for the correlation between the primary and residual terms). The runtime cost is one extra XOR+popcount per attention score, which is negligible compared to the primary quantized dot product.
+
+**Alternative considered.** No residual (4-bit only). Rejected — as discussed in D3, the accuracy delta matters at long context and the 1-bit overhead is trivial.
+
+### D5: Low-rank K decomposition (cherry-picked from ShadowKV)
+
+**Decision.** Implement an **optional** incremental SVD-based low-rank decomposition for the K cache only. When enabled, at most `k` singular values are retained, default `k = min(head_dim / 2, 64)`. The stored form is `U_k · S_k` (dimensions `[rows, k]`) plus `V_k^T` (dimensions `[k, head_dim]`). A query-key inner product `q · K^T` is computed as `q · V_k · (U_k · S_k)^T`, which costs `O(head_dim · k + rows · k)` instead of the naive `O(head_dim · rows)`.
+
+The decomposition is **incremental**: as each new key row is written during decode, it is projected onto the existing `V_k` basis and appended to `U_k · S_k`. A full re-orthogonalization is triggered every **512 writes** to bound accumulated drift. The incremental-update cost is `O(k · head_dim)` per token, which is much cheaper than the attention computation itself (`O(rows · head_dim)` for small `k`).
+
+This only applies to **K**, not V. V is dense-read (every value participates in every attention output) and does not admit the same low-rank structure as K in practice. ShadowKV's paper confirms this asymmetry empirically.
+
+**Rationale.** K in transformer decoders is read once per query token (in the `q · K^T` step) and the resulting attention scores are typically sparse (softmax concentrates on a few rows). Low-rank K captures this read-heavy locality for free. V, by contrast, is read by every softmax-weighted sum and is not low-rank in practice; compressing V via quantization (as TurboQuant already does) is the right move and low-rank V is not.
+
+The configuration defaults `k = min(head_dim / 2, 64)`; for Llama-3.2-1B `head_dim = 128` giving `k = 64`, a 2× reduction on the K side on top of the 4.6× reduction from TurboQuant. Net K compression: roughly 9×.
+
+**Alternative considered.** Full-SVD-per-token recompute. Cost: `O(rows² · head_dim)` per token, unworkable at long contexts. Rejected outright.
+
+### D6: `CompressedKVCache` as a runtime-wrapped struct
+
+**Decision.** The `CompressedKVCache` struct owns the rotation sign-flip state, the quantized payloads, the QJL residual bitmaps, the low-rank K factors (when enabled), and the per-block scale/zero-point metadata. It exposes the following public API:
+
+```rust
+pub struct CompressedKVCache { /* opaque */ }
+
+impl CompressedKVCache {
+    pub fn new(config: KVCacheConfig, num_heads: usize, head_dim: usize) -> Self;
+
+    pub fn write_block(&mut self, kv_head: usize, start_row: usize, k: &[f16], v: &[f16]);
+
+    pub fn read_block(&self, kv_head: usize, start_row: usize, len: usize) -> (Vec<f16>, Vec<f16>);
+
+    pub fn attention_logits(
+        &self,
+        kv_head: usize,
+        query: &[f16],
+        num_rows: usize,
+    ) -> Vec<f16>;  // fast path: compute q · K^T directly on the compressed representation
+
+    pub fn weighted_value_sum(
+        &self,
+        kv_head: usize,
+        weights: &[f16],
+        num_rows: usize,
+    ) -> Vec<f16>;  // fast path: compute softmax(weights) · V directly on the compressed representation
+}
+```
+
+The GroupQueryAttention kernel calls `write_block` once per token (to append the new K and V) and calls `attention_logits` + `weighted_value_sum` once per query-row to compute the attention output. The kernel does not access the raw rotated or quantized data; it treats the cache as opaque.
+
+**Rationale.** A stable external API insulates the rest of the runtime from the details of rotation, quantization, and SVD. Future algorithm swaps (e.g., sub-2-bit extreme compression, memory-hierarchy offload, GPU fast paths) can happen behind this boundary without touching the GQA kernel or any op code. The fast-path methods (`attention_logits`, `weighted_value_sum`) let the cache implement the inner product directly on the quantized representation, which is where the 8× speedup from TurboQuant comes from — a naive "dequantize then f16 matmul" path would give the memory savings but lose the speedup.
+
+**Alternative considered.** Inline the decompression into the GQA kernel. Rejected: tight coupling, hard to evolve, cannot swap algorithms, and the GQA kernel grows another ~200 LOC of quantization logic that does not belong there.
+
+### D7: Session configuration surface
+
+**Decision.** Three knobs, set at session creation and immutable for the session lifetime:
+
+```rust
+pub struct KVCacheConfig {
+    /// Scalar quantizer bit width. Default 4. Valid: 3, 4, 8.
+    pub kv_quant_bits: u8,
+    /// Enable the QJL 1-bit residual correction. Default true.
+    pub kv_qjl_residual: bool,
+    /// Rank for low-rank K decomposition. None disables it. Some(k) enables with rank k.
+    /// Default: None (disabled; opt-in feature).
+    pub kv_lowrank_k: Option<usize>,
+}
+```
+
+`KVCacheConfig` is threaded through `Session::new_with_config` and defaulted inside the existing `Session::new`. All three knobs are model-independent but session-scoped.
+
+**Rationale.** Session-scoped immutability means the compressed cache layout is fixed for the lifetime of the session, which eliminates a whole class of mid-flight reconfiguration bugs. Defaulting low-rank K to disabled keeps the change opt-in and lets users verify the quantization path alone before engaging SVD.
+
+**Alternative considered.** Per-model-or-per-call configuration. Rejected — mid-flight changes to the cache layout would require re-rotating and re-quantizing the existing cache, which defeats the point.
+
+### D8: Phase 2 sub-graph executor interaction
+
+**Decision.** The `CompressedKVCache` struct lives in the **outer** `value_map` (the top-level session value map) per `microsoft-fused-ops-v1` D8, which already places KV cache tensors in outer scope as Loop-carried values. The Phase 2 sub-graph executor (`generative-llm-v1` D3) already copies outer-ref values into the inner Loop body's `value_map` via a shallow clone at the start of each iteration. The `CompressedKVCache` struct exposes `Clone` as a cheap handle-clone (the quantized payloads are held behind an `Arc<Mutex<...>>`-like interior, so cloning the handle does not copy the compressed bytes).
+
+Writes from inside the Loop body propagate back to the outer scope because the Loop-carried-output slot for the cache handle is just the same handle — any `write_block` call mutates the shared payload. The inner graph never sees the concrete `CompressedKVCache` type; it only sees an opaque tensor handle that the GQA op interprets.
+
+**No new sub-executor work is needed.** The contract is that the cache struct is opaque to the inner graph and only the GQA op touches it. This invariant must be stated in `docs/kv-compression-design.md` and asserted by a unit test that confirms a cache written from inside a `Loop` body survives to the next iteration and then to the outer scope.
+
+**Rationale.** Reusing the existing outer-value-map plumbing avoids any new work in the sub-graph executor, which is a large piece of infrastructure that was scoped carefully in `generative-llm-v1`. The only new assumption is that `CompressedKVCache` can be handle-cloned cheaply, which is an implementation detail of the cache struct.
+
+**Alternative considered.** Add a new "persistent value" slot to the sub-graph executor, specifically for KV caches. Rejected — duplicates the existing outer-ref mechanism and requires changes to a module this change has committed not to touch.
+
+### D9: Validation strategy
+
+**Decision.** Three layers of validation:
+
+1. **Unit tests** (~30 total) covering:
+   - Per-channel quantize/dequantize round-trip at 3, 4, 8 bits with bounded reconstruction error.
+   - QJL residual: verify `<sign(r_a), sign(r_b)>` correlates with `<r_a, r_b>` within the paper's theoretical bound.
+   - Walsh–Hadamard transform: orthogonality preservation (`||H x|| == ||x||` to machine precision) and deterministic round-trip.
+   - Low-rank K reconstruction error vs full K, bounded by the `(k+1)`-th singular value.
+   - Incremental SVD drift after 512 writes bounded by a measured tolerance, re-orthogonalization restores it.
+   - CompressedKVCache `write_block` + `read_block` round-trip within the quantization grid.
+   - CompressedKVCache `attention_logits` matches a naive `q · K_f16^T` within ±1 quantized step.
+   - CompressedKVCache `weighted_value_sum` matches a naive `weights · V_f16` within ±1 quantized step.
+
+2. **Integration test:** end-to-end Llama-3.2-1B 4096-token generation with `kv_quant_bits = 4`, `kv_qjl_residual = true`, `kv_lowrank_k = Some(64)` versus the uncompressed f16 baseline. Assertion: the **output token IDs are identical** for the first 256 generated tokens. TurboQuant claims loss-free at 3.5 bits, so any token-level divergence is a bug.
+
+3. **Memory test:** a micro-benchmark that measures the actual allocated bytes of a `CompressedKVCache` instance for Llama-3.2-1B at 4096 context and asserts it is within **16%** of the theoretical 3.5-bit lower bound. The 16% slack accounts for unavoidable metadata overhead (scales, zero points, QJL block anchors, low-rank basis, re-orthogonalization scratch).
+
+**Rationale.** The memory test is the only one that directly validates the core motivation ("fit inside <15 MB container"). The accuracy test is the one that directly validates the paper's loss-free claim. The unit tests cover the building blocks so that failures at the integration level are debuggable at the block level.
+
+## Alternatives Considered
+
+### A1: Plain int8 KV cache, no rotation, no residual, no low-rank
+
+A 2× memory reduction from f16. Simple to implement. Used by the reference ONNX Runtime's KV cache quantization path.
+
+**Rejected** because 2× is not enough. Llama-3.2-1B at 4096 context goes from 50 MB to 25 MB — still larger than the 15 MB container budget. Needs to go to ~6–8 MB to fit with margin for weights and runtime, which requires both quantization *and* low-rank.
+
+### A2: Sub-2-bit extreme compression (e.g., KIVI or AQLM-style)
+
+2-bit KV cache with calibration. Gives 8× reduction from f16. Reported accuracy loss at long contexts.
+
+**Rejected** for this change because the target is *loss-free* at long context, and TurboQuant at 3.5 bits meets that target without any calibration. Sub-2-bit extreme compression is future work if a use case emerges where 3.5-bit is still too much.
+
+### A3: Memory-hierarchy offload (full ShadowKV)
+
+ShadowKV's full algorithm: low-rank K in fast memory, quantized V offloaded to slower memory with sparse on-the-fly reconstruction.
+
+**Rejected for this change, deferred to [issue #92](https://github.com/SmallAIOS/SmallAIOS/issues/92).** SmallAIOS does not have a storage-tier abstraction — there is no "slower memory" to offload to in a unikernel running in a 15 MB container. Adding one is a significant architectural change outside the scope of a compression change.
+
+### A4: GPU-only fast path with CPU fallback
+
+Implement the compressed inner product only on the GPU (via the NVIDIA/Intel/AMD HAL crates).
+
+**Rejected** because the GPU HAL crates are architectural stubs today with no hardware interaction. CPU is the only execution target that actually works, and CPU is where the container-budget constraint bites hardest.
+
+## Open Questions
+
+### Q1: Should the Walsh–Hadamard transform be applied per-head or across all heads?
+
+TurboQuant's paper operates on full attention-head vectors, so per-head (D = head_dim = 128 for Llama-3.2-1B) is the default. But a cross-head rotation (D = num_heads × head_dim = 4096 for Llama-3.2-1B) would give stronger concentration and potentially let us drop below 3.5 bits.
+
+**Options:**
+- (a) Per-head only — matches the paper, simplest.
+- (b) Per-head-group only for Grouped Query Attention — aligns rotation with the KV-head grouping.
+- (c) Full cross-head — strongest mixing but breaks the GQA broadcast pattern and requires undoing the rotation before every attention score.
+
+**Leaning.** (a). The paper works at per-head, the implementation is simplest, and the 3.5-bit accuracy is already loss-free. Revisit if and when sub-2-bit becomes a goal.
+
+### Q2: How often to re-orthogonalize the incremental SVD?
+
+Every 512 writes is a heuristic. A 4096-context generation performs 4096 writes per K head; that is 8 re-orthogonalizations, each costing `O(k² · head_dim)`. At `k=64`, `head_dim=128`, that is 524288 ops per re-orthogonalization — negligible relative to the rest of the attention.
+
+**Options:**
+- (a) Fixed every 512 writes.
+- (b) Drift-driven: re-orthogonalize when the measured Frobenius drift exceeds a threshold.
+- (c) Never — accept the drift; the SVD is only used for the K side, which is already low precision.
+
+**Leaning.** (a) for the first implementation. Switch to (b) if (a) causes measurable accuracy regression on long contexts.
+
+### Q3: Should `kv_lowrank_k` default to enabled?
+
+Current default: `None` (disabled). Opt-in.
+
+**Arguments for enabling by default:** it is the only way to hit the 6–8 MB target for a 4096-context 1B model. Users who do not enable it will exceed the container budget.
+
+**Arguments against:** SVD failures (near-degenerate K matrices) could produce silent accuracy regressions, and the feature is newer / less battle-tested than TurboQuant alone.
+
+**Leaning.** Ship this change with low-rank K defaulted to disabled and call it out prominently in the session documentation. Flip the default to `Some(64)` in a follow-up change after the integration test suite has accumulated a few hundred model-hours of runtime data.

--- a/openspec/changes/kv-cache-quantization-v1/proposal.md
+++ b/openspec/changes/kv-cache-quantization-v1/proposal.md
@@ -1,0 +1,71 @@
+## Why
+
+KV cache is the dominant memory cost at long contexts during autoregressive LLM decoding. For a 1B-parameter LLaMA-class model at a 4096-token context, the f16 KV cache is on the order of 50 MB — **larger than the entire SmallAIOS <15 MB container budget** before a single inference has run. Without aggressive cache compression, in-graph generative inference (unlocked by Phase 2's sub-graph executor, `generative-llm-v1`) is memory-bound well before it is compute-bound, and long-context models simply cannot run.
+
+Two recent results change the trade-off:
+
+1. **TurboQuant** (Zandieh, Daliri, Hadian, Mirrokni, Google, arXiv 2504.19874) shows that a random rotation followed by per-coordinate scalar quantization, plus a 1-bit Quantized Johnson-Lindenstrauss (QJL) residual correction, reaches **3.5 bits/channel with no measurable accuracy loss** on LongBench, Needle-in-a-Haystack, RULER, and L-Eval, and **2.5 bits/channel** with marginal degradation. This is a **6× KV memory reduction** over f16, data-oblivious (no retraining, no calibration), with "negligible runtime overhead". The paper reports an **8× attention-logit speedup at 4 bits on H100** because the rotated-quantized representation enables an SIMD-friendly inner-product accumulator.
+2. **ShadowKV** (Sun et al., CMU + ByteDance, arXiv 2410.21465) shows that the K-cache is low-rank in practice and that an SVD-based factorization of K gives another 2–3× compression *on top of* quantization, with no accuracy cost, because K is accessed once per query token and tolerates reconstruction latency that V cannot.
+
+This change adopts **TurboQuant wholesale** for both K and V, and **cherry-picks only the low-rank K decomposition** from ShadowKV. The rest of ShadowKV — memory-hierarchy offload, sparse on-the-fly reconstruction, storage-tier placement — is explicitly deferred to [issue #92](https://github.com/SmallAIOS/SmallAIOS/issues/92) until SmallAIOS grows a storage-tier abstraction.
+
+Combined, compressed 3.5-bit K (further factorized low-rank) + 3.5-bit V cuts a 50 MB KV cache to roughly 6–8 MB, fitting comfortably inside the <15 MB container with margin for model weights, network, and runtime.
+
+This change layers on top of `microsoft-fused-ops-v1` (PR #91), which introduces `GroupQueryAttention` with KV-cache lifecycle management. The GQA kernel there is the natural — and only — consumer of the compressed cache.
+
+## What Changes
+
+A new runtime module `onnx-rt/src/kv_compression.rs` that implements a drop-in compressed KV cache layer. Concretely:
+
+1. **`PolarQuantizer`** — applies a deterministic random rotation matrix (a Walsh–Hadamard transform with random sign flips, seed derived from the model hash) and then a per-coordinate scalar quantizer at **3, 4, or 8 bits**. Stores the quantized payload plus per-channel scale and per-channel zero point. The rotation is O(D log D) per vector and requires no stored D×D matrix.
+2. **`QJLResidualEncoder`** — computes a 1-bit sign quantization of the residual left over after `PolarQuantizer`, packed one bit per channel. Used as a correction term during attention inner-product reconstruction. Adds a fraction of a bit of effective precision to the dominant inner-product estimate (the main "3.5-bit" claim in the TurboQuant paper comes from combining a 4-bit scalar quantizer with this residual).
+3. **`LowRankKeyDecomposer`** — performs an **incremental** SVD on the K-cache as new key rows are written during decode. Retains the top-*k* singular values, default `k = min(head_dim / 2, 64)`. Stores `U·S` (the low-rank factored form) rather than the full K. **This is the cherry-picked piece from ShadowKV.**
+4. **`CompressedKVCache`** — a struct that owns the rotation matrix state, the quantized payloads (keys and values), the QJL residual bitmaps, and the low-rank K factors. Exposes a stable **`read_block(head, start, len) -> (K_slice, V_slice)`** / **`write_block(head, start, data)`** API so that the `GroupQueryAttention` kernel from `microsoft-fused-ops-v1` can use it transparently. The GQA kernel does not need to know about rotation, quantization, or SVD — it asks for K and V blocks and gets uncompressed slices on demand (or, in the fast path, asks for the quantized inner-product result directly).
+
+The change also extends `ops/microsoft.rs`'s GQA kernel to read/write through `CompressedKVCache` instead of raw tensors, and adds three session-level configuration knobs: `kv_quant_bits`, `kv_qjl_residual`, and `kv_lowrank_k`.
+
+## Capabilities
+
+### Modified Capabilities
+- `onnx-cpu-execution`: Add requirements for `CompressedKVCache`, the PolarQuant + QJL encode/decode pipeline, and the optional low-rank K factorization.
+
+## Impact
+
+- **Code:**
+  - `onnx-rt/src/kv_compression.rs` — **new file**, approximately 1200 LOC, including the PolarQuantizer, QJLResidualEncoder, LowRankKeyDecomposer, and CompressedKVCache struct and their unit tests.
+  - `onnx-rt/src/ops/microsoft.rs` — **modified**. The `GroupQueryAttention` kernel (landing in `microsoft-fused-ops-v1`) reads and writes through `CompressedKVCache` instead of raw K/V tensors. No changes to public op attributes or ONNX conformance.
+  - `onnx-rt/src/session.rs` — **modified**. Session configuration gains three new knobs (`kv_quant_bits`, `kv_qjl_residual`, `kv_lowrank_k`), set at session creation, immutable for the session lifetime.
+  - `onnx-rt/src/lib.rs` — **modified**. Re-export `CompressedKVCache` and the three config knobs.
+  - **No changes** to the sub-graph executor, the WCET budget machinery, or any other crate.
+
+- **Memory:** Approximately **6× reduction** in KV cache footprint at 3.5 bits/channel versus f16, plus an additional 2–3× from low-rank K on top of quantization. A 1B-param LLM at 4096 context drops from ~50 MB uncompressed to ~6–8 MB compressed — fitting inside the <15 MB container target with margin.
+
+- **Speed:** At 4 bits the attention-logit inner product is 8× faster than f32 (TurboQuant paper claim for H100; on CPU the speedup is smaller but still positive because the rotated quantized representation is an SIMD-friendly `i8` dot product with a small scalar correction term). No slowdown expected in any configuration; at 8 bits the pipeline is pass-through-equivalent to the f16 baseline.
+
+- **Accuracy:** TurboQuant claims **loss-free** at 3.5 bits on long-context benchmarks. SmallAIOS adds an empirical regression test: Llama-3.2-1B 4096-token generation with compressed cache versus uncompressed, asserting **identical output token IDs** and inner-product reconstruction within **±1 quantized step** of an f16 reference.
+
+- **APIs:** No breaking changes. `CompressedKVCache` is a new type, and the three config knobs default to `kv_quant_bits = 4`, `kv_qjl_residual = true`, `kv_lowrank_k = None` (low-rank disabled by default; opt-in).
+
+- **Dependencies:** None new. The math is elementary linear algebra (Hadamard transform, SVD via Jacobi rotations, 1-bit sign), all implementable in `#![no_std]` with `alloc`.
+
+- **Testing:** ~40 new unit tests, plus one end-to-end accuracy test against Llama-3.2-1B at 4096 context.
+
+## Out of Scope
+
+Deliberately excluded from this change and tracked elsewhere:
+
+- **Memory-hierarchy KV offload** — the rest of ShadowKV (offloading V to slower tiers with on-the-fly sparse reconstruction). Tracked in [issue #92](https://github.com/SmallAIOS/SmallAIOS/issues/92). Deferred until SmallAIOS grows a storage-tier abstraction; without one there is nowhere to offload *to*.
+- **Disk-backed KV cache** — same reason, same issue.
+- **Sub-2-bit extreme compression** — beyond the QJL 1-bit residual. Not on the critical path until 3.5-bit accuracy proves insufficient on some target model.
+- **Weight quantization** — this change is KV cache only. Weight matmuls continue to use the Phase 2 real i8 GEMM kernel from `generative-llm-v1`.
+- **GPU dispatch of the compressed-cache fast path** — CPU only. The GPU HAL stays untouched. A future change can teach the NVIDIA / Intel / AMD crates to consume the same `CompressedKVCache` layout.
+- **JIT of the rotated-quantized inner product** — the implementation is a plain Rust SIMD-friendly loop. Machine-code generation is out of scope.
+- **Changes to the Phase 2 sub-graph executor** — the executor is treated as a black box per `docs/sub-graph-executor-design.md`. The `CompressedKVCache` lives in the outer value_map and is passed into Loop bodies as an outer reference, which the existing sub-executor already supports.
+
+## Risks
+
+- **Random-rotation reproducibility.** The rotation must produce the same outputs on every machine running the same model, otherwise a cache saved on one host cannot be replayed on another. *Mitigation:* seed the Walsh–Hadamard sign flips from `BLAKE3(model_bytes) XOR SMALLAIOS_KV_ROTATION_SALT` where the salt is a fixed project constant. Document the seed derivation in `docs/kv-compression-design.md` so third-party toolchains can match it.
+- **KV cache lifecycle inside Loop bodies.** When `GroupQueryAttention` inside a `Loop` body writes to the cache, the compressed representation must persist across iterations. The `CompressedKVCache` struct lives in the **outer** value_map (per `microsoft-fused-ops-v1` D8, which puts KV-cache tensors in outer scope as Loop-carried values). The Phase 2 sub-graph executor (per `generative-llm-v1` D3) already copies outer-ref values into the inner scope per iteration; that copy is a shallow clone of the struct handle, not a deep copy of the compressed payload. The invariant "cache handle is shared across iterations" must be documented and asserted in a unit test.
+- **QJL dot-product correction cost.** The 1-bit residual adds a second `popcount`-based inner product to every attention score computation. On a modern CPU the cost is under 5% of the primary quantized inner product, but it is non-zero and must be measured.
+- **Incremental SVD stability.** Incremental SVD accumulates rounding error per step. For K caches that grow to 4096 rows, the accumulated drift must be bounded. *Mitigation:* re-orthogonalize every 512 writes; document the budget and validate with a round-trip reconstruction test.
+- **Parameter interaction with GQA head grouping.** GQA broadcasts one K/V head across multiple Q heads. The compressed cache is indexed by KV-head (not Q-head), and the GQA kernel must respect this indexing. The API on `CompressedKVCache` takes `kv_head: usize` explicitly to make the indexing unambiguous.

--- a/openspec/changes/kv-cache-quantization-v1/specs/onnx-cpu-execution/spec.md
+++ b/openspec/changes/kv-cache-quantization-v1/specs/onnx-cpu-execution/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Compressed KV Cache
+The ONNX runtime SHALL provide a `CompressedKVCache` struct that owns a compressed representation of the per-head K and V caches used by autoregressive attention operators, exposes a stable block-wise read/write API for use by `GroupQueryAttention`, `MultiHeadAttention`, and `RotaryEmbedding` kernels, and hides the details of rotation, quantization, and low-rank factorization from its callers.
+
+#### Scenario: GroupQueryAttention reads and writes through CompressedKVCache
+- **WHEN** a `GroupQueryAttention` op is dispatched inside a `Loop` body and receives a `CompressedKVCache` handle from the outer value_map
+- **THEN** the op MUST call `write_block(kv_head, start_row, k_new, v_new)` once for each new token row appended on this iteration
+- **AND** the op MUST compute attention logits via `attention_logits(kv_head, query, num_rows)` or, at the caller's choice, via `read_block(...)` followed by an f16 inner product
+- **AND** the op MUST compute the weighted value sum via `weighted_value_sum(kv_head, weights, num_rows)` or via `read_block(...)` followed by an f16 matmul
+- **AND** the op MUST NOT access the cache's internal quantized, rotated, or low-rank representation directly
+
+#### Scenario: Cache handle survives across Loop iterations
+- **WHEN** a `CompressedKVCache` handle is placed in the outer value_map before a `Loop` node and referenced by name from inside the Loop body
+- **THEN** the sub-graph executor MUST make the cache handle visible inside the body's value_map per iteration (via the existing outer-ref copy mechanism)
+- **AND** writes performed by the body MUST persist on the cache between iterations
+- **AND** writes performed by the body MUST remain visible in the outer scope after the Loop completes
+
+### Requirement: PolarQuant and QJL Residual Pipeline
+The runtime SHALL implement the TurboQuant two-stage encoder and decoder, consisting of a deterministic random rotation (Walsh–Hadamard transform with random sign flips), a per-channel scalar quantizer at a configurable bit width (3, 4, or 8 bits), and an optional 1-bit Quantized Johnson–Lindenstrauss residual correction, with bit-exact reproducibility across machines running the same model.
+
+#### Scenario: Round-trip dequantization within the grid step
+- **WHEN** a block of 64 f16 vectors is encoded with `kv_quant_bits = 4` and the QJL residual disabled
+- **THEN** decoding each vector MUST produce a reconstruction whose per-element error is bounded by one half of the per-channel grid step after the inverse rotation
+- **AND** the reconstructed vector MUST have the same shape as the original
+
+#### Scenario: Deterministic rotation across machines
+- **WHEN** the same model bytes and the same input vectors are encoded on two different machines with the same `kv_quant_bits` setting
+- **THEN** the stored quantized payloads MUST be bit-identical on both machines
+- **AND** the reconstructed vectors MUST be bit-identical on both machines
+- **AND** the rotation seed MUST be derivable from `BLAKE3(model_bytes) XOR SMALLAIOS_KV_ROTATION_SALT`
+
+### Requirement: Low-Rank K Factorization (Optional)
+The runtime SHALL implement an optional incremental singular value decomposition of the K cache that retains the top-*k* singular values (default `k = min(head_dim / 2, 64)`), stores only the factored form, re-orthogonalizes every 512 writes to bound accumulated drift, and is enabled via the session configuration knob `kv_lowrank_k = Some(k)`.
+
+#### Scenario: Low-rank reconstruction error bounded by the (k+1)-th singular value
+- **WHEN** a K cache of 1024 rows is built with `kv_lowrank_k = Some(64)` and then reconstructed back to full K
+- **THEN** the Frobenius norm of `K_reconstructed - K_original` MUST be bounded above by `sqrt(sum of squares of singular values s_{k+1..})` of the original K with a slack factor of 2 for incremental-SVD accumulated error
+- **AND** re-orthogonalization MUST be invoked at iteration counts 512 and 1024
+
+#### Scenario: Low-rank K disabled by default
+- **WHEN** a session is created with default `KVCacheConfig`
+- **THEN** `kv_lowrank_k` MUST be `None`
+- **AND** the K cache MUST be stored in the same quantized-rotated format as V
+- **AND** no SVD MUST be computed

--- a/openspec/changes/kv-cache-quantization-v1/tasks.md
+++ b/openspec/changes/kv-cache-quantization-v1/tasks.md
@@ -1,0 +1,77 @@
+## 1. PolarQuantizer Module
+
+- [ ] 1.1 Create `onnx-rt/src/kv_compression.rs` module skeleton with the `PolarQuantizer` struct, field definitions for the per-head sign-flip vector, per-block f16 scale, per-block f16 zero point, and the quantized payload byte buffer
+- [ ] 1.2 Implement the Walsh–Hadamard transform in-place butterfly over an `&mut [f16]` of power-of-two length; return an error if length is not a power of two
+- [ ] 1.3 Implement the sign-flip application (`x[i] *= sign[i]`) and the seed-to-sign-vector derivation via a deterministic PRNG seeded from `BLAKE3(model_bytes) XOR SMALLAIOS_KV_ROTATION_SALT`
+- [ ] 1.4 Implement `PolarQuantizer::encode_block` that rotates a block of 64 vectors, computes per-channel min/max across the block, derives per-channel f16 scale and zero point, quantizes each rotated coordinate to the configured bit width (3, 4, or 8), and packs the quantized values into the payload buffer
+- [ ] 1.5 Implement `PolarQuantizer::decode_block` that unpacks the quantized payload, dequantizes using the stored scale/zero point, and applies the inverse rotation (sign-flip then Walsh–Hadamard transform, which is self-inverse up to a normalization factor)
+- [ ] 1.6 Unit test: round-trip at 4 bits with the QJL residual disabled stays within ½ grid step per channel
+- [ ] 1.7 Unit test: round-trip at 8 bits matches f16 within 1 ULP
+- [ ] 1.8 Unit test: Walsh–Hadamard transform applied twice (with appropriate scaling) returns the original vector to machine precision
+- [ ] 1.9 Unit test: deterministic rotation — same model seed on two `PolarQuantizer` instances yields byte-identical payloads
+
+## 2. QJLResidualEncoder Module
+
+- [ ] 2.1 Add the `QJLResidualEncoder` struct that owns a packed-bit residual buffer (1 bit per channel, packed 64 bits per u64)
+- [ ] 2.2 Implement `QJLResidualEncoder::encode` that computes `residual = x_rotated - dequantize(q)` and writes the sign bit (0 for non-negative, 1 for negative) into the packed buffer; also precomputes and stores the per-block average `|residual|` magnitude for use as the correction coefficient `C`
+- [ ] 2.3 Implement `QJLResidualEncoder::inner_product_correction(kv_head, row_a, row_b) -> f16` that computes `C * (D - 2 * popcount(bits_a XOR bits_b))` via a u64 XOR + popcount loop
+- [ ] 2.4 Unit test: the sum of the primary quantized inner product plus the QJL correction matches the true f16 inner product within the theoretical QJL error bound `O(sqrt(log(D) / D)) * ||a|| * ||b||`
+- [ ] 2.5 Unit test: sign-bit packing and unpacking round-trip
+- [ ] 2.6 Unit test: popcount-based correction computation matches a naive per-bit reference loop
+
+## 3. LowRankKeyDecomposer (Incremental SVD)
+
+- [ ] 3.1 Add the `LowRankKeyDecomposer` struct owning `U_S: Vec<Vec<f16>>` (row-major `[rows, k]`), `Vt: Vec<Vec<f16>>` (`[k, head_dim]`), a write counter, and a re-orthogonalization cadence constant
+- [ ] 3.2 Implement `LowRankKeyDecomposer::new(head_dim, k)` that initializes `Vt` to an orthonormal basis derived from the first `k` key rows via Gram-Schmidt
+- [ ] 3.3 Implement `LowRankKeyDecomposer::write_row(k_new: &[f16])` that projects `k_new` onto the existing `Vt`, appends the projection coefficients as a new row of `U_S`, and increments the write counter
+- [ ] 3.4 Implement `LowRankKeyDecomposer::maybe_reorthogonalize()` that, when the write counter is a multiple of 512, performs a full SVD on `U_S * Vt` and replaces both factors with the top-`k` components from a fresh SVD via Jacobi rotations
+- [ ] 3.5 Implement `LowRankKeyDecomposer::reconstruct_row(row_idx) -> Vec<f16>` that returns `U_S[row_idx] * Vt`
+- [ ] 3.6 Implement `LowRankKeyDecomposer::inner_product(query: &[f16], num_rows: usize) -> Vec<f16>` that computes `q * K^T = q * Vt^T * (U_S)^T` in `O(head_dim * k + num_rows * k)`
+- [ ] 3.7 Unit test: reconstruction error after 1024 writes bounded by 2x the theoretical (k+1)-th singular value
+- [ ] 3.8 Unit test: re-orthogonalization triggers at writes 512 and 1024, drift is reset to near zero
+- [ ] 3.9 Unit test: `inner_product` matches naive `q * K_full^T` within the reconstruction error bound
+- [ ] 3.10 Unit test: initialization with fewer than `k` rows falls back to using `num_rows` as the effective rank and grows to `k` as more rows arrive
+
+## 4. CompressedKVCache Wrapper
+
+- [ ] 4.1 Add the `CompressedKVCache` struct owning a `KVCacheConfig`, per-head `PolarQuantizer` instances for K and V, per-head `QJLResidualEncoder` instances for K and V (when enabled), and per-head optional `LowRankKeyDecomposer` instances for K (when `kv_lowrank_k` is Some)
+- [ ] 4.2 Implement `CompressedKVCache::new(config, num_heads, head_dim)` that allocates empty per-head state
+- [ ] 4.3 Implement `CompressedKVCache::write_block(kv_head, start_row, k, v)` that quantizes both K and V via `PolarQuantizer::encode_block`, encodes the QJL residual when enabled, and additionally feeds K rows through `LowRankKeyDecomposer::write_row` when enabled
+- [ ] 4.4 Implement `CompressedKVCache::read_block(kv_head, start_row, len) -> (Vec<f16>, Vec<f16>)` that dequantizes via `PolarQuantizer::decode_block` and applies the QJL correction on reconstruction where applicable; when low-rank K is enabled, K is reconstructed via `LowRankKeyDecomposer::reconstruct_row` per row
+- [ ] 4.5 Implement `CompressedKVCache::attention_logits(kv_head, query, num_rows) -> Vec<f16>` fast path: compute `q * K^T` directly on the compressed representation (quantized inner product + QJL correction + low-rank factor product when enabled)
+- [ ] 4.6 Implement `CompressedKVCache::weighted_value_sum(kv_head, weights, num_rows) -> Vec<f16>` fast path: compute `weights * V` directly on the compressed V representation
+- [ ] 4.7 Unit test: `write_block` followed by `read_block` round-trip within ±1 grid step per channel at 4 bits
+- [ ] 4.8 Unit test: `attention_logits` matches `q * K_f16^T` within ±1 quantized step
+- [ ] 4.9 Unit test: `weighted_value_sum` matches `weights * V_f16` within ±1 quantized step
+
+## 5. GroupQueryAttention Integration
+
+- [ ] 5.1 In `onnx-rt/src/ops/microsoft.rs`, modify the `GroupQueryAttention` kernel (landing in `microsoft-fused-ops-v1`) to accept a `CompressedKVCache` handle from the value_map instead of raw K/V tensors
+- [ ] 5.2 Replace the current K/V append paths with `CompressedKVCache::write_block` calls, one per new token row
+- [ ] 5.3 Replace the current `q * K^T` computation with `CompressedKVCache::attention_logits`
+- [ ] 5.4 Replace the current softmax-weighted `V` sum with `CompressedKVCache::weighted_value_sum`
+- [ ] 5.5 Unit test: GQA with a compressed cache produces outputs matching GQA with an uncompressed cache within ±1 quantized step on a hand-built 8-row input
+
+## 6. Session Configuration Surface
+
+- [ ] 6.1 Add the `KVCacheConfig { kv_quant_bits, kv_qjl_residual, kv_lowrank_k }` struct and a `Default` impl (`4`, `true`, `None`) in `onnx-rt/src/session.rs`
+- [ ] 6.2 Extend `Session::new_with_config` (or add a new constructor) that accepts a `KVCacheConfig` and threads it into any `CompressedKVCache` allocated inside the session's value_map for GQA/MHA initializer tensors
+- [ ] 6.3 Re-export `KVCacheConfig` and `CompressedKVCache` from `onnx-rt/src/lib.rs`
+
+## 7. End-to-End Model Validation
+
+- [ ] 7.1 Add an integration test fixture that loads Llama-3.2-1B from a local ONNX export (or a tiny mock standing in for Llama when the real model is not available in CI)
+- [ ] 7.2 Run 4096-token generation from a fixed prompt with `kv_quant_bits = 4`, `kv_qjl_residual = true`, `kv_lowrank_k = Some(64)`
+- [ ] 7.3 Run the same 4096-token generation with the uncompressed f16 baseline and capture its output token IDs
+- [ ] 7.4 Assert the first 256 generated token IDs are **identical** between compressed and uncompressed runs (TurboQuant loss-free claim)
+- [ ] 7.5 Add a memory-footprint assertion: the `CompressedKVCache` allocated bytes are within 16% of the theoretical `ceil(3.5 bits/channel * num_heads * head_dim * 4096 * 2)` target
+
+## 8. Validation, Benchmarks, and Documentation
+
+- [ ] 8.1 `cargo fmt --check` passes
+- [ ] 8.2 `cargo clippy -- -D warnings` passes for `onnx-rt` with the new module
+- [ ] 8.3 `cargo test --workspace` passes including all new unit tests and the end-to-end Llama-3.2-1B accuracy test
+- [ ] 8.4 Add a memory micro-benchmark to `bench/` measuring `CompressedKVCache` allocated bytes at 512, 1024, 2048, and 4096 context lengths
+- [ ] 8.5 Add an accuracy micro-benchmark to `bench/` measuring the Frobenius error of `CompressedKVCache::attention_logits` versus the f16 reference across a synthetic random-query workload
+- [ ] 8.6 Update `docs/kv-compression-design.md` with any implementation-driven refinements discovered during the task list (for example, the exact re-orthogonalization cadence if 512 turns out to be wrong)
+- [ ] 8.7 Add a section to `docs/inference-bus.md` (or the GQA op doc if one exists by then) noting that GQA requires a `CompressedKVCache` in the outer value map when `KVCacheConfig` is non-default


### PR DESCRIPTION
## Summary

Plan-only OpenSpec change for compressing the KV cache during autoregressive LLM inference. Combines **TurboQuant** (Google, arXiv 2504.19874 — random rotation + per-coordinate scalar quantization at 3.5 bits/channel + 1-bit QJL residual, 6x KV memory reduction, loss-free at long context per the paper) with a cherry-picked **low-rank K decomposition** from ShadowKV (arXiv 2410.21465). The rest of ShadowKV (memory-hierarchy offload) is explicitly deferred to issue #92.

Motivation: at f16 a 1B-param LLM's KV cache at 4096 tokens is already larger than the entire SmallAIOS <15 MB container budget. Compressed to ~3.5 bits/channel with optional low-rank K, it fits with margin for weights, network, and runtime.

Layered on top of `microsoft-fused-ops-v1` (PR #91, planning) which adds GroupQueryAttention with KV-cache lifecycle management. The GQA kernel reads/writes through a new `CompressedKVCache` struct that hides rotation, quantization, and SVD from callers.

## Artifacts

- `openspec/changes/kv-cache-quantization-v1/proposal.md` — Why / What / Impact / Out of Scope / Risks
- `openspec/changes/kv-cache-quantization-v1/design.md` — Decisions D1-D9 (algorithm choice, rotation, per-channel quantizer, QJL, low-rank K, cache struct, config surface, sub-graph interaction, validation)
- `openspec/changes/kv-cache-quantization-v1/specs/onnx-cpu-execution/spec.md` — 3 requirements (CompressedKVCache, PolarQuant+QJL, low-rank K) with scenarios
- `openspec/changes/kv-cache-quantization-v1/tasks.md` — 8 sections, 43 tasks
- `docs/kv-compression-design.md` — ~3.3k-word standalone design doc with algorithm math, ASCII data-flow, byte-level memory layout, sizing example, Walsh-Hadamard pseudocode, incremental SVD pseudocode, performance model, future-work pointers

## Validation

```
$ openspec validate kv-cache-quantization-v1 --strict
Change 'kv-cache-quantization-v1' is valid
```

## Test plan

- [ ] Review the algorithm picks in design D1-D5 (TurboQuant vs alternatives, Walsh-Hadamard vs dense rotation, 3.5-bit encoding via 4-bit + QJL, incremental SVD cadence)
- [ ] Confirm the cherry-pick scope: we adopt only ShadowKV's low-rank K, not its offload pipeline
- [ ] Review the `CompressedKVCache` API surface (D6) and confirm it is the right boundary for GQA to call through
- [ ] Confirm the sub-graph executor interaction (D8) — no new executor work needed, only an outer-ref-copy-of-handle invariant
- [ ] Review the sizing analysis in `docs/kv-compression-design.md` §5: block-size tradeoff may need revisiting in benchmark (task 8.4)

No code changes in this PR — implementation happens after the spec is reviewed and merged.

Refs: #92 (deferred memory-hierarchy offload), #91 (microsoft-fused-ops-v1 dependency, planning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design documentation for a KV cache compression system to reduce memory usage during autoregressive language model generation, including specifications for a quantization pipeline, integration approach with attention kernels, task breakdown for implementation, and validation strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->