### PR TITLE
feat(arch/aarch64): unikernel-orin-bringup-v1 phase 2d — first observable signal

### DIFF
--- a/arch/aarch64/src/boot_uefi.rs
+++ b/arch/aarch64/src/boot_uefi.rs
@@ -4,34 +4,42 @@
 //! UEFI boot path for Tegra234 (Jetson Orin family).
 //!
 //! Entered via `efi_main(image_handle, system_table) -> Status` from the
-//! `aarch64-unknown-uefi` bin target (`smallaios-uefi`). This sub-PR (2c)
-//! lands the entry-point shape and a minimal configuration-table walk to
-//! locate the Devicetree blob via `EFI_DTB_TABLE_GUID`. It deliberately
-//! does **not** call `ExitBootServices` yet — that, plus the actual
-//! handoff to `kernel_main`, lands in sub-PR 2d alongside the real TCU
-//! UART driver (otherwise the kernel would exit boot services and then
-//! immediately go silent on a board with no working serial).
+//! `aarch64-unknown-uefi` bin target (`smallaios-uefi`).
 //!
-//! Until 2d lands, `efi_main` records what it found, then halts in a
-//! `wfi` loop. The point of 2c is to (1) prove the .efi PE/COFF artifact
-//! builds, (2) prove the configuration-table walk finds the DTB, and (3)
-//! give 2d a stable surface to extend.
+//! This sub-PR (2d) adds the **first observable signal**: efi_main
+//! prints a banner via UEFI's `SimpleTextOutputProtocol` (the
+//! `con_out` slot of the system table) before halting. On Jetson Orin
+//! the firmware routes `con_out` through the TCU mailbox, so the
+//! banner reaches whatever serial console the user has attached to the
+//! J-class carrier's UART header. This validates the .efi-load path
+//! end-to-end (PE/COFF parse → image load → entry → DTB lookup →
+//! console output) without yet requiring a post-`ExitBootServices`
+//! kernel-side TCU UART driver.
+//!
+//! What's NOT here yet: `ExitBootServices`, the actual jump to
+//! `kernel_main`, and the kernel-side TCU UART driver. Those land in
+//! the sub-PR after this one. After ExitBootServices `con_out` is no
+//! longer valid, so we need the kernel-side UART before we can keep
+//! producing output. Splitting the milestones this way isolates "did
+//! the .efi load and run?" from "does the post-handoff kernel reach
+//! and drive the TCU?" — the failure modes are different and worth
+//! catching independently.
 
 #![cfg(feature = "tegra234")]
 
 use crate::uefi::{ConfigurationTable, Handle, Status, SystemTable, EFI_DTB_TABLE_GUID};
 use core::ffi::c_void;
 
-/// Devicetree blob pointer captured during `efi_main`. Sub-PR 2d will
-/// pass this to `kernel_main` after `ExitBootServices`. Stored as a
-/// `static mut` (rather than a parameter) so the eventual jump from
-/// `efi_main` → `kernel_main` doesn't have to thread it through the
-/// halt loop.
+/// Devicetree blob pointer captured during `efi_main`. Sub-PR 2d-real
+/// (the next one) will pass this to `kernel_main` after
+/// `ExitBootServices`. Stored as a `static mut` (rather than threading
+/// it through the halt loop) so the eventual jump from `efi_main` →
+/// `kernel_main` doesn't have to re-derive it.
 ///
 /// # Safety
 /// Only written from `efi_main`, only once, while still under UEFI's
 /// boot-services environment (single-threaded, identity-mapped). After
-/// `ExitBootServices` (sub-PR 2d) it becomes effectively immutable.
+/// `ExitBootServices` it becomes effectively immutable.
 static mut DTB_PTR: *const c_void = core::ptr::null();
 
 /// Walk the system table's configuration entries and return the
@@ -42,7 +50,7 @@ static mut DTB_PTR: *const c_void = core::ptr::null();
 /// pointer with `configuration_table` and `number_of_table_entries`
 /// set as the firmware provided them. We trust the firmware here —
 /// there is no realistic way for the unikernel to validate beyond the
-/// header signature, which we don't bother checking in 2c.
+/// header signature, which we don't bother checking.
 unsafe fn find_dtb(system_table: *const SystemTable) -> *const c_void {
     let st = unsafe { &*system_table };
     let count = st.number_of_table_entries;
@@ -57,31 +65,115 @@ unsafe fn find_dtb(system_table: *const SystemTable) -> *const c_void {
     core::ptr::null()
 }
 
+/// Maximum length of a single `print` call's message, including the
+/// trailing NUL. UEFI strings are UCS-2 (UTF-16), so a stack buffer of
+/// `[u16; CON_OUT_BUF]` is twice this many bytes. 256 is plenty for
+/// the banner + a hex address; if a future caller wants more they can
+/// chunk into multiple `print` calls.
+const CON_OUT_BUF: usize = 256;
+
+/// Print a 7-bit ASCII string via UEFI's `con_out`. Converts each byte
+/// to a UCS-2 code point (one-to-one for ASCII) and appends a NUL,
+/// then calls `output_string`. Caller is responsible for any `\r\n`
+/// the terminal expects — UEFI converts neither.
+///
+/// # Safety
+/// `system_table` must be a live, well-formed system table pointer
+/// (the same one efi_main was called with). `s` must be ASCII; non-ASCII
+/// bytes get widened naively, which produces nonsense for the high
+/// half but doesn't violate memory safety.
+unsafe fn print(system_table: *const SystemTable, s: &str) {
+    let st = unsafe { &*system_table };
+    let con_out = st.con_out;
+    if con_out.is_null() {
+        return;
+    }
+    let mut buf = [0u16; CON_OUT_BUF];
+    let mut i = 0;
+    for byte in s.bytes() {
+        if i + 1 >= CON_OUT_BUF {
+            break; // Reserve last slot for NUL.
+        }
+        buf[i] = byte as u16;
+        i += 1;
+    }
+    buf[i] = 0;
+    let f = unsafe { (*con_out).output_string };
+    let _ = unsafe { f(con_out, buf.as_ptr()) };
+}
+
+/// Print a 64-bit value as `0x` + 16 hex digits (uppercase, zero-padded)
+/// via UEFI's `con_out`. Mirrors `uart::put_hex` shape. Splits the
+/// output into one call per digit which is wasteful — UEFI would
+/// happily take a 19-character buffer — but keeps this auxiliary tool
+/// simple and dependency-free.
+///
+/// # Safety
+/// Same preconditions as `print`.
+unsafe fn print_hex64(system_table: *const SystemTable, val: u64) {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    let mut buf = [0u8; 18];
+    buf[0] = b'0';
+    buf[1] = b'x';
+    for i in 0..16 {
+        let nibble = ((val >> ((15 - i) * 4)) & 0xF) as usize;
+        buf[2 + i] = HEX[nibble];
+    }
+    // SAFETY: buf is all ASCII bytes (`0`, `x`, `0-9A-F`).
+    let s = unsafe { core::str::from_utf8_unchecked(&buf) };
+    unsafe { print(system_table, s) };
+}
+
 /// UEFI image entry point. Called by the firmware after `LoadImage` +
 /// `StartImage`. Spec signature: `EFI_STATUS efi_main(EFI_HANDLE,
 /// EFI_SYSTEM_TABLE*)`.
 ///
 /// # Safety
 /// Called exactly once by UEFI firmware with `image_handle` and
-/// `system_table` set per UEFI 2.10 §4.1. Until sub-PR 2d wires in
-/// `ExitBootServices` and the kernel handoff, this function never
-/// returns control to UEFI — it parks in a `wfi` loop after capturing
-/// the DTB pointer.
+/// `system_table` set per UEFI 2.10 §4.1. Until the sub-PR after this
+/// wires in `ExitBootServices` and the kernel handoff, this function
+/// never returns control to UEFI — it parks in a `wfi` loop after
+/// printing the banner and capturing the DTB pointer.
 #[no_mangle]
 pub unsafe extern "efiapi" fn efi_main(
     _image_handle: Handle,
     system_table: *const SystemTable,
 ) -> Status {
+    unsafe {
+        print(
+            system_table,
+            "\r\n========================================\r\n",
+        );
+        print(
+            system_table,
+            "  Hello, world from SmallAIOS on Tegra234\r\n",
+        );
+        print(system_table, "========================================\r\n");
+    }
+
     // Locate the Devicetree blob. The firmware on Jetson Orin's UEFI
-    // exposes it via EFI_DTB_TABLE_GUID; we record it here so sub-PR 2d
-    // can pass it to kernel_main.
+    // exposes it via EFI_DTB_TABLE_GUID; we record it here so the
+    // next sub-PR can pass it to kernel_main, and print it now so the
+    // user can confirm the lookup worked over serial.
     let dtb = unsafe { find_dtb(system_table) };
     unsafe {
         DTB_PTR = dtb;
+        if dtb.is_null() {
+            print(
+                system_table,
+                "[boot] DTB lookup via EFI_DTB_TABLE_GUID: not found\r\n",
+            );
+        } else {
+            print(system_table, "[boot] DTB at ");
+            print_hex64(system_table, dtb as u64);
+            print(system_table, "\r\n");
+        }
+        print(
+            system_table,
+            "[boot] efi_main reached, halting (Phase 2 first-observable-signal milestone)\r\n",
+        );
     }
 
-    // Sub-PR 2c stops here: park the CPU. Sub-PR 2d will replace this
-    // with the ExitBootServices + jump-to-kernel_main sequence.
     loop {
         unsafe {
             core::arch::asm!("wfi");

--- a/arch/aarch64/src/uefi.rs
+++ b/arch/aarch64/src/uefi.rs
@@ -96,24 +96,47 @@ pub struct SystemTable {
     pub console_in_handle: Handle,
     pub con_in: *const c_void,
     pub console_out_handle: Handle,
-    pub con_out: *const c_void,
+    pub con_out: *mut SimpleTextOutputProtocol,
     pub standard_error_handle: Handle,
-    pub std_err: *const c_void,
+    pub std_err: *mut SimpleTextOutputProtocol,
     pub runtime_services: *const c_void,
     pub boot_services: *const BootServices,
     pub number_of_table_entries: usize,
     pub configuration_table: *const ConfigurationTable,
 }
 
-/// `EFI_BOOT_SERVICES` (UEFI 2.10 §7) — opaque to us in sub-PR 2c.
-/// Sub-PR 2d adds the `ExitBootServices` and memory-map function
-/// pointers needed to actually leave UEFI. Defining the struct as
-/// header-only here keeps the `SystemTable.boot_services` typed without
-/// pinning the layout of fields we don't yet use.
+/// `EFI_BOOT_SERVICES` (UEFI 2.10 §7) — opaque to us until the sub-PR
+/// that lands `ExitBootServices` + memory-map handoff to `kernel_main`.
+/// Defining the struct as header-only here keeps the
+/// `SystemTable.boot_services` pointer typed without pinning the layout
+/// of fields we don't yet use.
 #[repr(C)]
 pub struct BootServices {
     pub header: TableHeader,
-    // Real fields land in sub-PR 2d.
+    // ExitBootServices + GetMemoryMap fields land alongside the real
+    // post-ExitBootServices kernel handoff.
+}
+
+/// `EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL` (UEFI 2.10 §12.4). The
+/// `SystemTable.con_out` field points to one of these. On Jetson Orin
+/// the firmware routes `con_out` through the TCU mailbox, so calling
+/// `output_string` here lands on whatever serial console the user has
+/// attached to the J-class carrier's UART header — which is exactly
+/// what we need for the "first observable signal" milestone before any
+/// kernel-side TCU driver exists.
+///
+/// Layout: `Reset` is the first slot, `OutputString` the second; spec
+/// guarantees stable ordering. We only call `output_string` here.
+/// `TestString`, `QueryMode`, `SetMode`, `SetAttribute`, `ClearScreen`,
+/// `SetCursorPosition`, `EnableCursor`, and the `Mode` pointer are
+/// defined by the spec but unused — declaring the trailing fields would
+/// require more spec types we don't need yet, so we deliberately stop
+/// at the second fn pointer. Pointer arithmetic stays correct because
+/// we never index past the declared end.
+#[repr(C)]
+pub struct SimpleTextOutputProtocol {
+    pub reset: unsafe extern "efiapi" fn(this: *mut Self, extended_verification: bool) -> Status,
+    pub output_string: unsafe extern "efiapi" fn(this: *mut Self, string: *const u16) -> Status,
 }
 
 #[cfg(test)]

--- a/openspec/changes/unikernel-orin-bringup-v1/tasks.md
+++ b/openspec/changes/unikernel-orin-bringup-v1/tasks.md
@@ -54,11 +54,19 @@
 - [x] 2.8 Modify `arch/aarch64/src/boot.rs` to dispatch on feature: `tegra-x1` keeps the existing X1 boot-ROM hand-off; `tegra234` enters via `boot_uefi.rs`. **Resolved at the bin target level rather than inside `boot.rs`**: bare-metal `aarch64-unknown-none` builds (qemu-virt / tegra-x1 / tegra234 chain-loaded via U-Boot) use `[[bin]] smallaios-aarch64` which links against `boot.rs::_start`; UEFI builds use `[[bin]] smallaios-uefi` (`required-features = ["tegra234"]`, target `aarch64-unknown-uefi`) which links against `boot_uefi::efi_main`. `boot.rs` itself is now `#[cfg(target_os = "none")]`-gated in `lib.rs` so it isn't compiled into UEFI builds (it references linker-script symbols `__bss_start` etc. that don't exist for PE/COFF).
 - [x] 2.9 Build smoke: `cargo build --target aarch64-unknown-uefi -p smallaios-kernel --features tegra234` produces a `smallaios.efi` PE/COFF artifact. **Landed**, with the package corrected to `smallaios-arch-aarch64` (the original wording referenced `smallaios-kernel` but that crate has no bin target — `arch/aarch64/Cargo.toml` is where the bin definitions live). `just build-kernel-uefi` produces `target/aarch64-unknown-uefi/release/smallaios-uefi.efi` (1.1 MB PE32+ Aarch64 EFI application).
 
-### 2d. Tegra234 UART (first observable signal)
+### 2d. First observable signal (UEFI `con_out` route)
 
-- [ ] 2.10 Create `arch/aarch64/src/tegra234_uart.rs` — Tegra Combined UART (TCU) MMIO driver at `0x0c280000`. NS16550-compatible register layout. Polling write_byte initially; interrupt-driven later
-- [ ] 2.11 Wire `tegra234_uart` into the `console` module under the `tegra234` feature, replacing the X1 `uart`
-- [ ] 2.12 First milestone observable on the J4012: kernel UEFI-boots from USB, prints "Hello, world from SmallAIOS on Tegra234" over the TCU. Capture the serial output via a USB-to-TTL cable on the J4012's UART header. Paste in the PR description
+The original split for 2d coupled three tasks (TCU driver, console wiring,
+hardware test). In practice it was easier to ship the on-board
+proof-of-life via UEFI's `SimpleTextOutputProtocol` first and defer the
+kernel-side TCU driver until after `ExitBootServices` is wired up. This
+isolates two distinct failure modes — "did the .efi load?" vs. "does
+the post-handoff kernel reach the TCU?" — and reaches the milestone
+sooner.
+
+- [~] 2.10 Create `arch/aarch64/src/tegra234_uart.rs` — Tegra Combined UART (TCU) MMIO driver at `0x0c280000`. NS16550-compatible register layout. Polling write_byte initially; interrupt-driven later. **Deferred** to the post-2d sub-PR that lands `ExitBootServices` + the actual `kernel_main` handoff (the kernel-side TCU driver is only needed once UEFI's `con_out` is no longer available, i.e. after ExitBootServices).
+- [~] 2.11 Wire `tegra234_uart` into the `console` module under the `tegra234` feature, replacing the X1 `uart`. **Deferred** alongside 2.10.
+- [x] 2.12 First milestone observable on the J4012: kernel UEFI-boots from USB, prints "Hello, world from SmallAIOS on Tegra234" over the TCU. Capture the serial output via a USB-to-TTL cable on the J4012's UART header. Paste in the PR description. **Landed in sub-PR 2d**: `efi_main` prints the banner via `EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL` (`SystemTable.con_out`) before halting in `wfi`. On the Orin's UEFI firmware `con_out` is routed through the TCU mailbox, so the banner reaches whatever serial console is wired to the J-class carrier's UART header. The output isn't yet produced by the kernel itself (it's UEFI-side, before ExitBootServices) but it lands on the documented TCU port and validates the .efi-load pipeline end-to-end.
 
 ### 2e. GICv3 + timer + minimal interrupt dispatch
 


### PR DESCRIPTION
## Summary

**Phase 2 milestone — first on-board signal from SmallAIOS via the Jetson Orin's UEFI console.** When you load `smallaios-uefi.efi` from a USB stick on a J-class carrier, you see a banner on the UART. That validates the .efi-load pipeline end-to-end (PE/COFF parse → image load → entry → DTB lookup → console output) without yet requiring a kernel-side TCU UART driver.

Stacked on #135 (sub-PR 2c). Rebases onto develop after 2c merges.

## On-board evidence (task 2.12)

**Captured 2026-05-04** on Orin NX 16 GB (P3767-0000 + P3768-0000, JetPack 6.2.1 / L4T R36.4.7, hostname `nx`). Build host: Apple Silicon Mac, nightly-2026-02-01. .efi written to a SanDisk Ultra 14 GB USB stick (FAT32, single MS-DOS partition, `EFI/BOOT/BOOTAA64.EFI`). Read via picocom on Mac at 115200 8N1 over USB-to-TTL cable to the J-carrier UART header.

```
I/TC: WARNING: Test UEFI variable auth key is being used !
I/TC: WARNING: UEFI variable protection is not fully enabled !

  Jetson System firmware version 36.4.7-gcid-42132812 date 2025-09-18T22:10:05+00:00
  ESC   to enter Setup.
  F11   to enter Boot Manager Menu.
  Enter to continue boot.
  ......
  ========================================
    Hello, world from SmallAIOS on Tegra234
  ========================================
  [boot] DTB at 0x000000046799D000
  [boot] efi_main reached, halting (Phase 2 first-observable-signal milestone)
```

Each line that matters:

- `Jetson System firmware version 36.4.7-gcid-42132812` — NVIDIA's UEFI/edk2 fork on JetPack 6.2.1; loaded `BOOTAA64.EFI` from the USB stick via the standard UEFI fallback path with no manual menu intervention.
- `Hello, world from SmallAIOS on Tegra234` — `efi_main` ran on a Cortex-A78AE under UEFI's identity-mapped boot-services environment. `extern "efiapi"` ABI matched. `con_out` → TCU → user's TTL.
- `[boot] DTB at 0x000000046799D000` — `EFI_DTB_TABLE_GUID` (`b1b6_21d5-f19c-41a5-830b-d9152c69aae0`) is exposed by the firmware and points at a valid address near the top of physical DRAM (Orin NX 16 GB has DRAM at `[0x8000_0000, 0x4_8000_0000)`).
- `efi_main reached, halting` — the `wfi` loop is running; the kernel did not return control to UEFI (deliberate; no `ExitBootServices` yet).

The OP-TEE warnings are pre-existing on JetPack 6.2.1 dev images and unrelated.

## What's deferred to the next sub-PR

`ExitBootServices` + the jump to `kernel_main` + the kernel-side TCU UART driver (tasks 2.10/2.11). After ExitBootServices `con_out` is no longer valid, so we need a kernel-side UART before we can keep producing output. Splitting at this seam isolated two failure modes — "did the .efi load and run?" vs. "does the post-handoff kernel reach the TCU?" — and let us close 2.12 atomically.

## Changes (3 files, +162 / -39)

### `arch/aarch64/src/uefi.rs`

- Add `SimpleTextOutputProtocol` (the `con_out` slot's pointee). Two `extern "efiapi"` fn pointers — `reset` and `output_string`. Spec defines more (TestString, QueryMode, …) but `output_string` is the only one this milestone needs.
- Re-type `SystemTable.con_out` and `SystemTable.std_err` from `*const c_void` to `*mut SimpleTextOutputProtocol`.

### `arch/aarch64/src/boot_uefi.rs`

- Replace the silent `wfi`-on-entry loop with two helpers — `print` (ASCII → UCS-2 widening + NUL-terminated buffer → `con_out.output_string`) and `print_hex64` (zero-padded uppercase) — and call them around the existing DTB lookup.
- `static mut DTB_PTR` still captured for the next sub-PR's `kernel_main` handoff.

### `openspec/changes/unikernel-orin-bringup-v1/tasks.md`

- Mark task **2.12** done with the captured evidence above.
- Defer **2.10** / **2.11** (TCU UART driver, console wiring) to the next sub-PR with rationale.

## Verification

```
$ just build-kernel-uefi
Finished `release` profile [optimized] target(s) in 0.31s

$ file target/aarch64-unknown-uefi/release/smallaios-uefi.efi
target/aarch64-unknown-uefi/release/smallaios-uefi.efi:
  PE32+ executable (EFI application) Aarch64, for MS Windows

$ ls -la target/aarch64-unknown-uefi/release/smallaios-uefi.efi
1114624 bytes (~1.1 MB)
```

## Test plan

- [x] `just build-kernel-uefi` clean; PE32+ EFI binary produced
- [x] `cargo fmt --check` clean
- [x] Existing builds (`just build-kernel-arm` qemu-virt, `just build-kernel-tegra234`) unaffected
- [x] **On-board**: Boot Orin from USB, capture TTL serial output. Banner + DTB-found line + halt marker visible — see "On-board evidence" above

## Related

- Phase 1 (merged): #132
- Sub-PR 2a (merged): #133
- Sub-PR 2b (merged): #134
- Sub-PR 2c (open): #135 — UEFI entry scaffolding (this PR's base)
- Next sub-PR (after 2d): TCU UART driver + ExitBootServices + kernel_main handoff. Closes 2.10, 2.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
