### PR TITLE
docs(openspec): propose unikernel-orin-bringup-v1

### DIFF
--- a/openspec/changes/unikernel-orin-bringup-v1/design.md
+++ b/openspec/changes/unikernel-orin-bringup-v1/design.md
@@ -1,0 +1,142 @@
+# Design — unikernel-orin-bringup-v1
+
+## Goal
+
+Two ordered milestones, both verified by serial-console output on a Seeed reComputer J4012 (Jetson Orin NX 16 GB):
+
+1. **Phase 1 — KVM smoke test.** Boot the existing `aarch64-unknown-none` SmallAIOS kernel under `qemu-system-aarch64 -accel kvm -cpu host` running on the J4012's L4T host OS. Success = "SmallAIOS boot banner over the QEMU PL011 UART, observed over `qemu -nographic`, with a recognized GICv3 init line and the cooperative scheduler reaching its idle loop."
+2. **Phase 2 — UEFI USB bare-metal boot.** Boot the same kernel (rebuilt for `aarch64-unknown-uefi` with a `tegra234` feature) directly on the J4012 from a USB stick, no L4T involved at runtime. Success = "SmallAIOS boot banner over the J4012's physical UART header, GICv3 init, scheduler idle, observable to a serial cable on a separate machine."
+
+GPU, eMMC writes, NVMe boot, network boot, and Secure-Boot signing are explicitly out of scope.
+
+## Phase 1 — KVM-on-L4T
+
+### Why KVM first, not kexec or UEFI
+
+KVM has the smallest delta to what already works:
+
+- The existing `Build AArch64 Kernel` CI job already produces a kernel that boots under QEMU `virt`. The only delta for KVM is `-accel kvm -cpu host`, which only changes the execution mode (TCG → KVM); the guest sees the same `virt` machine.
+- KVM on Orin requires JetPack 6's `kvm` kernel module, which ships enabled on JetPack 6 / L4T R36.4 by default. Verified by `lsmod | grep kvm` + `cat /sys/devices/system/cpu/cpu0/...` for HCR_EL2 access. (The J4012 verification commands the user is collecting include this check.)
+- L4T is still in the picture, so a panic during early boot just terminates the QEMU process — no risk to the host. Iteration loop is fast: `cargo build` → `scp` → `qemu-system-aarch64 ...` → console output, sub-30-second cycle.
+- KVM gives us "real Cortex-A78AE instructions" plus "real ARMv8 generic timer" plus "real GICv3 (KVM virtualizes a GICv3 by default on aarch64 hosts)". So we are exercising real hardware behavior for the CPU/timer/interrupt paths, even though peripherals are paravirtualized.
+
+`kexec` is rejected for Phase 1 because L4T has already initialized DRAM training, clocks, PMC, and most peripheral controllers; jumping to SmallAIOS via kexec means SmallAIOS inherits a partially-initialized hardware state that doesn't represent a real boot path. UEFI USB boot is rejected for Phase 1 because we don't have a Tegra234 BSP yet — we'd boot off the USB stick and immediately panic on the first MMIO access to a wrong UART base.
+
+### Phase 1 deliverables (no new Rust code)
+
+1. `just run-jetson-kvm SSH_HOST` recipe — cross-builds `smallaios-kernel.bin` for `aarch64-unknown-none`, scp's it to `$SSH_HOST:~`, ssh's into `$SSH_HOST` and runs `qemu-system-aarch64 -M virt,gic-version=3 -cpu host -accel kvm -m 1G -nographic -kernel ~/smallaios-kernel.bin`. The `-nographic` flag pipes the PL011 UART to the user's terminal.
+2. `scripts/test-jetson-kvm.sh [SSH_HOST]` — non-interactive smoke test wrapping the recipe, with a serial-output assertion (greps the boot output for an expected banner). Exits 0 on success, non-zero with a captured-output dump on failure.
+3. `kvm-smoke-build` CI job — runs `cargo build --target aarch64-unknown-none -p smallaios-kernel --release` and uploads the resulting binary as a workflow artifact, then runs the same kernel under TCG-emulated `virt` (since GitHub runners have no nested KVM). Asserts the same boot banner. Catches regressions in the QEMU-virt boot path that the J4012 can't catch automatically until we have a self-hosted runner.
+4. `docs/jetson-kvm-quickstart.md` — prerequisites (`apt install qemu-system-arm`, KVM module check, ssh access), the `just run-jetson-kvm` invocation, expected boot output snippet, troubleshooting (missing KVM module, GICv3 mismatch, virtio panic).
+
+### Why we keep Phase 1 separable
+
+If Phase 2 estimates blow out, Phase 1 still ships a real iteration loop for kernel hackers using the J4012 as a test target. The Phase 1 CI gate (`kvm-smoke-build`) enforces the existing AArch64 kernel boots under QEMU on every PR — useful regardless of what happens in Phase 2.
+
+## Phase 2 — UEFI USB bare-metal
+
+### Why UEFI USB and not other paths
+
+| Boot path | Risk | Iteration cost | Picks up our bring-up code? |
+|-----------|------|----------------|------------------------------|
+| **UEFI USB stick** | None — fail = remove stick + reboot | Medium (USB write loop) | Yes — we own from `_start` onward |
+| `kexec` from L4T | Low — bad jump = reboot | Fast (no flash) | Partial — L4T already initialized clocks/UART/etc. |
+| `extlinux.conf` swap | High — bad kernel = brick (recovery via SDK Manager + USB-recovery from x86 host) | Fast | Yes |
+| `flash.sh` to NVMe | High — wrong slot = brick | Slow (full flash) | Yes |
+| `flash.sh` to eMMC | Highest — wrong layout = brick | Slowest | Yes |
+
+UEFI USB is the only path that combines "we own the hardware from `_start`" with "no risk to the eMMC". JetPack 6 ships UEFI on Orin platforms (Jetson Linux R36.4 release notes confirm `Tegra UEFI` as the top of the boot chain), and the firmware menu lets us select a removable boot device at power-on. This is the standard Linux-on-arm-server boot flow, just on Tegra silicon.
+
+### Build target choice
+
+**`aarch64-unknown-uefi`**, not `aarch64-unknown-none`. UEFI provides a defined entry signature (`efi_main(handle, system_table) -> Status`), gives us the firmware's UART for early debug before our own UART driver is up, and lets us use `ExitBootServices` to take ownership of the hardware exactly when we are ready. The existing `aarch64-unknown-none` kernel can be linked against `uefi-rs` style entry stubs without a wholesale rewrite — the Tegra X1 path uses a similar shape with the X1 boot ROM hand-off.
+
+We do **not** support both targets simultaneously in Phase 2. The `tegra234` feature implies UEFI entry; `tegra-x1` continues to use `aarch64-unknown-none` with the X1 boot-ROM hand-off in `boot.rs`. Two boot entry points, two linker scripts, gated by their feature.
+
+### Tegra234 BSP — fork-from-X1 deltas
+
+Existing Tegra X1 (Tegra210 / cc 5.3) BSP layout:
+
+```
+arch/aarch64/
+  src/
+    boot.rs              ← X1 boot-ROM entry, sets up MMU + stack + jumps to kernel main
+    gicv2.rs             ← GICv2 (Tegra X1)
+    uart.rs              ← Tegra UART base = 0x70006000 (X1)
+    paging.rs, interrupts.rs, image_header.rs, platform.rs
+    tegra_dc.rs, tegra_sor.rs, tegra_edid.rs, tegra_pcie.rs   ← display/PCIe (X1-specific, not needed for Orin Phase 2)
+  linker-tegra.ld        ← Tegra210 memory map
+  dts/tegra210-smallaios.dts
+```
+
+Tegra234 BSP additions for Phase 2:
+
+```
+arch/aarch64/
+  src/
+    boot_uefi.rs         ← UEFI efi_main entry — gets RAM map + DTB pointer from system table, exits boot services, jumps into kernel main
+    gicv3.rs             ← GICv3 distributor + redistributor + ITS (Orin uses GICv3 LPIs but Phase 2 only needs SGIs/PPIs)
+    tegra234_uart.rs     ← Tegra Combined UART (TCU) at 0x0c280000 (Tegra234 base) — different MMIO from X1
+    tegra234_platform.rs ← memory-map descriptor, SoC ID, A78AE specific tweaks
+  linker-tegra234.ld     ← Tegra234 DRAM at 0x80000000+, image base for UEFI loadable PE/COFF
+  dts/tegra234-smallaios.dts  ← extracted from upstream L4T tegra234.dtsi, trimmed to UART + GIC + timer + memory only
+```
+
+Files that **stay X1-specific** and are not built when `tegra234` is on:
+- `tegra_dc.rs`, `tegra_sor.rs`, `tegra_edid.rs`, `tegra_pcie.rs` — X1 display/PCIe drivers; not needed for Phase 2 (we use UART, not framebuffer, and no PCIe peripherals are touched).
+- `gicv2.rs` — X1 only; the `tegra234` build links `gicv3.rs` instead.
+- `arch/nvidia/src/tegra/` — Maxwell GM20B GPU HAL; out of scope.
+
+Files that **are shared** between X1 and Orin:
+- `paging.rs`, `interrupts.rs` (the dispatch shape, not the controller driver), `image_header.rs`, the kernel main code paths.
+
+### Cargo feature naming
+
+| Crate | Feature | Selects |
+|-------|---------|---------|
+| `smallaios-arch-aarch64` | `tegra-x1` (existing) | Tegra X1 / cc 5.3 bare-metal HAL via `aarch64-unknown-none` |
+| `smallaios-arch-aarch64` | **`tegra234`** (new in Phase 2) | Tegra234 / Orin-family bare-metal HAL via `aarch64-unknown-uefi` |
+| `smallaios-arch-nvidia` | `tegra` (existing) | Same as `tegra-x1`, kept for back-compat — see PR #124 |
+| `smallaios-arch-nvidia` | `tegra-orin` (existing, from PR #124) | **Userspace CUDA** for cc 8.7 (Orin) — container path, not bare-metal |
+
+The two `tegra-orin`-shaped concepts (userspace CUDA target vs. bare-metal HAL) are deliberately given different names on different crates. `tegra-orin` on `arch/nvidia` means "userspace CUDA for Orin"; `tegra234` on `arch/aarch64` means "bare-metal HAL for the Tegra234 SoC family". A future `unikernel-orin-gpu-v1` change might add a third feature (e.g. `tegra234-gpu` on `arch/nvidia`) for the bare-metal Ampere GA10B HAL.
+
+### Risk: UEFI Secure Boot
+
+JetPack 6 may ship with Secure Boot enabled by default. Our `smallaios.efi` is unsigned in Phase 2; the firmware will refuse to load it. Two mitigations, documented in `docs/jetson-orin-uefi-boot.md`:
+
+1. **Disable Secure Boot in the firmware menu** for development. Restorable.
+2. **Enroll our development key** as a UEFI MOK (Machine Owner Key). Slightly more work, doesn't require disabling Secure Boot globally.
+
+Production UEFI signing is a follow-up change.
+
+### Risk: brick recovery
+
+Even though USB-stick boot can't write to eMMC, the user must not be tempted to "fix it permanently" by rewriting the EFI variables to make USB the default boot device. We document the firmware-menu workflow only and warn against `efibootmgr`-style permanent EFI-var changes during Phase 2.
+
+If something does brick the J4012 (e.g. user error during a future `flash.sh` follow-up), recovery is via NVIDIA SDK Manager + USB-recovery from an x86 Linux host. We add a one-paragraph "if you bricked the box" section to `docs/jetson-orin-uefi-boot.md` linking to NVIDIA's recovery procedure. In the Phase 2 critical path itself, no brick is possible.
+
+## Build/CI surface
+
+### Phase 1
+- New `just` recipe: `run-jetson-kvm` (parameterized by SSH host).
+- New script: `scripts/test-jetson-kvm.sh`.
+- New CI job: `kvm-smoke-build` — builds the kernel, runs it under TCG `virt`, asserts banner. Gates the change.
+- New docs: `docs/jetson-kvm-quickstart.md`.
+
+### Phase 2
+- New cargo feature `tegra234` on `smallaios-arch-aarch64`.
+- New build target: `aarch64-unknown-uefi` added to `rust-toolchain.toml` `targets`.
+- New CI job: `Build Jetson Orin UEFI` — builds `cargo build --target aarch64-unknown-uefi -p smallaios-kernel --features tegra234`, packages `smallaios.efi`, runs through a CI-side QEMU OVMF-aarch64 boot test (same shape as the OVMF tests Linux distros use to validate kernel images). Advisory initially.
+- New artifact: `build-jetson-usb.img` — FAT32 ESP image with `EFI/BOOT/BOOTAA64.EFI` for `dd`-to-USB.
+- New docs: `docs/jetson-orin-uefi-boot.md`.
+
+### Promote to gate later
+Both new CI jobs start advisory. Promote to gate (`change-gates` blocking) once a self-hosted Jetson runner is wired (separate change).
+
+## What this change explicitly does NOT do
+
+- It does not modify the existing Tegra X1 / Jetson Nano boot path. `tegra-x1` continues to mean what it means today.
+- It does not modify the merged Jetson container path. `Dockerfile.jetson*` and the GHCR strategy (still pending) are unaffected.
+- It does not add any GPU code. The unikernel boots and prints; everything beyond that is explicitly outside the change.
+- It does not change the workspace dependency layering. Both phases live in `arch/aarch64` (Layer 2) and consume only Layer 0/1 services.

--- a/openspec/changes/unikernel-orin-bringup-v1/proposal.md
+++ b/openspec/changes/unikernel-orin-bringup-v1/proposal.md
@@ -1,0 +1,57 @@
+# unikernel-orin-bringup-v1
+
+## Summary
+
+PR #124 landed the Jetson Orin **container** path: SmallAIOS runs as a Docker workload on top of L4T, using cuDNN/cuBLAS through NVIDIA's CDI runtime. That is the right deployment for Tegra-Orin-as-an-AI-server today. It is not, however, the SmallAIOS unikernel running on the Tegra Orin SoC — it's the SmallAIOS userspace running inside an Ubuntu-derived L4T host kernel. There is currently no path to exercise the native `aarch64-unknown-none` SmallAIOS kernel on Jetson Orin hardware (J4012 / Orin NX 16 GB) at all.
+
+This change opens that path in two phases. **Phase 1** (Goal A — small, fast) hosts the existing `aarch64-unknown-none` SmallAIOS kernel under `qemu-system-aarch64 -accel kvm -cpu host` running on the J4012's L4T host OS. The Orin Cortex-A78AE cores execute SmallAIOS instructions directly via KVM; the unikernel sees a generic ARM `virt` machine (PL011 UART, GICv3, virtio devices). This proves the cross-compile target works on Orin silicon, gives us a serial-console boot we can iterate on, and ships in days — but it does not exercise any Tegra234 hardware specifically. **Phase 2** (Goal B — larger, real) adds a Tegra234 board support package to `smallaios-arch-aarch64` (board file forking the existing Tegra X1 / Tegra210 BSP), then ships a USB-stick UEFI image that the J4012 can boot from without touching its eMMC. After Phase 2, the unikernel runs directly on the Tegra Orin SoC with its own UART, interrupt controller (GICv3), and memory map; L4T is not in the picture at runtime. GPU access (Ampere GA10B host1x) is **out of scope** for both phases — explicitly deferred.
+
+The two phases are released as one change because they share a goal (testing the native unikernel on the J4012), one design (the same cross-build pipeline feeds both), and one verification surface (serial-console boot output). They could split into two changes if Phase 2 grows beyond estimate; the proposal calls out the split point.
+
+## Why
+
+- **Container path is GPU-validated, but the unikernel itself is unproven on Orin silicon.** The existing AArch64 kernel (`smallaios-arch-aarch64`) builds for `aarch64-unknown-none` and is exercised in CI under QEMU `virt` only. There is no CI job and no documented procedure for running it on a real ARMv8 device, let alone a Tegra234 SoC. That is the blocker on every claim about SmallAIOS-as-a-unikernel for Jetson workloads. Phase 1 closes the cheap half (KVM execution) in days; Phase 2 closes the expensive half (real Tegra234 hardware) in weeks.
+- **The Tegra X1 (Tegra210 / Jetson Nano original) BSP already exists.** `arch/aarch64/src/{boot,uart,gicv2,paging,interrupts,platform}.rs`, `arch/aarch64/linker-tegra.ld`, `arch/aarch64/dts/tegra210-smallaios.dts`, plus `arch/nvidia/src/tegra/{clock,power,fifo,gmmu,gr,falcon,regs,mod}.rs` form a working bare-metal Tegra board package gated by the `tegra-x1` Cargo feature, built every PR by the existing `Build Jetson Nano (Tegra X1)` CI job. **Tegra234 is a fork-and-modify of that BSP**, not greenfield: same Cargo workspace, same linker-script pattern, same DTS pattern, similar initialization shape. The deltas are bounded (different MMIO bases, GICv3 instead of GICv2, A78AE-specific quirks, JetPack 6 UEFI entry point instead of the X1 boot ROM hand-off). This radically lowers the risk of a multi-month surprise.
+- **USB-stick UEFI boot is the right risk profile for a development kernel.** JetPack 6 ships a UEFI firmware on Orin; entering the firmware menu and booting a removable device is a standard supported path. Failure means "remove the USB stick and reboot to L4T". No flashing, no recovery mode, no risk to the eMMC. Compare to overwriting `/boot/extlinux/extlinux.conf` (one bad boot bricks the box; recovery requires SDK Manager + USB-recovery from an x86 host) or `kexec` from L4T (works but L4T has already initialized the peripherals — we wouldn't be exercising our own bring-up code).
+- **Tegra234 BSP is the foundation for any future SmallAIOS-as-Tegra story.** Whether we eventually run on Orin Nano Super, Orin NX, or AGX Orin, they all share the same SoC family (Tegra234) and the same UEFI / DRAM / interrupt / clock topology. Investing in this BSP once unlocks the whole Orin family. The container path remains the production-deployment recommendation for Jetson workloads; the unikernel path is for research, RTOS-grade workloads, formal-verification end-to-end coverage, and DAL A claim coverage that needs to span hardware init.
+
+## Phase 1 — KVM-on-L4T smoke test (Goal A, ~3-5 days)
+
+The existing AArch64 kernel build (`cargo build --target aarch64-unknown-none -p smallaios-kernel` for QEMU `virt`, the default no-Tegra build) produces an ELF that QEMU can boot. Phase 1 validates that the same ELF boots under KVM on the J4012's L4T host — Orin's own A78AE cores executing SmallAIOS instructions, virtio devices providing peripherals, PL011 UART providing the serial console.
+
+We add: (a) a CI job `kvm-smoke-build` that re-uses the existing `Build AArch64 Kernel` artifact and verifies a boot under TCG-emulated `virt` (since GitHub runners can't host KVM); (b) a `just run-jetson-kvm [SSH_HOST]` recipe that scp's the kernel to a configurable Jetson host and runs `qemu-system-aarch64 -M virt,gic-version=3 -cpu host -accel kvm -nographic -kernel smallaios-kernel.bin`; (c) `scripts/test-jetson-kvm.sh` that wraps the recipe with a serial-output assertion; (d) `docs/jetson-kvm-quickstart.md` covering prerequisites, the one-command run, and what successful boot output looks like.
+
+No new Rust code is introduced in Phase 1. The deliverable is a documented procedure plus a CI smoke-build plus a `just` recipe — all the kernel changes Phase 1 needs are already in `develop`.
+
+## Phase 2 — UEFI USB bare-metal boot (Goal B, ~3-5 weeks)
+
+Phase 2 adds a `tegra234` Cargo feature to `smallaios-arch-aarch64` (analogous to the existing `tegra-x1`), gated on a Tegra234 board support package. New files: `arch/aarch64/src/gicv3.rs` (GICv3 driver — Orin uses GICv3 LPIs and ITS), `arch/aarch64/src/tegra234_uart.rs` (Tegra234 NS16550-compatible UART at the Tegra234 MMIO base — different from X1), `arch/aarch64/linker-tegra234.ld` (Orin DRAM at `0x80000000`+, image base + reset entry), `arch/aarch64/dts/tegra234-smallaios.dts` (extracted from upstream L4T device tree, trimmed to what the unikernel uses). Modifications: `boot.rs` learns a `tegra234` entry path (same shape as `tegra-x1` but for the Orin DRAM map), `platform.rs` learns the Tegra234 platform descriptor, `interrupts.rs` learns the GICv3 dispatch shape.
+
+The image is built as a UEFI application — `cargo build --target aarch64-unknown-uefi -p smallaios-kernel --features tegra234` produces `smallaios.efi`. We package it into a FAT32 disk image (`build-jetson-usb.img`) with the standard UEFI ESP layout (`/EFI/BOOT/BOOTAA64.EFI`), so any user can `dd` it to a USB stick. CI gains a `Build Jetson Orin UEFI` job (advisory initially, gate later with self-hosted runner) running `cargo build --target aarch64-unknown-uefi -p smallaios-kernel --features tegra234`.
+
+A new `docs/jetson-orin-uefi-boot.md` covers: prerequisites, where to download `build-jetson-usb.img` (CI artifact), how to dd it to a USB stick, the J4012 firmware-menu key sequence to boot from the USB device, the expected serial-console output ("Hello, world from SmallAIOS on Tegra234"), and the recovery procedure (remove stick, reboot to L4T) — emphasizing that nothing is written to the J4012's eMMC.
+
+## Out of scope
+
+- **GPU access (Ampere GA10B / host1x v6).** The existing `arch/nvidia/src/tegra/` HAL targets the Maxwell GM20B GPU on Tegra X1. An Orin GPU port is its own multi-month effort — host1x v6 layout differs from v3 on X1, channel/syncpoint semantics shifted, and Ampere GR class registers diverge from Maxwell. Tracked for a future change (`unikernel-orin-gpu-v1`). Phase 1+2 deliver "the unikernel boots and prints over UART"; that is a meaningful milestone in its own right.
+- **eMMC replacement / overwriting L4T.** Out of scope by deliberate choice — USB-stick boot keeps the J4012 a usable L4T machine for the container path while the unikernel is iterated. eMMC replacement would require NVIDIA's `flash.sh` from a host x86 Linux machine and is reversible only via SDK Manager USB-recovery. Defer indefinitely.
+- **NVMe boot.** Possible follow-up once UEFI USB boot is solid (UEFI can boot from NVMe with the same `smallaios.efi` payload), but USB is the no-risk first cut. Tracked for a future change.
+- **Verified Boot integration.** The existing `verified-boot` Cargo feature on `smallaios-security` validates module signatures inside the kernel; integrating UEFI Secure Boot signing of `smallaios.efi` is a separate concern. Phase 2 documents the requirement to disable UEFI Secure Boot (or enroll our key) in the firmware menu before booting our unsigned EFI image. Production signing is a follow-up.
+- **PXE / network boot.** Useful for development iteration speed (no USB removal), but USB stick is the documented path for the first cut. Could be a thin add-on once Phase 2 lands.
+- **Reusing the `tegra-orin` feature name.** The existing `tegra-orin` feature on `smallaios-arch-nvidia` selects `cc_87` for the **userspace CUDA** path (PR #124). The new bare-metal feature lives on `smallaios-arch-aarch64` and is named `tegra234` (the SoC family) to avoid overloading the userspace name. Two features, two crates, two distinct meanings — documented in their respective Cargo manifests.
+
+## Sequencing
+
+Phase 1 lands first. It is independent of Phase 2 and provides immediate iteration value (a 1-minute build/scp/run loop for testing kernel changes against real Orin cores). Phase 2 starts after Phase 1 is green and follows the standard intra-phase order: (a) Tegra234 board file scaffolding + UEFI build target + minimal `boot.rs` that reaches `_start`, (b) Tegra234 UART hello-world over the J4012's serial header, (c) GICv3 + timer + minimal interrupt dispatch, (d) USB-image packaging + boot procedure docs + CI advisory job. Each sub-step has a serial-console-observable exit criterion.
+
+If Phase 2 grows beyond ~5 weeks of effort, we split it out as `unikernel-orin-bare-metal-v1` and archive this change with only Phase 1 implemented. The proposal makes the split point easy: Phase 1 deliverables are independent of any Phase 2 Rust code.
+
+## Effort estimate
+
+| Phase | Scope | Estimate |
+|-------|-------|----------|
+| 1 | KVM-on-L4T smoke test + `just` recipe + CI build + docs | ~3-5 days |
+| 2 | Tegra234 BSP fork + UEFI build target + USB image + bare-metal boot to UART | ~3-5 weeks |
+| **Total** | | **~4-6 weeks** |
+
+GPU and any eMMC-write paths add multi-month follow-ups outside this change.

--- a/openspec/changes/unikernel-orin-bringup-v1/specs/unikernel-jetson-orin/spec.md
+++ b/openspec/changes/unikernel-orin-bringup-v1/specs/unikernel-jetson-orin/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: KVM-hosted unikernel boot on Jetson Orin
+
+The repository SHALL provide a documented and CI-gated procedure for booting the existing `aarch64-unknown-none` SmallAIOS kernel under `qemu-system-aarch64 -accel kvm -cpu host` running on a Jetson Orin host (J4012 / Orin NX or any Tegra234 device with JetPack 6 / L4T R36.4+).
+
+#### Scenario: One-command run from a developer workstation
+
+- **GIVEN** a developer with `cargo`, `rustup`, and ssh access to a Jetson Orin running JetPack 6
+- **WHEN** they run `just run-jetson-kvm <ssh-host>` from the workspace root
+- **THEN** the recipe SHALL cross-build the SmallAIOS kernel for `aarch64-unknown-none`, copy the artifact to the Jetson host, launch `qemu-system-aarch64 -M virt,gic-version=3 -cpu host -accel kvm -nographic -kernel <artifact>`, and stream the PL011 UART output back to the developer's terminal
+- **AND** the boot banner SHALL appear within 30 seconds of recipe invocation
+- **AND** the kernel SHALL not panic before reaching the cooperative scheduler's idle loop
+
+#### Scenario: Smoke test wrapper for non-interactive use
+
+- **GIVEN** the same prerequisites as the developer flow
+- **WHEN** a CI / cron job invokes `scripts/test-jetson-kvm.sh <ssh-host>`
+- **THEN** the script SHALL grep the captured serial output for the documented boot banner, exit 0 on a hit, and exit non-zero with a captured-output dump on a miss
+- **AND** the script SHALL accept an `SSH_HOST` argument or environment variable so it can be parameterized per-runner without code changes
+
+#### Scenario: CI-side smoke build (no self-hosted Jetson runner required)
+
+- **GIVEN** a PR that touches the `aarch64-unknown-none` kernel build path or the `arch/aarch64` crate
+- **WHEN** the PR pipeline runs
+- **THEN** a `kvm-smoke-build` CI job SHALL build the kernel for `aarch64-unknown-none --release`, run it under TCG-emulated `qemu-system-aarch64 -M virt,gic-version=3 -nographic -kernel <bin>` for at most 30 seconds, and assert the documented boot banner appears
+- **AND** the `kvm-smoke-build` job SHALL be wired into the `change-gates` meta-job and SHALL block merge on failure
+- **AND** a comment block in the workflow file SHALL note that the job uses TCG (not KVM) because GitHub-hosted runners do not provide nested virtualization, and that on-Jetson KVM execution is verified by the `scripts/test-jetson-kvm.sh` script run manually or on a future self-hosted Jetson runner
+
+### Requirement: UEFI USB-bootable unikernel image for Jetson Orin
+
+The repository SHALL produce a UEFI-bootable USB image (`build-jetson-usb.img`) that boots the SmallAIOS unikernel directly on a Jetson Orin device (J4012 / Orin NX) without writing to the device's eMMC and without requiring NVIDIA's `flash.sh` recovery toolchain.
+
+#### Scenario: Image is a standard UEFI ESP layout
+
+- **GIVEN** a developer who has built `smallaios.efi` from `cargo build --target aarch64-unknown-uefi -p smallaios-kernel --features tegra234`
+- **WHEN** they run `just build-jetson-usb-image`
+- **THEN** the recipe SHALL produce a FAT32 disk image at `build-jetson-usb.img` containing `EFI/BOOT/BOOTAA64.EFI` (a copy of `smallaios.efi`) at the root of the FAT32 filesystem
+- **AND** the image SHALL be `dd`-able to a USB stick of size ≥ 256 MB without further preparation
+- **AND** no other partitions, no GPT, no EFI System Partition GUID gymnastics SHALL be required — the firmware SHALL detect the FAT32 ESP-style layout directly
+
+#### Scenario: USB-stick boot does not modify the J4012's eMMC
+
+- **GIVEN** a J4012 with stock JetPack 6 / L4T installed on its eMMC
+- **WHEN** the developer inserts a USB stick imaged with `build-jetson-usb.img` and selects it in the J4012's UEFI boot menu
+- **THEN** the J4012 SHALL boot into the SmallAIOS unikernel
+- **AND** removing the USB stick and power-cycling SHALL restore the original L4T boot
+- **AND** the workflow SHALL NOT modify EFI variables, EFI BootOrder, eMMC contents, or QSPI bootloader state at any point — verified by `efibootmgr -v` showing identical output before and after the boot test
+
+#### Scenario: Tegra234 UART produces observable boot output
+
+- **GIVEN** a J4012 booted from the USB stick image with a USB-to-TTL serial cable connected to the Tegra234 UART header
+- **WHEN** the SmallAIOS unikernel reaches its main entry point
+- **THEN** the boot banner SHALL appear over the Tegra Combined UART (TCU) at the documented MMIO base (`0x0c280000`) at the documented baud rate
+- **AND** the GICv3 distributor + redistributor init SHALL log success
+- **AND** the cooperative scheduler SHALL reach its idle loop and emit at least one heartbeat tick that is observable on the serial console
+
+### Requirement: tegra234 Cargo feature is distinct from existing Tegra features
+
+The `tegra234` Cargo feature on `smallaios-arch-aarch64` SHALL be the sole feature for the bare-metal Tegra234 / Orin-family BSP, and SHALL NOT overlap or conflict with the existing `tegra-x1` feature on the same crate or the existing `tegra-orin` feature on `smallaios-arch-nvidia`.
+
+#### Scenario: Three feature names, three meanings
+
+- **GIVEN** a developer reading the workspace `Cargo.toml` files
+- **THEN** `smallaios-arch-aarch64`'s `tegra-x1` feature SHALL select the Tegra X1 / Tegra210 / cc 5.3 bare-metal HAL via `aarch64-unknown-none`
+- **AND** `smallaios-arch-aarch64`'s `tegra234` feature SHALL select the Tegra234 / Orin-family bare-metal HAL via `aarch64-unknown-uefi`
+- **AND** `smallaios-arch-nvidia`'s `tegra-orin` feature SHALL continue to select cc 8.7 for the **userspace CUDA** container path (Tegra Orin via NVIDIA Container Toolkit)
+- **AND** the Cargo doc-comments on each feature SHALL explicitly call out the distinction so future contributors are not confused by the overlapping family names
+
+#### Scenario: tegra234 build excludes X1-specific drivers
+
+- **GIVEN** a build invocation `cargo build --target aarch64-unknown-uefi -p smallaios-kernel --features tegra234`
+- **THEN** the `tegra_dc.rs`, `tegra_sor.rs`, `tegra_edid.rs`, `tegra_pcie.rs`, and `gicv2.rs` files SHALL NOT be compiled (they are Tegra X1 specific and not relevant to Phase 2)
+- **AND** the `tegra234_uart.rs` and `gicv3.rs` files SHALL be compiled in their place
+- **AND** `arch/nvidia/src/tegra/` (Maxwell GM20B GPU HAL) SHALL NOT be compiled — GPU support for Orin is explicitly out of scope for this change
+
+### Requirement: CI build of the Tegra234 UEFI image
+
+A CI job SHALL build the `tegra234`-feature unikernel and exercise it under OVMF UEFI on QEMU on every PR, advisory initially.
+
+#### Scenario: PR build of the UEFI artifact
+
+- **GIVEN** a PR that touches the `aarch64-unknown-uefi` build path or the `arch/aarch64` crate under the `tegra234` feature
+- **WHEN** the PR pipeline runs
+- **THEN** a `Build Jetson Orin UEFI` CI job SHALL run `cargo build --target aarch64-unknown-uefi -p smallaios-kernel --features tegra234` and produce a `smallaios.efi` artifact
+- **AND** the job SHALL run with `continue-on-error: true` (advisory) until a self-hosted Jetson runner is available, at which point a follow-up change SHALL flip the gate to blocking
+- **AND** the workflow comment block SHALL document the promote-to-gate criterion
+
+#### Scenario: OVMF QEMU smoke test catches PE/COFF and UEFI entry regressions
+
+- **GIVEN** the same PR as above
+- **WHEN** the `Build Jetson Orin UEFI` job (or a sibling job) runs the produced `smallaios.efi` under `qemu-system-aarch64 -M virt -cpu cortex-a78 -bios edk2-aarch64-code.fd -drive file=fat:rw:<dir-with-EFI-BOOT-BOOTAA64.EFI>`
+- **THEN** the job SHALL assert the documented boot banner appears within 60 seconds
+- **AND** a regression that breaks the PE/COFF header, the UEFI entry signature, or the early UART init SHALL cause this job to fail

--- a/openspec/changes/unikernel-orin-bringup-v1/tasks.md
+++ b/openspec/changes/unikernel-orin-bringup-v1/tasks.md
@@ -1,0 +1,96 @@
+# Tasks — unikernel-orin-bringup-v1
+
+## 0. Verification on the J4012 (prereq for both phases)
+
+- [ ] 0.1 Capture and record the output of `cat /proc/cmdline | tr ' ' '\n' | grep root=`, `lsblk`, `cat /etc/nv_tegra_release`, `ls /sys/firmware/efi/efivars/ 2>/dev/null && echo UEFI-PRESENT || echo NO-UEFI`, `lsmod | grep kvm`, `cat /proc/device-tree/compatible` — paste in the change PR description so the design assumptions are pinned to ground truth on this specific J4012 SKU
+- [ ] 0.2 Confirm UEFI is present (Phase 2 prerequisite) — if not, escalate before starting Phase 2
+- [ ] 0.3 Confirm `kvm` module is loaded (Phase 1 prerequisite) — if not, document the `modprobe kvm` workaround in the Phase 1 quickstart
+
+## 1. Phase 1 — KVM-on-L4T smoke test
+
+### 1a. `just` recipe + smoke script
+
+- [ ] 1.1 Add `run-jetson-kvm SSH_HOST [KERNEL_PATH=target/aarch64-unknown-none/release/smallaios-kernel.bin]` recipe to `Justfile`. Recipe: cross-build via `cargo build --target aarch64-unknown-none -p smallaios-kernel --release`, scp to `$SSH_HOST:~`, ssh into `$SSH_HOST` and `qemu-system-aarch64 -M virt,gic-version=3 -cpu host -accel kvm -m 1G -nographic -kernel ~/smallaios-kernel.bin`
+- [ ] 1.2 Add `scripts/test-jetson-kvm.sh [SSH_HOST]` — non-interactive wrapper around the recipe, with a serial-output assertion (greps the captured stdout for an expected boot banner). Exit 0 on hit, non-zero with a captured-output dump on miss
+- [ ] 1.3 Document expected vs failure exit codes inside the script header (mirroring the convention in `scripts/test-jetson-gpu.sh`)
+- [ ] 1.4 Verify the recipe end-to-end on the actual J4012 — capture the full boot output and paste in the PR description as the Phase 1 acceptance evidence
+
+### 1b. CI smoke build
+
+- [ ] 1.5 Add a `kvm-smoke-build` job to `.github/workflows/ci.yml`: `cargo build --target aarch64-unknown-none -p smallaios-kernel --release`, then run the artifact under TCG-emulated `qemu-system-aarch64 -M virt,gic-version=3 -nographic -kernel <bin>` with a 30-second timeout, asserting the same banner the J4012 test asserts
+- [ ] 1.6 Wire `kvm-smoke-build` into the `change-gates` meta-job so it blocks merge
+- [ ] 1.7 Verify the gate catches a deliberately-broken `boot.rs` (revert the deliberate break before pushing)
+
+### 1c. Docs
+
+- [ ] 1.8 Create `docs/jetson-kvm-quickstart.md` covering: prerequisites (`apt install qemu-system-arm` on the J4012, KVM module check), one-command run, expected boot output snippet, troubleshooting (missing KVM, GICv3 mismatch, virtio panic, "Hello, world but then page fault" — common early-boot symptoms)
+- [ ] 1.9 Add a Jetson-KVM row to `README.md`'s deployment matrix linking to the quickstart, distinct from the existing Jetson container row
+- [ ] 1.10 Update `CLAUDE.md` "Current state" to note Phase 1 lands a KVM-hosted unikernel test path on Orin
+
+### 1d. Phase 1 close-out
+
+- [ ] 1.11 Tag Phase 1 sub-PR title `feat(arch/aarch64): unikernel-orin-bringup-v1 phase 1 — KVM smoke on Orin`, target `develop`
+- [ ] 1.12 PR green + reviewer sign-off + squash-merge
+
+## 2. Phase 2 — Tegra234 BSP scaffolding
+
+### 2a. Cargo + toolchain
+
+- [ ] 2.1 Add `aarch64-unknown-uefi` to `rust-toolchain.toml` `targets` so `rustup target add` resolves cleanly for local devs
+- [ ] 2.2 Add `tegra234` feature to `arch/aarch64/Cargo.toml` (`tegra234 = []` initially, gates conditional code), with a doc-comment distinguishing it from `tegra-x1` (X1 / cc 5.3 bare-metal) and from `arch/nvidia`'s `tegra-orin` (Orin userspace CUDA)
+- [ ] 2.3 Update `arch/aarch64/Cargo.toml` to gate `tegra-x1`-only files (display, PCIe, GICv2) so `tegra234` builds don't pull them in
+
+### 2b. Linker script + DTS
+
+- [ ] 2.4 Create `arch/aarch64/linker-tegra234.ld` modeled on `linker-tegra.ld`, with Orin DRAM at `0x80000000` and PE/COFF-compatible image base for UEFI loadable
+- [ ] 2.5 Create `arch/aarch64/dts/tegra234-smallaios.dts` extracted from the upstream Linux `arch/arm64/boot/dts/nvidia/tegra234.dtsi` (or L4T's), trimmed to just the nodes the unikernel uses: `cpus`, `psci`, `timer`, GIC, the Tegra Combined UART (TCU) at `0x0c280000`, and the memory node. Strip everything else
+- [ ] 2.6 Document the DTS extraction provenance (which upstream commit, license boilerplate) in a header comment in the DTS file
+
+### 2c. UEFI entry + boot
+
+- [ ] 2.7 Create `arch/aarch64/src/boot_uefi.rs` — `efi_main(handle, system_table) -> Status` entry. Uses `uefi-rs` (or hand-rolled minimal UEFI bindings) to: walk `system_table.boot_services()` for the memory map, locate the DTB via `EFI_DTB_TABLE_GUID`, call `ExitBootServices`, jump to kernel main with the DTB pointer and memory map
+- [ ] 2.8 Modify `arch/aarch64/src/boot.rs` to dispatch on feature: `tegra-x1` keeps the existing X1 boot-ROM hand-off; `tegra234` enters via `boot_uefi.rs`
+- [ ] 2.9 Build smoke: `cargo build --target aarch64-unknown-uefi -p smallaios-kernel --features tegra234` produces a `smallaios.efi` PE/COFF artifact
+
+### 2d. Tegra234 UART (first observable signal)
+
+- [ ] 2.10 Create `arch/aarch64/src/tegra234_uart.rs` — Tegra Combined UART (TCU) MMIO driver at `0x0c280000`. NS16550-compatible register layout. Polling write_byte initially; interrupt-driven later
+- [ ] 2.11 Wire `tegra234_uart` into the `console` module under the `tegra234` feature, replacing the X1 `uart`
+- [ ] 2.12 First milestone observable on the J4012: kernel UEFI-boots from USB, prints "Hello, world from SmallAIOS on Tegra234" over the TCU. Capture the serial output via a USB-to-TTL cable on the J4012's UART header. Paste in the PR description
+
+### 2e. GICv3 + timer + minimal interrupt dispatch
+
+- [ ] 2.13 Create `arch/aarch64/src/gicv3.rs` — GICv3 distributor + redistributor enable, SGI/PPI handling. LPI/ITS not needed for Phase 2 (no MSI-capable peripherals exercised)
+- [ ] 2.14 Modify `arch/aarch64/src/interrupts.rs` to feature-gate dispatch: `gicv2` for `tegra-x1`, `gicv3` for `tegra234`
+- [ ] 2.15 Wire the ARM Generic Timer to the cooperative scheduler tick under `tegra234`
+- [ ] 2.16 Second milestone observable on the J4012: scheduler reaches its idle loop, prints periodic ticks (or yields to a pinned heartbeat task that does), confirming the timer + GICv3 are live
+
+### 2f. USB image packaging
+
+- [ ] 2.17 Add a `build-jetson-usb-image` `just` recipe that takes the built `smallaios.efi`, `mkfs.fat -F32` an image of size N (parameter, default 256 MB), copies `smallaios.efi` to `EFI/BOOT/BOOTAA64.EFI`, emits `build-jetson-usb.img`
+- [ ] 2.18 Document the `dd if=build-jetson-usb.img of=/dev/sdX bs=4M status=progress` workflow in `docs/jetson-orin-uefi-boot.md`, with a prominent warning to confirm the target device
+
+### 2g. Boot procedure docs (the primary user surface)
+
+- [ ] 2.19 Create `docs/jetson-orin-uefi-boot.md` covering: prerequisites (USB stick ≥256 MB, USB-to-TTL serial cable connected to the J4012 UART header, terminal emulator configured at the documented baud rate), the `dd` step with target-device confirmation guidance, the J4012 firmware-menu key sequence (likely Esc at boot — confirm against Seeed J4012 docs), the UEFI Secure Boot disable-or-enroll step, the expected serial-console output, and the recovery procedure ("remove stick, power-cycle, reboot to L4T")
+- [ ] 2.20 Add a one-paragraph "if you accidentally bricked the box" section linking to NVIDIA's SDK Manager + USB-recovery procedure — even though Phase 2 itself can't brick the box, an `efibootmgr` follow-up could
+
+### 2h. CI advisory build + OVMF QEMU smoke
+
+- [ ] 2.21 Add a `Build Jetson Orin UEFI` job to `.github/workflows/ci.yml` (advisory, `continue-on-error: true`) running `cargo build --target aarch64-unknown-uefi -p smallaios-kernel --features tegra234`
+- [ ] 2.22 Extend the same job (or add a sibling `jetson-orin-ovmf-smoke` job) that runs `qemu-system-aarch64 -M virt -cpu cortex-a78 -bios edk2-aarch64-code.fd -drive file=fat:rw:build/efi-root` (OVMF UEFI on QEMU) with `smallaios.efi` as `BOOTAA64.EFI`, asserting the boot banner appears. Catches PE/COFF + UEFI entry regressions even without a self-hosted Jetson runner
+- [ ] 2.23 Add a comment block in the workflow file noting "promote to gate when self-hosted Jetson runner is available"
+
+### 2i. Phase 2 close-out
+
+- [ ] 2.24 Tag Phase 2 sub-PR title `feat(arch/aarch64): unikernel-orin-bringup-v1 phase 2 — Tegra234 UEFI USB boot`, target `develop`
+- [ ] 2.25 PR green + on-J4012 boot evidence pasted in PR description + reviewer sign-off + squash-merge
+
+## 3. Verify + archive
+
+- [ ] 3.1 Run `openspec validate unikernel-orin-bringup-v1 --strict` after both phases land
+- [ ] 3.2 Open archive PR moving the change to `openspec/changes/archive/YYYY-MM-DD-unikernel-orin-bringup-v1` and syncing the spec deltas to main specs
+
+## Phase split escape hatch (if Phase 2 grows)
+
+- [ ] If Phase 2 effort exceeds ~5 weeks of focused work, split out tasks 2.x into a new change `unikernel-orin-bare-metal-v1` and archive this change with only Phase 1 (tasks 0.x, 1.x, 3.x) implemented. Update `proposal.md` "Out of scope" to reference the new change name.


### PR DESCRIPTION
## Summary

Two-phase OpenSpec proposal to test the native SmallAIOS `aarch64-unknown-none` unikernel on Jetson Orin (J4012 / Orin NX 16 GB).

- **Phase 1 (~3-5 days)** — KVM-on-L4T smoke: host the existing AArch64 kernel under `qemu-system-aarch64 -accel kvm -cpu host` on the J4012's L4T host. Adds a `just run-jetson-kvm <ssh-host>` recipe, `scripts/test-jetson-kvm.sh`, a CI gate that builds + boots under TCG (since GitHub runners can't host KVM), and `docs/jetson-kvm-quickstart.md`. **No new Rust code** — proves the existing cross-compile target works on Orin silicon and gives us a fast iteration loop.
- **Phase 2 (~3-5 weeks)** — Tegra234 BSP for `smallaios-arch-aarch64` gated by a new `tegra234` Cargo feature. New files: `gicv3.rs`, `tegra234_uart.rs` (Tegra Combined UART at `0x0c280000`), `linker-tegra234.ld`, `dts/tegra234-smallaios.dts`, `boot_uefi.rs` (`efi_main` entry). Build target is `aarch64-unknown-uefi`; output is a FAT32 ESP image (`build-jetson-usb.img`) `dd`-able to a USB stick — boots the unikernel directly on Tegra Orin silicon without touching eMMC. Recovery is "remove stick, reboot to L4T". GPU is **explicitly out of scope** (separate future change).

Builds on the merged `jetson-orin-container-v1` (PR #124, archived in PR #129) by adding the *unikernel* path alongside the *container* path.

## Why this scope is tractable

The Tegra X1 (Tegra210 / Jetson Nano original) bare-metal BSP **already exists** in `arch/aarch64/src/{boot,uart,gicv2,paging,interrupts,...}.rs` + `linker-tegra.ld` + `dts/tegra210-smallaios.dts`, gated by `tegra-x1` and built every PR by `Build Jetson Nano (Tegra X1)` in CI. **Tegra234 is a fork-and-modify of that BSP**, not greenfield — bounded deltas (different MMIO bases, GICv3 vs GICv2, JetPack 6 UEFI entry vs X1 boot ROM). This radically lowers the risk of a multi-month surprise.

## Cargo feature naming (deliberately distinct)

| Crate | Feature | Selects |
|-------|---------|---------|
| `arch/aarch64` | `tegra-x1` (existing) | Tegra X1 / cc 5.3 bare-metal HAL via `aarch64-unknown-none` |
| `arch/aarch64` | **`tegra234`** (new in Phase 2) | Tegra234 / Orin-family bare-metal HAL via `aarch64-unknown-uefi` |
| `arch/nvidia` | `tegra-orin` (existing, PR #124) | **Userspace CUDA** for cc 8.7 (Orin) — container path, NOT bare-metal |

## Out of scope (explicit)

- GPU access (Ampere GA10B / host1x v6) — separate `unikernel-orin-gpu-v1` change
- eMMC replacement / overwriting L4T
- NVMe boot
- UEFI Secure Boot signing of `smallaios.efi` (Phase 2 documents disabling Secure Boot or enrolling a development MOK; production signing is a follow-up)
- PXE / network boot

## Verification still needed (task 0.1)

The proposal assumes JetPack 6 + UEFI presence + KVM module loaded on the J4012. The first task (0.1) captures the actual command outputs from the J4012 to pin those assumptions to ground truth before Phase 1 implementation begins.

## Test plan

- [x] `openspec validate unikernel-orin-bringup-v1 --strict` → green (run from worktree)
- [ ] CI green on this PR
- [ ] Reviewer sign-off on the proposal scope (especially Phase 2 effort estimate)

This PR ships the proposal/design/tasks/spec only — implementation lands in subsequent PRs (Phase 1 sub-PR, then Phase 2 sub-PRs). Standard OpenSpec workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive bring-up documentation for SmallAIOS on Jetson Orin hardware, including design specifications and implementation roadmap.
  * Documented two-phase approach: KVM-based testing via QEMU and bare-metal UEFI USB boot workflows.
  * Included CI requirements, testing specifications, and developer quickstart guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->