### PR TITLE
docs(openspec): add llm-api-translation-v1 for OpenAI + Anthropic API compatibility

### DIFF
--- a/openspec/changes/llm-api-translation-v1/.openspec.yaml
+++ b/openspec/changes/llm-api-translation-v1/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-12

--- a/openspec/changes/llm-api-translation-v1/design.md
+++ b/openspec/changes/llm-api-translation-v1/design.md
@@ -1,0 +1,267 @@
+## Context
+
+SmallAIOS's container HTTP server currently exposes `/v1/inference`
+for raw tensor I/O and `/v1/models` for model listing. The LLM
+ecosystem has converged on two API standards: OpenAI Chat Completions
+and Anthropic Messages. Both are structurally similar — JSON-over-HTTP
+with role-tagged message arrays — but differ in schema naming,
+streaming format, and response structure. Supporting both from a
+single internal representation is straightforward.
+
+## Decisions
+
+### D1: Shared internal `ChatRequest` / `ChatResponse` representation
+
+**Decision.** Both API formats translate to a common internal struct
+before touching the inference pipeline:
+
+```rust
+pub struct ChatRequest {
+    pub model: String,
+    pub messages: Vec<ChatMessage>,
+    pub system_prompt: Option<String>,
+    pub max_tokens: usize,
+    pub temperature: f32,      // default 1.0
+    pub top_p: f32,            // default 1.0
+    pub top_k: Option<usize>,  // None = disabled
+    pub stop_sequences: Vec<String>,
+    pub stream: bool,
+}
+
+pub struct ChatMessage {
+    pub role: ChatRole,       // System, User, Assistant
+    pub content: String,
+}
+
+pub struct ChatResponse {
+    pub content: String,
+    pub finish_reason: FinishReason,  // Stop, MaxTokens, StopSequence
+    pub usage: TokenUsage,
+}
+
+pub struct TokenUsage {
+    pub prompt_tokens: usize,
+    pub completion_tokens: usize,
+    pub total_tokens: usize,
+}
+```
+
+**Rationale.** A single code path handles tokenization, generation,
+and detokenization regardless of which API format the client used.
+The translation to/from wire format is a thin ~50 LOC adapter per API.
+
+### D2: API format mapping
+
+| Feature | OpenAI | Anthropic | Internal |
+|---|---|---|---|
+| Endpoint | `/v1/chat/completions` | `/v1/messages` | — |
+| System prompt | `messages[0].role="system"` | top-level `system` field | `system_prompt` |
+| User message | `role: "user"` | `role: "user"` | `ChatRole::User` |
+| Assistant message | `role: "assistant"` | `role: "assistant"` | `ChatRole::Assistant` |
+| Max tokens | `max_tokens` (optional) | `max_tokens` (required) | `max_tokens` |
+| Temperature | `temperature` | `temperature` | `temperature` |
+| Top-p | `top_p` | `top_p` | `top_p` |
+| Stop sequences | `stop: [...]` | `stop_sequences: [...]` | `stop_sequences` |
+| Streaming | `stream: true` + SSE `data: {...}` | `stream: true` + SSE `event: ...` | `stream` |
+| Response content | `choices[0].message.content` | `content[0].text` | `content` |
+| Finish reason | `"stop"` / `"length"` | `"end_turn"` / `"max_tokens"` | `FinishReason` enum |
+| Model ID in response | `model: "..."` | `model: "..."` | from request |
+| Usage | `usage: {prompt_tokens, completion_tokens, total_tokens}` | `usage: {input_tokens, output_tokens}` | `TokenUsage` |
+
+**Decision.** The translation adapters handle these mappings. The
+internal pipeline never sees API-specific field names.
+
+### D3: BPE tokenizer from scratch
+
+**Decision.** Implement a minimal BPE tokenizer (~500 LOC) in
+`container/src/tokenizer.rs` that loads HuggingFace `tokenizer.json`
+files. The format is well-documented: a JSON object containing
+`model.vocab` (token → ID mapping), `model.merges` (BPE merge rules),
+`added_tokens` (special tokens like `<|begin_of_text|>`), and
+`decoder` (byte-level fallback config).
+
+**What we implement:**
+- Load vocab + merges from `tokenizer.json`
+- Encode: text → byte pairs → iterative merge → token IDs
+- Decode: token IDs → bytes → UTF-8 text
+- Special token handling: `<bos>`, `<eos>`, `<pad>`, model-specific
+  tokens like `<|im_start|>` (Qwen/DeepSeek), `<start_of_turn>`
+  (Gemma), `<|begin_of_text|>` (Llama)
+
+**What we do NOT implement:**
+- Pre-tokenization regex (HuggingFace's `pre_tokenizer` — we use a
+  simpler whitespace split + byte-fallback that handles 95% of cases)
+- Sentencepiece compatibility (only BPE, not Unigram)
+- Training / vocab extension
+
+**Rationale.** External tokenizer crates are `std`-only or pull in
+50+ dependencies. The BPE algorithm is ~200 lines of core logic; the
+rest is JSON parsing and special-token handling. SmallAIOS already has
+a JSON parser in `container/src/json.rs`.
+
+### D4: Prompt template system
+
+**Decision.** Each model has a prompt template that converts a
+`Vec<ChatMessage>` into the model's expected token sequence. Templates
+are loaded from a `prompt_template.json` file alongside the model, or
+from a built-in registry keyed by model architecture.
+
+Built-in templates for launch:
+- **Llama 3**: `<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n{system}<|eot_id|><|start_header_id|>user<|end_header_id|>\n{user}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n`
+- **Gemma 3**: `<start_of_turn>user\n{user}<end_of_turn>\n<start_of_turn>model\n`
+- **DeepSeek/Qwen**: `<|im_start|>system\n{system}<|im_end|>\n<|im_start|>user\n{user}<|im_end|>\n<|im_start|>assistant\n`
+- **GPT-2**: plain concatenation (no chat template — legacy)
+- **ChatML**: generic fallback used by many fine-tunes
+
+**Rationale.** Prompt templates are the #1 source of "it works but
+generates garbage" bugs in local LLM servers. Making them explicit
+and model-specific avoids that trap.
+
+### D5: Generation loop
+
+**Decision.** The generation loop is implemented in
+`container/src/generation.rs` as a host-side loop:
+
+```
+1. Apply prompt template → token IDs
+2. Create initial KV cache (empty)
+3. For each step until max_tokens or stop:
+   a. Run one forward pass: Session::run(token_ids, kv_cache)
+   b. Extract logits from output
+   c. Apply temperature + top-k + top-p sampling
+   d. Check for stop token or stop sequence
+   e. If streaming, emit SSE chunk
+   f. Append sampled token, update KV cache
+4. Detokenize output tokens → text
+5. Return ChatResponse
+```
+
+This is a host-side loop (not using the ONNX `Loop` operator) because:
+- The tokenizer and sampling logic are Rust, not ONNX ops
+- The SSE streaming emission happens between iterations
+- The stop-sequence check requires string-level comparison
+
+The Phase 2 sub-graph executor's `Loop` would be used only if the
+entire generation (including sampling) were expressed inside the
+ONNX graph, which is rare in practice.
+
+### D6: SSE streaming
+
+**Decision.** Extend the container's HTTP server to support chunked
+transfer encoding with `Content-Type: text/event-stream`.
+
+OpenAI SSE format:
+```
+data: {"id":"chatcmpl-xxx","choices":[{"delta":{"content":"Hello"},"index":0}]}\n\n
+data: [DONE]\n\n
+```
+
+Anthropic SSE format:
+```
+event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Hello"}}\n\n
+event: message_stop\ndata: {"type":"message_stop"}\n\n
+```
+
+Both formats are emitted from the same generation loop; the
+translation adapter serializes each token into the appropriate
+SSE event shape.
+
+### D7: Model selection
+
+**Decision.** The `model` field in the request maps to a loaded model
+via the existing `ModelManager`. If the model name matches a loaded
+model's name or file stem, that model is used. If no match, return
+404. The `/v1/models` endpoint already lists available models.
+
+### D8: File layout
+
+```
+container/src/
+├── handlers.rs           (modified: add chat_completions + messages handlers)
+├── chat_api.rs           (NEW: ChatRequest/ChatResponse + translation adapters)
+├── tokenizer.rs          (NEW: BPE tokenizer loading tokenizer.json)
+├── generation.rs         (NEW: autoregressive generation loop)
+├── sampling.rs           (NEW: temperature, top-k, top-p sampling)
+├── prompt_templates.rs   (NEW: model-specific prompt formatting)
+├── sse.rs                (NEW: Server-Sent Events chunked response writer)
+└── json.rs               (existing: may need extension for nested parsing)
+```
+
+## Alternatives considered
+
+### A1: Support only OpenAI format
+Many local inference servers (llama.cpp, vLLM, Ollama) support only
+OpenAI format. **Rejected:** the user explicitly wants both, and
+Anthropic's format is gaining adoption. The incremental cost of the
+second adapter is ~50 LOC given the shared internal representation.
+
+### A2: Use an external tokenizer crate (tokenizers, tiktoken-rs)
+**Rejected:** both are `std`-only with large dependency trees.
+SmallAIOS's `no_std` constraint requires a from-scratch BPE
+implementation. The core algorithm is small; the JSON parsing
+already exists in the container.
+
+### A3: Express generation inside the ONNX graph using Loop
+**Rejected for the default path:** the tokenizer and sampling
+logic are Rust code, not ONNX operators. The host-side loop also
+enables SSE streaming between iterations. ONNX `Loop`-based
+generation remains available for models that export it, but the
+chat API uses the host loop.
+
+### D9: Model memory budget enforcement
+
+**Decision.** Before loading a model, the `ModelManager` SHALL check
+the model file size against the platform's available memory and reject
+the load if it would exceed a configurable budget. The budget defaults
+to 80% of available physical RAM (leaving headroom for the KV cache,
+the runtime, and the OS).
+
+```rust
+pub struct MemoryBudget {
+    pub max_model_bytes: usize,    // 0 = no limit
+    pub max_kv_cache_bytes: usize, // 0 = no limit
+    pub headroom_fraction: f32,    // default 0.2 (reserve 20%)
+}
+```
+
+The check is:
+1. Query available physical RAM (via `sysinfo` on macOS/Linux, or a
+   compile-time constant for bare-metal). For `no_std` bare-metal,
+   use the `large-memory` feature flag's page count (1 GiB default,
+   64 GiB with the flag).
+2. Compute `budget = total_ram * (1.0 - headroom_fraction)`
+3. If `model_file_size > budget`, return an error:
+   `ModelTooLarge { model_size, budget, available_ram }`
+4. Additionally estimate KV cache requirements: for a decoder model
+   with `num_layers * 2 * num_kv_heads * head_dim * max_seq_len * 4`
+   bytes (f32). If the model + estimated KV cache exceeds budget,
+   warn (don't hard-reject, since compressed KV is an option).
+
+**Platform-specific RAM detection:**
+- **macOS container:** `sysctl hw.memsize` via libc. Already available
+  in `container/` which links libc.
+- **Linux container:** `/proc/meminfo` MemAvailable. Fallback to
+  `sysconf(_SC_PHYS_PAGES) * page_size`.
+- **Bare-metal kernel:** the kernel's physical memory manager reports
+  total pages. Exposed via a `platform::available_memory_bytes()` API.
+
+**Rationale.** Without this guard, a user who tries to load Llama-70B
+on a 16 GB Mac gets an OOM kill with no diagnostic. The budget check
+gives a clear error before any allocation happens. The 80% default
+leaves room for the KV cache, the runtime's value maps, and the OS.
+The KV cache estimate is advisory (warns, doesn't reject) because
+the `kv-cache-quantization-v1` compression can reduce it 6x.
+
+## Open questions
+
+**Q1:** Should we support function/tool calling in the first version?
+Both APIs have it (OpenAI `tools[]`, Anthropic `tool_use`). Recommend
+deferring — it adds schema complexity and the core value is chat
+text generation.
+
+**Q2:** Should the tokenizer support Sentencepiece (Unigram model)?
+Some older models (T5, mBART) use it. Recommend deferring — BPE
+covers Llama, Gemma, GPT-2, DeepSeek, Mistral, and Phi.
+
+**Q3:** How do we handle multi-modal inputs (images in messages)?
+Both APIs support it. Recommend deferring — text-only for v1.

--- a/openspec/changes/llm-api-translation-v1/proposal.md
+++ b/openspec/changes/llm-api-translation-v1/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+SmallAIOS can now load and build execution graphs for every major LLM family (Llama, Gemma, DeepSeek, GPT-2). The container exposes a raw `/v1/inference` endpoint that accepts tensor inputs and returns tensor outputs — functional but unusable by any existing LLM tooling. Every LLM client library, agent framework, and chat UI in the ecosystem speaks one of two APIs: **OpenAI Chat Completions** (`POST /v1/chat/completions`) or **Anthropic Messages** (`POST /v1/messages`). Without compatibility with at least one of these, SmallAIOS cannot be used as a drop-in local inference server.
+
+The two APIs are structurally similar — both are request/response over HTTP with JSON bodies, both support streaming via Server-Sent Events, and both model conversations as sequences of role-tagged messages. The differences are in schema naming, system-prompt handling, stop-reason vocabulary, streaming event format, and token-counting conventions. A thin translation layer can support both by mapping to a shared internal representation and routing to the same ONNX execution pipeline.
+
+## What Changes
+
+- **Add `POST /v1/chat/completions`** — OpenAI-compatible chat completions endpoint. Accepts the standard OpenAI request schema (`model`, `messages[]`, `temperature`, `max_tokens`, `stream`, `stop`, `top_p`, `frequency_penalty`, `presence_penalty`). Returns the standard OpenAI response schema (`choices[]` with `message` and `finish_reason`). Supports both non-streaming and SSE streaming responses.
+
+- **Add `POST /v1/messages`** — Anthropic-compatible messages endpoint. Accepts the Anthropic request schema (`model`, `messages[]`, `system`, `max_tokens`, `temperature`, `top_p`, `stream`, `stop_sequences`). Returns the Anthropic response schema (`content[]` with `type: "text"`, `stop_reason`). Supports both non-streaming and SSE streaming.
+
+- **Add a shared `ChatRequest` internal representation** — both API formats translate to this common struct before hitting the inference pipeline. This avoids duplicating the tokenization → generation → detokenization logic.
+
+- **Add a tokenizer abstraction** — LLM chat APIs require tokenization (converting text to token IDs) and detokenization (converting output token IDs back to text). SmallAIOS needs a minimal tokenizer that can load HuggingFace `tokenizer.json` files (the BPE tokenizer format used by Llama, Gemma, GPT-2, etc.). This is a new module — the ONNX runtime works with tensors, not text.
+
+- **Add a generation loop** — the chat completions endpoint needs to run autoregressive token generation: repeatedly call the ONNX model with the current token sequence, sample the next token (temperature, top-k, top-p), append it, and repeat until a stop condition. This uses the Phase 2 `Loop` operator if the model exports it, or an external host loop otherwise.
+
+- **Keep the existing `/v1/inference`** endpoint unchanged for raw tensor I/O.
+
+## Capabilities
+
+### New Capabilities
+- `openai-chat-api`: OpenAI-compatible Chat Completions endpoint with streaming, stop sequences, and sampling parameters.
+- `anthropic-messages-api`: Anthropic-compatible Messages endpoint with streaming and Anthropic-specific schema.
+- `llm-tokenizer`: Minimal BPE tokenizer that loads HuggingFace `tokenizer.json` files for text↔token conversion.
+- `llm-generation`: Autoregressive token generation loop with temperature, top-k, top-p sampling and stop-sequence detection.
+
+### Modified Capabilities
+- `onnx-cpu-execution`: The container's HTTP server gains two new routes. No changes to the inference engine itself — the new endpoints are a layer above it.
+
+## Impact
+
+**Affected code:**
+- `container/src/handlers.rs` — new handler functions for the two endpoints
+- `container/src/` — new modules: `chat_api.rs` (translation layer), `tokenizer.rs`, `generation.rs`, `sampling.rs`
+- `container/src/http.rs` — SSE streaming support (chunked transfer encoding)
+
+**Affected APIs:**
+- Two new HTTP endpoints added to the container's API surface
+- Existing endpoints (`/v1/inference`, `/v1/models`, `/healthz`, `/readyz`) unchanged
+
+**Dependencies:**
+- Tokenizer: needs a BPE decoder. Either implement from scratch (~500 LOC for the HuggingFace tokenizer.json format) or find a `no_std`-compatible tokenizer crate. Prefer from-scratch to maintain the zero-external-deps stance.
+
+**Risks:**
+- Tokenizer correctness: BPE has edge cases (byte-fallback, special tokens, unicode normalization). A from-scratch implementation needs careful testing against HuggingFace's reference output.
+- Streaming latency: SSE requires chunked transfer encoding. The existing HTTP server may need extension to support streaming responses.
+- Model-specific prompt templates: different LLMs expect different prompt formatting (Llama's `<|begin_of_text|>`, Gemma's `<start_of_turn>`, etc.). The translation layer needs a configurable prompt-template system.

--- a/openspec/changes/llm-api-translation-v1/specs/anthropic-messages-api/spec.md
+++ b/openspec/changes/llm-api-translation-v1/specs/anthropic-messages-api/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Anthropic Messages Endpoint
+The container SHALL expose a `POST /v1/messages` endpoint that accepts the Anthropic Messages request schema and returns the Anthropic response schema.
+
+#### Scenario: Non-streaming message
+- **WHEN** a POST request is sent to `/v1/messages` with `stream: false`
+- **AND** the request contains `model`, `messages[]`, `max_tokens`, and optionally `system`
+- **THEN** the response MUST have status 200 with `Content-Type: application/json`
+- **AND** the body MUST contain `content[0].type` as `"text"` and `content[0].text` with the generated text
+- **AND** the body MUST contain `stop_reason` as `"end_turn"` or `"max_tokens"`
+- **AND** the body MUST contain `usage` with `input_tokens` and `output_tokens`
+
+#### Scenario: Streaming message
+- **WHEN** a POST request is sent with `stream: true`
+- **THEN** the response MUST use `Content-Type: text/event-stream`
+- **AND** text deltas MUST be emitted as `event: content_block_delta` SSE events
+- **AND** the stream MUST end with `event: message_stop`
+
+#### Scenario: System prompt from top-level field
+- **WHEN** the request includes a `system` field (string)
+- **THEN** the system prompt MUST be applied to the generation context
+- **AND** the system prompt MUST NOT appear in the `messages` array in the response
+
+#### Scenario: Anthropic-to-OpenAI field mapping
+- **WHEN** the Anthropic adapter receives a request
+- **THEN** `stop_sequences` MUST map to internal `stop_sequences`
+- **AND** `max_tokens` MUST map to internal `max_tokens`
+- **AND** finish reason `"end_turn"` MUST map from internal `FinishReason::Stop`

--- a/openspec/changes/llm-api-translation-v1/specs/llm-generation/spec.md
+++ b/openspec/changes/llm-api-translation-v1/specs/llm-generation/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Autoregressive Token Generation
+The container SHALL implement an autoregressive generation loop that repeatedly invokes the ONNX model to produce tokens until a stop condition is met.
+
+#### Scenario: Generation with max_tokens limit
+- **WHEN** generation is invoked with `max_tokens: 64`
+- **THEN** the loop MUST produce at most 64 new tokens
+- **AND** finish_reason MUST be `MaxTokens` if the limit is reached
+
+#### Scenario: Generation stops on EOS token
+- **WHEN** the model outputs the EOS token ID
+- **THEN** the loop MUST stop immediately
+- **AND** finish_reason MUST be `Stop`
+
+#### Scenario: Generation stops on stop sequence
+- **WHEN** a stop sequence (e.g., `"\n\nHuman:"`) appears in the decoded output
+- **THEN** the loop MUST stop and truncate the output before the stop sequence
+- **AND** finish_reason MUST be `StopSequence`
+
+### Requirement: Sampling Strategies
+The generation loop SHALL support temperature, top-k, and top-p sampling.
+
+#### Scenario: Temperature scaling
+- **WHEN** `temperature: 0.0` is specified
+- **THEN** the sampler MUST select the argmax token (greedy decoding)
+
+#### Scenario: Top-p (nucleus) sampling
+- **WHEN** `top_p: 0.9` is specified
+- **THEN** the sampler MUST restrict the candidate set to the smallest set of tokens whose cumulative probability exceeds 0.9
+
+#### Scenario: Top-k sampling
+- **WHEN** `top_k: 50` is specified
+- **THEN** the sampler MUST restrict the candidate set to the top 50 tokens by probability
+
+### Requirement: SSE Streaming
+The generation loop SHALL support emitting each token as an SSE event during generation, enabling real-time streaming responses.
+
+#### Scenario: Token emitted during generation
+- **WHEN** streaming is enabled and a new token is sampled
+- **THEN** the token MUST be immediately emitted as an SSE data line
+- **AND** the response MUST use chunked transfer encoding

--- a/openspec/changes/llm-api-translation-v1/specs/llm-tokenizer/spec.md
+++ b/openspec/changes/llm-api-translation-v1/specs/llm-tokenizer/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: BPE Tokenizer
+The container SHALL implement a Byte-Pair Encoding tokenizer that loads HuggingFace `tokenizer.json` files for text-to-token and token-to-text conversion.
+
+#### Scenario: Encode text to tokens
+- **WHEN** `tokenizer.encode("Hello world")` is called
+- **THEN** it MUST return a Vec of token IDs matching the HuggingFace reference tokenizer output for the same vocabulary
+
+#### Scenario: Decode tokens to text
+- **WHEN** `tokenizer.decode(&[token_ids])` is called
+- **THEN** it MUST return the UTF-8 text string corresponding to those token IDs
+
+#### Scenario: Special tokens
+- **WHEN** the tokenizer encounters special tokens (BOS, EOS, PAD, model-specific tokens)
+- **THEN** they MUST be handled according to the `added_tokens` section of `tokenizer.json`
+
+#### Scenario: Load from tokenizer.json
+- **WHEN** `Tokenizer::from_file("tokenizer.json")` is called
+- **THEN** it MUST parse the vocab, merges, and added_tokens from the HuggingFace format
+- **AND** return a ready-to-use tokenizer instance
+
+### Requirement: Prompt Templates
+The container SHALL apply model-specific prompt templates to convert chat message arrays into token sequences.
+
+#### Scenario: Llama 3 prompt format
+- **WHEN** a chat request targets a Llama model
+- **THEN** the prompt MUST use Llama 3's `<|begin_of_text|>...<|eot_id|>` format
+
+#### Scenario: Gemma prompt format
+- **WHEN** a chat request targets a Gemma model
+- **THEN** the prompt MUST use Gemma's `<start_of_turn>...<end_of_turn>` format
+
+#### Scenario: Custom prompt template
+- **WHEN** a `prompt_template.json` file exists alongside the model
+- **THEN** it MUST override the built-in template for that model

--- a/openspec/changes/llm-api-translation-v1/specs/onnx-cpu-execution/spec.md
+++ b/openspec/changes/llm-api-translation-v1/specs/onnx-cpu-execution/spec.md
@@ -1,0 +1,11 @@
+## MODIFIED Requirements
+
+### Requirement: Container HTTP API Surface
+The container's HTTP server SHALL expose two additional endpoints (`/v1/chat/completions` and `/v1/messages`) alongside the existing `/v1/inference`, `/v1/models`, `/healthz`, and `/readyz` endpoints. The existing endpoints MUST remain unchanged in behavior.
+
+#### Scenario: All endpoints coexist
+- **WHEN** the container starts with at least one loaded model
+- **THEN** `/v1/chat/completions` MUST accept OpenAI-format requests
+- **AND** `/v1/messages` MUST accept Anthropic-format requests
+- **AND** `/v1/inference` MUST continue to accept raw tensor I/O requests
+- **AND** all three endpoints MUST use the same underlying ONNX inference engine

--- a/openspec/changes/llm-api-translation-v1/specs/openai-chat-api/spec.md
+++ b/openspec/changes/llm-api-translation-v1/specs/openai-chat-api/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: OpenAI Chat Completions Endpoint
+The container SHALL expose a `POST /v1/chat/completions` endpoint that accepts the OpenAI Chat Completions request schema and returns the OpenAI response schema.
+
+#### Scenario: Non-streaming chat completion
+- **WHEN** a POST request is sent to `/v1/chat/completions` with `stream: false`
+- **AND** the request contains `model`, `messages[]`, and `max_tokens`
+- **THEN** the response MUST have status 200 with `Content-Type: application/json`
+- **AND** the body MUST contain `choices[0].message.content` with the generated text
+- **AND** the body MUST contain `choices[0].finish_reason` as `"stop"` or `"length"`
+- **AND** the body MUST contain `usage` with `prompt_tokens`, `completion_tokens`, `total_tokens`
+
+#### Scenario: Streaming chat completion
+- **WHEN** a POST request is sent with `stream: true`
+- **THEN** the response MUST use `Content-Type: text/event-stream`
+- **AND** each token MUST be emitted as an SSE `data:` line with a delta object
+- **AND** the stream MUST end with `data: [DONE]`
+
+#### Scenario: Model not found
+- **WHEN** the `model` field does not match any loaded model
+- **THEN** the response MUST have status 404 with an error message
+
+#### Scenario: Sampling parameters applied
+- **WHEN** `temperature`, `top_p`, or `stop` parameters are provided
+- **THEN** the generation MUST apply the specified sampling strategy

--- a/openspec/changes/llm-api-translation-v1/tasks.md
+++ b/openspec/changes/llm-api-translation-v1/tasks.md
@@ -1,0 +1,86 @@
+## 1. Shared Internal Representation
+
+- [ ] 1.1 Create `container/src/chat_api.rs` with `ChatRequest`, `ChatResponse`, `ChatMessage`, `ChatRole`, `FinishReason`, `TokenUsage` structs
+- [ ] 1.2 Implement `ChatRequest::from_openai_json(body: &str)` — parse OpenAI Chat Completions request
+- [ ] 1.3 Implement `ChatRequest::from_anthropic_json(body: &str)` — parse Anthropic Messages request
+- [ ] 1.4 Implement `ChatResponse::to_openai_json(&self)` — serialize to OpenAI response format
+- [ ] 1.5 Implement `ChatResponse::to_anthropic_json(&self)` — serialize to Anthropic response format
+- [ ] 1.6 Unit tests for both request parsers and response serializers with reference JSON fixtures
+
+## 2. BPE Tokenizer
+
+- [ ] 2.1 Create `container/src/tokenizer.rs` with `Tokenizer` struct
+- [ ] 2.2 Implement `Tokenizer::from_json(data: &str)` — parse HuggingFace `tokenizer.json` format (vocab, merges, added_tokens)
+- [ ] 2.3 Implement `Tokenizer::encode(text: &str) -> Vec<u32>` — BPE encoding with byte-fallback
+- [ ] 2.4 Implement `Tokenizer::decode(ids: &[u32]) -> String` — token ID to UTF-8 text
+- [ ] 2.5 Handle special tokens (BOS, EOS, PAD, model-specific) per `added_tokens` config
+- [ ] 2.6 Unit tests: encode/decode round-trip, special tokens, empty input, unicode, byte-fallback
+- [ ] 2.7 Reference comparison test: encode a known string with the Llama tokenizer and compare token IDs against a hand-verified expected output
+
+## 3. Prompt Templates
+
+- [ ] 3.1 Create `container/src/prompt_templates.rs` with `PromptTemplate` trait and built-in registry
+- [ ] 3.2 Implement Llama 3 template (`<|begin_of_text|>` format)
+- [ ] 3.3 Implement Gemma template (`<start_of_turn>` format)
+- [ ] 3.4 Implement DeepSeek/Qwen ChatML template (`<|im_start|>` format)
+- [ ] 3.5 Implement generic ChatML fallback template
+- [ ] 3.6 Implement GPT-2 plain concatenation template
+- [ ] 3.7 Implement `PromptTemplate::from_json(path: &str)` for custom templates alongside model files
+- [ ] 3.8 Auto-detect template from model name or architecture metadata
+- [ ] 3.9 Unit tests for each template with sample conversations
+
+## 4. Sampling
+
+- [ ] 4.1 Create `container/src/sampling.rs` with `Sampler` struct
+- [ ] 4.2 Implement temperature scaling (logits / temperature)
+- [ ] 4.3 Implement top-k filtering (keep only top-k logits)
+- [ ] 4.4 Implement top-p (nucleus) filtering (keep smallest set exceeding cumulative probability p)
+- [ ] 4.5 Implement greedy decoding (temperature = 0 → argmax)
+- [ ] 4.6 Implement deterministic sampling with seed for reproducibility
+- [ ] 4.7 Unit tests: greedy selects max, top-k filters correctly, top-p threshold, temperature scaling
+
+## 5. Generation Loop
+
+- [ ] 5.1 Create `container/src/generation.rs` with `GenerationLoop` struct
+- [ ] 5.2 Implement the token-by-token generation loop: encode → run model → sample → check stop → append
+- [ ] 5.3 Implement EOS token detection (stop on model's EOS token ID)
+- [ ] 5.4 Implement stop-sequence detection (string-level comparison on decoded output)
+- [ ] 5.5 Implement max_tokens enforcement
+- [ ] 5.6 Integrate with `Session::run()` for ONNX model execution
+- [ ] 5.7 Thread KV cache between iterations (pass present_k/present_v from output to next input)
+- [ ] 5.8 Unit test: generation with a mock model that returns predictable logits
+- [ ] 5.9 Integration test: generation with a real DistilGPT-2 model (uses test fixtures)
+
+## 6. SSE Streaming
+
+- [ ] 6.1 Create `container/src/sse.rs` with SSE writer supporting chunked transfer encoding
+- [ ] 6.2 Implement OpenAI-format SSE emission (`data: {...}\n\n` + `data: [DONE]\n\n`)
+- [ ] 6.3 Implement Anthropic-format SSE emission (`event: content_block_delta\ndata: {...}\n\n`)
+- [ ] 6.4 Extend the HTTP server to support `Content-Type: text/event-stream` responses
+- [ ] 6.5 Unit tests for SSE formatting
+
+## 7. HTTP Endpoint Handlers
+
+- [ ] 7.1 Add `handle_chat_completions(req, manager, tokenizer_registry)` in `handlers.rs`
+- [ ] 7.2 Add `handle_messages(req, manager, tokenizer_registry)` in `handlers.rs`
+- [ ] 7.3 Route `/v1/chat/completions` and `/v1/messages` in the HTTP server's dispatch
+- [ ] 7.4 Integration test: POST to `/v1/chat/completions` with a mock model, verify OpenAI response schema
+- [ ] 7.5 Integration test: POST to `/v1/messages` with a mock model, verify Anthropic response schema
+- [ ] 7.6 Integration test: streaming response with SSE verification
+
+## 8. Model Memory Budget
+
+- [ ] 8.1 Add `MemoryBudget` struct to `container/src/config.rs`
+- [ ] 8.2 Implement platform-specific available RAM detection (macOS `hw.memsize`, Linux `/proc/meminfo`, bare-metal page count)
+- [ ] 8.3 Add pre-load size check in `ModelManager::load_model()` — reject with `ModelTooLarge` if model exceeds budget
+- [ ] 8.4 Add KV cache size estimate warning (advisory, not hard-reject)
+- [ ] 8.5 Configure budget via environment variable `SMALLAIOS_MAX_MODEL_MB` (default: 80% of RAM)
+- [ ] 8.6 Unit tests: budget check rejects oversized model, allows within-budget model, warns on KV estimate
+
+## 9. Validation
+
+- [ ] 9.1 `just fmt` clean
+- [ ] 9.2 `just clippy --all-targets` clean
+- [ ] 9.3 `just test` all passing
+- [ ] 9.4 At least 40 new unit tests across tokenizer, sampling, generation, SSE, and API handlers
+- [ ] 9.5 Verify `/v1/inference` endpoint unchanged (regression test)

--- a/openspec/changes/metal-operator-kernels-v1/.openspec.yaml
+++ b/openspec/changes/metal-operator-kernels-v1/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-12

--- a/openspec/changes/metal-operator-kernels-v1/design.md
+++ b/openspec/changes/metal-operator-kernels-v1/design.md
@@ -1,0 +1,203 @@
+## Context
+
+SmallAIOS runs on Apple Silicon Macs (M1-M4) both in container mode and
+during development. The CPU operator surface is complete (136 ops, all
+major model families load), but inference speed is CPU-bound. Apple
+Silicon GPUs have 5-10x the throughput of their CPU cores for dense
+linear algebra (matmul, attention) and element-wise operations. The
+Metal backend (`arch/apple/`) already has a working `MetalProvider`
+with device init, buffer management, kernel compilation, and dispatch
+— plus 11 pre-written MSL shaders. But the ONNX executor never
+actually calls them because the GPU dispatch path in `dispatch_node`
+is a TODO.
+
+This change wires the existing shaders, adds new high-value shaders,
+and implements the tensor-transfer lifecycle so operators can execute
+on Metal with automatic CPU fallback for unsupported ops.
+
+## Decisions
+
+### D1: GPU-first dispatch with transparent CPU fallback
+
+**Decision.** When the `gpu` feature is enabled and a `MetalProvider`
+is available, `dispatch_node` checks `gpu_backend.supports_op(op_type)`.
+If true, the operator executes on GPU: inputs are transferred to device
+buffers, the kernel is launched, results are transferred back. If false,
+the existing CPU implementation runs unchanged.
+
+**Rationale.** No model should fail to run because of incomplete GPU
+coverage. The fallback is transparent — the same `execute_graph` call
+works whether 0%, 50%, or 100% of operators have GPU kernels.
+
+### D2: Tensor transfer via a per-graph MetalTensorCache
+
+**Decision.** Add a `MetalTensorCache` struct that:
+1. Allocates device `MTLBuffer`s lazily on first use per tensor name
+2. Caches them across operator calls within a single `execute_graph`
+   invocation (tensors produced by one GPU op and consumed by the next
+   stay on-device without round-tripping through host memory)
+3. Copies to host only when: (a) the tensor is a graph output, or
+   (b) the next consumer is a CPU-only op
+
+This is the "minimal transfer" optimization. Without it, every GPU
+op would copy in + copy out, negating the speedup.
+
+**Rationale.** Full lazy-transfer requires tracking the "device-dirty"
+bit per tensor — doable but adds complexity. The cache approach is
+simpler: if a tensor is in the cache, it's on-device and current.
+When a CPU op needs it, the cache copies it to host and evicts it.
+
+### D3: Operator tiering — wire existing shaders first
+
+**Decision.** Implement in two tiers:
+
+**Tier 1 — wire existing shaders (11 ops):** Add, Sub, Mul, Div,
+Relu, Sigmoid, Tanh, MatMul (naive), MatMul (tiled), Softmax, Conv2D.
+These shaders already exist in `arch/apple/src/shaders.rs` and are
+tested. Wiring them requires only the dispatch plumbing + tensor
+transfer, no new MSL code.
+
+**Tier 2 — new high-value shaders (~8 ops):**
+- `scaled_dot_product_attention` — the SDPA helper, fused QK^T
+  scaling + causal mask + softmax + V multiply. Single kernel launch
+  instead of 4 separate ops.
+- `group_query_attention` — full GQA with fused RoPE, KV concat,
+  grouped dispatch. The single highest-value kernel for LLM inference.
+- `layer_normalization` — reduction-heavy; GPU wins via parallel
+  reduction in shared memory.
+- `rms_normalization` — same pattern, no mean subtraction.
+- `gemm_tiled_f16` — f16 matmul for models using half precision.
+- `gemm_i8_simdgroup` — int8 matmul using `simdgroup_matrix` on M3+,
+  with software fallback for M1/M2.
+- `rotary_embedding` — standalone fused RoPE for DeepSeek-style exports.
+- `batch_normalization` — standard BatchNorm via parallel reduction.
+
+### D4: MSL kernel conventions
+
+**Decision.** All MSL kernels follow these conventions:
+
+```metal
+kernel void op_name(
+    device const float* input0  [[buffer(0)]],
+    device const float* input1  [[buffer(1)]],
+    device float* output        [[buffer(2)]],
+    constant uint& N            [[buffer(3)]],  // element count or shape param
+    uint tid [[thread_position_in_grid]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint lid [[thread_position_in_threadgroup]])
+{
+    if (tid >= N) return;  // bounds guard
+    // ...
+}
+```
+
+- Inputs are `device const float*`, outputs are `device float*`
+- Shape parameters are `constant uint&` in the last buffer slots
+- Every kernel has a `tid >= N` bounds guard
+- Thread group size: 256 for element-wise, 16x16 for 2D (matmul tiles)
+- Shared memory (`threadgroup float[]`) used only for reductions
+
+**Rationale.** Consistent conventions make it easy to add new kernels
+and simplify the dispatch helper that maps `Tensor` → `MTLBuffer`.
+
+### D5: M1/M2 vs M3+ hardware feature detection
+
+**Decision.** The `MetalProvider` detects GPU family at init time via
+`MTLDevice::supportsFamily(.apple9)` (Apple9 = M3+). Kernels that
+use `simdgroup_matrix` (hardware 8x8 matmul, M3+ only) have a
+software fallback path selected at kernel-compile time via a
+preprocessor `#define HAS_SIMDGROUP_MATRIX`.
+
+**Rationale.** M1/M2 are the majority of developer machines today.
+Not supporting them would make Metal inference unusable for most
+contributors. The software fallback uses shared-memory tiling which
+is ~2x slower than `simdgroup_matrix` but still 3-5x faster than CPU.
+
+### D6: Session-level GPU opt-in
+
+**Decision.** GPU inference is opt-in via `Session` configuration:
+
+```rust
+let session = Session::builder()
+    .with_gpu(GpuConfig::metal())  // enable Metal
+    .build_from_bytes(&model_bytes)?;
+```
+
+If `.with_gpu()` is not called, the session runs pure CPU as before.
+The `GpuConfig::metal()` constructor initializes a `MetalProvider`
+and passes it to `execute_graph`. If Metal is unavailable (Linux,
+no GPU), it falls back to CPU silently.
+
+**Rationale.** Inference results may differ slightly between CPU and
+GPU (f32 rounding) so users should explicitly opt in. The builder
+pattern matches the existing `Session` API.
+
+### D7: Correctness testing strategy
+
+**Decision.** Every GPU kernel is tested via a "CPU reference"
+pattern:
+
+1. Run the operator on CPU (the existing implementation)
+2. Run the same operator on GPU
+3. Assert the results match within tolerance (±1e-5 relative for
+   f32, ±1 quantized step for int8)
+
+These tests run in the `arch/apple` crate's test module, gated by
+`#[cfg(target_os = "macos")]`. They are NOT run in CI (no macOS
+runner), but `just test-metal` invokes them locally.
+
+### D8: File layout
+
+```
+arch/apple/src/
+├── lib.rs
+├── metal_provider.rs   (extended: MetalTensorCache, GPU family detect)
+├── shaders.rs          (extended: new MSL kernels)
+├── dispatch.rs         (NEW: maps OpKind → kernel launch config)
+└── stub.rs             (unchanged: non-macOS stubs)
+
+onnx-rt/src/
+├── executor.rs         (modified: GPU dispatch path in dispatch_node)
+└── session.rs          (modified: GpuConfig builder)
+
+compute/src/
+└── lib.rs              (modified: ComputeProvider tensor transfer traits)
+```
+
+## Alternatives considered
+
+### A1: Write a Metal Performance Shaders (MPS) backend
+
+Use Apple's pre-built MPS kernels (MPSMatrixMultiplication, etc.)
+instead of hand-written MSL. **Rejected:** MPS requires Objective-C
+bridging and the `objc2` crate ecosystem, adding ~5 dependencies.
+Hand-written MSL gives us control over fusion (SDPA, GQA) that MPS
+doesn't support, and keeps the dependency count at zero.
+
+### A2: Use WebGPU/wgpu as the abstraction layer
+
+Target wgpu/WGSL instead of Metal directly, gaining portability to
+Vulkan/DX12. **Rejected:** wgpu is `std`-only and adds ~30
+dependencies. SmallAIOS is `no_std` first. Metal-native is the
+right choice for the Apple Silicon target; Vulkan can be added as
+a separate `arch/amd` or `arch/nvidia` backend later following the
+same pattern.
+
+### A3: Implement GPU dispatch inside the ops/ modules
+
+Have each `op_matmul` check for GPU availability internally.
+**Rejected:** scatters GPU logic across 136+ op files. Centralizing
+GPU dispatch in `executor.rs` + `arch/apple/src/dispatch.rs` keeps
+the separation clean and makes it easy to add new GPU backends.
+
+## Open questions
+
+**Q1:** Should the `MetalTensorCache` persist across multiple
+`Session::run()` calls for the same session? Currently scoped to
+one `execute_graph` invocation. Persisting would help autoregressive
+generation (KV cache stays on device between tokens). Recommend yes
+but defer to implementation.
+
+**Q2:** Should we add f16 storage on-device and convert only at
+the host boundary? Apple GPUs are ~2x faster at f16 than f32.
+Recommend yes for Tier 2 but not blocking Tier 1.

--- a/openspec/changes/metal-operator-kernels-v1/proposal.md
+++ b/openspec/changes/metal-operator-kernels-v1/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+SmallAIOS now loads every major LLM family end-to-end (BERT, ViT, GPT-2, Llama-3.2, DeepSeek-R1, Gemma 3, MobileNetV2) — but all 136 operators execute on CPU. The Apple Metal GPU backend in `arch/apple/` has a working `MetalProvider` (device init, buffer alloc, kernel compile, dispatch — 9 hardware-verified tests) and 11 pre-written MSL shaders (`shaders.rs`), but the executor's `dispatch_node` **always falls through to the CPU path** even when `gpu_backend.supports_op()` returns true. Wiring the existing shaders through the dispatch path and adding kernels for the highest-leverage transformer ops (SDPA, GroupQueryAttention, RoPE) is the single most impactful performance improvement available — MatMul and attention together account for ~80% of LLM inference time, and Apple Silicon's GPU is 5-10x faster than its CPU cores for these workloads.
+
+## What Changes
+
+- **Wire the existing 11 MSL shaders** through the GPU dispatch path in `executor.rs` so operators actually execute on Metal when the `gpu` feature is enabled and a `MetalProvider` is available. This is the "unblock" step — the shaders exist, they just need to be called.
+- **Add new MSL shaders** for the high-value transformer ops not yet covered:
+  - `scaled_dot_product_attention` (the SDPA helper from `ops/microsoft.rs`)
+  - `group_query_attention` (the full GQA kernel with fused RoPE + causal mask)
+  - `layer_normalization` / `rms_normalization` (reduction-heavy, big GPU win)
+  - `gemm_i8` (int8 matmul on GPU using Metal's `simdgroup_matrix` on M3+)
+- **Implement host↔device tensor transfer** in the dispatch path: copy input tensors to Metal buffers before launch, copy results back after synchronization.
+- **Add a `MetalTensorCache`** that reuses device buffers across operator calls within a single `execute_graph` invocation, avoiding per-op alloc/free overhead.
+- **Update `supports_op`** to reflect only the ops that have real, tested Metal kernels (currently it claims 11 but none are wired).
+- **Feature-gate** all Metal dispatch behind `#[cfg(feature = "gpu")]` + a runtime check for Metal device availability.
+
+## Capabilities
+
+### New Capabilities
+- `metal-gpu-inference`: Metal GPU execution path for ONNX operators on Apple Silicon, including tensor transfer, kernel dispatch, buffer lifecycle, and operator coverage for the hot-path transformer ops.
+
+### Modified Capabilities
+- `onnx-cpu-execution`: The executor's dispatch path gains a GPU-first-then-CPU-fallback pattern. When the `gpu` feature is enabled and a `MetalProvider` is available, supported operators dispatch to Metal; unsupported operators fall through to the existing CPU implementations transparently. No CPU behavior changes.
+
+## Impact
+
+**Affected code:**
+- `onnx-rt/src/executor.rs` — GPU dispatch wiring in `dispatch_node` (currently a TODO)
+- `arch/apple/src/shaders.rs` — new MSL kernels for SDPA, GQA, LayerNorm, RMSNorm, int8 GEMM
+- `arch/apple/src/metal_provider.rs` — `MetalTensorCache`, extended `supports_op`, tensor transfer helpers
+- `compute/src/lib.rs` — `ComputeProvider` trait may need minor extensions for tensor transfer
+- `onnx-rt/src/session.rs` — session creation optionally initializes a `MetalProvider`
+
+**Affected features:**
+- `onnx-rt` `gpu` feature flag (already exists, currently unused in practice)
+- `arch/apple` default feature (currently empty; may add `metal-inference`)
+
+**Dependencies:**
+- `metal = "0.33"` (already in `arch/apple/Cargo.toml`, macOS-only)
+- No new external dependencies
+
+**Risks:**
+- Metal shader correctness must match CPU reference within tolerance (±1e-5 relative for f32, ±1 quantized step for int8). Each kernel needs a CPU-vs-GPU comparison test.
+- Memory pressure: copying tensors to/from device doubles peak memory during transfer. The `MetalTensorCache` mitigates this but doesn't eliminate it for the first/last transfer.
+- Apple Silicon generational differences: `simdgroup_matrix` (hardware matmul) is M3+ only. Kernels must have a fallback path for M1/M2.

--- a/openspec/changes/metal-operator-kernels-v1/specs/metal-gpu-inference/spec.md
+++ b/openspec/changes/metal-operator-kernels-v1/specs/metal-gpu-inference/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: Metal GPU operator dispatch
+The ONNX runtime SHALL dispatch supported operators to the Apple Metal GPU when the `gpu` feature is enabled and a `MetalProvider` is available, with transparent fallback to the CPU implementation for unsupported operators.
+
+#### Scenario: GPU dispatch for a supported operator
+- **WHEN** the `gpu` feature is enabled and a `MetalProvider` is initialized
+- **AND** a graph node uses an operator in the GPU-supported set (e.g., MatMul)
+- **THEN** the operator MUST execute on the Metal GPU
+- **AND** the result MUST match the CPU reference within ±1e-5 relative tolerance for f32
+
+#### Scenario: CPU fallback for an unsupported operator
+- **WHEN** the `gpu` feature is enabled and a `MetalProvider` is initialized
+- **AND** a graph node uses an operator NOT in the GPU-supported set
+- **THEN** the operator MUST execute on the CPU path unchanged
+- **AND** the graph MUST complete successfully mixing GPU and CPU operators
+
+#### Scenario: No GPU available
+- **WHEN** the `gpu` feature is enabled but no Metal device is detected (e.g., Linux)
+- **THEN** all operators MUST fall back to the CPU path silently
+- **AND** no error SHALL be returned
+
+### Requirement: Metal tensor transfer and caching
+The runtime SHALL manage host↔device tensor transfer with a per-graph `MetalTensorCache` that minimizes unnecessary copies.
+
+#### Scenario: Tensor stays on-device between consecutive GPU ops
+- **WHEN** operator A produces a tensor on the GPU
+- **AND** operator B (also GPU-supported) consumes that tensor
+- **THEN** the tensor MUST remain in device memory without a host round-trip
+
+#### Scenario: Tensor copied to host for CPU consumer
+- **WHEN** a GPU operator produces a tensor
+- **AND** the next consumer is a CPU-only operator
+- **THEN** the tensor MUST be copied to host memory before the CPU op executes
+
+### Requirement: Tier 1 Metal shaders — existing operators
+The runtime SHALL provide tested Metal shaders for: Add, Sub, Mul, Div, Relu, Sigmoid, Tanh, MatMul, Softmax, Conv2D.
+
+#### Scenario: Element-wise Add on GPU matches CPU
+- **WHEN** `op_add` executes on Metal with two f32 tensors
+- **THEN** every output element MUST match the CPU result within ±1e-5
+
+#### Scenario: Tiled MatMul on GPU matches CPU
+- **WHEN** `op_matmul` executes on Metal with two 2D f32 tensors
+- **THEN** the output MUST match the CPU result within ±1e-4 (relaxed for accumulated FMA error)
+
+### Requirement: Tier 2 Metal shaders — transformer ops
+The runtime SHALL provide tested Metal shaders for: scaled_dot_product_attention, group_query_attention, layer_normalization, rms_normalization, rotary_embedding.
+
+#### Scenario: SDPA on GPU matches CPU
+- **WHEN** `scaled_dot_product_attention` executes on Metal
+- **THEN** the attention output MUST match the CPU reference within ±1e-4
+
+#### Scenario: GroupQueryAttention on GPU matches CPU
+- **WHEN** `op_group_query_attention` executes on Metal with KV cache
+- **THEN** the attention output and updated KV cache MUST match CPU within ±1e-4
+
+### Requirement: M1/M2 hardware compatibility
+All Metal shaders SHALL execute correctly on Apple Silicon M1 and M2, with optional acceleration via `simdgroup_matrix` on M3+.
+
+#### Scenario: MatMul runs on M1
+- **WHEN** the Metal device does not support Apple GPU family 9 (M3+)
+- **THEN** the tiled MatMul shader MUST use shared-memory tiling instead of `simdgroup_matrix`
+- **AND** the result MUST still match the CPU reference within tolerance
+
+### Requirement: Session-level GPU opt-in
+GPU inference SHALL be opt-in via the `Session` builder API.
+
+#### Scenario: Default session runs on CPU
+- **WHEN** a `Session` is created without `.with_gpu()`
+- **THEN** all operators MUST execute on CPU regardless of Metal availability
+
+#### Scenario: GPU-enabled session uses Metal
+- **WHEN** a `Session` is created with `.with_gpu(GpuConfig::metal())`
+- **AND** a Metal device is available
+- **THEN** supported operators MUST dispatch to Metal

--- a/openspec/changes/metal-operator-kernels-v1/specs/onnx-cpu-execution/spec.md
+++ b/openspec/changes/metal-operator-kernels-v1/specs/onnx-cpu-execution/spec.md
@@ -1,0 +1,10 @@
+## MODIFIED Requirements
+
+### Requirement: Operator Dispatch Path
+The executor's `dispatch_node` function SHALL check for an available GPU backend before falling through to CPU execution. When a GPU backend is present and the operator is in its supported set, execution SHALL occur on the GPU. When no GPU backend is present or the operator is not supported, execution SHALL fall through to the existing CPU implementation with zero behavioral change.
+
+#### Scenario: Mixed GPU/CPU graph execution
+- **WHEN** a model graph contains both GPU-supported and unsupported operators
+- **THEN** the executor MUST interleave GPU and CPU dispatch within the same graph traversal
+- **AND** tensor values MUST be transferred between host and device as needed
+- **AND** the final graph outputs MUST be identical (within floating-point tolerance) to a pure-CPU execution of the same graph

--- a/openspec/changes/metal-operator-kernels-v1/tasks.md
+++ b/openspec/changes/metal-operator-kernels-v1/tasks.md
@@ -1,0 +1,70 @@
+## 1. GPU Dispatch Plumbing
+
+- [ ] 1.1 Create `arch/apple/src/dispatch.rs` with `MetalDispatcher` that maps `OpKind` → kernel name + launch config (grid size, threadgroup size, buffer bindings)
+- [ ] 1.2 Add `MetalTensorCache` to `metal_provider.rs`: lazy buffer allocation, on-device tensor tracking, host↔device copy helpers
+- [ ] 1.3 Extend `ComputeProvider` trait in `compute/src/lib.rs` with `copy_tensor_to_device` / `copy_tensor_from_device` methods (or equivalent)
+- [ ] 1.4 Wire `dispatch_node` in `executor.rs` to call `MetalDispatcher::execute` when `gpu_backend.supports_op()` returns true (replace the existing TODO comment)
+- [ ] 1.5 Implement the host→device→launch→device→host flow for a single operator: input tensors → Metal buffers → kernel launch → synchronize → output tensor
+- [ ] 1.6 Implement the on-device caching path: when the previous op left a result on-device and the next op also runs on GPU, skip the host round-trip
+- [ ] 1.7 Implement the device→host eviction path: when a CPU op needs a tensor that's currently on-device, copy it back to host
+- [ ] 1.8 Unit tests for `MetalTensorCache`: alloc, round-trip, eviction, reuse
+
+## 2. Session GPU Opt-in
+
+- [ ] 2.1 Add `GpuConfig` struct and `Session::builder().with_gpu(GpuConfig::metal())` API
+- [ ] 2.2 Thread the `MetalProvider` (or `None`) through `Session::run()` → `execute_graph()` → `dispatch_node()`
+- [ ] 2.3 Test: session without `.with_gpu()` runs pure CPU
+- [ ] 2.4 Test: session with `.with_gpu()` on macOS dispatches to Metal for supported ops
+- [ ] 2.5 Test: session with `.with_gpu()` on non-macOS silently falls back to CPU
+
+## 3. Tier 1 — Wire Existing Shaders (11 ops)
+
+- [ ] 3.1 Wire `elementwise_add` shader → `OpKind::Add`
+- [ ] 3.2 Wire `elementwise_sub` shader → `OpKind::Sub`
+- [ ] 3.3 Wire `elementwise_mul` shader → `OpKind::Mul`
+- [ ] 3.4 Wire `elementwise_div` shader → `OpKind::Div`
+- [ ] 3.5 Wire `elementwise_relu` shader → `OpKind::Relu`
+- [ ] 3.6 Wire `elementwise_sigmoid` shader → `OpKind::Sigmoid`
+- [ ] 3.7 Wire `elementwise_tanh` shader → `OpKind::Tanh`
+- [ ] 3.8 Wire `matmul` / `matmul_tiled` shader → `OpKind::MatMul` / `OpKind::Gemm`
+- [ ] 3.9 Wire `softmax` shader → `OpKind::Softmax`
+- [ ] 3.10 Wire `conv2d` shader → `OpKind::Conv`
+- [ ] 3.11 CPU-vs-GPU comparison tests for all 11 Tier 1 ops
+
+## 4. M1/M2 Hardware Compatibility
+
+- [ ] 4.1 Add GPU family detection in `MetalProvider::new()` via `MTLDevice::supportsFamily`
+- [ ] 4.2 Add `#define HAS_SIMDGROUP_MATRIX` preprocessor toggle for MSL compilation
+- [ ] 4.3 Implement shared-memory tiled MatMul fallback for M1/M2 in `matmul_tiled` shader
+- [ ] 4.4 Test: MatMul runs correctly on M1/M2 (without `simdgroup_matrix`)
+
+## 5. Tier 2 — New High-Value Shaders
+
+- [ ] 5.1 Write `scaled_dot_product_attention` MSL kernel: fused QK^T scaling + causal mask + softmax + V multiply
+- [ ] 5.2 Write `layer_normalization` MSL kernel: parallel mean + variance reduction in threadgroup shared memory
+- [ ] 5.3 Write `rms_normalization` MSL kernel: same pattern, no mean subtraction
+- [ ] 5.4 Write `rotary_embedding` MSL kernel: interleaved and non-interleaved RoPE
+- [ ] 5.5 Write `group_query_attention` MSL kernel: fused RoPE + KV concat + grouped SDPA + causal mask
+- [ ] 5.6 Write `gemm_i8_simdgroup` MSL kernel: int8 matmul with i32 accumulator, `simdgroup_matrix` on M3+ with shared-memory fallback
+- [ ] 5.7 Write `gemm_f16` MSL kernel: f16 matmul for half-precision models
+- [ ] 5.8 Write `batch_normalization` MSL kernel: parallel reduction
+- [ ] 5.9 Wire all Tier 2 shaders through `MetalDispatcher`
+- [ ] 5.10 Update `supports_op` to reflect the full GPU-supported set
+- [ ] 5.11 CPU-vs-GPU comparison tests for all Tier 2 ops
+
+## 6. Integration Testing
+
+- [ ] 6.1 End-to-end test: load MobileNetV2 and run a single inference on Metal, compare output to CPU reference
+- [ ] 6.2 End-to-end test: load BERT-base and run a single inference on Metal (mixed GPU/CPU — some ops fall back)
+- [ ] 6.3 Performance benchmark: MatMul 1024x1024 on CPU vs Metal, print speedup ratio
+- [ ] 6.4 Performance benchmark: SDPA (batch=1, seq=512, heads=12, dim=64) on CPU vs Metal
+- [ ] 6.5 Memory test: verify `MetalTensorCache` reuses buffers (peak allocation stays bounded)
+
+## 7. Validation
+
+- [ ] 7.1 `just fmt` clean
+- [ ] 7.2 `just clippy --all-targets` clean
+- [ ] 7.3 `just test` all passing (CPU tests unaffected)
+- [ ] 7.4 `just test-metal` all passing (GPU tests on macOS)
+- [ ] 7.5 All Tier 1 + Tier 2 GPU-vs-CPU comparison tests within tolerance
+- [ ] 7.6 Update `docs/onnx-coverage-roadmap.md` to note GPU kernel coverage


### PR DESCRIPTION
## Summary
Plan-only OpenSpec change for an LLM API translation layer:
- **POST /v1/chat/completions** — OpenAI Chat Completions compatible
- **POST /v1/messages** — Anthropic Messages compatible
- Shared internal `ChatRequest`/`ChatResponse` representation
- BPE tokenizer (from-scratch, loads HuggingFace tokenizer.json)
- Model-specific prompt templates (Llama 3, Gemma, DeepSeek/ChatML)
- Autoregressive generation loop with sampling (temperature, top-k, top-p)
- SSE streaming for both API formats
- **Model memory budget enforcement** (D9) — rejects models exceeding 80% of available RAM

57 tasks, 5 spec files (23 scenarios), 9-decision design doc.

## Test plan
- [x] `openspec validate llm-api-translation-v1 --strict` clean
- [x] No code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenAI Chat Completions API endpoint with streaming support
  * Added Anthropic Messages API endpoint with streaming support
  * Implemented LLM text-token conversion using Byte-Pair Encoding
  * Enabled autoregressive generation with temperature and top-p sampling
  * Added Metal GPU acceleration for operators on Apple Silicon with CPU fallback
  * Introduced model-specific prompt templating for Llama 3, Gemma, and DeepSeek models

<!-- end of auto-generated comment: release notes by coderabbit.ai -->