### PR TITLE
feat(arch/aarch64): unikernel-orin-bringup-v1 phase 2d — first observable signal

### DIFF
--- a/arch/aarch64/src/boot_uefi.rs
+++ b/arch/aarch64/src/boot_uefi.rs
@@ -4,34 +4,42 @@
 //! UEFI boot path for Tegra234 (Jetson Orin family).
 //!
 //! Entered via `efi_main(image_handle, system_table) -> Status` from the
-//! `aarch64-unknown-uefi` bin target (`smallaios-uefi`). This sub-PR (2c)
-//! lands the entry-point shape and a minimal configuration-table walk to
-//! locate the Devicetree blob via `EFI_DTB_TABLE_GUID`. It deliberately
-//! does **not** call `ExitBootServices` yet — that, plus the actual
-//! handoff to `kernel_main`, lands in sub-PR 2d alongside the real TCU
-//! UART driver (otherwise the kernel would exit boot services and then
-//! immediately go silent on a board with no working serial).
+//! `aarch64-unknown-uefi` bin target (`smallaios-uefi`).
 //!
-//! Until 2d lands, `efi_main` records what it found, then halts in a
-//! `wfi` loop. The point of 2c is to (1) prove the .efi PE/COFF artifact
-//! builds, (2) prove the configuration-table walk finds the DTB, and (3)
-//! give 2d a stable surface to extend.
+//! This sub-PR (2d) adds the **first observable signal**: efi_main
+//! prints a banner via UEFI's `SimpleTextOutputProtocol` (the
+//! `con_out` slot of the system table) before halting. On Jetson Orin
+//! the firmware routes `con_out` through the TCU mailbox, so the
+//! banner reaches whatever serial console the user has attached to the
+//! J-class carrier's UART header. This validates the .efi-load path
+//! end-to-end (PE/COFF parse → image load → entry → DTB lookup →
+//! console output) without yet requiring a post-`ExitBootServices`
+//! kernel-side TCU UART driver.
+//!
+//! What's NOT here yet: `ExitBootServices`, the actual jump to
+//! `kernel_main`, and the kernel-side TCU UART driver. Those land in
+//! the sub-PR after this one. After ExitBootServices `con_out` is no
+//! longer valid, so we need the kernel-side UART before we can keep
+//! producing output. Splitting the milestones this way isolates "did
+//! the .efi load and run?" from "does the post-handoff kernel reach
+//! and drive the TCU?" — the failure modes are different and worth
+//! catching independently.
 
 #![cfg(feature = "tegra234")]
 
 use crate::uefi::{ConfigurationTable, Handle, Status, SystemTable, EFI_DTB_TABLE_GUID};
 use core::ffi::c_void;
 
-/// Devicetree blob pointer captured during `efi_main`. Sub-PR 2d will
-/// pass this to `kernel_main` after `ExitBootServices`. Stored as a
-/// `static mut` (rather than a parameter) so the eventual jump from
-/// `efi_main` → `kernel_main` doesn't have to thread it through the
-/// halt loop.
+/// Devicetree blob pointer captured during `efi_main`. Sub-PR 2d-real
+/// (the next one) will pass this to `kernel_main` after
+/// `ExitBootServices`. Stored as a `static mut` (rather than threading
+/// it through the halt loop) so the eventual jump from `efi_main` →
+/// `kernel_main` doesn't have to re-derive it.
 ///
 /// # Safety
 /// Only written from `efi_main`, only once, while still under UEFI's
 /// boot-services environment (single-threaded, identity-mapped). After
-/// `ExitBootServices` (sub-PR 2d) it becomes effectively immutable.
+/// `ExitBootServices` it becomes effectively immutable.
 static mut DTB_PTR: *const c_void = core::ptr::null();
 
 /// Walk the system table's configuration entries and return the
@@ -42,7 +50,7 @@ static mut DTB_PTR: *const c_void = core::ptr::null();
 /// pointer with `configuration_table` and `number_of_table_entries`
 /// set as the firmware provided them. We trust the firmware here —
 /// there is no realistic way for the unikernel to validate beyond the
-/// header signature, which we don't bother checking in 2c.
+/// header signature, which we don't bother checking.
 unsafe fn find_dtb(system_table: *const SystemTable) -> *const c_void {
     let st = unsafe { &*system_table };
     let count = st.number_of_table_entries;
@@ -57,31 +65,115 @@ unsafe fn find_dtb(system_table: *const SystemTable) -> *const c_void {
     core::ptr::null()
 }
 
+/// Maximum length of a single `print` call's message, including the
+/// trailing NUL. UEFI strings are UCS-2 (UTF-16), so a stack buffer of
+/// `[u16; CON_OUT_BUF]` is twice this many bytes. 256 is plenty for
+/// the banner + a hex address; if a future caller wants more they can
+/// chunk into multiple `print` calls.
+const CON_OUT_BUF: usize = 256;
+
+/// Print a 7-bit ASCII string via UEFI's `con_out`. Converts each byte
+/// to a UCS-2 code point (one-to-one for ASCII) and appends a NUL,
+/// then calls `output_string`. Caller is responsible for any `\r\n`
+/// the terminal expects — UEFI converts neither.
+///
+/// # Safety
+/// `system_table` must be a live, well-formed system table pointer
+/// (the same one efi_main was called with). `s` must be ASCII; non-ASCII
+/// bytes get widened naively, which produces nonsense for the high
+/// half but doesn't violate memory safety.
+unsafe fn print(system_table: *const SystemTable, s: &str) {
+    let st = unsafe { &*system_table };
+    let con_out = st.con_out;
+    if con_out.is_null() {
+        return;
+    }
+    let mut buf = [0u16; CON_OUT_BUF];
+    let mut i = 0;
+    for byte in s.bytes() {
+        if i + 1 >= CON_OUT_BUF {
+            break; // Reserve last slot for NUL.
+        }
+        buf[i] = byte as u16;
+        i += 1;
+    }
+    buf[i] = 0;
+    let f = unsafe { (*con_out).output_string };
+    let _ = unsafe { f(con_out, buf.as_ptr()) };
+}
+
+/// Print a 64-bit value as `0x` + 16 hex digits (uppercase, zero-padded)
+/// via UEFI's `con_out`. Mirrors `uart::put_hex` shape. Splits the
+/// output into one call per digit which is wasteful — UEFI would
+/// happily take a 19-character buffer — but keeps this auxiliary tool
+/// simple and dependency-free.
+///
+/// # Safety
+/// Same preconditions as `print`.
+unsafe fn print_hex64(system_table: *const SystemTable, val: u64) {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    let mut buf = [0u8; 18];
+    buf[0] = b'0';
+    buf[1] = b'x';
+    for i in 0..16 {
+        let nibble = ((val >> ((15 - i) * 4)) & 0xF) as usize;
+        buf[2 + i] = HEX[nibble];
+    }
+    // SAFETY: buf is all ASCII bytes (`0`, `x`, `0-9A-F`).
+    let s = unsafe { core::str::from_utf8_unchecked(&buf) };
+    unsafe { print(system_table, s) };
+}
+
 /// UEFI image entry point. Called by the firmware after `LoadImage` +
 /// `StartImage`. Spec signature: `EFI_STATUS efi_main(EFI_HANDLE,
 /// EFI_SYSTEM_TABLE*)`.
 ///
 /// # Safety
 /// Called exactly once by UEFI firmware with `image_handle` and
-/// `system_table` set per UEFI 2.10 §4.1. Until sub-PR 2d wires in
-/// `ExitBootServices` and the kernel handoff, this function never
-/// returns control to UEFI — it parks in a `wfi` loop after capturing
-/// the DTB pointer.
+/// `system_table` set per UEFI 2.10 §4.1. Until the sub-PR after this
+/// wires in `ExitBootServices` and the kernel handoff, this function
+/// never returns control to UEFI — it parks in a `wfi` loop after
+/// printing the banner and capturing the DTB pointer.
 #[no_mangle]
 pub unsafe extern "efiapi" fn efi_main(
     _image_handle: Handle,
     system_table: *const SystemTable,
 ) -> Status {
+    unsafe {
+        print(
+            system_table,
+            "\r\n========================================\r\n",
+        );
+        print(
+            system_table,
+            "  Hello, world from SmallAIOS on Tegra234\r\n",
+        );
+        print(system_table, "========================================\r\n");
+    }
+
     // Locate the Devicetree blob. The firmware on Jetson Orin's UEFI
-    // exposes it via EFI_DTB_TABLE_GUID; we record it here so sub-PR 2d
-    // can pass it to kernel_main.
+    // exposes it via EFI_DTB_TABLE_GUID; we record it here so the
+    // next sub-PR can pass it to kernel_main, and print it now so the
+    // user can confirm the lookup worked over serial.
     let dtb = unsafe { find_dtb(system_table) };
     unsafe {
         DTB_PTR = dtb;
+        if dtb.is_null() {
+            print(
+                system_table,
+                "[boot] DTB lookup via EFI_DTB_TABLE_GUID: not found\r\n",
+            );
+        } else {
+            print(system_table, "[boot] DTB at ");
+            print_hex64(system_table, dtb as u64);
+            print(system_table, "\r\n");
+        }
+        print(
+            system_table,
+            "[boot] efi_main reached, halting (Phase 2 first-observable-signal milestone)\r\n",
+        );
     }
 
-    // Sub-PR 2c stops here: park the CPU. Sub-PR 2d will replace this
-    // with the ExitBootServices + jump-to-kernel_main sequence.
     loop {
         unsafe {
             core::arch::asm!("wfi");

--- a/arch/aarch64/src/uefi.rs
+++ b/arch/aarch64/src/uefi.rs
@@ -96,24 +96,47 @@ pub struct SystemTable {
     pub console_in_handle: Handle,
     pub con_in: *const c_void,
     pub console_out_handle: Handle,
-    pub con_out: *const c_void,
+    pub con_out: *mut SimpleTextOutputProtocol,
     pub standard_error_handle: Handle,
-    pub std_err: *const c_void,
+    pub std_err: *mut SimpleTextOutputProtocol,
     pub runtime_services: *const c_void,
     pub boot_services: *const BootServices,
     pub number_of_table_entries: usize,
     pub configuration_table: *const ConfigurationTable,
 }
 
-/// `EFI_BOOT_SERVICES` (UEFI 2.10 §7) — opaque to us in sub-PR 2c.
-/// Sub-PR 2d adds the `ExitBootServices` and memory-map function
-/// pointers needed to actually leave UEFI. Defining the struct as
-/// header-only here keeps the `SystemTable.boot_services` typed without
-/// pinning the layout of fields we don't yet use.
+/// `EFI_BOOT_SERVICES` (UEFI 2.10 §7) — opaque to us until the sub-PR
+/// that lands `ExitBootServices` + memory-map handoff to `kernel_main`.
+/// Defining the struct as header-only here keeps the
+/// `SystemTable.boot_services` pointer typed without pinning the layout
+/// of fields we don't yet use.
 #[repr(C)]
 pub struct BootServices {
     pub header: TableHeader,
-    // Real fields land in sub-PR 2d.
+    // ExitBootServices + GetMemoryMap fields land alongside the real
+    // post-ExitBootServices kernel handoff.
+}
+
+/// `EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL` (UEFI 2.10 §12.4). The
+/// `SystemTable.con_out` field points to one of these. On Jetson Orin
+/// the firmware routes `con_out` through the TCU mailbox, so calling
+/// `output_string` here lands on whatever serial console the user has
+/// attached to the J-class carrier's UART header — which is exactly
+/// what we need for the "first observable signal" milestone before any
+/// kernel-side TCU driver exists.
+///
+/// Layout: `Reset` is the first slot, `OutputString` the second; spec
+/// guarantees stable ordering. We only call `output_string` here.
+/// `TestString`, `QueryMode`, `SetMode`, `SetAttribute`, `ClearScreen`,
+/// `SetCursorPosition`, `EnableCursor`, and the `Mode` pointer are
+/// defined by the spec but unused — declaring the trailing fields would
+/// require more spec types we don't need yet, so we deliberately stop
+/// at the second fn pointer. Pointer arithmetic stays correct because
+/// we never index past the declared end.
+#[repr(C)]
+pub struct SimpleTextOutputProtocol {
+    pub reset: unsafe extern "efiapi" fn(this: *mut Self, extended_verification: bool) -> Status,
+    pub output_string: unsafe extern "efiapi" fn(this: *mut Self, string: *const u16) -> Status,
 }
 
 #[cfg(test)]

--- a/openspec/changes/unikernel-orin-bringup-v1/tasks.md
+++ b/openspec/changes/unikernel-orin-bringup-v1/tasks.md
@@ -54,11 +54,19 @@
 - [x] 2.8 Modify `arch/aarch64/src/boot.rs` to dispatch on feature: `tegra-x1` keeps the existing X1 boot-ROM hand-off; `tegra234` enters via `boot_uefi.rs`. **Resolved at the bin target level rather than inside `boot.rs`**: bare-metal `aarch64-unknown-none` builds (qemu-virt / tegra-x1 / tegra234 chain-loaded via U-Boot) use `[[bin]] smallaios-aarch64` which links against `boot.rs::_start`; UEFI builds use `[[bin]] smallaios-uefi` (`required-features = ["tegra234"]`, target `aarch64-unknown-uefi`) which links against `boot_uefi::efi_main`. `boot.rs` itself is now `#[cfg(target_os = "none")]`-gated in `lib.rs` so it isn't compiled into UEFI builds (it references linker-script symbols `__bss_start` etc. that don't exist for PE/COFF).
 - [x] 2.9 Build smoke: `cargo build --target aarch64-unknown-uefi -p smallaios-kernel --features tegra234` produces a `smallaios.efi` PE/COFF artifact. **Landed**, with the package corrected to `smallaios-arch-aarch64` (the original wording referenced `smallaios-kernel` but that crate has no bin target — `arch/aarch64/Cargo.toml` is where the bin definitions live). `just build-kernel-uefi` produces `target/aarch64-unknown-uefi/release/smallaios-uefi.efi` (1.1 MB PE32+ Aarch64 EFI application).
 
-### 2d. Tegra234 UART (first observable signal)
+### 2d. First observable signal (UEFI `con_out` route)
 
-- [ ] 2.10 Create `arch/aarch64/src/tegra234_uart.rs` — Tegra Combined UART (TCU) MMIO driver at `0x0c280000`. NS16550-compatible register layout. Polling write_byte initially; interrupt-driven later
-- [ ] 2.11 Wire `tegra234_uart` into the `console` module under the `tegra234` feature, replacing the X1 `uart`
-- [ ] 2.12 First milestone observable on the J4012: kernel UEFI-boots from USB, prints "Hello, world from SmallAIOS on Tegra234" over the TCU. Capture the serial output via a USB-to-TTL cable on the J4012's UART header. Paste in the PR description
+The original split for 2d coupled three tasks (TCU driver, console wiring,
+hardware test). In practice it was easier to ship the on-board
+proof-of-life via UEFI's `SimpleTextOutputProtocol` first and defer the
+kernel-side TCU driver until after `ExitBootServices` is wired up. This
+isolates two distinct failure modes — "did the .efi load?" vs. "does
+the post-handoff kernel reach the TCU?" — and reaches the milestone
+sooner.
+
+- [~] 2.10 Create `arch/aarch64/src/tegra234_uart.rs` — Tegra Combined UART (TCU) MMIO driver at `0x0c280000`. NS16550-compatible register layout. Polling write_byte initially; interrupt-driven later. **Deferred** to the post-2d sub-PR that lands `ExitBootServices` + the actual `kernel_main` handoff (the kernel-side TCU driver is only needed once UEFI's `con_out` is no longer available, i.e. after ExitBootServices).
+- [~] 2.11 Wire `tegra234_uart` into the `console` module under the `tegra234` feature, replacing the X1 `uart`. **Deferred** alongside 2.10.
+- [x] 2.12 First milestone observable on the J4012: kernel UEFI-boots from USB, prints "Hello, world from SmallAIOS on Tegra234" over the TCU. Capture the serial output via a USB-to-TTL cable on the J4012's UART header. Paste in the PR description. **Landed in sub-PR 2d**: `efi_main` prints the banner via `EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL` (`SystemTable.con_out`) before halting in `wfi`. On the Orin's UEFI firmware `con_out` is routed through the TCU mailbox, so the banner reaches whatever serial console is wired to the J-class carrier's UART header. The output isn't yet produced by the kernel itself (it's UEFI-side, before ExitBootServices) but it lands on the documented TCU port and validates the .efi-load pipeline end-to-end.
 
 ### 2e. GICv3 + timer + minimal interrupt dispatch
 


### PR DESCRIPTION
## Summary

**Replaces #136** which was auto-closed by GitHub when its base branch (the old `change/unikernel-orin-bringup-v1-phase2c`) was deleted on squash-merge of #135. This is the same content rebased onto `develop`.

Phase 2 milestone: first on-board signal from SmallAIOS via the Jetson Orin's UEFI console (`con_out` → TCU mailbox → user's TTL serial cable). When you load `smallaios-uefi.efi` from a USB stick on a J-class carrier, you'll see this on the UART:

```
========================================
  Hello, world from SmallAIOS on Tegra234
========================================
[boot] DTB at 0xXXXXXXXXXXXXXXXX
[boot] efi_main reached, halting (Phase 2 first-observable-signal milestone)
```

**Hardware-verified on Orin NX 16 GB** (P3767-0000 + P3768-0000, JetPack 6.2.1) — see #136 description for the captured TTL output.

## Changes (3 files, +162 / -39)

- `arch/aarch64/src/uefi.rs` — add `SimpleTextOutputProtocol`, re-type `SystemTable.con_out` and `std_err`
- `arch/aarch64/src/boot_uefi.rs` — replace silent `wfi`-on-entry with `print` / `print_hex64` helpers + banner output around the existing DTB lookup
- `openspec/changes/unikernel-orin-bringup-v1/tasks.md` — task 2.12 marked done, 2.10/2.11 deferred to next sub-PR

## Related

- Phase 1 (merged): #132
- Sub-PRs 2a/2b/2c (merged): #133, #134, #135
- Sub-PR 2e (open): #137 — ExitBootServices + kernel_main handoff
- Sub-PR 2e-output (open): #138 — interim kernel-side output via con_out, hardware-verified end-to-end

## Closed PR reference

#136 — auto-closed, replaced by this one. Same commit content, rebased onto develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Boot console output**: The system now displays startup banners and detailed initialization status messages via UEFI console output
* **Device tree blob detection**: DTB search results are logged with memory address information when the blob is successfully located
* **Enhanced boot diagnostics**: Early boot phases now provide visible status updates to help verify the system initialization sequence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->