### PR TITLE
docs(openspec): propose formal-proving-and-redteam-v1 (3-phase roadmap)

### DIFF
--- a/openspec/changes/formal-proving-and-redteam-v1/.openspec.yaml
+++ b/openspec/changes/formal-proving-and-redteam-v1/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/formal-proving-and-redteam-v1/design.md
+++ b/openspec/changes/formal-proving-and-redteam-v1/design.md
@@ -1,0 +1,168 @@
+# Design — formal-proving-and-redteam-v1
+
+This change closes three structural gaps in SmallAIOS verification + security evidence required for DO-178C DAL A traceability:
+1. Lean 4 proofs not type-checked in CI ("aspirational" rot).
+2. TLA+ corpus missing capability delegation monotonicity + scheduler state-machine fairness; zero SMT coverage.
+3. Threat model documented but unexercised — no syscall ABI fuzzer, no PQC NIST KAT, no adversarial test corpus.
+
+The phased structure follows: each phase produces evidence the next builds on. Phase 1 adds the verification scaffolding; Phase 2 adds adversarial coverage of crypto + ABI; Phase 3 unifies it into a red-team gate.
+
+---
+
+## Phase 1: Verification stack expansion — design decisions
+
+### D1.1 Lean 4 CI integration approach
+
+**Decision:** Add a new `lean-verify` job to `.github/workflows/ci.yml` as a **hard gate** alongside `clippy` and `unit-tests`. The job:
+
+1. Installs `elan` (the Lean version manager) via the official `leanprover/elan` install script, pinned to a specific elan release commit for supply-chain stability.
+2. Reads the toolchain version from a new `formal/lean4/lean-toolchain` file (single line, e.g. `leanprover/lean4:v4.15.0`). `elan` honors this file automatically. Pinning here keeps the Lean version under PR review.
+3. Runs `lake build` from `formal/lean4/` to compile every existing proof (`CapabilityNonForgery`, `InformationFlow`, `IntegrityLattice`, `LabelComposition`, `MessageTypeProperties`, `TensorTypeInvariants`).
+4. Caches `formal/lean4/.lake/build/` and `~/.elan/toolchains/` keyed on `lean-toolchain` + `lakefile.lean` hash to keep cold-build (~5–8 min) off the hot path.
+
+**Build tool: `lake`, not `leanpkg`.** `leanpkg` is the deprecated Lean 3 tool; every existing proof in `formal/lean4/` already targets Lean 4, so `lake` is the only valid choice. We also add a `lakefile.lean` to declare the package and any `mathlib` dependency the proofs need.
+
+**Failure mode: hard gate, not advisory.** Lean's type checker is deterministic and proofs that build today will keep building. Demoting to advisory (the current de-facto state) is what produced "aspirational" rot in the first place. The job runs in <2 min once cached, well under the existing CI budget.
+
+**Toolchain version:** pin to `v4.15.0` (latest stable as of 2026-04). Lean 4 is post-1.0 and stable; the cost of a major upgrade later is small relative to the cost of unpinned drift. The pin lives in `formal/lean4/lean-toolchain` so `elan` picks it up implicitly.
+
+### D1.2 TLA+ model additions
+
+**Decision:** Extend `formal/tla/CapabilitySecurity.tla` with two new invariants and add one new model `formal/tla/SchedStateMachine.tla`. `IpcCapabilityTransfer.tla` is **deferred to Phase 2** (out of Phase 1 scope — see risks).
+
+**`CapabilitySecurity.tla` extensions** (DAL A traceable to capability non-forgery requirement):
+- `DelegationMonotonicity`: for every delegation edge `parent → child`, `child.rights ⊆ parent.rights`. This is the structural form of "no privilege escalation" and complements the existing non-forgery property by making the lattice ordering explicit on every state.
+- `CapabilityIdStrictlyIncreasing`: the global capability ID counter is monotonically non-decreasing across every state transition, and freshly minted IDs are strictly greater than any ID present in the prior state. This rules out ID reuse / replay against revoked caps.
+
+**`SchedStateMachine.tla`** (new model, DAL A traceable to scheduler liveness requirement):
+- States: `Ready`, `Running`, `Yielded`, `Blocked`.
+- Transitions: `Ready → Running` (dispatch), `Running → Yielded` (cooperative yield at op boundary), `Running → Blocked` (await), `Yielded → Ready` (requeue), `Blocked → Ready` (wake).
+- Safety invariants: at most one task in `Running` per core; no `Blocked → Running` transition (must go via `Ready`).
+- LTL fairness: `[]<>(task.state = Ready) ⇒ <>(task.state = Running)` under weak fairness on dispatch — every Ready task eventually runs. This is the exact property `docs/scheduling-model.md` claims but never machine-checks.
+
+Bounded with N=3 cores, M=6 tasks. Stays inside the 5-minute TLC budget.
+
+**Why these invariants and not others for DAL A:** capability monotonicity is the keystone of the security argument (a capability system without it cannot claim non-forgery); the scheduler liveness LTL is the keystone of the cooperative-async correctness argument that downstream worst-case execution time analysis depends on. Other potential additions (e.g., buddy-allocator merge correctness, NDP cache liveness) already have TLA+ coverage today.
+
+**`IpcCapabilityTransfer.tla`: out of Phase 1.** Modeling capability passage across IPC rings between cores is genuinely useful but pulls in the multi-core IPC ring spec, which is a 1–2 week effort on its own. Deferred to Phase 2 to keep Phase 1 inside the 3-week budget.
+
+### D1.3 SMT solver choice
+
+**Decision: Z3 first**, behind a new `formal-smt` Cargo feature on the `smallaios-kernel` crate. Add `z3 = "0.12"` (which wraps `z3-sys` and the upstream Z3 4.x C API) as an optional dependency.
+
+**Why Z3 over CVC5 / Bitwuzla:**
+- **Maturity of Rust bindings.** `z3-sys` and `z3` (high-level wrapper) are the most-used Rust SMT bindings, regularly published, and have working examples for our likely first-proof patterns (allocator monotonicity, bounded BV reasoning).
+- **Theory coverage matches our targets.** Our anticipated proof corpus (allocator pointer monotonicity, capability ID arithmetic, ring-buffer index monotonicity) lives squarely in QF_BV + QF_LIA — Z3's strongest fragments. CVC5's edge in non-linear arithmetic is irrelevant here. Bitwuzla's edge in pure bitvector / crypto-style proofs is real but narrow; we prefer one solver for now and can add Bitwuzla later for the PQC arithmetic phase.
+- **Build hygiene.** `z3-sys` can either link a system Z3 (libz3-dev) or build from vendored sources via the `bundled` Cargo feature. We start with `bundled` for hermetic CI builds; revisit if compile time hurts.
+
+**First proof target: `BumpAllocator::alloc` pointer monotonicity.** Encode the bump allocator state (`base`, `current`, `end`) as 64-bit bitvectors and prove: for any sequence of N successful `alloc(size_i)` calls, `current_after ≥ current_before` and `current_after ≤ end`. Bounded model at N=8. Lives in a new `kernel/proofs/bump_allocator_smt.rs` test module guarded by `#[cfg(feature = "formal-smt")]`. Runs in CI under a new `smt-verify` advisory job initially; promotes to hard gate once stable.
+
+The `formal-smt` feature is opt-in and never enabled by default, so the `std`-pulling Z3 dependency stays out of `#![no_std]` kernel builds.
+
+### D1.4 Risks and open questions
+
+- **Lean toolchain drift.** Pinning to `v4.15.0` works today, but a future contributor adding a proof that needs a newer Lean might require a global bump. Mitigation: document the bump-Lean procedure in `formal/lean4/README.md` (Phase 1 task).
+- **`mathlib` dependency weight.** If any existing proof imports `mathlib`, cold-build inflates to >30 min. We need to inspect lakefile imports as task 1.1.2 and decide whether to vendor minimal lemma subset vs. accept the cache-warm path.
+- **Z3 `bundled` build time.** Bundled Z3 adds ~3–5 min to a clean `formal-smt`-enabled build. Acceptable for an opt-in feature; revisit if it shows up on developer machines.
+- **Open: SMT proof framing.** Bump allocator state is small enough that a Lean proof might be cleaner than SMT. We pick SMT here specifically to exercise the scaffolding; the choice between SMT and Lean per-proof becomes a per-target decision in later phases.
+- **Open: TLA+ → Lean refinement story.** Both tools cover overlapping ground for capabilities. A future phase will decide whether to express refinement (Lean implementation of the TLA+-modeled state machine) or keep them as independent evidence strands. Out of Phase 1.
+
+---
+
+## Phase 2: Fuzzing expansion + crypto KAT — design decisions
+
+Phase 1 ships verification scaffolding. Two adversarial gaps remain: the **~65-syscall ABI surface** has no fuzzer, and PQC primitives (ML-KEM-768, ML-DSA-65) lack NIST KAT vectors and a differential check. Phase 2 closes both and adds a side-channel guardrail track. Effort: ~3 weeks.
+
+### D2.1 Syscall ABI fuzzer
+
+`fuzz/fuzz_targets/fuzz_syscall_abi.rs` driven by `libfuzzer-sys`. Each iteration owns a `MockKernel` (in-memory capability table with monotone generations, stub allocator, stub IPC ring). Inputs parse via `arbitrary::Arbitrary` into `SyscallCall { number: u32, args: Vec<u8> }` and dispatch through a new `cfg(fuzzing)` shim `kernel::syscall::dispatch_for_fuzz()`.
+
+Per-syscall `Arbitrary` impls cover malformed length prefixes (zero, `usize::MAX`, off-by-one), alignment violations, forged capability handles (random `u64`, expired generation, wrong-type tag), and resource exhaustion (`sys_tensor_alloc(usize::MAX)`, IPC depth 1024). Pass criteria: no panics; `MockKernel` invariants hold; out-of-range numbers return `Err(ENOSYS)`. Lifetime: 60 s PR CI, 1 h nightly; corpus seeded from `kernel/tests/syscall_*.rs`.
+
+### D2.2 PQC differential fuzz
+
+`fuzz/fuzz_targets/fuzz_pqc_mlkem768.rs` and `fuzz_pqc_mldsa65.rs` against **`pqcrypto-kyber = "0.8"`** and **`pqcrypto-dilithium = "0.5"`** as `fuzz/` dev-deps. Rationale: pure-Rust bindings to the official PQClean C reference, already used by rustls-post-quantum and rage; avoids adding `bindgen` + C toolchain.
+
+Equivalence: bit-for-bit on **deterministic** API — both algorithms expose `derand_keypair`, `derand_encapsulate`, `derand_sign`; same seeds → byte-equal outputs. Non-deterministic API uses **functional equivalence** (own encapsulate → ref decapsulate, and reverse). Divergence panics with hex-dumped seeds.
+
+### D2.3 KAT vector ingestion
+
+`security/tests/kat_mlkem768.rs` and `kat_mldsa65.rs`, gated by a new `pqc-kat` feature. Source: NIST `.rsp` files from FIPS 203 / 204 reference packages, vendored under `security/tests/kat-vectors/` (≤ 4 MiB) so CI is hermetic. Pinning: `SHA256SUMS` lockfile; `scripts/refresh-pqc-kats.sh` downloads from canonical NIST URLs and updates the lockfile; mismatched digests abort setup. Parser: ~100 LOC `kat_parser.rs` (line-oriented `KEY = HEX`). CI gate: new **blocking** `pqc-kat-verify` job.
+
+### D2.4 Side-channel scope
+
+In scope (advisory): `docs/pqc-side-channel.md` documenting CT invariants (NTT loops, rejection sampling, comparison via `subtle::ConstantTimeEq`); leaky ops tagged `// NOT-CT:` with rationale.
+
+Stretch (advisory CI): `dudect-rs` tests, weekly `pqc-timing-leak` cron on `self-hosted-isolated`, report-only (t > 4.5 → warning). Blocking promotion deferred to Phase 3. Formal CT proofs (`ct-verif` / Jasmin) DEFERRED to a follow-up change.
+
+### D2.5 Risks and open questions
+
+| Risk | Mitigation |
+|------|-----------|
+| `pqcrypto-kyber` has a bug we duplicate | Cross-check vs NIST KAT — three independent oracles |
+| KAT files exceed repo size | `zstd -19`; uncompressed ≈ 3.2 MiB |
+| `MockKernel` drift masks real bugs | Phase 3 Kani on real `dispatch()`; Phase 2 fuzzer is coverage, not oracle |
+| `dudect` flakes on shared CI | Dedicated `self-hosted-isolated` runner; weekly cadence absorbs noise |
+
+Open questions: (1) vendor `.rsp` vs Git submodule? *Lean: vendor.* (2) Fuzz `verified-boot` syscalls? *Lean: no — measurement-log writes are idempotent.* (3) Use `arbitrary-derive`? *Lean: yes.*
+
+---
+
+## Phase 3: Red-team / adversarial — design decisions
+
+Effort: ~3-4 weeks. Drives adversarial evidence for the threat model in `openspec/smallaios-kernel/specs/06-security-model.md` and the DAL A audit trail required by `openspec/smallaios-kernel/specs/12-safety-critical.md`.
+
+### D3.1 Test crate structure
+
+**Options:**
+- (A) New workspace crate `crates/red-team-tests/` with its own `Cargo.toml`, depending on `kernel`, `security`, `onnx-rt`, `ipc`, `net`, `container`.
+- (B) Co-located `tests/red-team/` directory inside each affected crate.
+
+**Recommendation: (A) `crates/red-team-tests/`.** Adversarial tests cross crate boundaries (capability forgery touches `security` + `ipc`; ONNX injection touches `onnx-rt` + `kernel`). A dedicated crate gives one CI gate (`red-team-suite`), one corpus path (`crates/red-team-tests/corpus/`), and a single `lib.rs` of attack helpers. Trade-off: increases the layer-3 fan-in slightly; mitigated by gating compilation behind a `red-team` feature so production builds skip it.
+
+### D3.2 Attack scenario taxonomy
+
+Scenarios are grouped by threat-model line in `06-security-model.md`:
+
+| Category | Threat-model ref | Test module |
+|----------|------------------|-------------|
+| Capability forgery / over-delegation | T-01, T-04 | `capability::forge` |
+| ONNX graph injection | T-02 (malicious ONNX) | `onnx::inject` |
+| IPC amplification / DoS | T-07 (DoS) | `ipc::flood` |
+| Boot integrity tampering | T-03 (boot) | `boot::tamper` |
+| Network protocol abuse | T-05 (network) | `net::abuse` |
+
+**Gating policy.** `red-team-suite` runs as a **non-blocking advisory job** for the first 3 PRs that touch it (matching the cargo-careful pattern in `.github/workflows/ci.yml`). Promoted to **blocking** once the suite is green for 5 consecutive `develop` builds. Promotion is recorded in `docs/red-team-playbook.md` § "Gating history".
+
+### D3.3 Property-test framework choice
+
+**Options: `proptest` vs `quickcheck`.**
+
+**Recommendation: `proptest`.** Reasons:
+- Already implied by the existing fuzz corpus tooling; shrinking is more predictable than `quickcheck` for kernel state machines.
+- `proptest-state-machine` models cascading capability revocation cleanly.
+- `no_std`-compatible via `proptest = { default-features = false }` for use inside `kernel` test harness.
+
+Properties (4-6 initial):
+1. `prop_delegation_subset_rights` — child rights ⊆ parent rights.
+2. `prop_revocation_cascades` — revoking parent invalidates all transitive children within one tick.
+3. `prop_cap_id_unique` — capability IDs never reused after revocation.
+4. `prop_no_upgrade_via_alias` — aliasing a capability cannot grant rights the original lacked.
+5. `prop_quota_monotone` — delegated quota never exceeds parent quota.
+6. `prop_audit_log_complete` — every cap operation appears in the audit log exactly once.
+
+### D3.4 Attack-surface tracking doc
+
+`docs/attack-surface.md` is a single Markdown table with columns:
+
+| Interface | Source file | Threat-model line | Adversarial coverage | Owner |
+
+Rows enumerate: ~46 syscalls (one row each, grouped), TCP/UDP listen ports, IPC topics (per-topic ACL), USB endpoint classes, CAN routes (see `docs/can-inference.md`), GPU device ABI (CUDA stub today). Each row links to a test in `crates/red-team-tests/` or marks coverage as `NONE` / `FUZZ-ONLY` / `PROPERTY` / `INTEGRATION`. The doc is regenerated quarterly and reviewed by Security Lead per `docs/security/security-governance.md`.
+
+### D3.5 Risks and open questions
+
+- **R1 — flaky DoS tests.** Topic-flood timing is sensitive to CI runner load. Mitigation: tests assert behavior (refuse / drop / audit), not throughput.
+- **R2 — corpus size growth.** Malformed protobuf / TCP corpora can bloat the repo. Mitigation: store seeds only; expand at runtime.
+- **R3 — boot integrity coverage gap.** Per `docs/boot-security-matrix.md` most boot mechanisms are "No" or "Partial". Phase 3 covers Multiboot2 self-measurement only; UEFI / TPM tampering deferred until those mechanisms move past "Partial".
+- **OQ1** — should `red-team-suite` run on `main` only, or also on `develop`? Recommend both, advisory on PRs.
+- **OQ2** — do we mirror property tests into Kani harnesses? Defer to a follow-up phase.

--- a/openspec/changes/formal-proving-and-redteam-v1/proposal.md
+++ b/openspec/changes/formal-proving-and-redteam-v1/proposal.md
@@ -1,0 +1,47 @@
+# formal-proving-and-redteam-v1
+
+## Summary
+
+SmallAIOS targets DO-178C DAL A and ships meaningful formal verification scaffolding today — 25 TLA+ models (22 in CI), 6 SPIN/Promela models, 6 Lean 4 proofs, 6 fuzz targets, plus CodeQL / SonarCloud / cargo-deny / cargo-vet / cargo-careful / cargo-geiger / Miri / Kani in CI. But three structural gaps prevent that scaffolding from constituting verification *evidence*: (1) the 6 Lean 4 proofs are not type-checked in CI — they are aspirational text on disk; (2) the TLA+ corpus lacks two load-bearing invariant families (capability delegation monotonicity, scheduler state-machine fairness) and has zero SMT coverage of low-level invariants like allocator monotonicity; (3) the threat model in `06-security-model.md` is documented but **unexercised** — there is no syscall ABI fuzzer, no PQC differential fuzz vs reference, no NIST KAT vectors, no adversarial test corpus, and no attack-surface inventory. This change proposes a phased plan to close those gaps, in the order in which downstream evidence depends on them.
+
+The change is structured as a roadmap: **three phases, ~9 weeks total**, each producing artifacts that gate the next. Implementation may proceed phase-by-phase as separate sub-changes once this umbrella is approved, or in one go if scope permits. The umbrella stays active in `openspec/changes/` until all phases are done.
+
+## Phase 1 — Verification stack expansion (~3 weeks)
+
+SmallAIOS already ships 25 TLA+ models (22 in CI), 6 SPIN/Promela models, and 6 Lean 4 proofs covering capability non-forgery, information flow, the integrity lattice, label composition, message-type properties, and tensor type invariants. The Lean proofs are not built by CI today — they are aspirational text on disk. Two structurally important TLA+ invariant families are missing: capability **delegation monotonicity** (the keystone of the non-forgery argument) and **scheduler state-machine fairness** (the keystone of the cooperative-async correctness argument that downstream WCET reasoning depends on). And the stack contains zero SMT coverage — no Z3, CVC5, or Bitwuzla bindings, no `.smt2` files, no Rust crate deps — even though several low-level kernel invariants (allocator monotonicity, ring-buffer indices, capability ID arithmetic) fit naturally in QF_BV. For a system targeting DO-178C DAL A traceability, each of these is a documented gap in the verification evidence trail.
+
+Phase 1 closes those three gaps in roughly three weeks of focused work. We wire the existing Lean 4 proofs into a hard-gate CI job (`lean-verify`) via `elan` + pinned `lean-toolchain` + `lake build` with cached `.lake/build/`, so the type checker enforces the proofs on every PR. We extend `formal/tla/CapabilitySecurity.tla` with `DelegationMonotonicity` and `CapabilityIdStrictlyIncreasing` invariants, and add a new `formal/tla/SchedStateMachine.tla` modeling `Ready/Running/Yielded/Blocked` transitions with LTL liveness under weak fairness on dispatch. Finally we stand up the SMT scaffolding behind a new `formal-smt` Cargo feature (Z3 first, justified by mature Rust bindings and theory fit) and land a first proof — bump allocator pointer monotonicity by bounded model checking — to validate the toolchain end-to-end.
+
+## Phase 2 — Fuzzing expansion + crypto KAT (~3 weeks)
+
+SmallAIOS today has six structural fuzz targets covering parsers (ONNX protobuf, tensor, IPC, TCP, UDP, USB) but **zero adversarial coverage on the ~65-syscall ABI surface**. Forged capability handles, expired generations, out-of-range numbers, and `usize::MAX` allocation requests are caught only by hand-written property tests on the safe Rust wrappers — the raw `dispatch()` entry is never fuzzed. Phase 2 adds `fuzz/fuzz_targets/fuzz_syscall_abi.rs` driven by a `MockKernel`, fuzzed under libFuzzer + sanitizers for 60 s in PR CI and 1 h nightly.
+
+The PQC stack (ML-KEM-768, ML-DSA-65) is also validated only by hand-written round-trip tests inside its own crate — no NIST KAT gate, no differential check. Phase 2 vendors NIST KAT vectors under `security/tests/kat-vectors/` (SHA-256-pinned) and runs them as a blocking `pqc-kat-verify` CI job; two new `cargo-fuzz` targets drive identical seeds through our impl and `pqcrypto-kyber 0.8` / `pqcrypto-dilithium 0.5` and assert bit-for-bit ciphertext and shared-secret equality. Differential fuzz catches own-impl regressions cheaply — divergence on any seed surfaces as a hex-dumped CI reproducer. A stretch side-channel track adds a `dudect`-based weekly advisory job and `docs/pqc-side-channel.md`; full Jasmin / `ct-verif` proofs are explicitly deferred.
+
+## Phase 3 — Red-team / adversarial test suite (~3-4 weeks)
+
+SmallAIOS has a documented threat model (`openspec/smallaios-kernel/specs/06-security-model.md`) and a NIST 800-53 control mapping (`docs/security/nist-800-53-ssp.md`), but the threat model is currently **unexercised**: no automated tests synthesize forged capability handles, malformed ONNX graphs, IPC floods, tampered Multiboot2 headers, or abusive network protocol sequences. DAL A certification under `openspec/smallaios-kernel/specs/12-safety-critical.md` requires adversarial evidence in the audit trail, and our boot security matrix (`docs/boot-security-matrix.md`) shows multiple "No" / "Partial" mechanisms that need explicit coverage statements rather than implicit gaps.
+
+Phase 3 closes that gap by introducing `docs/red-team-playbook.md`, `docs/attack-surface.md`, and a new `crates/red-team-tests/` workspace crate that unifies fuzz seeds, `proptest` capability invariants, and integration scenarios under a single CI gate (`red-team-suite`, advisory then blocking). Six initial property tests pin down capability delegation, cascading revocation, ID non-reuse, alias safety, quota monotonicity, and audit completeness. Five scenario suites (capability, ONNX, IPC, boot, network) map every in-scope threat-model line to a concrete refusal or audit-logged outcome. The work sets up future Kani harnesses to mirror the same properties under bounded model checking.
+
+## Out of scope
+
+- **Lifting Lean 4 proofs to Rust via `aeneas` / `verus` / `creusot`** — meaningful, but a multi-month effort with its own toolchain integration; tracked as a follow-up change.
+- **Bare-metal Miri** — non-trivial because Miri targets unsupported by `x86_64-unknown-none`, `aarch64-unknown-none`, `riscv64gc-unknown-none-elf`. Tracked as a separate investigation.
+- **Full constant-time formal proofs** (Jasmin / `ct-verif`) for PQC primitives — Phase 2 adds documented invariants and a `dudect` advisory check; full proofs are a follow-up.
+- **UEFI / TPM / TrustZone adversarial coverage** — the boot security matrix marks these "No" / "Partial"; Phase 3 covers Multiboot2 self-measurement only and explicitly defers the rest.
+- **Capability-system Kani harnesses** — Phase 3 lays the property-test groundwork; mirroring into Kani is a Phase 4 follow-up.
+- **SMT proofs of cryptographic primitives** — Bitwuzla is well-suited but the first SMT proof targets `BumpAllocator` to validate scaffolding before tackling crypto arithmetic.
+
+## Sequencing
+
+Phases run in declared order. Each phase is implementable independently once Phase 1 lands (Phase 2 + Phase 3 do not depend on each other and could parallelize). The recommended sequence is 1 → 2 → 3 because the verification scaffolding (Lean CI, SMT) makes it cheaper to land regressions caught later. Each phase has explicit exit criteria; archival of this umbrella waits until all three exit-criteria sets are satisfied, with deferred items marked inline.
+
+## Effort estimate
+
+| Phase | Scope | Estimate |
+|-------|-------|----------|
+| 1 | Lean 4 CI + TLA+ extensions + SMT scaffolding | ~3 weeks |
+| 2 | Syscall ABI fuzzer + PQC differential + NIST KAT + side-channel guardrails | ~3 weeks |
+| 3 | Adversarial playbook + red-team test crate + property tests + CI gate | ~3-4 weeks |
+| **Total** | | **~9-10 weeks** |

--- a/openspec/changes/formal-proving-and-redteam-v1/specs/06-security-model/spec.md
+++ b/openspec/changes/formal-proving-and-redteam-v1/specs/06-security-model/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Adversarial test playbook
+The kernel SHALL maintain a red-team playbook at `docs/red-team-playbook.md` that enumerates every threat-model line with at least one corresponding adversarial test in `crates/red-team-tests/`.
+
+#### Scenario: Every in-scope threat has a test
+- **WHEN** the threat model lists a threat as in-scope
+- **THEN** the playbook MUST cite a test module name and the test MUST exist under `crates/red-team-tests/tests/`
+
+#### Scenario: Out-of-scope threats are explicitly marked
+- **WHEN** a threat is out-of-scope (physical, host kernel, etc.)
+- **THEN** the playbook MUST note the rationale rather than omit it
+
+### Requirement: Capability invariants are property-tested
+The kernel SHALL verify capability invariants via `proptest` properties covering delegation, revocation, ID uniqueness, aliasing, quota, and audit completeness.
+
+#### Scenario: Delegated rights never exceed parent
+- **WHEN** a parent capability delegates to a child
+- **THEN** the child rights set MUST be a subset of the parent rights set, and the property test MUST exercise this on randomized chains
+
+#### Scenario: Revocation cascades within one tick
+- **WHEN** a parent capability is revoked
+- **THEN** all transitively delegated children MUST be invalidated before the next scheduler tick
+
+#### Scenario: Capability IDs are not reused
+- **WHEN** a capability is revoked
+- **THEN** its ID MUST NOT be issued to any future capability for the lifetime of the kernel instance
+
+### Requirement: Adversarial inputs are refused or audited
+All adversarial scenarios in the playbook MUST result in one of: refusal at the boundary, panic-halt with audit log entry, or rate-limited drop with audit log entry — never silent acceptance.
+
+#### Scenario: Forged capability handle is refused
+- **WHEN** a syscall presents a capability handle that was never issued by the kernel
+- **THEN** the call MUST return an error and emit an audit log entry
+
+#### Scenario: Malformed ONNX graph fails at load
+- **WHEN** an ONNX model contains a cyclic graph, op-count overflow, or attribute type confusion
+- **THEN** `onnx-rt` MUST refuse to load before any tensor allocation
+
+#### Scenario: IPC topic flood does not panic
+- **WHEN** N publishers flood a single topic past its queue depth
+- **THEN** the kernel MUST apply back-pressure or drop with audit and MUST NOT panic
+
+### Requirement: Attack-surface inventory is current
+The kernel SHALL maintain `docs/attack-surface.md` enumerating every external interface (syscalls, listen ports, IPC topics, USB endpoint classes, CAN routes, GPU device ABI) with its current adversarial coverage status.
+
+#### Scenario: New external interface adds an attack-surface row
+- **WHEN** a PR introduces a new syscall, listen port, or IPC topic
+- **THEN** the PR MUST add a row to `docs/attack-surface.md` with coverage status `NONE`, `FUZZ-ONLY`, `PROPERTY`, or `INTEGRATION`

--- a/openspec/changes/formal-proving-and-redteam-v1/specs/08-crypto-hardware-security/spec.md
+++ b/openspec/changes/formal-proving-and-redteam-v1/specs/08-crypto-hardware-security/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: PQC NIST KAT verification
+ML-KEM-768 and ML-DSA-65 SHALL pass the official NIST PQC Known Answer Test vectors from the FIPS 203 / 204 reference packages, vendored under `security/tests/kat-vectors/` and pinned by SHA-256 in `SHA256SUMS`. CI gate `pqc-kat-verify` is blocking.
+
+#### Scenario: ML-KEM-768 KAT vector matches reference output
+- **WHEN** the harness drives `mlkem768::keypair_from_seed(seed)` and `encapsulate_derand(pk, coins)` for every vector in `PQCkemKAT.rsp`
+- **THEN** the produced `pk`, `sk`, `ct`, and `ss` are byte-exact equal to the reference
+
+#### Scenario: ML-DSA-65 KAT vector signs deterministically
+- **WHEN** the harness calls `mldsa65::sign_derand(sk, message, randomness)` for every vector in `PQCsignKAT.rsp`
+- **THEN** the produced signature is byte-exact equal to the reference, and `verify(pk, message, sig)` returns `Ok(())`
+
+#### Scenario: KAT vectors fail digest check
+- **WHEN** any `.rsp` file under `security/tests/kat-vectors/` has a SHA-256 digest mismatching `SHA256SUMS`
+- **THEN** the harness aborts setup before any comparisons and the CI job fails
+
+### Requirement: PQC differential fuzz vs independent reference
+ML-KEM-768 and ML-DSA-65 SHALL be fuzzed against `pqcrypto-kyber 0.8` and `pqcrypto-dilithium 0.5` for 60 s in PR CI and 1 h nightly. Bit-for-bit equality is required on deterministic API; functional equivalence (cross-decapsulate, cross-verify) is required on non-deterministic API.
+
+#### Scenario: Seeded encapsulate produces byte-equal ciphertext
+- **WHEN** the fuzzer drives `mlkem768::encapsulate_derand(pk, coins)` and `pqcrypto_kyber::kyber768::derand_encapsulate(pk, coins)` with identical inputs
+- **THEN** both produce byte-equal `ct` and `ss`
+
+#### Scenario: Cross-implementation decapsulate succeeds
+- **WHEN** the fuzzer encapsulates with the own implementation and decapsulates with the reference (or vice versa)
+- **THEN** both sides recover the same shared secret
+
+### Requirement: PQC constant-time invariants documented
+Every PQC code path in `security/src/crypto/` SHALL document its constant-time invariants in `docs/pqc-side-channel.md`. Non-CT operations SHALL be tagged `// NOT-CT:` with rationale. Equality on secret-derived bytes SHALL use `subtle::ConstantTimeEq`.
+
+#### Scenario: Equality comparison on secret data uses constant-time
+- **WHEN** code under `security/src/crypto/` compares byte slices that depend on secret material (decapsulated keys, signatures, MAC tags)
+- **THEN** it uses `subtle::ConstantTimeEq::ct_eq`, never `==` or `slice::eq`

--- a/openspec/changes/formal-proving-and-redteam-v1/specs/12-safety-critical/spec.md
+++ b/openspec/changes/formal-proving-and-redteam-v1/specs/12-safety-critical/spec.md
@@ -1,0 +1,50 @@
+## MODIFIED Requirements
+
+### Requirement: Fuzz target coverage
+The CI fuzz matrix was six fuzz targets (ONNX protobuf, ONNX tensor, IPC, TCP, UDP, USB) at 60 s each. It SHALL now include nine targets — the original six plus `fuzz_syscall_abi`, `fuzz_pqc_mlkem768`, `fuzz_pqc_mldsa65`. PQC differential targets SHALL upload `cargo-fuzz coverage` HTML as a nightly artifact.
+
+#### Scenario: PR CI fuzz matrix executes all targets
+- **WHEN** a PR opens against `develop` or `main`
+- **THEN** the CI matrix runs each of the nine targets for 60 s and blocks merge on any panic, sanitizer violation, or differential mismatch
+
+## ADDED Requirements
+
+### Requirement: Syscall ABI adversarial coverage
+The full syscall ABI surface (~65 entries across `sys_cap_*`, `sys_mem_*`, `sys_tensor_*`, `sys_ipc_*`, `sys_device_*`) SHALL have a fuzz target `fuzz/fuzz_targets/fuzz_syscall_abi.rs` exercising out-of-range numbers, malformed argument structs, forged capability handles, and resource exhaustion. Runs 60 s in PR CI, 1 h nightly. Any panic or invariant violation fails the build.
+
+#### Scenario: Out-of-range syscall number rejected
+- **WHEN** the fuzzer dispatches a syscall with `number > MAX_SYSCALL_NUMBER`
+- **THEN** the dispatcher returns `Err(ENOSYS)` without panicking and without mutating any kernel state
+
+#### Scenario: Forged capability handle rejected
+- **WHEN** the fuzzer passes a capability handle with a generation not matching the entry in the capability table
+- **THEN** the syscall returns `Err(EBADF)` and the capability table is unchanged
+
+#### Scenario: Resource-exhaustion request rejected without OOM
+- **WHEN** the fuzzer issues `sys_tensor_alloc(usize::MAX)` or pushes an IPC pipeline deeper than the per-process cap
+- **THEN** the syscall returns `Err(ENOMEM)` or `Err(E2BIG)` and `MockKernel` invariants hold
+
+### Requirement: PQC timing-leak advisory monitoring
+PQC encapsulate and sign paths SHALL be exercised by a `dudect`-style detector on a weekly cron `pqc-timing-leak`. Advisory: t > 4.5 emits a warning, does not fail the build. Runs on `self-hosted-isolated`.
+
+#### Scenario: Timing leak detected above threshold
+- **WHEN** the weekly job observes Welch t > 4.5 on encapsulate or sign
+- **THEN** the job emits a CI warning and posts to the tracking issue, but does NOT fail the build
+
+### Requirement: Adversarial evidence in DAL A audit trail
+DAL A audit evidence SHALL include the result of each adversarial test category from `crates/red-team-tests/`, archived per release.
+
+#### Scenario: Release archives include red-team report
+- **WHEN** a release is tagged from `main`
+- **THEN** the release artifacts MUST include the `red-team-suite` CI job log and the playbook revision hash
+
+### Requirement: CI gates red-team suite
+The CI pipeline SHALL run `red-team-suite` on every PR targeting `develop` or `main`, advisory initially and blocking once stable per the gating policy in `docs/red-team-playbook.md`.
+
+#### Scenario: Suite is advisory before promotion
+- **WHEN** the suite has fewer than 5 consecutive green `develop` runs
+- **THEN** the job is marked `continue-on-error: true`
+
+#### Scenario: Suite is blocking after promotion
+- **WHEN** the suite has 5+ consecutive green `develop` runs
+- **THEN** the job is required for PR merge and the promotion is recorded in the playbook "Gating history" section

--- a/openspec/changes/formal-proving-and-redteam-v1/specs/13-formal-verification/spec.md
+++ b/openspec/changes/formal-proving-and-redteam-v1/specs/13-formal-verification/spec.md
@@ -1,0 +1,74 @@
+## MODIFIED Requirements
+
+### Requirement: Lean 4 proofs are machine-checked
+The existing Lean 4 proofs in `formal/lean4/` SHALL be type-checked by CI on every pull request. Lean 4 SHALL no longer be described as "aspirational" in this specification.
+
+#### Scenario: PR triggers `lean-verify`
+- **WHEN** a developer opens a PR
+- **THEN** the `lean-verify` job runs `lake build` and fails the PR if any proof fails to typecheck
+
+#### Scenario: Cached vs cold build
+- **WHEN** the CI cache is warm
+- **THEN** `lean-verify` completes in under 2 minutes
+- **AND** when cold, under 8 minutes
+
+#### Scenario: Toolchain pin is honored
+- **WHEN** a contributor changes `formal/lean4/lean-toolchain`
+- **THEN** `elan` installs the pinned version and `lake build` re-runs against that version
+
+## ADDED Requirements
+
+### Requirement: Lean 4 toolchain is pinned and reproducible
+The Lean 4 toolchain version SHALL be declared in `formal/lean4/lean-toolchain` and consumed by `elan`. The package SHALL be declared via `formal/lean4/lakefile.lean` using `lake` (not `leanpkg`).
+
+#### Scenario: CI installs pinned elan and Lean version
+- **WHEN** CI runs `lean-verify`
+- **THEN** it installs `elan` from a pinned commit, reads the toolchain version from `lean-toolchain`, and uses `lake build` to compile every `.lean` file under `formal/lean4/`
+
+#### Scenario: Toolchain bump goes through PR review
+- **WHEN** a PR introduces a Lean version not yet vetted
+- **THEN** the PR author updates `lean-toolchain` and re-runs the gate as part of review
+
+### Requirement: Capability delegation monotonicity is model-checked
+`formal/tla/CapabilitySecurity.tla` SHALL define and check a `DelegationMonotonicity` invariant ensuring every delegated capability's permission set is a subset of its parent's, and a `CapabilityIdStrictlyIncreasing` invariant ensuring the global capability ID counter is monotonic with no reuse.
+
+#### Scenario: TLC reports zero counterexamples
+- **WHEN** TLC runs `CapabilitySecurity.tla`
+- **THEN** it explores the state space and reports zero counterexamples for both invariants
+
+#### Scenario: Privilege-escalating change fails the gate
+- **WHEN** a future change introduces a delegation operation that grants extra rights
+- **THEN** TLC produces a counterexample trace and the `tla-verify` CI job fails
+
+### Requirement: Scheduler state-machine fairness is model-checked
+`formal/tla/SchedStateMachine.tla` SHALL model task transitions across `Ready`, `Running`, `Yielded`, `Blocked` states and check both safety (at most one task `Running` per core; no `Blocked → Running` shortcut) and LTL liveness (every `Ready` task is eventually `Running` under weak fairness on dispatch).
+
+#### Scenario: TLC succeeds at bounded sizes
+- **WHEN** TLC runs `SchedStateMachine.tla` at `N_CORES = 3` and `N_TASKS = 6`
+- **THEN** it reports zero counterexamples for the safety invariants and the LTL liveness property
+
+#### Scenario: Matrix wall-time stays under budget
+- **WHEN** the model is added to the `tla-verify` matrix
+- **THEN** the matrix grows from 22 to 23 models and total wall time stays under the 5-minute CI budget
+
+### Requirement: SMT-based proofs of low-level invariants are gated on CI
+The `smallaios-kernel` crate SHALL expose an opt-in `formal-smt` feature that pulls in the `z3` Cargo crate (with `bundled` Z3) and registers SMT-backed proofs as integration tests. CI SHALL run a `smt-verify` advisory job that builds the crate with `--features formal-smt` and executes those tests.
+
+#### Scenario: Default build is unaffected
+- **WHEN** `formal-smt` is disabled (the default)
+- **THEN** the kernel crate builds with no Z3 dependency and `#![no_std]` targets are unaffected
+
+#### Scenario: Opt-in build runs SMT proofs
+- **WHEN** `formal-smt` is enabled
+- **THEN** `cargo test -p smallaios-kernel --features formal-smt` runs the SMT proof suite, reports UNSAT for each proof obligation, and exits 0
+
+### Requirement: Bump allocator pointer monotonicity is SMT-proven
+The first SMT proof under `kernel/proofs/bump_allocator_smt.rs` SHALL encode `BumpAllocator` state (`base`, `current`, `end`) as 64-bit bitvectors and prove, by bounded model checking up to `N = 8` sequential `alloc(size)` calls, that `current` is monotonically non-decreasing and `current ≤ end` is invariant.
+
+#### Scenario: Z3 returns UNSAT on the negation
+- **WHEN** `smt-verify` runs the bump-allocator proof
+- **THEN** Z3 returns UNSAT on the negation of the monotonicity assertion for every `N` from 1 to 8
+
+#### Scenario: Mutated post-condition fails fast
+- **WHEN** a developer mutates the post-condition to a known-false form
+- **THEN** Z3 returns SAT and the test fails fast with a model witness logged

--- a/openspec/changes/formal-proving-and-redteam-v1/tasks.md
+++ b/openspec/changes/formal-proving-and-redteam-v1/tasks.md
@@ -1,0 +1,191 @@
+# Tasks — formal-proving-and-redteam-v1
+
+Three phases. Each phase has explicit exit criteria. Sub-changes may split phases for separate landing.
+
+---
+
+## Phase 1: Verification stack expansion (~3 weeks)
+
+### 1.1 Lean 4 CI integration
+
+- [ ] 1.1.1 Add `formal/lean4/lean-toolchain` pinning `leanprover/lean4:v4.15.0`
+- [ ] 1.1.2 Audit existing 6 proofs for `mathlib` imports and document findings in `formal/lean4/README.md`; decide vendor-vs-cache strategy
+- [ ] 1.1.3 Add `formal/lean4/lakefile.lean` declaring the `SmallAIOSProofs` package and any required dependencies (mathlib gated on §1.1.2 outcome)
+- [ ] 1.1.4 Verify `lake build` succeeds locally for `CapabilityNonForgery.lean`, `InformationFlow.lean`, `IntegrityLattice.lean`, `LabelComposition.lean`, `MessageTypeProperties.lean`, `TensorTypeInvariants.lean`
+- [ ] 1.1.5 Add `lean-verify` job to `.github/workflows/ci.yml`: install `elan` (pinned commit), run `lake build` from `formal/lean4/`
+- [ ] 1.1.6 Add GitHub Actions cache for `formal/lean4/.lake/build/` and `~/.elan/toolchains/` keyed on hash of `lean-toolchain` + `lakefile.lean`
+- [ ] 1.1.7 Wire `lean-verify` into the `change-gates` meta-job as a **required** check (hard gate)
+- [ ] 1.1.8 Update `CLAUDE.md` and `docs/architecture.md` to list `lean-verify` in the gate-jobs table
+- [ ] 1.1.9 **Verification:** open a draft PR that introduces a deliberately broken `lean-toolchain` version and confirm `lean-verify` fails the PR; revert before merge
+
+### 1.2 TLA+ gap-fill
+
+- [ ] 1.2.1 Extend `formal/tla/CapabilitySecurity.tla` with `DelegationMonotonicity` invariant: `\A edge \in DelegationGraph: edge.child.rights \subseteq edge.parent.rights`
+- [ ] 1.2.2 Extend `formal/tla/CapabilitySecurity.tla` with `CapabilityIdStrictlyIncreasing` invariant on the global ID counter, and prove fresh IDs are strictly greater than any prior live ID
+- [ ] 1.2.3 Update `formal/tla/CapabilitySecurity.cfg` to declare both new invariants under `INVARIANTS`
+- [ ] 1.2.4 Confirm `CapabilitySecurity` TLC run still finishes inside the 5-minute CI budget at existing bounds; reduce bounds if needed and document in the model header
+- [ ] 1.2.5 Create `formal/tla/SchedStateMachine.tla` modeling task states (`Ready`, `Running`, `Yielded`, `Blocked`) and transitions per design §D1.2
+- [ ] 1.2.6 Add safety invariants: `AtMostOneRunningPerCore`, `NoBlockedToRunningWithoutReady`
+- [ ] 1.2.7 Add LTL liveness property: `[]<>(t \in ReadyTasks => <>(t \in RunningTasks))` under weak fairness on the dispatch action
+- [ ] 1.2.8 Create `formal/tla/SchedStateMachine.cfg` bounded at `N_CORES = 3`, `N_TASKS = 6`
+- [ ] 1.2.9 Wire `SchedStateMachine` into `.github/workflows/ci.yml` `tla-verify` matrix (the existing 22-model job — bumps to 23)
+- [ ] 1.2.10 Update `openspec/smallaios-kernel/specs/13-formal-verification.md` to list both extensions and the new `SchedStateMachine` model
+- [ ] 1.2.11 **Verification:** TLC reports zero counterexamples for all new invariants and the LTL property; total `tla-verify` job wall time stays under the 5-minute budget
+
+### 1.3 SMT solver scaffolding
+
+- [ ] 1.3.1 Add `formal-smt` feature flag to `kernel/Cargo.toml` with `optional = true` dep `z3 = { version = "0.12", features = ["bundled"] }`
+- [ ] 1.3.2 Document the `formal-smt` feature in `CLAUDE.md` "Crate Feature Flags" — opt-in, pulls Z3, requires `std`
+- [ ] 1.3.3 Create `kernel/proofs/mod.rs` (gated `#[cfg(feature = "formal-smt")]`) holding shared SMT helpers (Context, Solver, BV builder)
+- [ ] 1.3.4 Create `kernel/proofs/bump_allocator_smt.rs`: encode `BumpAllocator` `(base, current, end)` state as 64-bit BVs
+- [ ] 1.3.5 Encode the `alloc(size)` post-condition: `current' = current + size /\ current' <= end`
+- [ ] 1.3.6 Prove pointer monotonicity over `N = 8` bounded sequential allocations: `current_after >= current_before` and `current_after <= end` for all reachable states; assert via `solver.check_assumptions(...) == Unsat` on the negation
+- [ ] 1.3.7 Add a `smt-verify` advisory job to `.github/workflows/ci.yml` running `cargo test -p smallaios-kernel --features formal-smt --test bump_allocator_smt`
+- [ ] 1.3.8 Cache the bundled-Z3 build artifact in CI (target/release/build/z3-sys-*) keyed on `z3-sys` version
+- [ ] 1.3.9 Update `openspec/smallaios-kernel/specs/13-formal-verification.md` with a new "SMT (Z3)" section listing the feature flag, first proof, and CI job
+- [ ] 1.3.10 **Verification:** `smt-verify` CI job succeeds, prints the SAT/UNSAT result for the monotonicity query, and fails fast on a deliberately mutated post-condition (smoke-test the negative path locally before merge)
+
+### 1.4 Phase 1 exit criteria
+
+- [ ] 1.4.1 All 6 existing Lean 4 proofs build in CI as a hard gate
+- [ ] 1.4.2 `CapabilitySecurity.tla` checks `DelegationMonotonicity` and `CapabilityIdStrictlyIncreasing` in CI
+- [ ] 1.4.3 `SchedStateMachine.tla` checks safety invariants and LTL liveness in CI (bringing the TLA+ corpus to 23 models)
+- [ ] 1.4.4 Z3-backed bump-allocator monotonicity proof runs in the new `smt-verify` CI job
+- [ ] 1.4.5 `docs/architecture.md`, `CLAUDE.md`, and spec 13 reflect the new gates and feature flag
+
+---
+
+## Phase 2: Fuzzing expansion + crypto KAT (~3 weeks)
+
+### 2.1 Syscall ABI fuzzer
+
+- [ ] 2.1.1 Add `cfg(fuzzing)` shim `kernel::syscall::dispatch_for_fuzz()` exporting dispatch with the `MockKernel` backend
+- [ ] 2.1.2 Implement `MockKernel` in `fuzz/src/mock_kernel.rs` — capability table with monotone generations, stub allocator, stub IPC ring
+- [ ] 2.1.3 Per-family `arbitrary::Arbitrary` impls in `fuzz/fuzz_targets/syscall_args.rs` (Cap, Mem, Tensor, Ipc, Device)
+- [ ] 2.1.4 Create `fuzz/fuzz_targets/fuzz_syscall_abi.rs` driving `dispatch_for_fuzz()` on `SyscallCall { number: u32, args: Vec<u8> }`
+- [ ] 2.1.5 Generate seed corpus from `kernel/tests/syscall_*.rs` via `cargo run -p smallaios-kernel --example dump_syscall_corpus`
+- [ ] 2.1.6 Coverage: out-of-range numbers, malformed lengths, forged handles, expired generations, wrong-type tags, resource exhaustion
+- [ ] 2.1.7 Assert no panics; assert `MockKernel` invariants after every call
+- [ ] 2.1.8 Add to `.github/workflows/ci.yml` fuzz matrix: 60 s PR CI, 1 h nightly cron
+- [ ] 2.1.9 Document harness + `MockKernel` limitations in `fuzz/README.md`
+
+### 2.2 PQC differential fuzz
+
+- [ ] 2.2.1 Add `pqcrypto-kyber = "0.8"` and `pqcrypto-dilithium = "0.5"` to `fuzz/Cargo.toml` `[dev-dependencies]`
+- [ ] 2.2.2 Create `fuzz/fuzz_targets/fuzz_pqc_mlkem768.rs` — seeded keygen + encapsulate; assert bit-for-bit `ct` + `ss` equality vs `pqcrypto-kyber`
+- [ ] 2.2.3 Round-trip path: own-impl encapsulate → ref decapsulate, and reverse; assert shared secrets match
+- [ ] 2.2.4 Create `fuzz/fuzz_targets/fuzz_pqc_mldsa65.rs` — seeded keygen + sign; assert byte-equal signatures vs `pqcrypto-dilithium` derand path
+- [ ] 2.2.5 Cross-verify: own-impl sign → ref verify, ref sign → own-impl verify
+- [ ] 2.2.6 Surface failures with hex-dumped seeds, `pk`, `sk`, message, expected/actual output
+- [ ] 2.2.7 Coverage target: every path in `security/src/crypto/{mlkem768,mldsa65}.rs` reached within 2^16 iterations; archive `cargo-fuzz coverage` HTML as a nightly CI artifact
+- [ ] 2.2.8 Document differential model in `docs/pqc-differential-fuzz.md`
+
+### 2.3 NIST KAT vectors
+
+- [ ] 2.3.1 Add `pqc-kat` feature to `security/Cargo.toml` (test-only)
+- [ ] 2.3.2 Vendor `.rsp` files from FIPS 203 / 204 reference packages under `security/tests/kat-vectors/{mlkem768,mldsa65}/`
+- [ ] 2.3.3 Add `security/tests/kat-vectors/SHA256SUMS`; harness rejects mismatched digests at setup
+- [ ] 2.3.4 Add `scripts/refresh-pqc-kats.sh` — downloads from canonical NIST URLs, updates `SHA256SUMS`, requires manual review before commit
+- [ ] 2.3.5 Implement shared `security/tests/kat_parser.rs` — `KEY = HEX` parser yielding `Iterator<Item = KatVector>`
+- [ ] 2.3.6 Implement `security/tests/kat_mlkem768.rs` — drive `keypair_from_seed`, `encapsulate_derand`, `decapsulate`; assert byte-exact `pk`, `sk`, `ct`, `ss`
+- [ ] 2.3.7 Implement `security/tests/kat_mldsa65.rs` — drive `keypair_from_seed`, `sign_derand`, `verify`; assert byte-exact `pk`, `sk`, `sig`
+- [ ] 2.3.8 Add CI job `pqc-kat-verify` (`cargo test -p smallaios-security --features pqc-kat`); **required check** on `develop` and `main`
+- [ ] 2.3.9 Document harness, refresh procedure, version pinning in `docs/pqc-kat.md`
+
+### 2.4 Side-channel guardrails (stretch — advisory)
+
+- [ ] 2.4.1 Audit `security/src/crypto/{mlkem768,mldsa65}.rs` for data-dependent branches; tag leaky ops `// NOT-CT:` + rationale
+- [ ] 2.4.2 Replace plain `==` ciphertext / tag comparisons with `subtle::ConstantTimeEq`
+- [ ] 2.4.3 Write `docs/pqc-side-channel.md` documenting CT invariants per primitive (NTT, rejection sampling, comparison)
+- [ ] 2.4.4 Add `dudect-rs` dev-dep + `security/tests/timing_mlkem768.rs` and `timing_mldsa65.rs`
+- [ ] 2.4.5 Add weekly CI job `pqc-timing-leak` (advisory; t > 4.5 → warning) on `self-hosted-isolated` runner
+- [ ] 2.4.6 [DEFERRED] `ct-verif` / Jasmin-based formal CT proofs — follow-up change; multi-week effort
+
+### 2.5 CI integration & docs
+
+- [ ] 2.5.1 Update `.github/workflows/ci.yml` fuzz matrix: add `fuzz_syscall_abi`, `fuzz_pqc_mlkem768`, `fuzz_pqc_mldsa65`
+- [ ] 2.5.2 Wire `pqc-kat-verify` into the `change-gates` meta-job as a blocking gate
+- [ ] 2.5.3 Add `pqc-timing-leak` as an advisory weekly job
+- [ ] 2.5.4 Update `CLAUDE.md` "CI/CD" section with the three new jobs and the `pqc-kat` feature
+- [ ] 2.5.5 Update `fuzz/README.md` with new target descriptions, corpus locations, reproduction commands
+- [ ] 2.5.6 Cross-link `docs/pqc-side-channel.md`, `docs/pqc-kat.md`, `docs/pqc-differential-fuzz.md` from `docs/security.md`
+
+### 2.6 Phase 2 exit criteria
+
+- [ ] 2.6.1 Syscall ABI fuzz target runs 60 s in PR CI without panics or invariant violations
+- [ ] 2.6.2 PQC differential fuzz targets pass bit-for-bit on deterministic API and round-trip on non-deterministic API
+- [ ] 2.6.3 NIST KAT verification is a blocking CI gate for ML-KEM-768 and ML-DSA-65
+- [ ] 2.6.4 PQC side-channel invariants documented; equality-on-secret uses `subtle::ConstantTimeEq` everywhere
+- [ ] 2.6.5 `dudect`-style timing-leak job runs weekly as advisory
+
+---
+
+## Phase 3: Red-team / adversarial test suite (~3-4 weeks)
+
+### 3.1 Adversarial corpus, playbook, and attack-surface docs
+
+- [ ] 3.1.1 Create `docs/red-team-playbook.md` with sections: Scope, Scenario Catalog, Gating Policy, Gating History, Reporting
+- [ ] 3.1.2 Populate Scenario Catalog with 5 categories (capability, ONNX, IPC, boot, network), each row mapping to threat-model line(s) in `openspec/smallaios-kernel/specs/06-security-model.md` and to a test module name in `crates/red-team-tests/`
+- [ ] 3.1.3 Create `docs/attack-surface.md` per design §D3.4 — table of all external interfaces with adversarial coverage status
+- [ ] 3.1.4 Cross-link `docs/red-team-playbook.md` from `docs/security/security-governance.md` (CCB review duty) and from `openspec/smallaios-kernel/specs/12-safety-critical.md` (DAL A audit evidence)
+- [ ] 3.1.5 Add `just red-team` recipe stub to `Justfile` (runs the crate test once the scaffold lands in 3.2)
+
+### 3.2 Adversarial test crate scaffold
+
+- [ ] 3.2.1 Add `crates/red-team-tests/` to workspace `Cargo.toml` members list
+- [ ] 3.2.2 Create `crates/red-team-tests/Cargo.toml` with `[features] red-team = []`, dev-dependencies on `proptest`, `arbitrary`
+- [ ] 3.2.3 Create `crates/red-team-tests/src/lib.rs` with attack helper modules: `forge`, `corpus`, `assert_refused`, `assert_audit_logged`
+- [ ] 3.2.4 Create `crates/red-team-tests/tests/` directory with one empty integration test per category (capability, onnx, ipc, boot, net) returning `Ok(())` — fills out in 3.3-3.7
+- [ ] 3.2.5 Document corpus layout `crates/red-team-tests/corpus/{onnx,net,ipc}/seeds/`
+
+### 3.3 Capability-violation suite (proptest + integration)
+
+- [ ] 3.3.1 Implement `prop_delegation_subset_rights` (D3.3 P1)
+- [ ] 3.3.2 Implement `prop_revocation_cascades` (D3.3 P2)
+- [ ] 3.3.3 Implement `prop_cap_id_unique` (D3.3 P3)
+- [ ] 3.3.4 Implement `prop_no_upgrade_via_alias` (D3.3 P4)
+- [ ] 3.3.5 Implement `prop_quota_monotone` (D3.3 P5)
+- [ ] 3.3.6 Implement `prop_audit_log_complete` (D3.3 P6)
+- [ ] 3.3.7 Integration test: forge fake capability handle, attempt `ipc_send` on un-delegated topic — assert refused + audit-logged
+
+### 3.4 ONNX graph injection suite
+
+- [ ] 3.4.1 Add malformed protobuf seeds: cyclic graph, op-count overflow, attribute type confusion (3 seed files)
+- [ ] 3.4.2 Resource-exhaustion graph (initializer >100 MB) — assert load fails before allocation
+- [ ] 3.4.3 Deeply-nested subgraph (depth >64) — assert recursion bound rejection
+- [ ] 3.4.4 Hook into existing fuzz target naming (`onnx_parser_fuzz`) to share corpus seeds
+
+### 3.5 IPC amplification / DoS suite
+
+- [ ] 3.5.1 Topic-flood test: spawn N publishers on one topic, assert back-pressure and no panic
+- [ ] 3.5.2 Circular-wait deadlock test: 3-node ring with timeout assertion
+- [ ] 3.5.3 Broken topic permission bypass: attempt subscribe without capability — assert refused
+
+### 3.6 Boot integrity suite
+
+- [ ] 3.6.1 Multiboot2 header bit-flip corpus + replay test asserts kernel halts with audit entry
+- [ ] 3.6.2 Malformed DTB (truncated / cyclic phandle) — assert rejection at parse
+- [ ] 3.6.3 Fake measurement test: replay log with mismatched hash — assert verified-boot feature gate refuses to continue
+- [ ] 3.6.4 Document Phase-3 boot coverage gap (UEFI / TPM / TrustZone) in `docs/boot-security-matrix.md` § "Adversarial coverage"
+
+### 3.7 Network protocol abuse suite
+
+- [ ] 3.7.1 Malformed TCP option corpus beyond fuzzer seeds (TS-Echo, MD5 sig)
+- [ ] 3.7.2 UDP amplification reflection scenario — assert rate limit
+- [ ] 3.7.3 QUIC handshake manipulation: replay ClientHello with invalid PQC key share — assert TLS abort
+- [ ] 3.7.4 DNS resolver attacks (if resolver active in build) — assert refused or marked N/A in playbook
+
+### 3.8 CI integration
+
+- [ ] 3.8.1 Add `red-team-suite` job to `.github/workflows/ci.yml`, runs `cargo test -p red-team-tests --features red-team`
+- [ ] 3.8.2 Initially marked `continue-on-error: true` (advisory per D3.2 gating policy)
+- [ ] 3.8.3 Upload corpus failures as workflow artifacts
+- [ ] 3.8.4 After 5 green `develop` runs, flip to blocking and add entry to "Gating history" in `docs/red-team-playbook.md`
+- [ ] 3.8.5 Cross-reference `red-team-suite` from NIST 800-53 SSP `docs/security/nist-800-53-ssp.md` controls CA-8 (Penetration Testing) and SI-3 (Malicious Code Protection)
+
+### 3.9 Phase 3 exit criteria
+
+- [ ] 3.9.1 `docs/red-team-playbook.md` covers all 5 categories with threat-model line refs
+- [ ] 3.9.2 `crates/red-team-tests/` implements 6 property tests + 5 integration suites
+- [ ] 3.9.3 `red-team-suite` is at least advisory-green on `develop` for 1 release cycle
+- [ ] 3.9.4 `docs/attack-surface.md` enumerates every external interface with current coverage status


### PR DESCRIPTION
## Summary

Umbrella OpenSpec change for ~9-10 weeks of formal verification + adversarial-testing work to close DAL A traceability gaps. Structured as three phases that can land independently as sub-changes.

| Phase | Scope | Effort |
|-------|-------|--------|
| 1 — Verification stack | Lean 4 → hard-gate CI + TLA+ extensions (capability monotonicity, scheduler state-machine fairness) + SMT scaffolding (Z3, first proof on `BumpAllocator`) | ~3 weeks |
| 2 — Fuzzing + crypto KAT | Syscall ABI fuzzer (~65 syscalls), PQC differential fuzz vs `pqcrypto-kyber`/`pqcrypto-dilithium`, NIST FIPS 203/204 KAT vectors, optional `dudect` advisory | ~3 weeks |
| 3 — Red-team adversarial suite | New `crates/red-team-tests/` + `proptest` capability invariants + scenario suites + `docs/red-team-playbook.md` + `docs/attack-surface.md` | ~3-4 weeks |

## Why this matters

Per the inventory captured during proposal drafting:
- **Lean 4** proofs in `formal/lean4/` are *aspirational text* — never type-checked in CI.
- **TLA+** corpus has 25 models in CI but lacks two load-bearing invariant families: capability delegation monotonicity (non-forgery keystone) and scheduler state-machine fairness (cooperative-async / WCET keystone).
- **SMT** coverage is **zero** — no Z3/CVC5/Yices/Bitwuzla bindings, no .smt2 files, no Rust crate deps.
- **Syscall ABI** (~65 syscalls) has zero adversarial coverage.
- **PQC** (ML-KEM-768, ML-DSA-65) has no NIST KAT validation, no differential fuzz vs reference.
- **Threat model** is documented but unexercised — no adversarial test corpus, no attack-surface inventory, no red-team playbook.

## What ships in this PR

**Docs only.** This is the umbrella roadmap proposal. Code lands in sub-changes per phase.

- `openspec/changes/formal-proving-and-redteam-v1/proposal.md`
- `openspec/changes/formal-proving-and-redteam-v1/design.md` (D1.1–D1.4, D2.1–D2.5, D3.1–D3.5 decisions documented)
- `openspec/changes/formal-proving-and-redteam-v1/tasks.md` (119 tasks across 3 phases with exit criteria)
- `openspec/changes/formal-proving-and-redteam-v1/.openspec.yaml`
- 4 spec deltas:
  - `specs/13-formal-verification/spec.md` — 1 MODIFIED + 5 ADDED requirements
  - `specs/08-crypto-hardware-security/spec.md` — 3 ADDED
  - `specs/12-safety-critical/spec.md` — 1 MODIFIED + 4 ADDED
  - `specs/06-security-model/spec.md` — 4 ADDED

## Out of scope (explicit)

- Lifting Lean 4 proofs to Rust via `aeneas` / `verus` / `creusot`
- Bare-metal Miri (target-support gap)
- Formal CT proofs via `ct-verif` / Jasmin (Phase 2 stops at `dudect` advisory)
- UEFI / TPM / TrustZone adversarial coverage (boot matrix shows No/Partial)
- Capability-system Kani harnesses (Phase 4 follow-up)
- SMT proofs of cryptographic primitives (first SMT proof targets `BumpAllocator` to validate scaffolding)

## Test plan

- [ ] OpenSpec structure validation passes (file naming, spec format)
- [ ] CI green (this is a docs-only change; expect format / clippy / unit / build / TLA+ / SPIN to all pass unchanged)
- [ ] Reviewer sign-off on phase scoping + sequencing before Phase 1 implementation begins

## Drafted via parallel agent teams

Three subagents drafted Phase 1, Phase 2, and Phase 3 sections in parallel (`_drafts/` working dir, since cleaned up). Final assembly normalized the spec-delta format to match prior changes (`### Requirement:` under `## ADDED Requirements` / `## MODIFIED Requirements` headers, `#### Scenario:` blocks with WHEN/THEN bullets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Introduced formal verification framework with Lean 4 proof CI enforcement and TLA+ model verification
* Added red-team and adversarial testing specification including attack surface inventory and playbook structure
* Established post-quantum cryptography security requirements with KAT verification and differential fuzzing
* Defined new safety-critical CI gates for syscall ABI fuzzing and security testing coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->