### PR TITLE
feat(container): jetson-orin-container-v1 — Jetson Orin GPU + cuda fix

### DIFF
--- a/.claude/commands/opsx/bulk-archive.md
+++ b/.claude/commands/opsx/bulk-archive.md
@@ -80,7 +80,7 @@ This skill allows you to batch-archive changes, handling spec conflicts intellig
    Display a table summarizing all changes:
 
    ```
-   | Change               | Artifacts | Tasks | Specs   | Conflicts | Status |
+   | Change              | Artifacts | Tasks | Specs   | Conflicts | Status |
    |---------------------|-----------|-------|---------|-----------|--------|
    | schema-management   | Done      | 5/5   | 2 delta | None      | Ready  |
    | project-config      | Done      | 3/3   | 1 delta | None      | Ready  |

--- a/.claude/commands/opsx/onboard.md
+++ b/.claude/commands/opsx/onboard.md
@@ -464,21 +464,21 @@ This same rhythm works for any size change—a small fix or a major feature.
 
 **Core workflow:**
 
-| Command | What it does |
-|---------|--------------|
-| `/opsx:propose` | Create a change and generate all artifacts |
-| `/opsx:explore` | Think through problems before/during work |
-| `/opsx:apply` | Implement tasks from a change |
-| `/opsx:archive` | Archive a completed change |
+ | Command           | What it does                               |
+ |-------------------|--------------------------------------------|
+ | `/opsx:propose` | Create a change and generate all artifacts |
+ | `/opsx:explore` | Think through problems before/during work  |
+ | `/opsx:apply`   | Implement tasks from a change              |
+ | `/opsx:archive` | Archive a completed change                 |
 
 **Additional commands:**
 
-| Command | What it does |
-|---------|--------------|
-| `/opsx:new` | Start a new change, step through artifacts one at a time |
-| `/opsx:continue` | Continue working on an existing change |
-| `/opsx:ff` | Fast-forward: create all artifacts at once |
-| `/opsx:verify` | Verify implementation matches artifacts |
+ | Command            | What it does                                             |
+ |--------------------|----------------------------------------------------------|
+ | `/opsx:new`      | Start a new change, step through artifacts one at a time |
+ | `/opsx:continue` | Continue working on an existing change                   |
+ | `/opsx:ff`       | Fast-forward: create all artifacts at once               |
+ | `/opsx:verify`   | Verify implementation matches artifacts                  |
 
 ---
 
@@ -516,21 +516,21 @@ If the user says they just want to see the commands or skip the tutorial:
 
 **Core workflow:**
 
-| Command | What it does |
-|---------|--------------|
-| `/opsx:propose <name>` | Create a change and generate all artifacts |
-| `/opsx:explore` | Think through problems (no code changes) |
-| `/opsx:apply <name>` | Implement tasks |
-| `/opsx:archive <name>` | Archive when done |
+ | Command                  | What it does                               |
+ |--------------------------|--------------------------------------------|
+ | `/opsx:propose <name>` | Create a change and generate all artifacts |
+ | `/opsx:explore`        | Think through problems (no code changes)   |
+ | `/opsx:apply <name>`   | Implement tasks                            |
+ | `/opsx:archive <name>` | Archive when done                          |
 
 **Additional commands:**
 
-| Command | What it does |
-|---------|--------------|
-| `/opsx:new <name>` | Start a new change, step by step |
-| `/opsx:continue <name>` | Continue an existing change |
-| `/opsx:ff <name>` | Fast-forward: all artifacts at once |
-| `/opsx:verify <name>` | Verify implementation |
+ | Command                   | What it does                        |
+ |---------------------------|-------------------------------------|
+ | `/opsx:new <name>`      | Start a new change, step by step    |
+ | `/opsx:continue <name>` | Continue an existing change         |
+ | `/opsx:ff <name>`       | Fast-forward: all artifacts at once |
+ | `/opsx:verify <name>`   | Verify implementation               |
 
 Try `/opsx:propose` to start your first change.
 ```

--- a/.claude/commands/opsx/verify.md
+++ b/.claude/commands/opsx/verify.md
@@ -35,7 +35,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
    openspec instructions apply --change "<name>" --json
    ```
 
-   This returns the change directory and context files. Read all available artifacts from `contextFiles`.
+   This returns the change directory and `contextFiles` (artifact ID -> array of concrete file paths). Read all available artifacts from `contextFiles`.
 
 4. **Initialize verification report structure**
 
@@ -49,7 +49,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
 5. **Verify Completeness**
 
    **Task Completion**:
-   - If tasks.md exists in contextFiles, read it
+   - If `contextFiles.tasks` exists, read every file path in it
    - Parse checkboxes: `- [ ]` (incomplete) vs `- [x]` (complete)
    - Count complete vs total tasks
    - If incomplete tasks exist:
@@ -88,7 +88,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
 7. **Verify Coherence**
 
    **Design Adherence**:
-   - If design.md exists in contextFiles:
+   - If `contextFiles.design` exists:
      - Extract key decisions (look for sections like "Decision:", "Approach:", "Architecture:")
      - Verify implementation follows those decisions
      - If contradiction detected:

--- a/.claude/skills/openspec-bulk-archive-change/SKILL.md
+++ b/.claude/skills/openspec-bulk-archive-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.3.1"
 ---
 
 Archive multiple completed changes in a single operation.
@@ -84,7 +84,7 @@ This skill allows you to batch-archive changes, handling spec conflicts intellig
    Display a table summarizing all changes:
 
    ```
-   | Change               | Artifacts | Tasks | Specs   | Conflicts | Status |
+   | Change              | Artifacts | Tasks | Specs   | Conflicts | Status |
    |---------------------|-----------|-------|---------|-----------|--------|
    | schema-management   | Done      | 5/5   | 2 delta | None      | Ready  |
    | project-config      | Done      | 3/3   | 1 delta | None      | Ready  |

--- a/.claude/skills/openspec-continue-change/SKILL.md
+++ b/.claude/skills/openspec-continue-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.3.1"
 ---
 
 Continue working on a change by creating the next artifact.

--- a/.claude/skills/openspec-ff-change/SKILL.md
+++ b/.claude/skills/openspec-ff-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.3.1"
 ---
 
 Fast-forward through artifact creation - generate everything needed to start implementation in one go.

--- a/.claude/skills/openspec-new-change/SKILL.md
+++ b/.claude/skills/openspec-new-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.3.1"
 ---
 
 Start a new change using the experimental artifact-driven approach.

--- a/.claude/skills/openspec-onboard/SKILL.md
+++ b/.claude/skills/openspec-onboard/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.3.1"
 ---
 
 Guide the user through their first complete OpenSpec workflow cycle. This is a teaching experience—you'll do real work in their codebase while explaining each step.
@@ -468,21 +468,21 @@ This same rhythm works for any size change—a small fix or a major feature.
 
 **Core workflow:**
 
-| Command | What it does |
-|---------|--------------|
-| `/opsx:propose` | Create a change and generate all artifacts |
-| `/opsx:explore` | Think through problems before/during work |
-| `/opsx:apply` | Implement tasks from a change |
-| `/opsx:archive` | Archive a completed change |
+ | Command           | What it does                               |
+ |-------------------|--------------------------------------------|
+ | `/opsx:propose` | Create a change and generate all artifacts |
+ | `/opsx:explore` | Think through problems before/during work  |
+ | `/opsx:apply`   | Implement tasks from a change              |
+ | `/opsx:archive` | Archive a completed change                 |
 
 **Additional commands:**
 
-| Command | What it does |
-|---------|--------------|
-| `/opsx:new` | Start a new change, step through artifacts one at a time |
-| `/opsx:continue` | Continue working on an existing change |
-| `/opsx:ff` | Fast-forward: create all artifacts at once |
-| `/opsx:verify` | Verify implementation matches artifacts |
+ | Command            | What it does                                             |
+ |--------------------|----------------------------------------------------------|
+ | `/opsx:new`      | Start a new change, step through artifacts one at a time |
+ | `/opsx:continue` | Continue working on an existing change                   |
+ | `/opsx:ff`       | Fast-forward: create all artifacts at once               |
+ | `/opsx:verify`   | Verify implementation matches artifacts                  |
 
 ---
 
@@ -520,21 +520,21 @@ If the user says they just want to see the commands or skip the tutorial:
 
 **Core workflow:**
 
-| Command | What it does |
-|---------|--------------|
-| `/opsx:propose <name>` | Create a change and generate all artifacts |
-| `/opsx:explore` | Think through problems (no code changes) |
-| `/opsx:apply <name>` | Implement tasks |
-| `/opsx:archive <name>` | Archive when done |
+ | Command                  | What it does                               |
+ |--------------------------|--------------------------------------------|
+ | `/opsx:propose <name>` | Create a change and generate all artifacts |
+ | `/opsx:explore`        | Think through problems (no code changes)   |
+ | `/opsx:apply <name>`   | Implement tasks                            |
+ | `/opsx:archive <name>` | Archive when done                          |
 
 **Additional commands:**
 
-| Command | What it does |
-|---------|--------------|
-| `/opsx:new <name>` | Start a new change, step by step |
-| `/opsx:continue <name>` | Continue an existing change |
-| `/opsx:ff <name>` | Fast-forward: all artifacts at once |
-| `/opsx:verify <name>` | Verify implementation |
+ | Command                   | What it does                        |
+ |---------------------------|-------------------------------------|
+ | `/opsx:new <name>`      | Start a new change, step by step    |
+ | `/opsx:continue <name>` | Continue an existing change         |
+ | `/opsx:ff <name>`       | Fast-forward: all artifacts at once |
+ | `/opsx:verify <name>`   | Verify implementation               |
 
 Try `/opsx:propose` to start your first change.
 ```

--- a/.claude/skills/openspec-sync-specs/SKILL.md
+++ b/.claude/skills/openspec-sync-specs/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.3.1"
 ---
 
 Sync delta specs from a change to main specs.

--- a/.claude/skills/openspec-verify-change/SKILL.md
+++ b/.claude/skills/openspec-verify-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.2.0"
+  generatedBy: "1.3.1"
 ---
 
 Verify that an implementation matches the change artifacts (specs, tasks, design).
@@ -39,7 +39,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
    openspec instructions apply --change "<name>" --json
    ```
 
-   This returns the change directory and context files. Read all available artifacts from `contextFiles`.
+   This returns the change directory and `contextFiles` (artifact ID -> array of concrete file paths). Read all available artifacts from `contextFiles`.
 
 4. **Initialize verification report structure**
 
@@ -53,7 +53,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
 5. **Verify Completeness**
 
    **Task Completion**:
-   - If tasks.md exists in contextFiles, read it
+   - If `contextFiles.tasks` exists, read every file path in it
    - Parse checkboxes: `- [ ]` (incomplete) vs `- [x]` (complete)
    - Count complete vs total tasks
    - If incomplete tasks exist:
@@ -92,7 +92,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
 7. **Verify Coherence**
 
    **Design Adherence**:
-   - If design.md exists in contextFiles:
+   - If `contextFiles.design` exists:
      - Extract key decisions (look for sections like "Decision:", "Approach:", "Architecture:")
      - Verify implementation follows those decisions
      - If contradiction detected:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,15 @@ jobs:
     # `cargo check` does not link, so we don't need libcudart on the
     # runner — only the Rust toolchain. This unblocks GPU-feature
     # development without requiring a GPU CI host.
+    #
+    # We do NOT use `--workspace` here because `arch/aarch64` and
+    # `arch/riscv64` carry unguarded `core::arch::asm!` blocks that
+    # only assemble for their own target_arch. The `Unit Tests` job
+    # has the same constraint and uses the same curated-list pattern.
+    # The list below covers every workspace crate that touches the
+    # `cuda` / `nvidia_gpu` features either directly or via a
+    # dependency edge — adding a new crate that imports `cuda::*`
+    # means adding it here too.
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
@@ -164,7 +173,13 @@ jobs:
           toolchain: nightly-2026-02-01
           components: rust-src
       - name: cargo check --features cuda,nvidia_gpu
-        run: cargo check -p smallaios-onnx-rt -p smallaios-container --features cuda,nvidia_gpu
+        run: |
+          cargo check \
+            -p smallaios-onnx-rt \
+            -p smallaios-container \
+            -p smallaios-arch-nvidia \
+            -p smallaios-compute \
+            --features cuda,nvidia_gpu
 
   jetson-image-build:
     name: Jetson Image Build (advisory, QEMU)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,49 @@ jobs:
           -p smallaios-sdr
           -p smallaios-bench
 
+  cuda-check:
+    name: CUDA Feature Check (cargo check --features cuda)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # Cheap gate that catches Send/Sync regressions in the GPU code path.
+    # `cargo check` does not link, so we don't need libcudart on the
+    # runner — only the Rust toolchain. This unblocks GPU-feature
+    # development without requiring a GPU CI host.
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly-2026-02-01
+          components: rust-src
+      - name: cargo check --features cuda,nvidia_gpu
+        run: cargo check -p smallaios-onnx-rt -p smallaios-container --features cuda,nvidia_gpu
+
+  jetson-image-build:
+    name: Jetson Image Build (advisory, QEMU)
+    runs-on: ubuntu-latest
+    # Advisory until a self-hosted Jetson runner is available — there's no way
+    # to run a real Tegra runtime test on GitHub-hosted runners. This job
+    # at least catches Dockerfile.jetson syntactic / dependency rot under
+    # QEMU emulation.
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Build Dockerfile.jetson under QEMU (linux/arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.jetson
+          platforms: linux/arm64
+          push: false
+          load: false
+          cache-from: type=gha,scope=jetson
+          cache-to: type=gha,mode=max,scope=jetson
+
   test-formal-gate:
     name: Unit Tests (formal-gate)
     runs-on: ubuntu-latest
@@ -1074,7 +1117,7 @@ jobs:
     name: Change Gates
     runs-on: ubuntu-latest
     permissions: {}
-    needs: [check-format, clippy, test, test-formal-gate, build-x86_64, build-aarch64, build-riscv64, build-jetson, docker-build-local, semver-check, cargo-deny, check-cycles, semver-api-check, coverage-threshold]
+    needs: [check-format, clippy, test, test-formal-gate, cuda-check, build-x86_64, build-aarch64, build-riscv64, build-jetson, docker-build-local, semver-check, cargo-deny, check-cycles, semver-api-check, coverage-threshold]
     if: github.event_name == 'pull_request'
     steps:
       - name: All gates passed

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ Thumbs.db
 # Local artifacts (AI-generated, temp files, not for git)
 .local/
 
+# Local model fixtures pulled at runtime (e.g. by
+# scripts/test-jetson-gpu.sh or scripts/download-test-fixtures.sh).
+# Models are not source-of-truth and would balloon the repo.
+/models/
+
 # TLA+ model checker artifacts
 states/
 *_TTrace_*.bin

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 SmallAIOS is a minimal, secure, Rust-based OS kernel purpose-built for AI inference workloads. It boots directly to ONNX inference with ~46 syscalls (vs Linux ~450). Targets x86-64, ARM64, and RISC-V. Deploys as either a container (Docker/K8s) or bare-metal/VM via QEMU.
 
-**Current state:** Prototype phase — 4,143 tests passing. Production-quality networking (IPv4/IPv6/TCP/ARP/NDP), QUIC/HTTP3 with TLS 1.3, protobuf parser, ONNX runtime with 6 real operators, full PQC crypto stack (SHA-3, AES-256-GCM, ML-KEM-768, ML-DSA-65, Ed25519, X25519), capability system. GPU crates (NVIDIA, Intel, AMD) are architectural stubs with HAL interfaces but no hardware interaction.
+**Current state:** Prototype phase — 4,143 tests passing. Production-quality networking (IPv4/IPv6/TCP/ARP/NDP), QUIC/HTTP3 with TLS 1.3, protobuf parser, ONNX runtime with 29+ real operators, full PQC crypto stack (SHA-3, AES-256-GCM, ML-KEM-768, ML-DSA-65, Ed25519, X25519), capability system. NVIDIA CUDA container path validated on Jetson Orin NX (compute 8.7) via `Dockerfile.jetson` — cuDNN-backed Conv, cuBLAS-backed GEMM, captured CUDA Graphs, multi-stream overlap. AMD and Intel GPU crates remain architectural stubs.
 
 ## Build Commands
 
@@ -32,7 +32,14 @@ just run-x86                # Boot in QEMU x86-64
 just run-arm                # Boot in QEMU ARM64
 
 # Docker
-just docker-build           # Multi-arch container build
+just docker-build               # Multi-arch container build (CPU, slim, ~1 MB)
+just docker-build-gpu           # x86 + discrete GPU (Dockerfile.cuda, ~3 GB)
+just docker-build-jetson        # Jetson Orin full JetPack base (Dockerfile.jetson, ~10 GB)
+just docker-build-jetson-slim   # Jetson Orin slim (Dockerfile.jetson.slim, ~4 GB)
+just docker-local-jetson        # docker compose --profile jetson up --build
+just docker-local-jetson-slim   # docker compose --profile jetson-slim up --build
+just test-jetson-gpu            # End-to-end Jetson smoke test (full base; must run on Jetson)
+just test-jetson-gpu slim       # End-to-end smoke test against the slim variant
 
 # Dependency analysis (requires cargo-depgraph, cargo-modules, graphviz)
 just depgraph               # Crate-level DOT/SVG dependency graph

--- a/Dockerfile.jetson
+++ b/Dockerfile.jetson
@@ -1,0 +1,77 @@
+# SmallAIOS Jetson Orin Container Build (ARM64 + JetPack 6 / L4T R36.4)
+#
+# Targets the integrated Tegra GPU on Jetson Orin Nano Super, NX, and AGX
+# (compute capability 8.7). For x86-64 + discrete-GPU hosts, use
+# Dockerfile.cuda instead — the L4T base in this file does not run on
+# non-Tegra drivers, and conversely the nvcr.io/nvidia/cuda:13.0 base in
+# Dockerfile.cuda is rejected by Jetson's CDI runtime (driver 540 / CUDA 12.6).
+#
+# Usage:
+#   docker build -f Dockerfile.jetson -t smallaios:jetson .
+#   docker run --runtime=nvidia --rm -p 8080:8080 \
+#     -v "$(pwd)/models:/models:ro" \
+#     -e SMALLAIOS_GPU_BACKEND=cuda smallaios:jetson
+#
+# Or via compose:
+#   docker compose --profile jetson up --build smallaios-jetson
+#
+# See docs/jetson-quickstart.md for the full bring-up walkthrough.
+
+# === Builder + Runtime: NVIDIA L4T JetPack 6 (CUDA 12.6 + cuDNN 9.3) ===
+#
+# JetPack 6 is the stable Jetson stack as of L4T R36.4. The image is large
+# (~3 GB) but bundles the entire user-mode CUDA stack we link against
+# (libcudart.so.12, libcublas.so.12, libcudnn.so.9, libnvrtc.so.12), which
+# the NVIDIA Container Toolkit then complements with the host-mounted
+# libcuda.so.1 driver shim.
+ARG L4T_BASE=nvcr.io/nvidia/l4t-jetpack:r36.4.0
+
+FROM ${L4T_BASE} AS builder
+
+# Install Rust nightly + cross-compilation tools.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl ca-certificates build-essential pkg-config && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+    sh -s -- -y --default-toolchain nightly-2026-02-01 --profile minimal
+
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+RUN rustup target add aarch64-unknown-linux-gnu
+
+WORKDIR /app
+COPY . .
+
+# Make the L4T-hosted CUDA libs visible to the linker:
+#   * /usr/local/cuda/lib64 — libcudart, libcublas, libcublasLt, libnvrtc
+#   * /usr/local/cuda/lib64/stubs — libcuda stub (real driver shim is
+#     mounted at runtime by NVIDIA Container Toolkit)
+#   * /usr/lib/aarch64-linux-gnu — libcudnn (cuDNN 9.3 ships here on L4T)
+ENV RUSTFLAGS="-L /usr/local/cuda/lib64 -L /usr/local/cuda/lib64/stubs -L /usr/lib/aarch64-linux-gnu"
+
+# Build with cuda + nvidia_gpu features. tegra-orin selects cc_87 on
+# smallaios-arch-nvidia (Ampere Orin). The binary dynamically links
+# against libcudart/cublas/cudnn from the L4T base; libcuda comes
+# from the host driver via the NVIDIA Container Toolkit at runtime.
+RUN cargo build --release --target aarch64-unknown-linux-gnu \
+        -p smallaios-container \
+        --features cuda,nvidia_gpu,smallaios-arch-nvidia/tegra-orin && \
+    cp /app/target/aarch64-unknown-linux-gnu/release/smallaios-container \
+       /app/smallaios
+
+# === Runtime: same L4T JetPack base, slim copy ===
+FROM ${L4T_BASE}
+
+COPY --from=builder /app/smallaios /smallaios
+
+ENV SMALLAIOS_MODEL_DIR=/models
+ENV SMALLAIOS_PORT=8080
+ENV SMALLAIOS_GPU_BACKEND=cuda
+ENV SMALLAIOS_BUS_BACKEND=none
+
+EXPOSE 8080
+VOLUME /models
+
+ENTRYPOINT ["/smallaios"]

--- a/Dockerfile.jetson
+++ b/Dockerfile.jetson
@@ -64,7 +64,17 @@ RUN cargo build --release --target aarch64-unknown-linux-gnu \
 # === Runtime: same L4T JetPack base, slim copy ===
 FROM ${L4T_BASE}
 
-COPY --from=builder /app/smallaios /smallaios
+# Run as a dedicated non-root user. The smallaios binary only needs to
+# read /models and bind port 8080 (>1024) — neither requires root.
+# Fixed UID 10001 keeps host-side bind-mount permission semantics
+# predictable across hosts.
+RUN groupadd --system --gid 10001 smallaios && \
+    useradd --system --uid 10001 --gid 10001 \
+            --no-create-home --shell /usr/sbin/nologin \
+            --home-dir /nonexistent smallaios && \
+    mkdir -p /models && chown smallaios:smallaios /models
+
+COPY --from=builder --chown=smallaios:smallaios /app/smallaios /smallaios
 
 ENV SMALLAIOS_MODEL_DIR=/models
 ENV SMALLAIOS_PORT=8080
@@ -73,5 +83,6 @@ ENV SMALLAIOS_BUS_BACKEND=none
 
 EXPOSE 8080
 VOLUME /models
+USER smallaios
 
 ENTRYPOINT ["/smallaios"]

--- a/Dockerfile.jetson.slim
+++ b/Dockerfile.jetson.slim
@@ -5,7 +5,7 @@
 # smaller image footprint:
 #
 #   Dockerfile.jetson         ≈ 9.8 GB (full L4T JetPack 6 base)
-#   Dockerfile.jetson.slim    ≈ 3.0 GB (l4t-cuda runtime + just cuDNN)
+#   Dockerfile.jetson.slim    ≈ 4.1 GB (l4t-cuda runtime + just cuDNN)
 #
 # The build stage still uses the full JetPack image so cargo/rustc and
 # the CUDA dev libs are present at link time. The runtime stage is the
@@ -14,7 +14,7 @@
 # CUDA samples, nvcc, GStreamer, multimedia API.
 #
 # Trade-offs vs. the fat image:
-#   + ~6.8 GB smaller image — faster pulls, smaller K8s registry footprint
+#   + ~5.7 GB smaller image — faster pulls, smaller K8s registry footprint
 #   + No TensorRT / no nvcc / no VPI / no multimedia API / no DLA compiler
 #     in the runtime container (none of which SmallAIOS uses today)
 #   - First-time apt repo / cuDNN version drift is no longer NVIDIA-managed
@@ -92,7 +92,14 @@ COPY --from=builder \
 
 RUN ldconfig
 
-COPY --from=builder /app/smallaios /smallaios
+# Non-root user — see Dockerfile.jetson for the full rationale.
+RUN groupadd --system --gid 10001 smallaios && \
+    useradd --system --uid 10001 --gid 10001 \
+            --no-create-home --shell /usr/sbin/nologin \
+            --home-dir /nonexistent smallaios && \
+    mkdir -p /models && chown smallaios:smallaios /models
+
+COPY --from=builder --chown=smallaios:smallaios /app/smallaios /smallaios
 
 ENV SMALLAIOS_MODEL_DIR=/models
 ENV SMALLAIOS_PORT=8080
@@ -101,5 +108,6 @@ ENV SMALLAIOS_BUS_BACKEND=none
 
 EXPOSE 8080
 VOLUME /models
+USER smallaios
 
 ENTRYPOINT ["/smallaios"]

--- a/Dockerfile.jetson.slim
+++ b/Dockerfile.jetson.slim
@@ -1,0 +1,105 @@
+# SmallAIOS Jetson Orin — Slim Container Variant
+#
+# Same target as Dockerfile.jetson (Jetson Orin Nano Super / NX / AGX,
+# JetPack 6 / L4T R36.4+, compute capability 8.7), but built for a
+# smaller image footprint:
+#
+#   Dockerfile.jetson         ≈ 9.8 GB (full L4T JetPack 6 base)
+#   Dockerfile.jetson.slim    ≈ 3.0 GB (l4t-cuda runtime + just cuDNN)
+#
+# The build stage still uses the full JetPack image so cargo/rustc and
+# the CUDA dev libs are present at link time. The runtime stage is the
+# leaner `l4t-cuda:12.6.11-runtime` (~2 GB) plus the cuDNN .so files
+# copied from the builder. We drop everything else: TensorRT, NPP, VPI,
+# CUDA samples, nvcc, GStreamer, multimedia API.
+#
+# Trade-offs vs. the fat image:
+#   + ~6.8 GB smaller image — faster pulls, smaller K8s registry footprint
+#   + No TensorRT / no nvcc / no VPI / no multimedia API / no DLA compiler
+#     in the runtime container (none of which SmallAIOS uses today)
+#   - First-time apt repo / cuDNN version drift is no longer NVIDIA-managed
+#     (we pin libcudnn .so files at build time)
+#   - If a future SmallAIOS feature pulls in TensorRT or VPI, the slim
+#     image will need the missing libs added explicitly
+#
+# Usage:
+#   docker build -f Dockerfile.jetson.slim -t smallaios:jetson-slim .
+#   docker run --runtime=nvidia --rm -p 8080:8080 \
+#     -v "$(pwd)/models:/models:ro" \
+#     -e SMALLAIOS_GPU_BACKEND=cuda smallaios:jetson-slim
+#
+# Or via compose:
+#   docker compose --profile jetson-slim up --build
+
+ARG L4T_BUILDER_BASE=nvcr.io/nvidia/l4t-jetpack:r36.4.0
+ARG L4T_RUNTIME_BASE=nvcr.io/nvidia/l4t-cuda:12.6.11-runtime
+
+# === Builder: full JetPack (reuses Dockerfile.jetson's cached layer) ===
+FROM ${L4T_BUILDER_BASE} AS builder
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl ca-certificates build-essential pkg-config && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+    sh -s -- -y --default-toolchain nightly-2026-02-01 --profile minimal
+
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+RUN rustup target add aarch64-unknown-linux-gnu
+
+WORKDIR /app
+COPY . .
+
+ENV RUSTFLAGS="-L /usr/local/cuda/lib64 -L /usr/local/cuda/lib64/stubs -L /usr/lib/aarch64-linux-gnu"
+
+RUN cargo build --release --target aarch64-unknown-linux-gnu \
+        -p smallaios-container \
+        --features cuda,nvidia_gpu,smallaios-arch-nvidia/tegra-orin && \
+    cp /app/target/aarch64-unknown-linux-gnu/release/smallaios-container \
+       /app/smallaios
+
+# === Runtime: l4t-cuda runtime + cuDNN copied from builder ===
+FROM ${L4T_RUNTIME_BASE}
+
+# cuDNN 9 splits into several .so files that are dlopen'd lazily by
+# the frontend libcudnn.so. Ship all of them — collectively ~956 MB,
+# but trimming further requires per-workload knowledge of which
+# engines are reachable. Anyone wanting to go lower can drop
+# libcudnn_adv (288 MB) if the workload has no RNN / attention ops,
+# or libcudnn_engines_precompiled (510 MB) at the cost of cold-start
+# JIT compile time. The defaults below preserve full SmallAIOS Conv /
+# fused-op coverage.
+COPY --from=builder \
+    /usr/lib/aarch64-linux-gnu/libcudnn.so.9 \
+    /usr/lib/aarch64-linux-gnu/libcudnn.so.9.3.0 \
+    /usr/lib/aarch64-linux-gnu/libcudnn_cnn.so.9 \
+    /usr/lib/aarch64-linux-gnu/libcudnn_cnn.so.9.3.0 \
+    /usr/lib/aarch64-linux-gnu/libcudnn_ops.so.9 \
+    /usr/lib/aarch64-linux-gnu/libcudnn_ops.so.9.3.0 \
+    /usr/lib/aarch64-linux-gnu/libcudnn_graph.so.9 \
+    /usr/lib/aarch64-linux-gnu/libcudnn_graph.so.9.3.0 \
+    /usr/lib/aarch64-linux-gnu/libcudnn_adv.so.9 \
+    /usr/lib/aarch64-linux-gnu/libcudnn_adv.so.9.3.0 \
+    /usr/lib/aarch64-linux-gnu/libcudnn_engines_precompiled.so.9 \
+    /usr/lib/aarch64-linux-gnu/libcudnn_engines_precompiled.so.9.3.0 \
+    /usr/lib/aarch64-linux-gnu/libcudnn_engines_runtime_compiled.so.9 \
+    /usr/lib/aarch64-linux-gnu/libcudnn_engines_runtime_compiled.so.9.3.0 \
+    /usr/lib/aarch64-linux-gnu/libcudnn_heuristic.so.9 \
+    /usr/lib/aarch64-linux-gnu/libcudnn_heuristic.so.9.3.0 \
+    /usr/lib/aarch64-linux-gnu/
+
+RUN ldconfig
+
+COPY --from=builder /app/smallaios /smallaios
+
+ENV SMALLAIOS_MODEL_DIR=/models
+ENV SMALLAIOS_PORT=8080
+ENV SMALLAIOS_GPU_BACKEND=cuda
+ENV SMALLAIOS_BUS_BACKEND=none
+
+EXPOSE 8080
+VOLUME /models
+
+ENTRYPOINT ["/smallaios"]

--- a/Justfile
+++ b/Justfile
@@ -118,6 +118,14 @@ docker-build:
 docker-build-gpu:
     {{docker}} build -f Dockerfile.cuda -t smallaios/runtime:gpu .
 
+# Build Jetson Orin Docker image (NVIDIA L4T JetPack 6 base, cc_87)
+docker-build-jetson:
+    {{docker}} build -f Dockerfile.jetson -t smallaios/runtime:jetson .
+
+# Build Jetson Orin slim image (l4t-cuda runtime + cuDNN, ~3 GB vs ~9.8 GB)
+docker-build-jetson-slim:
+    {{docker}} build -f Dockerfile.jetson.slim -t smallaios/runtime:jetson-slim .
+
 # Build and push multi-arch Docker image
 docker-push:
     {{docker}} buildx build --platform linux/amd64,linux/arm64 \
@@ -130,6 +138,20 @@ docker-local:
 # Run local Docker with GPU profile
 docker-local-gpu:
     docker compose --profile gpu up --build
+
+# Run local Docker with Jetson profile (ARM64 + Tegra Orin GPU)
+docker-local-jetson:
+    docker compose --profile jetson up --build
+
+# Run local Docker with Jetson slim profile (~3 GB image)
+docker-local-jetson-slim:
+    docker compose --profile jetson-slim up --build
+
+# Smoke-test the Jetson GPU image end-to-end (build + boot + GPU init + /v1/inference).
+# Run this on a Jetson Orin Nano / NX / AGX with NVIDIA Container Runtime installed.
+# Pass variant=slim to test Dockerfile.jetson.slim instead of the default.
+test-jetson-gpu variant="":
+    ./scripts/test-jetson-gpu.sh {{variant}}
 
 # Clean local Docker resources
 docker-local-clean:

--- a/Justfile
+++ b/Justfile
@@ -122,7 +122,7 @@ docker-build-gpu:
 docker-build-jetson:
     {{docker}} build -f Dockerfile.jetson -t smallaios/runtime:jetson .
 
-# Build Jetson Orin slim image (l4t-cuda runtime + cuDNN, ~3 GB vs ~9.8 GB)
+# Build Jetson Orin slim image (l4t-cuda runtime + cuDNN, ~4 GB vs ~9.8 GB)
 docker-build-jetson-slim:
     {{docker}} build -f Dockerfile.jetson.slim -t smallaios/runtime:jetson-slim .
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,24 @@ qemu-system-riscv64 -machine virt -cpu rv64 -m 512M -nographic \
   -bios default -kernel target/riscv64gc-unknown-none-elf/release/smallaios-riscv64
 ```
 
+### Container deployments
+
+| Surface | Dockerfile | Compose profile | Image size | Hardware |
+|---------|-----------|-----------------|-----------|----------|
+| CPU only (slim, scratch base) | `Dockerfile` | (default) | ~1 MB | x86-64 / ARM64 / RISC-V hosts |
+| x86 + discrete NVIDIA GPU | `Dockerfile.cuda` | `gpu` | ~3 GB | x86-64 + Hopper / Blackwell / Ada / Ampere data-center GPUs |
+| Jetson Orin — slim | `Dockerfile.jetson.slim` | `jetson-slim` | ~4 GB | Jetson Orin Nano Super / NX / AGX (JetPack 6 / L4T R36.4+) — recommended for production |
+| Jetson Orin — full JetPack | `Dockerfile.jetson` | `jetson` | ~10 GB | Same hardware; bundles full JetPack 6 (TensorRT, VPI, NPP, multimedia) — convenience target for first-time bring-up |
+
+See [docs/jetson-quickstart.md](docs/jetson-quickstart.md) for the Jetson workflow and the slim/full trade-offs.
+
+```bash
+docker compose up                                  # CPU
+docker compose --profile gpu up --build            # x86 + discrete GPU
+docker compose --profile jetson-slim up --build    # Jetson Orin (recommended)
+docker compose --profile jetson up --build         # Jetson Orin (full JetPack base)
+```
+
 ## CI/CD
 
 The [CI pipeline](.github/workflows/ci.yml) runs on every push and PR:

--- a/arch/nvidia/Cargo.toml
+++ b/arch/nvidia/Cargo.toml
@@ -9,12 +9,22 @@ publish = false
 
 [features]
 default = []
-tegra = ["cc_53"]  # Tegra T210 SoC-integrated GM20B GPU
-cc_53 = []    # Maxwell (Jetson Nano)
+# `tegra` selects the legacy Tegra X1 (GM20B) bare-metal HAL — used by
+# `smallaios-arch-aarch64` for Jetson Nano original / TX1 boot. The
+# bare-metal Tegra register-level drivers under `src/tegra/` are
+# X1-specific (Falcon ucode, GM20B GR engine, etc.) and remain gated
+# by this flag.
+tegra = ["cc_53"]
+# `tegra-orin` is the container-side (CUDA via NGC L4T) target for the
+# Orin family — Nano Super 8 GB, NX 8 / 16 GB, AGX 32 / 64 GB. It does
+# NOT pull in the X1 bare-metal HAL — the Jetson container path uses
+# the userspace CUDA runtime mounted by NVIDIA Container Toolkit.
+tegra-orin = ["cc_87"]
+cc_53 = []    # Maxwell (Tegra X1 / Jetson Nano original / TX1)
 cc_70 = []    # Volta (V100)
 cc_75 = []    # Turing (T4)
 cc_80 = []    # Ampere (A100)
-cc_87 = []    # Ampere (Jetson Orin)
+cc_87 = []    # Ampere (Jetson Orin Nano / NX / AGX)
 cc_90 = []    # Hopper (H100)
 cc_100 = []   # Blackwell (B200, DGX Spark)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 # CPU:          docker compose up --build
 # GPU:          docker compose --profile gpu up --build           (x86 + discrete GPU)
 # Jetson:       docker compose --profile jetson up --build        (ARM64 + Tegra Orin, ~9.8 GB)
-# Jetson slim:  docker compose --profile jetson-slim up --build   (ARM64 + Tegra Orin, ~3 GB)
+# Jetson slim:  docker compose --profile jetson-slim up --build   (ARM64 + Tegra Orin, ~4 GB)
 
 services:
   smallaios:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 # SmallAIOS Local Development
-# CPU:  docker compose up --build
-# GPU:  docker compose --profile gpu up --build
+# CPU:          docker compose up --build
+# GPU:          docker compose --profile gpu up --build           (x86 + discrete GPU)
+# Jetson:       docker compose --profile jetson up --build        (ARM64 + Tegra Orin, ~9.8 GB)
+# Jetson slim:  docker compose --profile jetson-slim up --build   (ARM64 + Tegra Orin, ~3 GB)
 
 services:
   smallaios:
@@ -53,3 +55,56 @@ services:
       timeout: 5s
       retries: 3
       start_period: 5s
+
+  smallaios-jetson:
+    build:
+      context: .
+      dockerfile: Dockerfile.jetson
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./models:/models:ro
+    restart: unless-stopped
+    runtime: nvidia
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - SMALLAIOS_MODEL_DIR=/models
+      - SMALLAIOS_PORT=8080
+      - SMALLAIOS_GPU_BACKEND=cuda
+      - SMALLAIOS_BUS_BACKEND=none
+    profiles:
+      - jetson
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/healthz || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      # Build is slow on first run (cold L4T pull + cold cargo); allow a
+      # generous start window before the runtime considers the container
+      # unhealthy.
+      start_period: 30s
+
+  smallaios-jetson-slim:
+    build:
+      context: .
+      dockerfile: Dockerfile.jetson.slim
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./models:/models:ro
+    restart: unless-stopped
+    runtime: nvidia
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - SMALLAIOS_MODEL_DIR=/models
+      - SMALLAIOS_PORT=8080
+      - SMALLAIOS_GPU_BACKEND=cuda
+      - SMALLAIOS_BUS_BACKEND=none
+    profiles:
+      - jetson-slim
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/healthz || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s

--- a/docs/jetson-quickstart.md
+++ b/docs/jetson-quickstart.md
@@ -1,0 +1,242 @@
+# Jetson Orin Quickstart
+
+This walks you through building and running SmallAIOS as a GPU-accelerated
+container on an NVIDIA Jetson Orin (Nano Super, NX, or AGX).
+
+## Hardware support matrix
+
+| Board                 | SoC      | GPU        | CC  | Tested |
+|-----------------------|----------|------------|-----|--------|
+| Jetson Orin Nano Super (8 GB) | Orin     | Ampere | 8.7 | yes (NX dev box) |
+| Jetson Orin NX (8 / 16 GB)    | Orin     | Ampere | 8.7 | yes |
+| Jetson AGX Orin (32 / 64 GB)  | Orin     | Ampere | 8.7 | architectural — same image |
+| Jetson Nano (original)        | Tegra X1 | Maxwell | 5.3 | NO — see "Why not Nano original?" below |
+
+The Orin family ships with JetPack 6 / L4T R36.4+ and a fixed CUDA 12.6
+user-mode stack. SmallAIOS's container build links against
+`libcudart.so.12 / libcublas.so.12 / libcudnn.so.9` from that base image
+and dynamically picks up the host driver shim (`libcuda.so.1`) at runtime.
+
+## Prerequisites
+
+- JetPack 6 (≥ L4T R36.4) — confirm with `cat /etc/nv_tegra_release`. The
+  first line should look like `# R36 (release), REVISION: 4.7, ...`.
+- Docker Engine (≥ 24).
+- NVIDIA Container Toolkit (`nvidia-container-toolkit`). Confirm with
+  `docker info | grep nvidia` — you should see `nvidia` listed under
+  `Runtimes:` and ideally as `Default Runtime:` for `--runtime=nvidia`
+  to be implicit.
+- ~10 GB free disk space (the L4T base image is ~3 GB; build artifacts
+  add another few GB).
+
+## Two image variants
+
+There are two Jetson Dockerfiles. Pick based on whether you value image
+size or a full JetPack toolbox:
+
+| Variant | Dockerfile | Compose profile | Image size | Includes |
+|---------|-----------|-----------------|-----------|----------|
+| **Slim (recommended)** | `Dockerfile.jetson.slim` | `jetson-slim` | **~4 GB** | CUDA 12.6 runtime + cuDNN 9.3 only |
+| Full JetPack | `Dockerfile.jetson` | `jetson` | ~10 GB | CUDA + cuDNN + TensorRT + VPI + NPP + multimedia API + DLA compiler |
+
+Both run the same SmallAIOS binary on the same Tegra Orin GPU and
+report identical `compute 8.7` boot lines. The slim variant copies just
+the cuDNN `.so` files from the JetPack builder stage onto an
+`l4t-cuda:12.6.11-runtime` base; it has full SmallAIOS Conv / fused-op
+coverage. The full variant exists for users who want the rest of
+JetPack pre-installed (e.g. for ad-hoc tooling, samples, or future
+TensorRT integration). **For most production deployments, use the
+slim variant.**
+
+## One-command run
+
+```bash
+# Slim (recommended)
+docker compose --profile jetson-slim up --build
+
+# Full JetPack base
+docker compose --profile jetson up --build
+```
+
+After ~30s the service serves on port 8080.
+
+To smoke-test end-to-end:
+
+```bash
+just test-jetson-gpu          # full JetPack variant
+just test-jetson-gpu slim     # slim variant
+# or directly:
+./scripts/test-jetson-gpu.sh slim
+```
+
+The smoke test downloads SqueezeNet, builds the image, asserts the
+container reports `compute 8.7` (proving the integrated Tegra GPU was
+probed, not a silent CPU fallback), and confirms `/v1/inference` is
+reachable.
+
+## Manual flow
+
+```bash
+# 1. Get a model. Anything in models/ is loaded at boot.
+mkdir -p models
+curl -L \
+  -o models/squeezenet.onnx \
+  https://github.com/onnx/models/raw/main/validated/vision/classification/squeezenet/model/squeezenet1.1-7.onnx
+
+# 2. Build the Jetson-specific image.
+just docker-build-jetson
+# or: docker build -f Dockerfile.jetson -t smallaios:jetson .
+
+# 3. Run it. --runtime=nvidia is implicit on Jetson where the default
+#    Docker runtime is already nvidia, but pass it explicitly to be safe.
+docker run --runtime=nvidia --rm -p 8080:8080 \
+  -v "$(pwd)/models:/models:ro" \
+  -e SMALLAIOS_GPU_BACKEND=cuda \
+  smallaios:jetson
+
+# 4. Verify GPU init from the logs (look for `compute 8.7`):
+#    SmallAIOS 0.2.1
+#    Container mode: ...
+#    Config: model_dir=/models, port=8080, gpu=cuda, ...
+#    GPU precision mode: TF32
+#    CUDA initialized: Orin (compute 8.7, 8192 MB VRAM, CUDA 12.6)
+#    Loading models from '/models'...
+#      Model 'squeezenet': 4956208 bytes [onnx] OK
+#    HTTP inference sessions ready: 1
+#    Ready. Listening on 0.0.0.0:8080
+
+# 5. Health checks.
+curl http://localhost:8080/healthz   # {"status":"healthy"}
+curl http://localhost:8080/readyz    # {"status":"ready"}
+curl http://localhost:8080/v1/models # [{"name":"squeezenet","file_size":4956208,"loaded":true}]
+```
+
+## Troubleshooting
+
+### "requirements not met: cuda>=13.0..."
+
+```
+docker: Error response from daemon: failed to create task for container:
+... failed to construct OCI spec modifier: requirements not met:
+cuda>=13.0||brand=...&&driver>=535... not met
+```
+
+You're trying to run an x86 + discrete-GPU image (`Dockerfile.cuda` / NGC
+`nvidia/cuda:13.0`) on a Jetson. The NVIDIA Container Toolkit's CDI
+runtime checks the image's `com.nvidia.cuda.requirements` label against
+the Jetson's driver (540.x for L4T R36.4) and rejects 13.0. Fix: use
+`Dockerfile.jetson` (this guide) instead.
+
+### "compute 8.7" missing — silent CPU fallback
+
+If the logs show `WARNING: GPU backend=cuda requested but CUDA init failed`
+and falling back to CPU, the most common causes are:
+
+- The container was started without `--runtime=nvidia` (or the default
+  runtime isn't `nvidia` and the `runtime: nvidia` in `docker-compose.yml`
+  was lost). Fix: `docker compose --profile jetson up` always sets
+  `runtime: nvidia`; verify the override didn't get clobbered.
+- `nvidia-container-toolkit` isn't installed. Fix:
+  `sudo apt install nvidia-container-toolkit && sudo systemctl restart docker`.
+- The Jetson is running in low-power mode and `nvgpu` isn't loaded. Fix:
+  `sudo nvpmodel -m 0 && sudo jetson_clocks` (production-mode clocks).
+
+### Image is huge
+
+If you built the full JetPack image (`Dockerfile.jetson`, profile
+`jetson`) you got ~10 GB. About 95% of that is unused JetPack 6 stack
+(TensorRT, VPI, NPP, multimedia, samples, nvcc) — SmallAIOS only links
+against CUDA runtime + cuBLAS + cuDNN.
+
+**Just use the slim variant** (`Dockerfile.jetson.slim`, profile
+`jetson-slim`). It comes in at ~4 GB, passes the same smoke test, and
+keeps full Conv / fused-op coverage. The size difference is purely the
+JetPack toolbox you weren't using.
+
+If 4 GB is still too big you can drop further by editing
+`Dockerfile.jetson.slim`:
+
+- Remove `libcudnn_engines_precompiled.so.9*` (510 MB) — at the cost of
+  cold-start JIT compilation for cuDNN kernels on the first inference.
+- Remove `libcudnn_adv.so.9*` (288 MB) — only safe if your workload
+  has no RNN, LSTM, or multi-head attention ops.
+
+Both are documented in the comments at the top of the slim Dockerfile.
+
+### Why not Jetson Nano (original)?
+
+The original Jetson Nano runs a Tegra X1 (Maxwell, cc 5.3) on JetPack 4.x
+with CUDA 10.2. The L4T base images for Tegra X1 are end-of-life as of
+JetPack 4.6.4, and SmallAIOS's CUDA path uses cuDNN 9 / cuBLAS APIs that
+are not available on CUDA 10.2. We do not support Tegra X1 in the
+container path; the bare-metal HAL under `arch/nvidia/src/tegra/` is
+present for the X1 boot path (see `arch/aarch64/Cargo.toml` —
+`smallaios-arch-nvidia/tegra` feature) and is independent of this
+container target.
+
+## Performance — measured cold-start
+
+Benchmarked on a Jetson Orin NX (16 GB), JetPack 6 / L4T R36.4.7,
+NVIDIA Container Runtime as default Docker runtime. Metric: wall-clock
+time from `docker run` to the first 200 response from the readiness
+endpoint, with the SqueezeNet 1.1 ONNX model loaded GPU-side. 5 runs
+each, median reported.
+
+| Container | Work done at ready signal | Median | × slim | Image |
+|-----------|--------------------------|-------:|-------:|------:|
+| `nvcr.io/nvidia/l4t-cuda:12.6.11-runtime` + `echo ok` (control — pure Docker overhead) | nothing | 769 ms | 1.01× | 2.09 GB |
+| **smallaios slim** (`Dockerfile.jetson.slim`) | CUDA init + SqueezeNet → GPU session + HTTP listen | **762 ms** | **1.00×** | **4.09 GB** |
+| smallaios fat (`Dockerfile.jetson`) | same as slim | 901 ms | 1.18× | 9.83 GB |
+| `python:3.11-slim` + stdlib `http.server` (no GPU) | interpreter + HTTP listen | 862 ms | 1.13× | 0.13 GB |
+| **NVIDIA Triton** (`tritonserver:24.10-py3-igpu`) + SqueezeNet, gRPC + metrics disabled | ORT backend + SqueezeNet → /v2/health/ready | **3,300 ms** | **4.33×** | **9.04 GB** |
+
+**Takeaway:** smallaios slim cold-starts ~4.3× faster than NVIDIA Triton
+on the same hardware with the same model loaded, in an image 55%
+smaller. The smallaios init time is at the floor that the NVIDIA
+Container Runtime hook allows on Jetson — there is no measurable
+difference between "smallaios is GPU-ready and serving SqueezeNet" and
+"the L4T base image's `echo ok` exited."
+
+**Caveats:**
+- Triton supports many more backends (TensorRT, PyTorch, custom Python),
+  dynamic batching, ensembles, gRPC, model versioning, auth. SmallAIOS
+  does ONNX-only with a fixed operator set.
+- Steady-state inference latency is GPU-bound by the same cuDNN kernels
+  in both — the gap is at cold-start, not throughput.
+- The 4.3× number is for SqueezeNet specifically; larger models shift
+  both numbers up but not necessarily proportionally.
+- Run on a single dev box; numbers will vary on other Orin SKUs and
+  with different CUDA / JetPack versions.
+
+To reproduce on your own hardware, see the bench scripts in this PR's
+description (or equivalent: `time` a `docker run -d` followed by
+polling `/healthz` / `/v2/health/ready` until 200).
+
+## Running the SmallAIOS smoke test
+
+```bash
+just test-jetson-gpu
+```
+
+That script:
+
+1. Confirms `nvidia-container-toolkit` is installed.
+2. Downloads SqueezeNet to `./models` if absent.
+3. Builds and starts the Jetson service.
+4. Polls `/healthz` + `/readyz` until ready (≤ 120 s).
+5. Asserts `compute 8.7` is in the logs (catches silent CPU fallback).
+6. Hits `POST /v1/inference` against SqueezeNet.
+7. Tears the service down on exit.
+
+Exit codes are documented in the script header.
+
+## Related docs
+
+- [Inference bus](./inference-bus.md) — pub/sub topic conventions when
+  pairing Jetson with Zenoh / DDS dataflow.
+- [CAN inference](./can-inference.md) — CAN bus inference bridge for
+  vehicle / industrial integrations.
+- [Architecture](./architecture.md) — workspace layering (the Jetson
+  container path lives entirely in Layer 3 + Layer 1 userspace; no
+  Layer 2 bare-metal HAL involvement).
+- [Local testing](./local-testing.md) — general developer workflow.

--- a/docs/jetson-quickstart.md
+++ b/docs/jetson-quickstart.md
@@ -7,9 +7,9 @@ container on an NVIDIA Jetson Orin (Nano Super, NX, or AGX).
 
 | Board                 | SoC      | GPU        | CC  | Tested |
 |-----------------------|----------|------------|-----|--------|
-| Jetson Orin Nano Super (8 GB) | Orin     | Ampere | 8.7 | yes (NX dev box) |
-| Jetson Orin NX (8 / 16 GB)    | Orin     | Ampere | 8.7 | yes |
-| Jetson AGX Orin (32 / 64 GB)  | Orin     | Ampere | 8.7 | architectural — same image |
+| Jetson Orin Nano Super (8 GB) | Orin     | Ampere | 8.7 | not directly — same SoC + cc 8.7 as the validated NX |
+| Jetson Orin NX (8 / 16 GB)    | Orin     | Ampere | 8.7 | yes — 16 GB validated end-to-end |
+| Jetson AGX Orin (32 / 64 GB)  | Orin     | Ampere | 8.7 | not directly — same SoC + cc 8.7 |
 | Jetson Nano (original)        | Tegra X1 | Maxwell | 5.3 | NO — see "Why not Nano original?" below |
 
 The Orin family ships with JetPack 6 / L4T R36.4+ and a fixed CUDA 12.6
@@ -115,7 +115,7 @@ curl http://localhost:8080/v1/models # [{"name":"squeezenet","file_size":4956208
 
 ### "requirements not met: cuda>=13.0..."
 
-```
+```text
 docker: Error response from daemon: failed to create task for container:
 ... failed to construct OCI spec modifier: requirements not met:
 cuda>=13.0||brand=...&&driver>=535... not met

--- a/onnx-rt/src/cuda/graph.rs
+++ b/onnx-rt/src/cuda/graph.rs
@@ -16,17 +16,36 @@
 //!
 //! # Safety contract for `Send + Sync`
 //!
-//! CUDA primary contexts are bound to a process and become "current"
-//! on whichever thread last called `cudaSetDevice`. Stream and graph
-//! handles do not own a thread — they own a (process, device) pair.
-//! `cudaGraphLaunch`, `cudaStreamSynchronize`, `cudaStreamCreate`, and
-//! `cudaStreamDestroy` are all documented as thread-safe with respect
-//! to the same handle as long as the calling thread has a current
-//! context for the same device. `Session` pins itself to a single
-//! device and the executor re-asserts the device before each inference
-//! via [`crate::cuda::CudaRuntime`]. Therefore moving these handles
-//! between worker threads is sound, and the data they reference (graph
-//! topology, captured kernels) is never mutated after creation.
+//! Per the CUDA Runtime API, stream / event / graph handles can only
+//! be safely used from a thread that has the **owning device made
+//! current** via `cudaSetDevice`. Each host thread has its own
+//! "current device" state; HTTP worker pools enter with no device
+//! current. Lazy primary-context bind (the default for a single-GPU
+//! process) papers over many cases, but the soundness of moving these
+//! handles between threads requires an explicit guarantee, not luck.
+//!
+//! The guarantee `Session` makes:
+//!
+//! 1. **Single device per `Session`.** A `Session` is constructed
+//!    against exactly one [`crate::cuda::CudaRuntime`], which records
+//!    one [`crate::cuda::CudaDeviceInfo::device_id`]. The Session
+//!    never re-targets across devices.
+//! 2. **Re-bind on every cross-thread entry point.** Every public
+//!    method on `Session` that may be invoked from an HTTP worker
+//!    thread or a `std::thread::spawn` body — `Session::run` and
+//!    `Session::ensure_stream_pool` — calls
+//!    `crate::cuda::set_device(rt.device.device_id)` *before*
+//!    acquiring any of the cached-handle mutexes. The rebind is
+//!    cheap (a thread-local pointer write in libcudart) and is the
+//!    point at which the Send claim is discharged.
+//!
+//! Together, these mean the `unsafe impl Send + Sync` is sound for
+//! the deployments smallaios supports today (single-GPU host;
+//! container-mode HTTP request thread pool). Multi-device hosts
+//! would require either a per-`Session` device pin enforced with a
+//! thread-pinning newtype, or a dedicated CUDA worker thread — both
+//! out of scope for the current milestone. Anyone widening that
+//! envelope MUST audit this contract.
 
 use core::ptr;
 

--- a/onnx-rt/src/cuda/graph.rs
+++ b/onnx-rt/src/cuda/graph.rs
@@ -10,8 +10,23 @@
 //! `cudaGraphInstantiate`.
 //!
 //! All three types release their underlying resource in `Drop`. The
-//! handles are not `Send`/`Sync` because cuDNN/cuBLAS handles bound to
-//! a stream are thread-local.
+//! raw handles are wrapped here with `unsafe impl Send + Sync` so a
+//! [`Session`](crate::session::Session) can be embedded in a
+//! multi-threaded HTTP request handler.
+//!
+//! # Safety contract for `Send + Sync`
+//!
+//! CUDA primary contexts are bound to a process and become "current"
+//! on whichever thread last called `cudaSetDevice`. Stream and graph
+//! handles do not own a thread — they own a (process, device) pair.
+//! `cudaGraphLaunch`, `cudaStreamSynchronize`, `cudaStreamCreate`, and
+//! `cudaStreamDestroy` are all documented as thread-safe with respect
+//! to the same handle as long as the calling thread has a current
+//! context for the same device. `Session` pins itself to a single
+//! device and the executor re-asserts the device before each inference
+//! via [`crate::cuda::CudaRuntime`]. Therefore moving these handles
+//! between worker threads is sound, and the data they reference (graph
+//! topology, captured kernels) is never mutated after creation.
 
 use core::ptr;
 
@@ -24,6 +39,10 @@ use super::CudaError;
 pub struct CaptureStream {
     stream: ffi::cudaStream_t,
 }
+
+// SAFETY: see module-level safety contract.
+unsafe impl Send for CaptureStream {}
+unsafe impl Sync for CaptureStream {}
 
 impl CaptureStream {
     /// Create a fresh CUDA stream via `cudaStreamCreate`. The stream
@@ -81,6 +100,10 @@ pub struct CudaGraph {
     graph: ffi::cudaGraph_t,
 }
 
+// SAFETY: see module-level safety contract.
+unsafe impl Send for CudaGraph {}
+unsafe impl Sync for CudaGraph {}
+
 impl CudaGraph {
     /// Wrap a previously-captured graph handle. Caller transfers
     /// ownership; Drop will release the underlying graph.
@@ -115,6 +138,10 @@ impl Drop for CudaGraph {
 pub struct CudaGraphExec {
     graph_exec: ffi::cudaGraphExec_t,
 }
+
+// SAFETY: see module-level safety contract.
+unsafe impl Send for CudaGraphExec {}
+unsafe impl Sync for CudaGraphExec {}
 
 impl CudaGraphExec {
     /// Instantiate an immutable [`CudaGraph`] into an executable

--- a/onnx-rt/src/cuda/mod.rs
+++ b/onnx-rt/src/cuda/mod.rs
@@ -113,9 +113,17 @@ impl core::fmt::Display for CudaError {
 
 // ── Compile-time CUDA major version ─────────────────────────────────
 
-/// CUDA major version these bindings target.
-/// Used for runtime compatibility check.
-const TARGET_CUDA_MAJOR: i32 = 13;
+/// Lowest CUDA major version these bindings are known to be ABI-
+/// compatible with. The FFI surface we use (cudaMalloc / cudaMemcpy /
+/// cudaGetDeviceCount / cublas{Sgemm,GemmEx} / cudnnConvolutionForward
+/// / cudaGraphLaunch) has been stable since CUDA 11; we explicitly
+/// support 12.x (Jetson Orin / JetPack 6 / L4T R36.4) and 13.x (DGX
+/// Spark, x86 + discrete GPU images). Anything outside that range
+/// is rejected because the cudaDeviceProp layout (which we don't
+/// rely on, but other CUDA call sites do) and the cublasGemmEx
+/// compute-type enum can shift.
+const MIN_CUDA_MAJOR: i32 = 12;
+const MAX_CUDA_MAJOR: i32 = 13;
 
 // ── Device discovery ────────────────────────────────────────────────
 
@@ -222,14 +230,15 @@ pub fn runtime_version() -> Result<i32, CudaError> {
     Ok(version)
 }
 
-/// Check that the CUDA runtime major version matches compiled bindings.
+/// Check that the CUDA runtime major version is within the supported
+/// range (currently 12.x – 13.x). See `MIN_CUDA_MAJOR` / `MAX_CUDA_MAJOR`.
 pub fn check_version() -> Result<i32, CudaError> {
     let version = runtime_version()?;
     // CUDA version encoding: major * 1000 + minor * 10
     let major = version / 1000;
-    if major != TARGET_CUDA_MAJOR {
+    if !(MIN_CUDA_MAJOR..=MAX_CUDA_MAJOR).contains(&major) {
         return Err(CudaError::VersionMismatch {
-            expected_major: TARGET_CUDA_MAJOR,
+            expected_major: MAX_CUDA_MAJOR,
             actual_major: major,
         });
     }

--- a/onnx-rt/src/cuda/mod.rs
+++ b/onnx-rt/src/cuda/mod.rs
@@ -237,8 +237,16 @@ pub fn check_version() -> Result<i32, CudaError> {
     // CUDA version encoding: major * 1000 + minor * 10
     let major = version / 1000;
     if !(MIN_CUDA_MAJOR..=MAX_CUDA_MAJOR).contains(&major) {
+        // Report the boundary that was actually violated, not always
+        // the upper bound — otherwise a CUDA 11.x runtime gets the
+        // misleading "expected major 13" message.
+        let expected_major = if major < MIN_CUDA_MAJOR {
+            MIN_CUDA_MAJOR
+        } else {
+            MAX_CUDA_MAJOR
+        };
         return Err(CudaError::VersionMismatch {
-            expected_major: MAX_CUDA_MAJOR,
+            expected_major,
             actual_major: major,
         });
     }

--- a/onnx-rt/src/cuda/streams.rs
+++ b/onnx-rt/src/cuda/streams.rs
@@ -23,11 +23,16 @@
 
 extern crate alloc;
 use alloc::vec::Vec;
-use core::cell::RefCell;
 use core::ptr;
+use std::sync::Mutex;
 
 use super::ffi;
 use super::CudaError;
+
+// SAFETY: see `crate::cuda::graph` module-level safety contract.
+// Stream and Event raw handles point to CUDA primary-context-bound
+// kernel-side resources. They are valid in any thread that has the
+// same device current. `Session` pins itself to a single device.
 
 /// Owned non-default CUDA stream. Created by `cudaStreamCreate`,
 /// destroyed by `cudaStreamDestroy` on Drop. Best-effort
@@ -36,6 +41,10 @@ use super::CudaError;
 pub struct Stream {
     stream: ffi::cudaStream_t,
 }
+
+// SAFETY: see module top.
+unsafe impl Send for Stream {}
+unsafe impl Sync for Stream {}
 
 impl Stream {
     pub fn new() -> Result<Self, CudaError> {
@@ -86,6 +95,10 @@ impl Drop for Stream {
 pub struct Event {
     event: ffi::cudaEvent_t,
 }
+
+// SAFETY: see module top.
+unsafe impl Send for Event {}
+unsafe impl Sync for Event {}
 
 impl Event {
     pub fn new() -> Result<Self, CudaError> {
@@ -160,7 +173,7 @@ pub struct StreamPool {
     /// Event reuse pool. Events are cheap but `cudaEventCreate`
     /// still has measurable cost; keep a small free list so the
     /// hot path can `acquire_event` instead of allocating.
-    events: RefCell<Vec<Event>>,
+    events: Mutex<Vec<Event>>,
 }
 
 impl StreamPool {
@@ -183,7 +196,7 @@ impl StreamPool {
             compute,
             h2d,
             d2h,
-            events: RefCell::new(starter),
+            events: Mutex::new(starter),
         })
     }
 
@@ -191,7 +204,7 @@ impl StreamPool {
     /// pool is empty. Caller must call [`release_event`] when done so
     /// the event can be reused.
     pub fn acquire_event(&self) -> Result<Event, CudaError> {
-        if let Some(e) = self.events.borrow_mut().pop() {
+        if let Some(e) = self.events.lock().unwrap().pop() {
             return Ok(e);
         }
         Event::new()
@@ -200,7 +213,7 @@ impl StreamPool {
     /// Return an event to the pool for reuse. No-op if the pool is
     /// already at its soft cap (16); the event is dropped instead.
     pub fn release_event(&self, e: Event) {
-        let mut pool = self.events.borrow_mut();
+        let mut pool = self.events.lock().unwrap();
         if pool.len() < 16 {
             pool.push(e);
         }

--- a/onnx-rt/src/session.rs
+++ b/onnx-rt/src/session.rs
@@ -636,7 +636,21 @@ impl Session {
                 transfer_streams
             )));
         }
-        let mut slot = self.stream_pool.lock().unwrap();
+        // Re-bind device on the calling thread before touching CUDA
+        // (StreamPool::new calls cudaStreamCreate). See
+        // `cuda::graph` for the Send + Sync safety story.
+        if let Some(rt) = self.cuda_runtime.as_deref() {
+            crate::cuda::set_device(rt.device.device_id).map_err(|e| {
+                SessionError::ExecutionFailed(alloc::format!(
+                    "cudaSetDevice({}): {}",
+                    rt.device.device_id,
+                    e
+                ))
+            })?;
+        }
+        let mut slot = self.stream_pool.lock().map_err(|_| {
+            SessionError::ExecutionFailed(String::from("stream_pool mutex poisoned"))
+        })?;
         if slot.is_some() {
             return Ok(());
         }
@@ -749,12 +763,30 @@ impl Session {
                     use alloc::collections::BTreeMap;
                     use alloc::sync::Arc;
                     if let Some(rt) = self.cuda_runtime.as_deref() {
+                        // Re-bind the Session's device on the calling
+                        // thread before any CUDA op. cudaSetDevice is
+                        // per-thread; HTTP worker pools enter with no
+                        // current device, and the Send/Sync safety
+                        // contract for our cached handles depends on
+                        // this rebind. See `crate::cuda::graph` module
+                        // docs for the full safety story.
+                        crate::cuda::set_device(rt.device.device_id).map_err(|e| {
+                            SessionError::ExecutionFailed(alloc::format!(
+                                "cudaSetDevice({}): {}",
+                                rt.device.device_id,
+                                e
+                            ))
+                        })?;
                         // Lazy-populate the device-resident initializer
                         // cache on first hybrid run. Skips re-decoding
                         // every TensorProto and re-uploading every
                         // initializer to device on each inference.
                         let cache = {
-                            let mut slot = self.device_initializer_cache.lock().unwrap();
+                            let mut slot = self.device_initializer_cache.lock().map_err(|_| {
+                                SessionError::ExecutionFailed(String::from(
+                                    "device_initializer_cache mutex poisoned",
+                                ))
+                            })?;
                             if slot.is_none() {
                                 let mut map: BTreeMap<
                                     String,
@@ -781,13 +813,21 @@ impl Session {
                             }
                             slot.as_ref().unwrap().clone()
                         };
-                        let mut cache_slot = self.cuda_graph_cache.lock().unwrap();
+                        let mut cache_slot = self.cuda_graph_cache.lock().map_err(|_| {
+                            SessionError::ExecutionFailed(String::from(
+                                "cuda_graph_cache mutex poisoned",
+                            ))
+                        })?;
                         // Lazily allocate the multi-stream pool (no-op
                         // on SingleStream config). Errors propagate as
                         // SessionError::InvalidConfig before any
                         // inference work happens.
                         self.ensure_stream_pool()?;
-                        let pool_slot = self.stream_pool.lock().unwrap();
+                        let pool_slot = self.stream_pool.lock().map_err(|_| {
+                            SessionError::ExecutionFailed(String::from(
+                                "stream_pool mutex poisoned",
+                            ))
+                        })?;
                         return crate::executor_hybrid::execute_graph_hybrid_with_capture(
                             graph,
                             &input_pairs,

--- a/onnx-rt/src/session.rs
+++ b/onnx-rt/src/session.rs
@@ -365,8 +365,11 @@ pub struct Session {
     /// for hybrid mode and a CUDA runtime is attached. Stored as
     /// `Arc<DeviceTensor>` so the hybrid value map can share buffers
     /// across inferences without device→device memcpy.
+    ///
+    /// `Mutex` (not `RefCell`) so `Session: Send + Sync` for use in
+    /// multi-threaded HTTP request handlers.
     #[cfg(feature = "cuda")]
-    pub device_initializer_cache: core::cell::RefCell<DeviceInitCacheSlot>,
+    pub device_initializer_cache: std::sync::Mutex<DeviceInitCacheSlot>,
     /// Per-Session CUDA Graph cache for the hybrid + capture path.
     /// Populated lazily on the first `Session::run` call when the
     /// session is configured for `GpuResidency::Hybrid` and
@@ -374,7 +377,7 @@ pub struct Session {
     /// stream and one or more captured `cudaGraphExec_t` keyed by
     /// input shape + dtype.
     #[cfg(feature = "cuda")]
-    pub cuda_graph_cache: core::cell::RefCell<crate::cuda::graph_cache::CudaGraphCacheSlot>,
+    pub cuda_graph_cache: std::sync::Mutex<crate::cuda::graph_cache::CudaGraphCacheSlot>,
     /// Per-Session CUDA stream pool for multi-stream overlap. `None`
     /// when `SessionConfig::stream_config = SingleStream` (default)
     /// or before the first multi-stream inference. Lazily allocated
@@ -382,10 +385,21 @@ pub struct Session {
     /// `Overlap`-mode `run` call. Holds one compute stream + N H2D +
     /// N D2H streams + an event reuse pool.
     #[cfg(feature = "cuda")]
-    pub stream_pool: core::cell::RefCell<Option<crate::cuda::streams::StreamPool>>,
+    pub stream_pool: std::sync::Mutex<Option<crate::cuda::streams::StreamPool>>,
     /// Discriminator for the session's origin / dispatch path.
     pub kind: SessionKind,
 }
+
+// Static assertion: `Session` must remain `Send + Sync` so it can be
+// embedded in `HttpServer::route_fn` closures and `std::thread::spawn`
+// bodies. CUDA-feature regressions historically reintroduced
+// `RefCell<...>` and bare `*mut c_void` here; this trips at
+// `cargo check` instead of waiting for a downstream link error.
+#[cfg(feature = "cuda")]
+const _: fn() = || {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<Session>();
+};
 
 /// ONNX model file magic bytes: `\x08` (field 1, varint wire type).
 ///
@@ -596,11 +610,11 @@ impl Session {
             #[cfg(feature = "cuda")]
             gpu_weights: None,
             #[cfg(feature = "cuda")]
-            device_initializer_cache: core::cell::RefCell::new(None),
+            device_initializer_cache: std::sync::Mutex::new(None),
             #[cfg(feature = "cuda")]
-            cuda_graph_cache: core::cell::RefCell::new(None),
+            cuda_graph_cache: std::sync::Mutex::new(None),
             #[cfg(feature = "cuda")]
-            stream_pool: core::cell::RefCell::new(None),
+            stream_pool: std::sync::Mutex::new(None),
             kind: SessionKind::Onnx,
         }
     }
@@ -622,7 +636,7 @@ impl Session {
                 transfer_streams
             )));
         }
-        let mut slot = self.stream_pool.borrow_mut();
+        let mut slot = self.stream_pool.lock().unwrap();
         if slot.is_some() {
             return Ok(());
         }
@@ -740,7 +754,7 @@ impl Session {
                         // every TensorProto and re-uploading every
                         // initializer to device on each inference.
                         let cache = {
-                            let mut slot = self.device_initializer_cache.borrow_mut();
+                            let mut slot = self.device_initializer_cache.lock().unwrap();
                             if slot.is_none() {
                                 let mut map: BTreeMap<
                                     String,
@@ -767,13 +781,13 @@ impl Session {
                             }
                             slot.as_ref().unwrap().clone()
                         };
-                        let mut cache_slot = self.cuda_graph_cache.borrow_mut();
+                        let mut cache_slot = self.cuda_graph_cache.lock().unwrap();
                         // Lazily allocate the multi-stream pool (no-op
                         // on SingleStream config). Errors propagate as
                         // SessionError::InvalidConfig before any
                         // inference work happens.
                         self.ensure_stream_pool()?;
-                        let pool_slot = self.stream_pool.borrow();
+                        let pool_slot = self.stream_pool.lock().unwrap();
                         return crate::executor_hybrid::execute_graph_hybrid_with_capture(
                             graph,
                             &input_pairs,
@@ -1132,9 +1146,9 @@ impl Session {
                     .into_iter()
                     .collect::<BTreeMap<String, crate::cuda::gpu_executor::DeviceTensor>>(),
             )),
-            device_initializer_cache: core::cell::RefCell::new(None),
-            cuda_graph_cache: core::cell::RefCell::new(None),
-            stream_pool: core::cell::RefCell::new(None),
+            device_initializer_cache: std::sync::Mutex::new(None),
+            cuda_graph_cache: std::sync::Mutex::new(None),
+            stream_pool: std::sync::Mutex::new(None),
             kind: SessionKind::Safetensors,
         })
     }

--- a/openspec/changes/jetson-orin-container-v1/design.md
+++ b/openspec/changes/jetson-orin-container-v1/design.md
@@ -1,0 +1,108 @@
+## Context
+
+`Session` is the central object that owns model state, optimized graphs, and (with `feature = "cuda"`) GPU-side caches. The `arm64-gpu-container-v1` and `cuda-graphs-v1` changes both touched this type without exercising the multi-threaded code path that `container/src/main.rs` uses.
+
+Concretely, `container/src/main.rs:125` constructs a per-model `Session` and stores it inside the route closure passed to `HttpServer::route_fn`. The route function takes `Fn + Send + Sync + 'static` because `HttpServer` worker threads dispatch requests from a thread pool. `cuda-graphs-v1` then added `RefCell<Option<CudaGraphCache>>` and a raw `*mut c_void` (cudaGraphExec_t handle) into `Session`. Once `--features cuda` is enabled, those fields propagate `!Send` / `!Sync` upward — the closure is rejected at compile time. The error is invisible without the feature, which is why the `develop` branch is green while `cargo build --features cuda` is broken.
+
+On the deployment side, `Dockerfile.cuda` uses `nvcr.io/nvidia/cuda:13.0.0-devel-ubuntu24.04`. NVIDIA's CDI runtime evaluates the image's `com.nvidia.cuda.requirements` label against the host driver before mounting GPU files; CUDA 13 requires driver ≥ 535 in one of several version bands (535.x, 550.x, 565.x, 570.x, 575.x). Jetson's L4T R36.4 ships driver 540.4.0 — outside every band — so the runtime errors out: *"requirements not met: cuda>=13.0||..."*. There is no workaround at the container layer; JetPack 6 is fixed at CUDA 12.6 user-mode and an L4T-derived base image is the only correct choice.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Make `cargo build --features cuda,nvidia_gpu` succeed on every supported target (x86_64-linux-{musl,gnu}, aarch64-linux-{musl,gnu}). This is a compile-only fix; no runtime behavior changes for existing GPU users.
+- Provide a working `Dockerfile.jetson` that boots smallaios end-to-end on Jetson Orin (Nano / NX / AGX — they share cc 8.7), running real ONNX inference (SqueezeNet at minimum) on the integrated Tegra GPU.
+- Catch future `cuda`-feature regressions in CI without requiring a GPU runner.
+
+**Non-Goals**
+
+- TensorRT integration. JetPack ships TensorRT, but smallaios's GPU executor uses cuDNN+cuBLAS directly. TRT is a separate, future change.
+- Tegra X1 (Jetson Nano original) container support. cc 5.3 is end-of-life on JetPack 4.x and we're not investing in the legacy path.
+- Bare-metal Tegra GPU bring-up. The bare-metal Tegra HAL is its own track.
+- Replacing `Dockerfile.cuda`. The x86 + discrete-GPU image continues to use CUDA 13.0 NGC images for DGX Spark / standard server hosts.
+- Running TensorRT-format engines. SmallAIOS loads ONNX directly.
+
+## Decisions
+
+### Decision 1 — `Mutex<Option<T>>` over `unsafe impl Send` for higher-level caches
+
+`StreamPool`, `CudaGraphCache`, and the `Arc<BTreeMap<String, Arc<DeviceTensor>>>` weight cache are all *Rust types* whose unsoundness comes from interior `RefCell`. Switching to `Mutex<Option<T>>` is mechanical: the same get-or-init pattern keeps working, lock contention is negligible (these are one-shot inits and per-request reads), and we avoid sprinkling `unsafe` for what is fundamentally a data-race protection problem.
+
+For the raw CUDA handles (`*mut c_void` cudaGraphExec_t in `cuda::graph::CudaGraphExec`), `Mutex` would not change anything — the pointer remains `!Send` at the type-system level regardless of locking. Here we **do** need `unsafe impl Send + Sync` on a newtype wrapper, with a justification that captures CUDA's actual contract:
+
+> CUDA primary contexts are bound to a process and become "current" on whichever thread last set them. `cudaGraphLaunch` is documented as thread-safe with respect to the same graph handle as long as the calling thread has a current context for the same device. `Session` pins itself to a single device at construction (cudaSetDevice), and our HTTP request handler always re-asserts `cudaSetDevice(self.device)` before launching. Therefore the `cudaGraphExec_t` pointer can be transferred between worker threads safely.
+
+### Decision 2 — Ship both `Dockerfile.jetson` (full) and `Dockerfile.jetson.slim`
+
+Initial impulse was to ship only the full JetPack image because it's
+mechanically simpler — no cuDNN install step, no repo-key risk, just one
+`FROM nvcr.io/nvidia/l4t-jetpack:r36.4.0`. After validating end-to-end on
+the dev box, that image came in at **9.83 GB**. SmallAIOS dynamically
+links against six CUDA-side .so files; everything else in JetPack 6
+(TensorRT, VPI, NPP, multimedia API, DLA compiler, CUDA samples, nvcc)
+is dead weight.
+
+The slim variant uses `nvcr.io/nvidia/l4t-cuda:12.6.11-runtime` as the
+runtime base (2 GB) and copies just the cuDNN .so files from the
+JetPack builder stage. We don't try to apt-install cuDNN at build time
+— NVIDIA's L4T cuDNN apt package isn't pre-configured on l4t-cuda
+images and pinning the repo / GPG key adds churn for marginal layer
+benefit. Copying the files we need is reliable, version-locked to the
+builder, and ~956 MB total. The slim image lands at **4.09 GB** on the
+dev box and passes the identical smoke test (compute 8.7 boot,
+SqueezeNet `[GPU]`, /v1/inference reachable).
+
+We ship both rather than only the slim because:
+
+- `Dockerfile.jetson` is a one-line template anyone can extend without
+  thinking about cuDNN file lists. It's a useful "kitchen sink"
+  starting point for users who plan to adopt TensorRT or VPI later.
+- `Dockerfile.jetson.slim` is what production deployments should use,
+  and it's the variant the README points to as recommended.
+
+The README, CLAUDE.md, and `docs/jetson-quickstart.md` all surface the
+slim variant first and label it "recommended."
+
+### Decision 3 — `aarch64-unknown-linux-gnu`, not -musl
+
+The existing `Dockerfile` and `Dockerfile.cuda` target `aarch64-unknown-linux-musl` because the runtime is `FROM scratch`. On Jetson, the runtime base is L4T (Ubuntu 22.04) which is glibc, *and* `libcuda.so.1` mounted by NVIDIA Container Toolkit is glibc-linked. Mixing musl + glibc dynamic loaders works only by accident and would break the moment cuDNN's static initializer touches anything pthread-related (TLS layouts differ).
+
+We add `aarch64-unknown-linux-gnu` to `rust-toolchain.toml`'s `targets` and use it in `Dockerfile.jetson`. The slim x86 / ARM64 musl path is unaffected.
+
+### Decision 4 — Add `tegra-orin`, leave `tegra` alone
+
+The first draft of this change rewrote `tegra = ["cc_53"]` to `tegra = ["cc_87"]` and renamed the legacy flag to `tegra-x1`. That broke the existing `smallaios-arch-aarch64 = { ..., features = ["tegra"] }` dependency, which uses the X1-specific bare-metal HAL under `arch/nvidia/src/tegra/` (Falcon ucode / GM20B GR / FIFO / GMMU register drivers — none of that applies to Orin).
+
+We instead add a new `tegra-orin = ["cc_87"]` feature and leave `tegra = ["cc_53"]` untouched. The Orin container path is purely userspace CUDA (cuDNN + cuBLAS via the NVIDIA Container Toolkit's CDI mount); it does not touch the bare-metal HAL. Decoupling the two paths keeps the existing Jetson Nano boot caller working without migration churn and matches the intuition that "Tegra HAL" and "Tegra container target" are independent concerns.
+
+### Decision 5 — Compose profile separation
+
+`docker-compose.yml` already has a `gpu` profile that targets the x86 + discrete-GPU `Dockerfile.cuda` flow. Adding the Jetson service under the same profile would silently target the wrong base image on x86 hosts and the wrong CDI label on Jetson hosts. We add a distinct `jetson` profile so the user picks the deployment surface explicitly.
+
+### Decision 6 — CI gate strategy
+
+Two new jobs:
+
+- **Gate job** (blocks PR merge): `cargo check --features cuda,nvidia_gpu` on a default GitHub-hosted runner. `cargo check` does not link, so it does not need CUDA libraries — only the headers, which `bindgen`-style FFI does not consume in this codebase (it uses hand-rolled `extern "C"` declarations). This catches all the `Send`/`Sync` regressions cheaply.
+- **Advisory job**: `docker buildx build -f Dockerfile.jetson --platform linux/arm64` under QEMU emulation. Slow (~10 min) but catches Dockerfile syntactic rot. `continue-on-error: true` because no GitHub-hosted runner has a Jetson, and we cannot do a runtime smoke test there.
+
+Real Jetson smoke testing happens on the user's hardware via `just test-jetson-gpu` and is documented in `docs/jetson-quickstart.md`. Once a self-hosted Jetson runner exists, the advisory job promotes to a gate.
+
+## Risks / Trade-offs
+
+- **3 GB image weight is uncomfortable** but matches NVIDIA's own published Jetson containers (l4t-pytorch, l4t-tensorflow, l4t-tensorrt are all 3-7 GB). Customers running the slim 15 MB CPU container continue to do so unchanged.
+- **`unsafe impl Send + Sync` is a real safety claim.** If we get the safety reasoning wrong (e.g. someone later spawns a worker that tries to launch a graph against a stale CUDA context), we get a use-after-free, not a panic. Mitigation: the `unsafe impl` lives on a tiny newtype with a doc comment that names the invariant; a `// TODO(jetson): consider Mutex` marker would invite a future tightening.
+- **Aarch64-gnu adds a fourth Rust target** the workspace has to keep installable. Risk is mainly CI minute cost on Linux distros where `rustup target add aarch64-unknown-linux-gnu` is a fast no-op.
+- **No breaking change for Tegra X1 callers.** `tegra` continues to mean Tegra X1 / cc 5.3. The Orin container target uses the new `tegra-orin` flag instead. Cost: one extra feature name to remember; benefit: zero migration burden on the Jetson Nano boot path.
+
+## Migration Plan
+
+1. Land Phase 1 first as a self-contained PR — Send/Sync fixes plus the `cargo check --features cuda` gate. This unbreaks any future GPU work on `develop`.
+2. Land Phase 2 + 3 as a follow-up PR. The two phases share the worktree and the OpenSpec change but split cleanly at the code-vs-deployment boundary.
+3. Run `just test-jetson-gpu` on the Jetson Orin NX dev box to confirm end-to-end inference. Capture the actual `cudaGetDeviceCount` + `compute 8.7` lines into the PR description as evidence.
+4. After merge, archive the change as `2026-05-02-jetson-orin-container-v1`.
+
+## Open Questions
+
+- Should the bare-metal Tegra X1 driver path under `arch/nvidia/src/tegra/` migrate behind the new `tegra-x1` feature too, for symmetry? (Probably yes; out of scope for this change but worth a follow-up note.)
+- Do we want to publish `smallaios:jetson` to GHCR as a prebuilt image? Skipped here to keep the change focused on bring-up; revisit when a self-hosted Jetson runner exists.

--- a/openspec/changes/jetson-orin-container-v1/proposal.md
+++ b/openspec/changes/jetson-orin-container-v1/proposal.md
@@ -1,0 +1,79 @@
+## Why
+
+Today the smallaios container only builds and runs with CUDA on x86-64 + discrete-GPU hosts. On NVIDIA Jetson (Orin / NX / Nano-Super) — the canonical ARM64 + integrated-Tegra-GPU target — `Dockerfile.cuda` cannot run at all and the underlying Rust code does not compile.
+
+Two distinct failures were observed when trying to validate `smallaios:gpu` on a Jetson Orin NX (L4T R36.4.7, JetPack 6, CUDA 12.6, cuDNN 9.3, driver 540.4.0):
+
+1. **CUDA build is broken on every platform (regression).** `cargo build --features cuda,nvidia_gpu` fails with seven `E0277` errors. The recently-merged CUDA Graphs (#118) and async-multistream (#120) changes added `RefCell<Option<CudaGraphCache>>`, `RefCell<Option<StreamPool>>`, `RefCell<Option<Arc<BTreeMap<String, Arc<DeviceTensor>>>>>`, and a raw `*mut c_void` (cudaGraphExec_t) into `Session`. None of these are `Send + Sync`, but `Session` is captured by HTTP handler closures (`HttpServer::route_fn` requires `Send + 'static`) and by `std::thread::spawn` calls in `container/src/main.rs:319,348` and `ipc/src/dataflow_runner.rs:75`. There is no CI gate building the `cuda` feature, so this regression slipped through.
+
+2. **`Dockerfile.cuda` cannot run on Jetson.** The image base `nvcr.io/nvidia/cuda:13.0.0-{devel,runtime}-ubuntu24.04` declares a CDI `requirements` clause of `cuda>=13.0 || driver>=535&&driver<536 || ... || driver>=575&&driver<576`. The Jetson driver is 540.4.0 with CUDA 12.6 capability and is rejected by `nvidia-container-runtime` *before the container even starts*, regardless of `--gpus`. JetPack 6's user-mode CUDA stack is fixed at 12.6 — there is no 13.0 path. The correct base image family for Jetson is `nvcr.io/nvidia/l4t-jetpack:r36.4.0` (or `nvcr.io/nvidia/l4t-cuda:12.6.x-devel/runtime`).
+
+Once both are fixed, smallaios's CUDA executor (Conv via cuDNN, GEMM via cuBLAS, fused ops) gets validated end-to-end on real Tegra hardware for the first time. The `tegra` feature flag in `arch/nvidia` currently selects only `cc_53` (Tegra X1 / Jetson Nano), which is wrong for every shipping Jetson Orin SKU; we extend it to cover Orin (cc_87) as well. CLAUDE.md's project state — "GPU crates are architectural stubs with HAL interfaces but no hardware interaction" — moves to "validated on Jetson Orin NX with cuDNN+cuBLAS dispatch."
+
+## What Changes
+
+### Phase 1 — fix the cross-platform CUDA build regression
+
+- Wrap the GPU-side caches and raw CUDA handles in `Session` so the type is `Send + Sync` again. Concretely:
+  - Replace `RefCell<Option<CudaGraphCache>>`, `RefCell<Option<StreamPool>>`, and `RefCell<Option<Arc<BTreeMap<String, Arc<DeviceTensor>>>>>` with `Mutex<...>` (or wrap the inner cache in a `SendCudaState` newtype with documented `unsafe impl Send + Sync`, since the underlying CUDA contexts are accessed under the existing executor lock).
+  - For `*mut c_void` carried in `cuda::graph::CudaGraphExec` and `cuda::graph_cache::CudaGraphCacheEntry` (per the `--> graph.rs:24` and `graph_cache.rs:98` error sites), introduce a `#[repr(transparent)] struct ExecHandle(*mut c_void); unsafe impl Send for ExecHandle {}; unsafe impl Sync for ExecHandle {}` with a `// SAFETY:` justification covering CUDA's API contract (graph execs may be launched from any thread that has the matching CUDA context current, and Session pins itself to a single device).
+- Add a CI gate that runs `cargo check --features cuda,nvidia_gpu` (CPU-host check is sufficient — link step needs CUDA dev libs but the `cargo check` does not). This prevents future regressions from re-breaking the GPU build.
+
+### Phase 2 — Jetson Orin container path
+
+- Add **two** Jetson Dockerfiles for different size/feature trade-offs:
+  - `Dockerfile.jetson` (full JetPack base, ~10 GB) — `nvcr.io/nvidia/l4t-jetpack:r36.4.0` for both stages. Convenient for first-time bring-up and for users who want the rest of JetPack (TensorRT, VPI, NPP, multimedia, samples, nvcc) preinstalled.
+  - `Dockerfile.jetson.slim` (recommended, ~4 GB) — JetPack builder + `nvcr.io/nvidia/l4t-cuda:12.6.11-runtime` runtime, with the cuDNN .so files copied across. SmallAIOS only links against CUDA runtime + cuBLAS + cuDNN, so dropping the rest of JetPack is safe; the slim variant passes the same end-to-end smoke test as the full one.
+- Build with `aarch64-unknown-linux-gnu` (glibc, not musl) in both, so the binary dynamically links against the host-driver-provided `libcuda.so.1` cleanly.
+- Pass `--features cuda,nvidia_gpu,smallaios-arch-nvidia/cc_87` (or equivalently `smallaios-arch-nvidia/tegra-orin`) to capture Orin's Ampere compute capability.
+- Add a new `tegra-orin` feature on `arch/nvidia` that selects `cc_87` (Orin family — Nano Super / NX / AGX all share cc 8.7). This is purely container-side: the Orin path uses the userspace CUDA runtime mounted by the NVIDIA Container Toolkit, not the X1-specific bare-metal HAL under `arch/nvidia/src/tegra/`. The existing `tegra` feature continues to mean "Tegra X1 bare-metal HAL" and remains unchanged so the `smallaios-arch-aarch64` Jetson Nano boot path is not disturbed.
+- Add `smallaios-jetson` (full JetPack) and `smallaios-jetson-slim` (recommended) services to `docker-compose.yml` under `jetson` and `jetson-slim` profiles respectively (both separate from `gpu` so x86 GPU users aren't accidentally targeting L4T).
+- Verify the binary boots on Jetson with `runtime: nvidia` (default on the test box), runs `cudaGetDeviceCount`, reports `compute 8.7`, loads the SqueezeNet fixture, and serves a successful inference round-trip.
+
+### Phase 3 — documentation + tests
+
+- Add `docs/jetson-quickstart.md` with: hardware requirements (JetPack 6 / L4T R36.4+, NVIDIA Container Toolkit), the `docker compose --profile jetson up` workflow, a one-liner `curl` check against `/v1/inference`, and a troubleshooting section covering the CDI driver-mismatch error pattern.
+- Update `README.md` to add a Jetson row to the deployment matrix (alongside x86 CPU and x86 GPU container).
+- Update `CLAUDE.md` "Current state" to reflect Jetson Orin GPU validation; add `Dockerfile.jetson` to the Build Configuration section.
+- Add a smoke test script `scripts/test-jetson-gpu.sh` that builds the image, runs it, hits `/healthz` + `/readyz` + `/v1/inference` against SqueezeNet, asserts the GPU init log line shows `compute 8.7`, and exits non-zero on any failure. Wire it into `Justfile` as `just test-jetson-gpu`.
+- Add a CI advisory job (initially `continue-on-error: true` since GitHub-hosted runners can't host Jetson) that builds `Dockerfile.jetson` under QEMU emulation to catch Dockerfile rot.
+- Update `bench/configs/jetson.env` (already exists for the upstream Orin Nano profile) with a comment pointing to `docker-compose --profile jetson` as the recommended invocation.
+
+## Capabilities
+
+### New Capabilities
+
+- `jetson-orin-container`: Jetson-specific Dockerfile, compose profile, smoke test, and quickstart doc validated on L4T R36.4+ with Orin Nano / NX / AGX.
+
+### Modified Capabilities
+
+- `cuda-container-runtime`: extend `Session` thread-safety contract to require `Send + Sync` so CUDA-feature builds can be served from multi-threaded HTTP handlers, and to forbid future raw-pointer cache regressions.
+- `docker-gpu-runtime`: extend with the Jetson L4T compose service and the runtime-detection rule that the container must report `compute 8.7` on Orin hardware before claiming GPU readiness.
+- `arch/nvidia` feature surface: existing `tegra` feature semantics unchanged (Tegra X1 / cc 5.3 bare-metal HAL — preserves the `smallaios-arch-aarch64` Jetson Nano boot caller). New `tegra-orin` feature added for the Orin-family container path (cc 8.7).
+
+## Impact
+
+- **Code:**
+  - `onnx-rt/src/cuda/graph.rs`, `graph_cache.rs`: newtype wrappers + `unsafe impl Send + Sync` with safety justification.
+  - `onnx-rt/src/session.rs`: replace `RefCell` with `Mutex` (or move to the wrapped types). Verify `Session: Send + Sync`.
+  - `arch/nvidia/Cargo.toml`: add `tegra-orin = ["cc_87"]` for the Orin-family container target. `tegra` (cc 5.3 / Tegra X1 bare-metal HAL) is unchanged.
+  - `Dockerfile.jetson` (full JetPack base, convenience target): new file.
+  - `Dockerfile.jetson.slim` (recommended runtime base, ~6 GB smaller): new file.
+  - `docker-compose.yml`: new `smallaios-jetson` and `smallaios-jetson-slim` services under `jetson` and `jetson-slim` profiles.
+- **Docs:** `docs/jetson-quickstart.md` (new), `README.md`, `CLAUDE.md`.
+- **Tests:** `scripts/test-jetson-gpu.sh` (new), `Justfile` `test-jetson-gpu` recipe.
+- **CI:** new advisory build job for `Dockerfile.jetson` under QEMU; new gate job for `cargo check --features cuda,nvidia_gpu`.
+- **Container size:** `Dockerfile.jetson.slim` lands at 4.09 GB on the dev box (l4t-cuda runtime + 956 MB cuDNN stack). `Dockerfile.jetson` (full JetPack) is 9.83 GB on the dev box. For comparison, NVIDIA's `tritonserver:24.10-py3-igpu` is 9.04 GB on the same host — the slim variant is **55% smaller than Triton's published Jetson image**. The slim CPU image and the existing x86 Dockerfile.cuda remain unchanged.
+
+- **Cold-start latency (measured on Jetson Orin NX, 5 runs, median, all `--runtime=nvidia`, SqueezeNet ONNX loaded GPU-side):**
+  - smallaios slim → /healthz 200: **762 ms**
+  - smallaios fat → /healthz 200: 901 ms
+  - NVIDIA Triton → /v2/health/ready 200 (gRPC + metrics disabled, same model): **3,300 ms**
+  - Docker baseline (`l4t-cuda` + `echo ok`, control): 769 ms
+  - python:3.11-slim + stdlib `http.server` (no GPU work): 862 ms
+
+  smallaios slim is **4.33× faster cold-start than Triton** while loading the same model on the same hardware. SmallAIOS's own init time is statistically indistinguishable from `docker run echo` on the same NVIDIA-runtime base — the smallaios contribution is bounded above by ~10 ms within measurement noise. Triton's 3.3 s comes from its ORT backend plugin load, server framework boot, and model repository scan, none of which smallaios incurs.
+
+  Caveat: this measures cold-start, not steady-state inference throughput. Both stacks are GPU-bound by the same cuDNN kernels at runtime; the gap is at boot, which matters for FaaS / per-request-cold-start workloads and matters less for long-lived services that warm up once.
+- **No new Rust crate dependencies.** All CUDA libs continue to come from the L4T base image at runtime via dynamic linking against `libcudart.so.12 / libcublas.so.12 / libcudnn.so.9`.
+- **No bare-metal `arch/aarch64` Tegra driver changes.** This change is container-only. The bare-metal Tegra HAL (`arch/aarch64/src/tegra_*.rs`, `arch/nvidia/src/tegra/`) stays as-is.

--- a/openspec/changes/jetson-orin-container-v1/specs/cuda-container-runtime/spec.md
+++ b/openspec/changes/jetson-orin-container-v1/specs/cuda-container-runtime/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: Session is thread-safe under the cuda feature
+
+When the `cuda` feature is enabled, `smallaios_onnx_rt::session::Session` SHALL be `Send + Sync` so it can be embedded in multi-threaded HTTP request handlers and `std::thread::spawn` closures.
+
+#### Scenario: Session held across HTTP worker threads
+
+- **GIVEN** the smallaios container compiled with `--features cuda,nvidia_gpu` is started with at least one model loaded
+- **WHEN** the `HttpServer::route_fn` thread pool dispatches an inference request to a worker thread different from the one that constructed the `Session`
+- **THEN** the worker SHALL be able to call `session.run(...)` without a Rust compile-time `Send`/`Sync` error
+- **AND** the worker SHALL not race with concurrent requests on the same `Session` (writes to the GPU graph cache, stream pool, and device weight cache are serialized via `Mutex`)
+
+#### Scenario: Static thread-safety assertion
+
+- **GIVEN** any future change touches `Session` or any field reachable from it under the `cuda` feature
+- **THEN** the workspace SHALL contain a `const _: fn() = || { fn assert_send_sync<T: Send + Sync>() {} assert_send_sync::<Session>(); };` (or equivalent static check)
+- **AND** the assertion SHALL be unconditionally compiled when the `cuda` feature is on, so any regression is caught at `cargo check` time before reaching review
+
+#### Scenario: Raw CUDA handles wrapped behind Send/Sync newtypes
+
+- **GIVEN** any cached CUDA handle (`cudaGraphExec_t`, `cudaGraph_t`, `cudaStream_t`, `cublasHandle_t`, `cudnnHandle_t`) stored on `Session` or a type owned by `Session`
+- **THEN** the handle SHALL be wrapped in a newtype with `unsafe impl Send + Sync` and a `// SAFETY:` comment naming the CUDA contract that justifies the impl
+- **AND** the newtype SHALL be the only place those bounds are asserted unsafely (no scattered `unsafe impl Send` for `*mut c_void` etc.)
+
+### Requirement: cargo check --features cuda is gated in CI
+
+The repository SHALL enforce a CI gate that runs `cargo check --workspace --features cuda,nvidia_gpu` on every PR.
+
+#### Scenario: cuda-only regression caught in CI
+
+- **GIVEN** a PR that breaks `cargo check --features cuda` without breaking the default-feature build
+- **WHEN** the PR pipeline runs
+- **THEN** the `cuda-check` job SHALL fail
+- **AND** the change-gates meta-job SHALL block merge until it is fixed

--- a/openspec/changes/jetson-orin-container-v1/specs/docker-gpu-runtime/spec.md
+++ b/openspec/changes/jetson-orin-container-v1/specs/docker-gpu-runtime/spec.md
@@ -31,6 +31,14 @@ The repository SHALL provide two Jetson-specific Dockerfiles, both producing ima
 - **AND** `docker compose --profile jetson up` and `docker compose --profile jetson-slim up` SHALL be the user-visible invocations
 - **AND** the existing `gpu` profile (x86 + discrete GPU via `Dockerfile.cuda`) SHALL remain functional and unchanged
 
+#### Scenario: Container runs as non-root user
+
+- **GIVEN** the runtime stage of `Dockerfile.jetson` or `Dockerfile.jetson.slim`
+- **THEN** the image SHALL declare a `USER` directive resolving to a dedicated non-root account (e.g. `smallaios` at UID 10001)
+- **AND** that account SHALL own `/smallaios` and `/models` so a plain `docker run` works without manual permission fixups
+- **AND** the `smallaios` binary SHALL launch with no Linux capabilities beyond what the unprivileged user inherits — listening on 8080 (>1024) and reading `/models` are the only privileged-resource interactions, neither of which requires root
+- **AND** any future Dockerfile that exposes a network endpoint SHALL follow the same non-root pattern
+
 #### Scenario: Slim variant runtime base
 
 - **GIVEN** `Dockerfile.jetson.slim`

--- a/openspec/changes/jetson-orin-container-v1/specs/docker-gpu-runtime/spec.md
+++ b/openspec/changes/jetson-orin-container-v1/specs/docker-gpu-runtime/spec.md
@@ -1,0 +1,75 @@
+## ADDED Requirements
+
+### Requirement: Jetson Orin container variants
+
+The repository SHALL provide two Jetson-specific Dockerfiles, both producing images bootable on NVIDIA Jetson Orin (Nano / NX / AGX) with GPU acceleration: a recommended slim variant (`Dockerfile.jetson.slim`) and a full-JetPack convenience variant (`Dockerfile.jetson`).
+
+#### Scenario: Image base is L4T-derived
+
+- **GIVEN** a developer building `Dockerfile.jetson`
+- **THEN** the base image SHALL be `nvcr.io/nvidia/l4t-jetpack:r36.4.0` or a documented L4T-derived alternative (e.g. `nvcr.io/nvidia/l4t-cuda:12.6.x-runtime` plus a manual cuDNN install)
+- **AND** the image SHALL NOT use `nvcr.io/nvidia/cuda:13.0.0-*` because the Jetson driver (L4T R36.4.x) reports CUDA 12.6 capability and the CDI runtime requirements check rejects 13.0 images
+
+#### Scenario: Build uses glibc, not musl
+
+- **GIVEN** the build invocation in `Dockerfile.jetson`
+- **THEN** the Rust target SHALL be `aarch64-unknown-linux-gnu`
+- **AND** the binary SHALL dynamically link against the host-mounted `libcuda.so.1` (glibc-compatible) provided by the NVIDIA Container Toolkit
+- **AND** the workspace `rust-toolchain.toml` SHALL list `aarch64-unknown-linux-gnu` so `rustup target add` resolves cleanly
+
+#### Scenario: Build enables Orin compute capability
+
+- **GIVEN** the build command in `Dockerfile.jetson`
+- **THEN** the cargo invocation SHALL pass `--features cuda,nvidia_gpu,smallaios-arch-nvidia/tegra-orin` (the `tegra-orin` feature on `smallaios-arch-nvidia` selects `cc_87`)
+- **AND** the resulting binary SHALL be tuned for compute capability 8.7 (Ampere on Tegra Orin)
+- **AND** the build SHALL NOT enable `smallaios-arch-nvidia/tegra` (which selects the Tegra X1 / cc 5.3 bare-metal HAL — irrelevant to the container path)
+
+#### Scenario: Compose profile separation
+
+- **GIVEN** `docker-compose.yml`
+- **THEN** the full-JetPack Jetson service SHALL live under a `jetson` profile and the slim Jetson service under a `jetson-slim` profile, both distinct from the existing `gpu` profile
+- **AND** `docker compose --profile jetson up` and `docker compose --profile jetson-slim up` SHALL be the user-visible invocations
+- **AND** the existing `gpu` profile (x86 + discrete GPU via `Dockerfile.cuda`) SHALL remain functional and unchanged
+
+#### Scenario: Slim variant runtime base
+
+- **GIVEN** `Dockerfile.jetson.slim`
+- **THEN** the runtime stage base SHALL be `nvcr.io/nvidia/l4t-cuda:12.6.x-runtime` (or a documented equivalent), NOT the full L4T JetPack image
+- **AND** the cuDNN .so files (`libcudnn.so.9`, `libcudnn_cnn`, `libcudnn_ops`, `libcudnn_graph`, `libcudnn_adv`, `libcudnn_engines_precompiled`, `libcudnn_engines_runtime_compiled`, `libcudnn_heuristic`) SHALL be copied from the JetPack builder stage into `/usr/lib/aarch64-linux-gnu/` of the runtime image
+- **AND** `ldconfig` SHALL be run after the copy so the runtime linker picks them up
+- **AND** the resulting image SHALL boot with `compute 8.7` and pass the same smoke test as `Dockerfile.jetson`
+- **AND** the resulting image SHALL be substantially smaller than the full-JetPack variant (target: at least 2× smaller; observed: 4.09 GB vs 9.83 GB on dev box)
+
+### Requirement: Jetson runtime smoke test
+
+The repository SHALL ship a `scripts/test-jetson-gpu.sh` smoke test that validates the Jetson container end-to-end on real hardware.
+
+#### Scenario: GPU init confirmed in logs
+
+- **GIVEN** the Jetson container started by the smoke test on a Jetson Orin NX / AGX / Nano (Super)
+- **WHEN** the smoke test inspects the container logs after the readiness probe succeeds
+- **THEN** the logs SHALL contain a line of the form `CUDA initialized: <name> (compute 8.7, ...)`
+- **AND** the smoke test SHALL fail loudly if `compute 8.7` is missing (e.g. silent CPU fallback, or wrong device cc)
+
+#### Scenario: SqueezeNet inference returns 200
+
+- **GIVEN** the smoke test has booted the container with `models/squeezenet.onnx` loaded
+- **WHEN** the smoke test issues a POST against `/v1/inference` for the `squeezenet` model with a properly-shaped float32 input tensor
+- **THEN** the response SHALL be HTTP 200 with a JSON body containing the model's output tensor
+
+#### Scenario: Always cleans up
+
+- **GIVEN** any path through the smoke test (success, assertion failure, timeout, ctrl-c)
+- **WHEN** the script exits
+- **THEN** the smoke test SHALL run `docker compose --profile jetson down` so no Jetson container leaks across runs
+
+### Requirement: Jetson advisory CI job
+
+The CI workflow SHALL include a job that builds `Dockerfile.jetson` under QEMU emulation on every PR, marked `continue-on-error: true` until a self-hosted Jetson runner is available.
+
+#### Scenario: Dockerfile rot caught in CI
+
+- **GIVEN** a PR that breaks `Dockerfile.jetson` in a way that prevents image build (e.g. base image tag rename, missing apt package)
+- **WHEN** the `jetson-image-build` advisory job runs
+- **THEN** it SHALL surface the failure in the PR check status
+- **AND** because it is advisory, it SHALL NOT block merge — gating waits until a self-hosted Jetson runner can also do a runtime smoke test

--- a/openspec/changes/jetson-orin-container-v1/tasks.md
+++ b/openspec/changes/jetson-orin-container-v1/tasks.md
@@ -1,0 +1,92 @@
+## 1. Reproduce + diagnose the CUDA build regression
+
+- [x] 1.1 Confirm `cargo build --features cuda,nvidia_gpu` fails on aarch64 with seven `E0277` errors (captured in proposal)
+- [x] 1.2 Map each error to its source: `RefCell<Option<CudaGraphCache>>`, `RefCell<Option<StreamPool>>`, `RefCell<Option<Arc<BTreeMap<String, Arc<DeviceTensor>>>>>`, raw `*mut c_void` cudaGraphExec_t in `onnx-rt/src/cuda/graph.rs:24` and `onnx-rt/src/cuda/graph_cache.rs:98`
+
+## 2. Fix Send + Sync on Session GPU caches (Phase 1)
+
+- [x] 2.1 In `onnx-rt/src/cuda/graph.rs`, replace the bare `*mut c_void` (cudaGraphExec_t) field with `pub(crate) struct ExecHandle(*mut core::ffi::c_void); unsafe impl Send for ExecHandle {} unsafe impl Sync for ExecHandle {}` and a `// SAFETY:` block citing CUDA's same-context-current contract
+- [x] 2.2 Apply the same wrapper to `onnx-rt/src/cuda/graph_cache.rs:98` cached graph pointer
+- [x] 2.3 In `onnx-rt/src/session.rs:312`, replace `RefCell<Option<CudaGraphCache>>` with `Mutex<Option<CudaGraphCache>>`. Update all call sites to `.lock().unwrap()` on the get-or-init path
+- [x] 2.4 Same conversion for `RefCell<Option<StreamPool>>` and `RefCell<Option<Arc<BTreeMap<String, Arc<DeviceTensor>>>>>` (the device weight cache)
+- [x] 2.5 Add a static assertion in `onnx-rt/src/session.rs`: `const _: fn() = || { fn assert_send_sync<T: Send + Sync>() {} assert_send_sync::<Session>(); };` — guarantees the regression cannot recur silently
+- [x] 2.6 Run `cargo build --features cuda,nvidia_gpu` natively (host CPU, no link to libcudart needed via `cargo check`) — must pass
+- [x] 2.7 Run `cargo test --features cuda` for any tests that exercise the cache types — verify no behavioral change
+
+## 3. CI gate for the cuda feature
+
+- [x] 3.1 Add a job `cuda-check` to `.github/workflows/ci.yml` that runs `cargo check --workspace --features cuda,nvidia_gpu` on `ubuntu-latest`
+- [x] 3.2 Wire `cuda-check` into the `change-gates` meta-job so it blocks merge
+- [x] 3.3 Verify on this PR that the new gate catches a deliberately-reverted-Send change (test-time only — revert local change after green run)
+
+## 4. arch/nvidia tegra-orin feature
+
+- [x] 4.1 In `arch/nvidia/Cargo.toml`, add `tegra-orin = ["cc_87"]` for the Orin-family container target. Leave `tegra = ["cc_53"]` (X1 bare-metal HAL) unchanged so the `smallaios-arch-aarch64` Jetson Nano boot path is not disturbed
+- [x] 4.2 Doc-comment both features explaining when each one applies (HAL bare-metal vs. container userspace CUDA)
+- [x] 4.3 Reference `tegra-orin` from `Dockerfile.jetson` build command
+
+## 5. Dockerfile.jetson (Phase 2)
+
+- [x] 5.1 Create `Dockerfile.jetson` based on `nvcr.io/nvidia/l4t-jetpack:r36.4.0` (full JetPack convenience target, ~10 GB)
+- [x] 5.2 Builder stage: install Rust nightly-2026-02-01 with `aarch64-unknown-linux-gnu` target
+- [x] 5.3 Build command: `cargo build --release --target aarch64-unknown-linux-gnu -p smallaios-container --features cuda,nvidia_gpu,smallaios-arch-nvidia/tegra-orin`
+- [x] 5.4 Runtime stage: same L4T base (cuDNN + CUDA already present), copy binary, set `SMALLAIOS_GPU_BACKEND=cuda` default
+- [x] 5.5 Add `EXPOSE 8080`, `VOLUME /models`, `ENTRYPOINT ["/smallaios"]`
+- [x] 5.6 Add `aarch64-unknown-linux-gnu` to `rust-toolchain.toml` `targets` so local devs can `rustup target add` it cleanly
+- [x] 5.7 Add `RUSTFLAGS="-L /usr/local/cuda/lib64 -L /usr/local/cuda/lib64/stubs -L /usr/lib/aarch64-linux-gnu"` so the linker can find libcudart / libcublas / libcudnn at link time
+
+## 5b. Dockerfile.jetson.slim (Phase 2, recommended variant)
+
+- [x] 5b.1 Create `Dockerfile.jetson.slim` — JetPack builder, `nvcr.io/nvidia/l4t-cuda:12.6.11-runtime` runtime
+- [x] 5b.2 Copy `libcudnn*.so.9` and `*.so.9.3.0` files from the JetPack builder stage into `/usr/lib/aarch64-linux-gnu/` of the runtime stage; run `ldconfig`
+- [x] 5b.3 Document the per-cuDNN-sub-library trim options (drop `libcudnn_engines_precompiled.so` for −510 MB or `libcudnn_adv.so` for −288 MB) in the Dockerfile header
+- [x] 5b.4 Verify slim variant passes the same smoke test (compute 8.7, SqueezeNet `[GPU]`, /v1/inference 200/400) on Jetson Orin NX
+
+## 6. docker-compose Jetson profiles
+
+- [x] 6.1 Add `smallaios-jetson` service under `profiles: [jetson]` (Dockerfile.jetson)
+- [x] 6.2 Add `smallaios-jetson-slim` service under `profiles: [jetson-slim]` (Dockerfile.jetson.slim)
+- [x] 6.3 Use `runtime: nvidia` and `NVIDIA_VISIBLE_DEVICES=all` on both
+- [x] 6.4 Use `/healthz` for the healthcheck (CPU service uses `/health`; the Jetson and GPU services correctly use `/healthz` per existing convention)
+- [x] 6.5 Mount `./models:/models:ro`
+- [x] 6.6 Update the comment block at the top of `docker-compose.yml` to list the new profile and image-size delta
+
+## 7. Smoke test script
+
+- [x] 7.1 Create `scripts/test-jetson-gpu.sh` (chmod +x) that:
+  - takes an optional `slim` argument to switch to the slim variant; default = full JetPack
+  - downloads SqueezeNet to `models/squeezenet.onnx` if absent
+  - runs `docker compose --profile jetson{,-slim} up -d --build smallaios-jetson{,-slim}`
+  - polls `/healthz` and `/readyz` until ready or 120 s timeout
+  - asserts logs include `compute 8.7` (with retry loop + `--no-color` to handle slow log flush on the slim variant)
+  - posts a minimal payload to `/v1/inference` and asserts 200 or 400 (probe — proves the endpoint is reachable; full numerics are covered by onnx-rt integration tests)
+  - tears the service down on success or failure (always cleans up)
+- [x] 7.2 Add `test-jetson-gpu [variant]` recipe to `Justfile` calling the script
+- [x] 7.3 Document expected vs failure exit codes inside the script header
+
+## 8. Documentation (Phase 3)
+
+- [x] 8.1 Create `docs/jetson-quickstart.md` covering: hardware support matrix (Orin Nano/NX/AGX), required JetPack version (≥ 6 / L4T R36.4), full vs slim image variants table, one-command run via `docker compose --profile jetson-slim up`, sample `/v1/inference` curl, troubleshooting CDI driver-mismatch errors, deeper-trim options (drop libcudnn_engines_precompiled / libcudnn_adv)
+- [x] 8.2 Add a Jetson row to `README.md`'s deployment matrix with a link to the quickstart
+- [x] 8.3 Update `CLAUDE.md` "Current state" to note Jetson Orin GPU validation, and add `Dockerfile.jetson` to the Build Configuration / Container Environment Variables sections as appropriate
+- [ ] 8.4 Cross-link `docs/jetson-quickstart.md` from `docs/safetensors-integration.md` and `docs/inference-bus.md` if the Jetson story changes anything for those subsystems (likely a single sentence each) — DEFERRED: nothing in the Jetson path changes either subsystem's contract
+- [ ] 8.5 Add a CHANGELOG entry under the next release describing both the Send/Sync fix and the new Jetson container path — DEFERRED: CHANGELOG is auto-generated by `git-cliff` from conventional commits per `docs/release-runbook.md`
+
+## 9. CI advisory build
+
+- [x] 9.1 Add a `jetson-image-build` job to `.github/workflows/ci.yml` running `docker buildx build -f Dockerfile.jetson --platform linux/arm64 --load .` with `continue-on-error: true`
+- [x] 9.2 Cache the L4T base layer with `cache-from`/`cache-to: type=gha`
+- [x] 9.3 Add a comment block in the workflow file noting "promote to gate when self-hosted Jetson runner is available"
+
+## 10. End-to-end validation on real hardware
+
+- [x] 10.1 Run `just test-jetson-gpu` on the dev Jetson Orin NX (L4T R36.4.7, JetPack 6, driver 540.4.0) — passes for both fat and slim variants
+- [x] 10.2 Capture the boot log with `compute 8.7` and the successful `/v1/inference` response into the PR description — recorded: `CUDA initialized: Orin (compute 8.7, 15655 MB VRAM, CUDA 12)`, `Session ready: squeezenet [GPU]`, `/v1/inference` returns 200 with [1, 1000] f32 logits
+- [x] 10.3 Run `nvidia-smi` inside the container to confirm GPU visibility (or note the equivalent `tegrastats` workflow if `nvidia-smi` is not present) — used `tegrastats` (host-side, since Jetson `nvidia-smi` is limited): GR3D_FREQ baseline 0% → bursts up to 23% during sustained inference → 0% after; 305/2822 samples non-zero
+- [x] 10.4 Compare the GPU inference output against CPU-mode output for SqueezeNet within 1e-3 relative tolerance — log result in PR. Result: max |gpu - cpu| = 5.07e-4, mean 1.62e-4, well within tolerance
+
+## 11. Verify + archive
+
+- [x] 11.1 Run `openspec validate jetson-orin-container-v1 --strict`
+- [ ] 11.2 Open PR against `develop` with proposal/design/tasks/specs and the implementation
+- [ ] 11.3 After merge, run `/opsx:archive jetson-orin-container-v1` (will move to `openspec/changes/archive/2026-05-02-jetson-orin-container-v1`)

--- a/openspec/changes/jetson-orin-container-v1/tasks.md
+++ b/openspec/changes/jetson-orin-container-v1/tasks.md
@@ -15,7 +15,7 @@
 
 ## 3. CI gate for the cuda feature
 
-- [x] 3.1 Add a job `cuda-check` to `.github/workflows/ci.yml` that runs `cargo check --workspace --features cuda,nvidia_gpu` on `ubuntu-latest`
+- [x] 3.1 Add a job `cuda-check` to `.github/workflows/ci.yml` that runs `cargo check --features cuda,nvidia_gpu` on `ubuntu-latest`. **Deviation:** `--workspace` is infeasible because `arch/aarch64` and `arch/riscv64` carry unguarded `core::arch::asm!` blocks that only assemble for their own target_arch (matches the existing `Unit Tests` job's curated-list pattern). The job covers `smallaios-onnx-rt` + `smallaios-container` + `smallaios-arch-nvidia` + `smallaios-compute` — every workspace crate that touches the `cuda`/`nvidia_gpu` features either directly or via a dependency edge. Comment in the workflow file documents the constraint and the rule for adding new crates.
 - [x] 3.2 Wire `cuda-check` into the `change-gates` meta-job so it blocks merge
 - [x] 3.3 Verify on this PR that the new gate catches a deliberately-reverted-Send change (test-time only — revert local change after green run)
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -6,4 +6,5 @@ targets = [
     "aarch64-unknown-none",
     "x86_64-unknown-linux-musl",
     "aarch64-unknown-linux-musl",
+    "aarch64-unknown-linux-gnu",
 ]

--- a/scripts/test-jetson-gpu.sh
+++ b/scripts/test-jetson-gpu.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Copyright 2026 SmallAIOS Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Jetson Orin GPU smoke test.
+#
+# Pass `slim` as $1 to test Dockerfile.jetson.slim (jetson-slim profile)
+# instead of the default fat-base Dockerfile.jetson (jetson profile).
+#
+# Builds smallaios:jetson{,-slim} via docker compose, boots it on the
+# local Jetson with the NVIDIA Container Runtime, downloads SqueezeNet
+# if needed, and validates:
+#   1. /healthz returns 200 within the readiness window
+#   2. /readyz returns 200 (model loaded)
+#   3. Container logs include "compute 8.7" — proves the integrated
+#      Tegra Orin GPU was probed by cudaGetDeviceProperties (NOT a
+#      CPU fallback)
+#   4. POST /v1/inference against squeezenet returns 200
+#
+# Always tears the service down on exit (success or failure).
+#
+# Exit codes:
+#   0   all checks passed
+#   10  docker compose build failed
+#   20  health/ready did not become green within the timeout
+#   30  GPU init line missing (silent CPU fallback or wrong device)
+#   40  inference request did not return 200
+#   50  prerequisite check failed (missing docker, no nvidia runtime, etc.)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_DIR"
+
+READY_TIMEOUT=120
+case "${1:-}" in
+    slim)
+        COMPOSE_SERVICE=smallaios-jetson-slim
+        COMPOSE_PROFILE=jetson-slim
+        VARIANT_LABEL="slim"
+        ;;
+    ""|fat|full)
+        COMPOSE_SERVICE=smallaios-jetson
+        COMPOSE_PROFILE=jetson
+        VARIANT_LABEL="full"
+        ;;
+    *)
+        echo "Unknown variant: $1 (expected 'slim' or '' / 'fat' / 'full')" >&2
+        exit 51
+        ;;
+esac
+
+red()    { printf "\033[31m%s\033[0m\n" "$*"; }
+green()  { printf "\033[32m%s\033[0m\n" "$*"; }
+yellow() { printf "\033[33m%s\033[0m\n" "$*"; }
+info()   { yellow "[jetson-gpu] $*"; }
+ok()     { green  "[jetson-gpu] $*"; }
+fail()   { red    "[jetson-gpu] $*"; }
+
+cleanup() {
+    info "Tearing down container ..."
+    docker compose --profile "$COMPOSE_PROFILE" down --remove-orphans >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# --- Prereqs --------------------------------------------------------
+command -v docker >/dev/null 2>&1 || { fail "docker not installed"; exit 50; }
+docker info 2>/dev/null | grep -q "Runtimes:.*nvidia" \
+    || { fail "NVIDIA Container Runtime not configured (install nvidia-container-toolkit)"; exit 50; }
+
+# --- Fetch the test model if needed --------------------------------
+mkdir -p models
+if [ ! -f models/squeezenet.onnx ]; then
+    info "Downloading SqueezeNet ONNX (~5 MB) ..."
+    curl -L --fail-with-body --progress-bar \
+        -o models/squeezenet.onnx \
+        https://github.com/onnx/models/raw/main/validated/vision/classification/squeezenet/model/squeezenet1.1-7.onnx
+fi
+
+# --- Build ----------------------------------------------------------
+info "Building smallaios:jetson [${VARIANT_LABEL}] (this can take 5-15 min cold; L4T base ~3 GB) ..."
+if ! docker compose --profile "$COMPOSE_PROFILE" build "$COMPOSE_SERVICE"; then
+    fail "compose build failed"
+    exit 10
+fi
+ok "Image built."
+
+# --- Boot -----------------------------------------------------------
+info "Starting service ..."
+docker compose --profile "$COMPOSE_PROFILE" up -d "$COMPOSE_SERVICE"
+
+# --- Wait for ready -------------------------------------------------
+info "Waiting up to ${READY_TIMEOUT}s for /healthz + /readyz ..."
+deadline=$(( $(date +%s) + READY_TIMEOUT ))
+while :; do
+    if curl -sf http://localhost:8080/healthz >/dev/null 2>&1 \
+        && curl -sf http://localhost:8080/readyz >/dev/null 2>&1; then
+        ok "Healthy + ready."
+        break
+    fi
+    if [ "$(date +%s)" -gt "$deadline" ]; then
+        fail "service did not become ready within ${READY_TIMEOUT}s"
+        docker compose --profile "$COMPOSE_PROFILE" logs --tail=50 "$COMPOSE_SERVICE" || true
+        exit 20
+    fi
+    sleep 2
+done
+
+# --- GPU init log check --------------------------------------------
+# Poll up to 10s — the GPU init line is logged before the readiness
+# probe flips, but `docker compose logs` is async and may briefly lag
+# the in-container stdout flush, especially on the slim variant whose
+# ldconfig + cuDNN dlopen are heavier on first launch. Use --no-color
+# so the grep is not fooled by ANSI escape sequences.
+info "Checking container logs for 'compute 8.7' ..."
+gpu_log_ok=false
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+    if docker compose --profile "$COMPOSE_PROFILE" logs --no-color "$COMPOSE_SERVICE" 2>&1 \
+        | grep -F "compute 8.7" >/dev/null; then
+        gpu_log_ok=true
+        break
+    fi
+    sleep 1
+done
+if $gpu_log_ok; then
+    ok "GPU initialised at compute 8.7 (Tegra Orin)."
+else
+    fail "Expected 'compute 8.7' in logs — silent CPU fallback or wrong device"
+    docker compose --profile "$COMPOSE_PROFILE" logs --no-color --tail=80 "$COMPOSE_SERVICE" || true
+    exit 30
+fi
+
+# --- Inference round-trip ------------------------------------------
+info "POST /v1/inference (squeezenet) ..."
+# SqueezeNet 1.1 takes a [1, 3, 224, 224] f32 input. We don't ship a
+# fixture-encoded request body in this smoke test — the goal is just
+# to confirm the endpoint is reachable end-to-end and returns 200 on
+# a well-formed but minimal payload. Inference contract details live
+# in onnx-rt integration tests.
+HTTP_CODE=$(curl -s -o /tmp/jetson-infer.out -w "%{http_code}" \
+    -X POST http://localhost:8080/v1/inference \
+    -H "Content-Type: application/json" \
+    -d '{"model":"squeezenet"}' || true)
+
+if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "400" ]; then
+    # 400 is acceptable here — the smoke test sends a minimal probe
+    # body, and the runtime correctly rejecting it (rather than
+    # crashing or timing out) still proves the pipeline is wired up
+    # GPU-side. 200 with a real fixture body would be a stronger
+    # check; that's covered by the onnx-rt integration tests.
+    ok "/v1/inference returned ${HTTP_CODE} (endpoint reachable)."
+else
+    fail "/v1/inference returned ${HTTP_CODE} (expected 200 or 400)"
+    cat /tmp/jetson-infer.out 2>/dev/null || true
+    exit 40
+fi
+
+ok "All Jetson GPU smoke checks passed."
+exit 0

--- a/scripts/test-jetson-gpu.sh
+++ b/scripts/test-jetson-gpu.sh
@@ -24,8 +24,9 @@
 #   10  docker compose build failed
 #   20  health/ready did not become green within the timeout
 #   30  GPU init line missing (silent CPU fallback or wrong device)
-#   40  inference request did not return 200
-#   50  prerequisite check failed (missing docker, no nvidia runtime, etc.)
+#   40  inference request did not return 200, or response shape is wrong
+#   50  prerequisite check failed (missing docker / curl / nvidia runtime / compose plugin / python3)
+#   51  unknown variant argument (only "slim", "fat", "full", or empty are accepted)
 
 set -euo pipefail
 
@@ -58,14 +59,23 @@ info()   { yellow "[jetson-gpu] $*"; }
 ok()     { green  "[jetson-gpu] $*"; }
 fail()   { red    "[jetson-gpu] $*"; }
 
+TMP_FILES_TO_REMOVE=()
+
 cleanup() {
     info "Tearing down container ..."
     docker compose --profile "$COMPOSE_PROFILE" down --remove-orphans >/dev/null 2>&1 || true
+    for f in "${TMP_FILES_TO_REMOVE[@]}"; do
+        rm -f "$f" 2>/dev/null || true
+    done
 }
 trap cleanup EXIT
 
 # --- Prereqs --------------------------------------------------------
 command -v docker >/dev/null 2>&1 || { fail "docker not installed"; exit 50; }
+command -v curl   >/dev/null 2>&1 || { fail "curl not installed";   exit 50; }
+command -v python3 >/dev/null 2>&1 || { fail "python3 not installed (needed to build the f32 inference payload)"; exit 50; }
+docker compose version >/dev/null 2>&1 \
+    || { fail "docker compose plugin not installed"; exit 50; }
 docker info 2>/dev/null | grep -q "Runtimes:.*nvidia" \
     || { fail "NVIDIA Container Runtime not configured (install nvidia-container-toolkit)"; exit 50; }
 
@@ -132,27 +142,54 @@ else
 fi
 
 # --- Inference round-trip ------------------------------------------
-info "POST /v1/inference (squeezenet) ..."
-# SqueezeNet 1.1 takes a [1, 3, 224, 224] f32 input. We don't ship a
-# fixture-encoded request body in this smoke test — the goal is just
-# to confirm the endpoint is reachable end-to-end and returns 200 on
-# a well-formed but minimal payload. Inference contract details live
-# in onnx-rt integration tests.
-HTTP_CODE=$(curl -s -o /tmp/jetson-infer.out -w "%{http_code}" \
+info "Generating a [1, 3, 224, 224] f32 input for SqueezeNet ..."
+# Build a real, deterministic input payload so /v1/inference receives
+# a well-formed tensor and the smoke test exercises the GPU-side
+# parse-decode-dispatch path end-to-end. Use python3 (universally
+# present on JetPack hosts) instead of jq, which doesn't handle a
+# 150528-element float array efficiently.
+REQ_FILE="$(mktemp -t smallaios-jetson-req.XXXXXX.json)"
+RESP_FILE="$(mktemp -t smallaios-jetson-resp.XXXXXX.txt)"
+# Make sure the temp files are cleaned up alongside container teardown.
+TMP_FILES_TO_REMOVE+=("$REQ_FILE" "$RESP_FILE")
+python3 - <<'PY' > "$REQ_FILE"
+import json
+shape = [1, 3, 224, 224]
+n = shape[0] * shape[1] * shape[2] * shape[3]
+data = [(i % 256) / 255.0 for i in range(n)]
+print(json.dumps({
+    "model": "squeezenet",
+    "inputs": {"data": {"shape": shape, "dtype": "float32", "data": data}}
+}))
+PY
+
+info "POST /v1/inference (squeezenet, real f32 input, expect 200) ..."
+HTTP_CODE=$(curl -s -o "$RESP_FILE" -w "%{http_code}" \
     -X POST http://localhost:8080/v1/inference \
     -H "Content-Type: application/json" \
-    -d '{"model":"squeezenet"}' || true)
+    --data-binary @"$REQ_FILE" || true)
 
-if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "400" ]; then
-    # 400 is acceptable here — the smoke test sends a minimal probe
-    # body, and the runtime correctly rejecting it (rather than
-    # crashing or timing out) still proves the pipeline is wired up
-    # GPU-side. 200 with a real fixture body would be a stronger
-    # check; that's covered by the onnx-rt integration tests.
-    ok "/v1/inference returned ${HTTP_CODE} (endpoint reachable)."
+if [ "$HTTP_CODE" = "200" ]; then
+    # Sanity-check the response shape: must contain a 1000-element
+    # output tensor (SqueezeNet ImageNet logits) under the model's
+    # output name. Don't assert exact values — those depend on
+    # numerical determinism we don't guarantee across CUDA versions.
+    if python3 -c "
+import json, sys
+with open('$RESP_FILE') as f: d = json.load(f)
+out = next(iter(d['outputs'].values()))
+assert out['dtype'] == 'float32', f'wrong dtype: {out[\"dtype\"]}'
+assert len(out['data']) == 1000, f'wrong output size: {len(out[\"data\"])}'
+" 2>/dev/null; then
+        ok "/v1/inference returned 200 with valid [1, 1000] f32 logits."
+    else
+        fail "/v1/inference returned 200 but response shape is wrong"
+        head -c 400 "$RESP_FILE" 2>/dev/null
+        exit 40
+    fi
 else
-    fail "/v1/inference returned ${HTTP_CODE} (expected 200 or 400)"
-    cat /tmp/jetson-infer.out 2>/dev/null || true
+    fail "/v1/inference returned ${HTTP_CODE} (expected 200)"
+    head -c 400 "$RESP_FILE" 2>/dev/null
     exit 40
 fi
 


### PR DESCRIPTION
## Summary

Implements OpenSpec change [`jetson-orin-container-v1`](openspec/changes/jetson-orin-container-v1/proposal.md). Two distinct deliverables in one PR because they were uncovered together during validation:

- **Phase 1 (cross-platform compile fix):** `cargo build --features cuda,nvidia_gpu` was broken on every platform after #118 (CUDA Graphs) + #120 (async-multistream) introduced `RefCell<Option<CudaGraphCache>>`, `RefCell<Option<StreamPool>>`, and a raw `*mut c_void` (cudaGraphExec_t) into `Session`. None are `Send + Sync`, but the HTTP route closures and `std::thread::spawn` bodies require it. Seven `E0277` errors, no CI gate covering the cuda feature.
- **Phase 2 (Jetson Orin container):** SmallAIOS could not run on Jetson — `Dockerfile.cuda` uses NGC `cuda:13.0` which the Jetson CDI runtime rejects (Jetson driver 540 / CUDA 12.6). New L4T-based Dockerfiles + `tegra-orin` feature.
- **Phase 3 (docs, smoke test, CI):** Quickstart, smoke test script, advisory CI job, README/CLAUDE.md updates.

A second commit refreshes `.claude/` skill templates that had drifted from OpenSpec CLI 1.3.1's emit (`generatedBy: 1.2.0 → 1.3.1`).

## What changed

### Phase 1 — Send + Sync on Session under cuda feature

- `unsafe impl Send + Sync` on `CaptureStream` / `CudaGraph` / `CudaGraphExec` / `Stream` / `Event` with safety contract documented in `cuda::graph` module docs (cites CUDA's same-context-current rule).
- `RefCell` → `Mutex` on `Session::{device_initializer_cache, cuda_graph_cache, stream_pool}` and the events pool inside `StreamPool`.
- Static `assert_send_sync::<Session>()` so the regression cannot recur silently.
- CUDA runtime major-version check relaxed from `== 13` to `12..=13` so the same binary works on JetPack 6 (12.6) and DGX Spark (13.x).
- New CI gate `cuda-check` (`cargo check --features cuda,nvidia_gpu` on `ubuntu-latest`, no GPU runner needed).

### Phase 2 — Jetson Orin container

- **`Dockerfile.jetson.slim`** (recommended, 4.09 GB) — l4t-cuda runtime + cuDNN copied from JetPack builder. **55% smaller than NVIDIA Triton's published Jetson image.**
- **`Dockerfile.jetson`** (full L4T JetPack 6, 9.83 GB) — convenience target.
- New `tegra-orin = ["cc_87"]` feature on `smallaios-arch-nvidia` for Orin Nano Super / NX / AGX. Existing `tegra` flag (Tegra X1 / cc 5.3 bare-metal HAL) untouched — Jetson Nano boot path unaffected.
- `aarch64-unknown-linux-gnu` added to `rust-toolchain.toml` targets.
- `docker-compose.yml`: `jetson` and `jetson-slim` profiles.

### Phase 3 — Docs + tests + CI advisory

- `docs/jetson-quickstart.md` with hardware matrix, both image variants, troubleshooting (CDI driver-mismatch error, deeper-trim options), and a measured cold-start benchmark section.
- `README.md` deployment matrix updated; `CLAUDE.md` "Current state" updated.
- `scripts/test-jetson-gpu.sh [variant]` smoke test (`just test-jetson-gpu`, `just test-jetson-gpu slim`).
- `.github/workflows/ci.yml` — advisory `jetson-image-build` job (linux/arm64 under QEMU, `continue-on-error` until a self-hosted Jetson runner is available).

## Validation evidence (Jetson Orin NX, L4T R36.4.7, JetPack 6, CUDA 12.6, driver 540.4.0)

**Boot log — proves GPU was probed at compute 8.7:**

```
SmallAIOS 0.2.1
Container mode: running as Linux userspace process
Config: model_dir=/models, port=8080, gpu=cuda, bus_backend=none
GPU precision mode: Tf32
CUDA initialized: Orin (compute 8.7, 15655 MB VRAM, CUDA 12)
Loading models from '/models'...
  Model 'squeezenet': 4956208 bytes [onnx] OK
  Session ready: squeezenet [GPU]
HTTP inference sessions ready: 1
Ready. Listening on 0.0.0.0:8080
```

**Cold-start (5 runs, median ms, `--runtime=nvidia`, SqueezeNet loaded):**

| Container | Median | × slim | Image |
|-----------|-------:|-------:|------:|
| Docker baseline (`l4t-cuda` + `echo`, control) | 769 ms | 1.01× | 2.09 GB |
| **smallaios slim** | **762 ms** | **1.00×** | **4.09 GB** |
| smallaios fat | 901 ms | 1.18× | 9.83 GB |
| python:3.11-slim + stdlib `http.server` (no GPU) | 862 ms | 1.13× | 0.13 GB |
| **NVIDIA Triton + ORT** (`tritonserver:24.10-py3-igpu`) | **3,300 ms** | **4.33×** | **9.04 GB** |

smallaios slim is **4.33× faster cold-start than Triton** on the same hardware loading the same model, in an image **55% smaller**.

**GPU dispatch confirmed via `tegrastats`** (200 ms sampling): GR3D_FREQ baseline 0% → bursts to **23%** during sustained inference → 0% after. 305 of 2,822 samples non-zero. SqueezeNet inference is short enough that the 200 ms poll mostly misses it; the bursts that did get sampled prove dispatch.

**GPU vs CPU output diff (same input, `SMALLAIOS_GPU_BACKEND=cuda` vs `cpu`):**

- `max |gpu - cpu|` = **5.07e-4**
- `mean |gpu - cpu|` = 1.62e-4
- Within the 1e-3 tolerance specified in `tasks.md` task 10.4 — proves the GPU path computes correct SqueezeNet outputs (not bypassed / no-op).

## Test plan

- [x] `cargo check --features cuda,nvidia_gpu` (host, no GPU runner needed) — clean
- [x] `cargo clippy -p smallaios-onnx-rt -p smallaios-container --features cuda,nvidia_gpu -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `openspec validate jetson-orin-container-v1 --strict` — clean
- [x] `just test-jetson-gpu` (full image) on Jetson Orin NX — green
- [x] `just test-jetson-gpu slim` (slim image) on Jetson Orin NX — green
- [x] GPU compute confirmed via tegrastats during sustained inference
- [x] GPU vs CPU output parity within 1e-3 — confirmed
- [ ] CI green — to be confirmed once the workflow runs

## Files

```
M  .github/workflows/ci.yml          (+ cuda-check gate, + jetson-image-build advisory)
M  .gitignore                        (+ /models/ for runtime-fetched fixtures)
M  CLAUDE.md
M  Justfile                          (+ docker-build-jetson{,-slim}, test-jetson-gpu)
M  README.md                         (deployment matrix)
M  arch/nvidia/Cargo.toml            (+ tegra-orin = ["cc_87"])
M  docker-compose.yml                (+ jetson{,-slim} profiles)
M  onnx-rt/src/cuda/{graph,streams,mod}.rs   (Send/Sync wrappers, CUDA 12 support)
M  onnx-rt/src/session.rs            (RefCell→Mutex + static assertion)
M  rust-toolchain.toml               (+ aarch64-unknown-linux-gnu)
A  Dockerfile.jetson                 (full JetPack base)
A  Dockerfile.jetson.slim            (recommended)
A  docs/jetson-quickstart.md
A  scripts/test-jetson-gpu.sh
A  openspec/changes/jetson-orin-container-v1/   (proposal/design/tasks/specs)
M  .claude/{commands/opsx/*,skills/openspec-*/SKILL.md}   (template refresh, separate commit)
```

## Notes

- Two deferrals tracked in `tasks.md`:
  - **8.4** (cross-link `safetensors-integration.md` / `inference-bus.md`) — Jetson path doesn't change either subsystem's contract; nothing to cross-link.
  - **8.5** (CHANGELOG) — repo CHANGELOG is auto-generated by `git-cliff` from conventional commits per `docs/release-runbook.md`; both commits in this PR conform.
- Post-merge: `chore(openspec): archive jetson-orin-container-v1` in a small follow-up commit per the repo's existing archival convention (#119, #121).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Jetson Orin container support for CUDA-accelerated ONNX inference (slim + full images) and new container deployment options.

* **Improvements**
  * Thread-safety and robustness for GPU execution paths; broader CUDA runtime compatibility; expanded ONNX operator support and GPU readiness checks.

* **Documentation**
  * Jetson quickstart, container deployment matrix, and deployment/runbook updates.

* **Tests**
  * End-to-end Jetson GPU smoke test script and compose profiles.

* **CI**
  * New advisory Jetson image build and CUDA-focused check added to PR gates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->