### PR TITLE
docs(openspec): scaffold embedded-filesystem-v1 (squashfs A/B + F2FS RW)

### DIFF
--- a/openspec/changes/embedded-filesystem-v1/design.md
+++ b/openspec/changes/embedded-filesystem-v1/design.md
@@ -1,0 +1,360 @@
+## Context
+
+SmallAIOS today has no on-disk read/write filesystem. The existing
+[posix/src/vfs.rs](posix/src/vfs.rs) is a 527-line in-memory
+read-only VFS that returns `EROFS` for every write. The boot
+partition is FAT32 (UEFI ESP) and that is the entire on-disk
+story. The recently-landed `management-login-v1` change writes
+to `/data/auth/shadow`, `/data/audit/log.jsonl`, and
+`/data/mgmt/policy.toml` with `stage → fsync → rename` atomicity
+— a contract that has no implementation. The upcoming
+`remote-update-v1` change assumes A/B partition swap. Both are
+blocked by the absence of a real filesystem substrate.
+
+This change introduces that substrate. The shape converged across
+30 design-walkthrough questions:
+
+- **Read-only `/models/` on squashfs**, A/B-partitioned, atomic
+  whole-image swap with bsdiff block-level deltas applied to the
+  inactive slot.
+- **Read-write `/data/` on F2FS**, log-structured, journaled,
+  power-fail-safe, mainline-readable.
+- **GPT** as the partition table (universal modern standard).
+- **Pure Rust, clean-room**, `#![no_std]`. No FFI to C drivers.
+  Squashfs zstd+xz+gzip+lz4 decoders, F2FS read+write, GPT,
+  bsdiff, A/B boot logic — all written or wrapped from scratch.
+- **Universal external interop**. Per-PR CI mounts the produced
+  images on stock Ubuntu LTS, Fedora current, and macOS via FUSE.
+  Operators with a recovery laptop must not need custom tooling.
+
+OverlayFS-style writable layering on `/models/` for
+per-deployment model injection is **explicitly deferred** to a
+follow-on `embedded-overlay-v1`. v1 ships A/B whole-image updates.
+
+## Goals / Non-Goals
+
+**Goals:**
+- New `fs/` Layer 1 crate (workspace 23 → 24 with `auth` + `mgmt`
+  from `management-login-v1`).
+- Single `BlockDevice` trait; v1 impls for virtio-blk (QEMU CI),
+  NVMe (x86), eMMC/SDHCI (Jetson), AHCI (legacy x86).
+- GPT partition table; protective MBR for tool compatibility.
+- Squashfs 4.0 read-only with zstd, xz, gzip, lz4 decoders;
+  appended manifest + ML-DSA-65 signature footer.
+- F2FS matching the Linux 6.6 LTS feature set; read → write →
+  fsync/checkpoint → GC phasing.
+- Dedicated 8 MiB GPT partition for the A/B boot pointer with
+  double-buffered records; UEFI variable mirror.
+- Watchdog timeout + explicit `boot_success` syscall as the
+  rollback trigger.
+- bsdiff block-level delta payloads with ML-DSA-65 signed
+  pre/post integrity checks.
+- Per-mount LRU block cache (16 MiB `/models/`, 4 MiB `/data/`)
+  + 256 KiB write-coalescing buffer.
+- Native 4 KiB block size; 512-byte slow-path emulation for
+  legacy devices.
+- ≥5100 total tests after the change (~+600 new); Kani + TLA+ +
+  SPIN + Coq formal coverage.
+
+**Non-Goals (v1):**
+- OverlayFS / writable layer on `/models/`. `embedded-overlay-v1`.
+- ext4 / xfs / btrfs as alternatives to F2FS.
+- LittleFS, JFFS2, UBIFS for raw-flash MCU targets.
+  `embedded-flash-fs-v1` if hardware drives the need.
+- Multi-disk RAID, encryption-at-rest, fscrypt, NFS, virtio-fs.
+- Quotas, ACLs, extended attributes beyond what F2FS provides.
+- Trim / discard performance tuning.
+
+## Decisions
+
+The 30 questions resolved during the walkthrough. Each decision
+is the source of one or more spec requirements.
+
+### Q1. Block device trait shape
+
+**Decision:** Single `BlockDevice` trait
+(`read_block`/`write_block`/`block_size_bytes`/`block_count`/`flush`).
+Per-arch impls. Layered queue trait (option B) and per-bus
+traits (option C) are documented evolution paths if NVMe-class
+parallelism or per-device quirks become binding.
+
+### Q2. Partition table
+
+**Decision:** GPT only. Protective MBR is written per the GPT
+spec for tool compatibility. Hybrid-MBR layouts (some macOS
+dual-boot disks) are honored as plain GPT.
+
+### Q3. Squashfs compression algorithms
+
+**Decision:** zstd + xz + gzip + lz4. Full compatibility with
+`mksquashfs` defaults across all distros. zstd is reused from
+`compute`; xz/gzip/lz4 are new clean-room decoders (~5 kLOC
+combined).
+
+### Q4. F2FS phasing
+
+**Decision:** Read → write → fsync/checkpoint → GC, four sub-phases
+each tested against `mkfs.f2fs`-produced reference images.
+
+### Q5. A/B boot pointer storage
+
+**Decision:** Dedicated 8 MiB GPT partition holds the source of
+truth (works on every arch, atomically flippable, externally
+inspectable with `dd`). UEFI variable holds a mirror so the UEFI
+bootloader can pick a slot without parsing GPT first. On
+disagreement, the partition wins.
+
+### Q6. Boot rollback trigger
+
+**Decision:** Watchdog timeout (60 s default) **and** explicit
+`boot_success` syscall, both required. Bootloader sets
+`tentative=true`; kernel calls `boot_success` after self-tests
+and first successful auth pass; failure of either path on next
+boot triggers slot rollback.
+
+### Q7. Delta format
+
+**Decision:** bsdiff. Better ratio than zstd `--patch-from` on
+binary blobs (Mender's choice for the same reason). Adds ~500
+LOC of clean-room bsdiff applier in `fs/src/delta.rs`.
+
+### Q8. Manifest placement
+
+**Decision:** Manifest + ML-DSA-65 signature appended as a sealed
+footer to the squashfs blob. Single artifact; squashfs ignores
+trailing bytes, so external `mount -t squashfs -o loop` still
+works without offset gymnastics.
+
+### Q9. VFS mount points
+
+**Decision:** Fixed in kernel code: `/models/` → active squashfs
+slot, `/data/` → F2FS partition, `/dev/` and `/proc/self/` → the
+existing in-memory tree. Compile-time constants. Avoids the
+chicken-and-egg of reading `/data/mgmt/...` to know how to mount
+`/data/`.
+
+### Q10. Block cache
+
+**Decision:** Per-mount LRU (16 MiB `/models/`, 4 MiB `/data/`)
+plus a 256 KiB write-coalescing buffer for `/data/`. Cache budgets
+configurable via `mgmt/policy.toml` (`fs.cache.models_bytes`,
+`fs.cache.data_bytes`).
+
+### Q11. Crate split
+
+**Decision:** Single `fs/` Layer 1 crate. Sub-crates
+(`fs-core`/`fs-squashfs`/`fs-f2fs`/`fs-update`) are documented
+evolution paths if cross-FS sharing becomes a problem.
+
+### Q12. Block error encoding
+
+**Decision:** Typed `BlockError` enum internally
+(`MediaError`/`NotPresent`/`Timeout`/`BadCrc`/`Unaligned`/`OutOfRange`);
+POSIX-aligned errno (`-EIO`/`-ENXIO`/`-ETIMEDOUT`) at the syscall
+boundary. Matches `management-login-v1`'s pattern.
+
+### Q13. Squashfs version
+
+**Decision:** Squashfs 4.0 only. Reject older (1.x/2.x/3.x) with
+a clear error. Forward-compatible reject-unknown-major-version
+check guards future 5.x.
+
+### Q14. F2FS feature-set target
+
+**Decision:** Linux 6.6 LTS feature set. Forward-compatible:
+unknown mandatory feature bits cause a clean refusal, not silent
+mis-mounts.
+
+### Q15. F2FS commit cadence
+
+**Decision:** Inline on `fsync` plus a 5-s background commit
+timer. Idle-detection commit (option D) is documented as an
+evolution path once a power-state observer exists.
+
+### Q16. Integrity check policy
+
+**Decision:** Manifest signature verified once at mount;
+per-block SHA-3-256 verified on every read before bytes leave
+the kernel. Fail-closed.
+
+### Q17. Both-slots-bad recovery
+
+**Decision:** Refuse to mount `/models/`. Print recovery hint.
+Login + audit + `/data/` remain available so the operator can
+investigate and re-image. Inference is hard-disabled.
+
+### Q18. Block I/O retry
+
+**Decision:** Per-op timeout (250 ms read, 1 s write) + 3 retries
+with exponential backoff (500 ms / 1 s / 2 s) → fail with `-EIO`.
+Retry counts and timeouts configurable via `mgmt/policy.toml`.
+The fail-after-retries behavior is **non-configurable**: an
+unattended appliance must never wedge on a bad sector.
+
+### Q19. F2FS crash safety
+
+**Decision:** Standard POSIX/F2FS guarantee: all `fsync`-acknowledged
+writes are durable; non-fsync data is lost up to the last
+checkpoint.
+
+### Q20. Boot-pointer atomicity
+
+**Decision:** Invariant: after any sequence of writes followed
+by an arbitrary power loss, the bootloader **always** finds at
+least one slot whose `valid=true` and whose generation counter is
+one of the two most recent. Generation counter is monotonically
+increasing. Modeled in Kani.
+
+### Q21. Delta-apply checks
+
+**Decision:** Pre: ML-DSA-65 signature on delta payload + reference
+blob hash check. Post: full SHA-3-256 manifest verify on the
+inactive partition + ML-DSA-65 signature verify. Fail-closed leaves
+inactive partition `unbootable`.
+
+### Q22. External interop CI
+
+**Decision:** Ubuntu LTS (current), Fedora (current), macOS via
+FUSE. Every PR mounts the produced squashfs and F2FS images on
+all three and round-trips data with `cmp`.
+
+### Q23. Sector size
+
+**Decision:** Native 4 KiB throughout. 512-byte logical / 4 KiB
+physical Advanced Format devices accessed in 4 KiB chunks.
+512-byte-only legacy devices handled by a slow-path emulation
+layer.
+
+### Q24. First-boot `/data/` formatting
+
+**Decision:** Format only when a `PhysicalPresenceProvider`
+indicator is asserted (mirrors `management-login-v1`'s
+`auth.skip-firstboot` policy). Otherwise halt with recovery hint.
+Format event audit-recorded.
+
+### Q25. Phase ordering
+
+**Decision:** 10-phase bottom-up sequence (block → GPT → squashfs
+→ A/B + delta → F2FS-RO → F2FS-RW → fsync → GC → integrity →
+interop CI). Each phase ends green.
+
+### Q26. Test target
+
+**Decision:** ≥5100 total tests after the change (~+600 new).
+DO-178C-target depth: exhaustive error paths, F2FS spec
+coverage, sector-size/cache/retry combinations.
+
+### Q27. Formal verification
+
+**Decision:**
+- Kani — A/B boot atomicity (Q20 invariant), delta-apply
+  pipeline (Q21), GPT bounds.
+- TLA+ — F2FS checkpoint commit interleaving.
+- SPIN — Promela model proving no path under integrity failure
+  leaks unverified bytes to user space.
+- Coq — bsdiff applier correctness proof.
+
+### Q28. Block device order
+
+**Decision:** virtio-blk → NVMe (x86) → eMMC/SDHCI (Jetson) →
+AHCI (legacy x86). CI signal first via QEMU; real-hardware
+bringup follows.
+
+### Q29. PR strategy
+
+**Decision:** Three checkpoint PRs into `develop`:
+- A: `block + GPT + squashfs read + A/B + delta`
+- B: `F2FS read-only + integrity`
+- C: `F2FS read-write + fsync + GC + interop CI`
+
+Each checkpoint is independently shippable. New on-disk mounts
+are gated behind a `fs-on-disk-mounts` cargo feature (off by
+default) until checkpoint C lands; `/data/` falls back to
+in-memory until the RW path is ready.
+
+### Q30. Session next step
+
+**Decision:** Draft `design.md`, the 10 spec deltas, and
+`tasks.md`; commit on `change/embedded-filesystem-v1`; run
+`openspec validate --strict`; push to origin. No `develop`
+touched.
+
+## Risks / Trade-offs
+
+- **[Risk] F2FS write path is the largest clean-room
+  implementation in the project to date** — Mitigation: Q4 phasing
+  delivers RO before RW; checkpoint B is shippable with reads
+  only behind the cargo feature; Coq-style assurance carries a
+  high bar but is restricted to bsdiff (a small applier), not the
+  whole F2FS write path. The F2FS write path leans on TLA+
+  checkpoint modeling + property-based fuzzing rather than full
+  proof.
+- **[Risk] Block-device drivers on bare-metal x86 (NVMe / AHCI)
+  may uncover gaps in PCIe enumeration** — Mitigation: virtio-blk
+  ships first (Q28) so CI is unblocked while hardware bringup
+  proceeds; NVMe second because USB-NVMe carriers are the cheapest
+  test bench; AHCI last because our deployment story doesn't lean
+  on legacy SATA.
+- **[Risk] Boot-pointer flip atomicity is the central correctness
+  invariant for `remote-update-v1`** — Mitigation: Q20 invariant
+  is Kani-modeled with a power-loss harness covering arbitrary
+  partial writes across the 8 MiB boot-config partition. The
+  proof carries across ABI changes.
+- **[Risk] Five compression decoders (zstd/xz/gzip/lz4 + bsdiff)
+  multiply the parser attack surface** — Mitigation: each decoder
+  has its own fuzz harness; CI runs them on every PR; Linux's CVE
+  history for these formats is the floor we measure against.
+- **[Risk] Cache budgets configurable from `mgmt/policy.toml`
+  introduces a feedback loop with `management-login-v1`'s
+  universal-exposure invariant** — Mitigation: cache fields use
+  `#[reload("live")]`; budget changes apply on next allocation
+  without remount. Validators reject budgets below a hard floor
+  (4 MiB `/models/`, 1 MiB `/data/`) so misconfiguration cannot
+  starve the FS layer.
+- **[Risk] Workspace count growth** — Mitigation: Q11 keeps it to
+  one new crate (`fs/`), bringing the post-`management-login-v1`
+  count from 23 → 24.
+- **[Risk] FAT32 ESP remains as the boot partition** — Out of
+  scope but worth flagging: this change does not replace the UEFI
+  boot partition, which stays FAT32 because UEFI requires it.
+  `verified-boot` covers the kernel image stored on FAT32; the
+  rest of the system runs on squashfs + F2FS.
+
+## Migration Plan
+
+This is a v0.x prototype change. There is no on-disk data from
+prior versions to migrate; the existing in-memory VFS holds no
+state across reboots.
+
+First boot of any image carrying this change:
+- If the disk has a recognized GPT with the v1 partition layout
+  and a valid F2FS superblock at partition 4 → mount normally.
+- If the disk is pristine (no GPT) and physical presence is
+  asserted → write the GPT, format `/data/` (Q24), populate slot
+  A from the boot image, mark slot B `unbootable`, write the
+  initial boot config.
+- If the disk has an unrecognized layout and physical presence is
+  not asserted → halt with a recovery hint.
+
+`management-login-v1` writes to `/data/` previously routed through
+the in-memory VFS will transparently flow to F2FS after the
+`fs-on-disk-mounts` cargo feature flips on. No application code
+changes.
+
+## Open Questions
+
+All ten of the proposal's open questions are now resolved (Q1–Q10
+above). Twenty additional design / specs / sequencing questions
+were resolved during the walkthrough (Q11–Q30).
+
+Items deferred to follow-on changes with explicit decisions:
+- **`embedded-overlay-v1`** — OverlayFS on top of `/models/` for
+  per-deployment model injection without a full image swap.
+- **`embedded-flash-fs-v1`** — LittleFS / JFFS2 / UBIFS support
+  for raw-flash MCU/FPGA targets if those platforms enter the
+  roadmap.
+- **F2FS idle-detection commit** — Q15 documented this as a
+  future addition once a power-state observer crate exists.
+- **NVMe queue-depth-32+ parallel I/O** — Q1 documented the
+  layered queue trait as a follow-on if NVMe performance becomes
+  binding.

--- a/openspec/changes/embedded-filesystem-v1/proposal.md
+++ b/openspec/changes/embedded-filesystem-v1/proposal.md
@@ -1,0 +1,266 @@
+## Why
+
+SmallAIOS today has no on-disk read/write filesystem driver. The
+existing `posix/src/vfs.rs` is a 527-line in-memory read-only VFS
+that returns `EROFS` for every write. The boot partition is FAT32
+(UEFI ESP) and that is the entire on-disk story. The
+`management-login-v1` change adds a write-heavy `/data/` layer
+(`auth/shadow`, `audit/log.jsonl`, `mgmt/policy.toml`,
+per-subsystem TOML config) that assumes POSIX `stage → fsync →
+rename` atomicity — a contract that has no implementation. The
+upcoming `remote-update-v1` change assumes A/B partition swap.
+Both are blocked by the absence of a real on-disk filesystem
+substrate.
+
+This change introduces the embedded-filesystem layer SmallAIOS
+needs to graduate from "the binary that runs in RAM" to "an
+attended appliance that boots, persists state, and survives
+power loss":
+
+1. **Read-only `/models/` on squashfs**, A/B-partitioned for
+   atomic update swap. Squashfs is universally readable on Linux
+   (`mount -t squashfs` is preinstalled on every mainstream
+   distro), provides per-block transparent decompression
+   (zstd / xz), and matches the read-mostly inference workload.
+2. **Read-write `/data/` on F2FS**. F2FS is a log-structured
+   journaling filesystem designed for flash storage (eMMC, NVMe,
+   SSD), mainline-readable since Linux kernel 3.8, gives
+   power-fail-safe atomic rename semantics, and handles the
+   wear-leveling story FAT32 does not.
+3. **Block-level delta updates**. Updates ship as binary diffs
+   (zstd `--patch-from` or bsdiff) applied against the active
+   squashfs blob to produce the inactive partition; a single
+   atomic boot-pointer flip activates the new image.
+4. **Pure Rust, clean-room implementations**, `#![no_std]`, no
+   FFI to C drivers. Squashfs and F2FS read paths first; F2FS
+   write path; integrity verification on every read.
+5. **Universal external interop**. A recovery laptop running
+   stock Linux must be able to mount both filesystems without
+   installing custom tooling. This is a hard requirement and
+   constrains every format and parameter choice.
+
+OverlayFS-style writable layering on `/models/` (so operators can
+add models without a full image swap) is **explicitly deferred**
+to a follow-on `embedded-overlay-v1`. v1 ships A/B whole-image
+updates only.
+
+## What Changes
+
+### New `fs/` Layer 1 crate
+
+A new Layer 1 workspace crate owns block-device I/O, partition
+table parsing, and the on-disk filesystem implementations. Layer
+1 placement keeps it accessible to `kernel` (Layer 0) for boot
+mounts and to `container` (Layer 3) for runtime use; it depends
+only on `kernel` and `security` (for hash-based integrity
+verification). Workspace count grows by one (current `auth` +
+`mgmt` from `management-login-v1` would take it to 23 → 24).
+
+### Block-device abstraction
+
+A `BlockDevice` trait (`read_block`, `write_block`,
+`block_size_bytes`, `block_count`, `flush`) sits at the bottom
+of the new crate. v1 implementations:
+
+- **AHCI/NVMe** on x86-64 — reuses or extends existing PCIe
+  bringup in `arch/x86_64`.
+- **eMMC** on Jetson Orin — wraps the Tegra234 SDHCI controller
+  exposed by `arch/aarch64`.
+- **virtio-blk** on QEMU — for CI smoke tests and developer
+  workflows.
+
+### Squashfs (read-only) driver
+
+`fs/src/squashfs.rs` — clean-room `#![no_std]` Rust parser for
+the squashfs 4.0 on-disk format. Read-only. Supports zstd
+decompression (already in the workspace via `compute`); xz
+support is optional. Mounts at `/models/`. Integrity-verifies
+every block against an SHA-3-256 manifest published with the
+image.
+
+### F2FS (read-write) driver
+
+`fs/src/f2fs.rs` — clean-room `#![no_std]` Rust implementation
+of the F2FS on-disk format. Read and write. Implements the
+checkpoint / segment / SIT / NAT structures, atomic rename via
+the journal, and `fsync`. Mounts at `/data/`. This is the
+biggest piece of work in the change and is phased: read path
+first (Phase 4), write path second (Phase 5), `fsync` and
+checkpoint behavior third (Phase 6).
+
+### Partition table
+
+GPT (GUID Partition Table) parser with the v1 layout:
+
+```text
+Partition  Type     Size       Purpose
+─────────────────────────────────────────────────────────────
+1          ESP      256 MiB    UEFI FAT32 — bootloader + kernel
+2          squashfs ~4 GiB     /models/ slot A
+3          squashfs ~4 GiB     /models/ slot B
+4          F2FS     remainder  /data/
+```
+
+GPT is universal. The two squashfs slots are equal-size and
+swappable. The single `/data/` partition is shared across boots.
+
+### A/B boot pointer
+
+A small (4 KiB) "boot config" region in a fixed location (either
+LBA 64-71 reserved, or a tiny dedicated partition) records:
+
+- Active squashfs slot (A or B)
+- Generation counter and boot-success counter
+- SHA-3-256 of the boot config itself for integrity
+
+The boot config is updated atomically by writing the alternate
+slot's bytes and flipping a `valid` pointer (similar to the EFI
+variable double-buffer pattern). On boot failure (watchdog
+timeout), the pointer reverts to the previous slot.
+
+### Block-level delta update
+
+`fs/src/delta.rs` — applies a zstd `--patch-from` or bsdiff
+delta against the active squashfs blob, writes the result to
+the inactive partition, verifies the SHA-3-256 manifest, then
+returns the new slot to `remote-update-v1` for the boot-pointer
+flip. v1 picks one delta format (zstd patch is leaner for
+embedded since zstd is already in the dep graph; bsdiff is
+documented as an alternative).
+
+### Integrity verification
+
+Every squashfs block read SHALL be verified against the
+manifest's SHA-3-256 hash before the bytes leave the kernel.
+F2FS metadata SHALL be verified via its native CRC32C; data
+blocks SHALL be checksummed at the application layer (the
+audit-chain for `/data/audit/`, the typed `Config` for
+`/data/mgmt/`).
+
+### Capabilities
+
+#### New Capabilities
+- `fs-block-device`: `BlockDevice` trait, per-arch
+  implementations, error encoding.
+- `fs-partition-table`: GPT parser, partition discovery, v1
+  layout enforcement.
+- `fs-squashfs-readonly`: squashfs 4.0 reader, zstd
+  decompression, manifest verification, `/models/` mount.
+- `fs-f2fs-readwrite`: F2FS read + write, journal, checkpoint,
+  atomic rename, `fsync` semantics, `/data/` mount.
+- `fs-ab-boot`: A/B boot config region, atomic slot pointer
+  flip, watchdog rollback on failed boot.
+- `fs-delta-update`: block-level delta application against
+  active squashfs to produce inactive squashfs, manifest
+  verification, hand-off to `remote-update-v1`.
+- `fs-integrity`: per-read hash verification, application-layer
+  checksums on `/data/`.
+
+#### Modified Capabilities
+- `posix-vfs`: extends the existing in-memory VFS with two
+  on-disk mounts (`/models/` squashfs, `/data/` F2FS); adds
+  write paths returning real I/O errors instead of `EROFS`.
+- `kernel-syscalls`: existing file syscalls (open, read, write,
+  fsync, rename, stat) gain real backing on the two mounts.
+- `mgmt-config-layout` (from `management-login-v1`): per-file
+  permission declarations get a real filesystem to enforce
+  against; mode-stricter-than-declared rule operates on F2FS
+  inode permissions.
+
+## Impact
+
+- **Code:**
+  - New crate `fs/` (Layer 1) — block device, GPT, squashfs,
+    F2FS, A/B boot, delta apply.
+  - `fs/src/squashfs.rs` — clean-room squashfs 4.0 reader.
+    Estimate ~2k LOC.
+  - `fs/src/f2fs.rs` — clean-room F2FS implementation.
+    Estimate ~6k LOC for read; ~10k more for write +
+    checkpoint. Largest piece in the change.
+  - `arch/x86_64/src/ahci.rs` (or equivalent NVMe) — block
+    device for x86 bare metal.
+  - `arch/aarch64/src/sdhci.rs` — eMMC block device for Jetson.
+  - `arch/{x86_64,aarch64}/src/virtio_blk.rs` — virtio-blk for
+    QEMU.
+  - `posix/src/vfs.rs` — extend with on-disk mount points.
+  - `kernel/src/boot.rs` — mount `/models/` and `/data/` after
+    `auth_login` is available.
+- **Tests:** ~250 new tests targeted: squashfs round-trip
+  against `mksquashfs`-produced images, F2FS round-trip against
+  `mkfs.f2fs` images, GPT parser fuzz, A/B boot-pointer atomic
+  flip under simulated crash, delta apply against known-good
+  patches, manifest verification (correct + corrupted),
+  per-arch block-device read/write KAT, mount-time integrity
+  fail-closed. Aim to keep `≥4500` (already targeted in
+  `management-login-v1`) growing to `≥4750`.
+- **Boot footprint:** F2FS is the dominant new code — likely
+  +100-150 KB compiled (no_std, `opt-level = "z"`, LTO). The
+  base SmallAIOS binary will exceed the prior <8 MB target by
+  ~2%; the trade is acceptable for the resilience and
+  interop guarantees.
+- **External interop:** A laptop running stock Ubuntu/Fedora
+  with no extra packages MUST be able to: (a) mount the
+  squashfs image read-only via `mount -t squashfs -o loop`,
+  (b) mount the F2FS partition read-write via `mount -t f2fs`.
+  This SHALL be CI-tested on every PR.
+- **Downstream:** Unblocks the `management-login-v1` write
+  paths (`/data/auth/shadow`, audit log, mgmt config) and the
+  `remote-update-v1` A/B swap mechanism. Establishes the
+  filesystem substrate every persistent feature inherits.
+- **Dependencies:** No new external Rust crates in the
+  production dep graph (clean-room rule). zstd is already
+  present. `mksquashfs` and `mkfs.f2fs` are dev-only host
+  tooling for producing test images.
+- **Risks:**
+  1. F2FS write path is the largest clean-room implementation
+     in the project to date. Phased delivery with read path
+     first lets us land squashfs end-to-end before the F2FS
+     write story is final.
+  2. Block-device drivers on bare-metal x86 (AHCI/NVMe) may
+     uncover gaps in PCIe enumeration. Mitigate by landing
+     virtio-blk first (works in QEMU CI) before bare-metal
+     hardware bringup.
+  3. Boot-pointer flip atomicity under power loss is the
+     central correctness invariant for `remote-update-v1`.
+     Cover with a Kani harness that models partial writes
+     across the boot-config region.
+
+## Out of scope for v1 (flagged)
+
+- OverlayFS-style writable layer on `/models/` for
+  per-deployment model injection. Captured as
+  `embedded-overlay-v1` follow-on.
+- ext4, xfs, btrfs as alternatives to F2FS. Re-evaluate only
+  if a hard target requirement appears.
+- LittleFS, JFFS2, UBIFS for raw-flash microcontroller
+  targets. Captured as `embedded-flash-fs-v1` follow-on for
+  future MCU/FPGA targets.
+- Multi-disk RAID, encrypted-at-rest filesystems, fscrypt,
+  network filesystems (NFS, 9P, virtio-fs).
+- Quotas, ACLs, extended attributes beyond what F2FS metadata
+  natively provides.
+- Trim / discard support beyond what's needed for correctness
+  (performance-tuning is a v2 concern).
+
+## Open Questions
+
+The following are filled in by the design walkthrough:
+
+1. Block device layer — single `BlockDevice` trait, or per-bus
+   trait hierarchy (NVMe vs AHCI vs SDHCI vs virtio-blk)?
+2. Partition table — GPT only, or both MBR (legacy x86) and GPT?
+3. Squashfs compression — zstd only (already in tree), or
+   zstd + xz (broader external compatibility)?
+4. F2FS implementation phasing — read path first, then write,
+   then `fsync`, or vertical-slice (one config file
+   end-to-end, then expand)?
+5. Boot-pointer storage — reserved LBA, dedicated tiny
+   partition, or UEFI variable?
+6. Boot rollback trigger — watchdog timeout, explicit
+   "boot success" syscall, or both?
+7. Delta format — zstd `--patch-from`, bsdiff, both?
+8. Manifest format — separate `.sig` file or inline at end of
+   squashfs blob?
+9. Where do mount points live in `posix-vfs`'s tree — fixed,
+   or driven by a config file?
+10. Block cache — single shared LRU, per-mount, or none in v1?

--- a/openspec/changes/embedded-filesystem-v1/specs/fs-ab-boot/spec.md
+++ b/openspec/changes/embedded-filesystem-v1/specs/fs-ab-boot/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: A/B boot config layout
+A dedicated 8 MiB GPT partition (#5, type GUID `A3F7C2E0-FACE-4FFF-BBBB-000000000000`) SHALL hold the A/B boot pointer. The partition SHALL contain two double-buffered records (call them slot-X and slot-Y, each 4 KiB) at fixed offsets 0x000 and 0x1000. Each record SHALL have:
+
+```text
+struct BootConfigRecord {
+    magic:        [u8; 8]    = "SmAIOSBC",
+    version:      u8         = 1,
+    valid:        u8,        // 1 = valid, 0 = invalid
+    active_slot:  u8,        // 0 = slot A squashfs, 1 = slot B squashfs
+    tentative:    u8,        // 1 = updated, awaiting boot_success
+    generation:   u64        // monotonically increasing
+    boot_success: u8         // 1 once kernel called boot_success
+    pad:          [u8; ...]
+    record_hash:  [u8; 32]   // SHA-3-256 of all preceding bytes
+}
+```
+
+The bootloader SHALL read both records, validate each by checking magic, version, and `record_hash`, and SHALL pick the valid record with the highest `generation`. If both are invalid, the bootloader SHALL halt with a recovery message.
+
+#### Scenario: Higher-generation record wins
+- **WHEN** slot-X has generation 5 valid and slot-Y has generation 4 valid
+- **THEN** the bootloader SHALL use slot-X (active_slot, tentative, etc.)
+
+#### Scenario: Invalid record skipped
+- **WHEN** slot-X has a wrong record_hash and slot-Y is valid at generation 4
+- **THEN** the bootloader SHALL use slot-Y
+
+#### Scenario: Both records invalid halts boot
+- **WHEN** both records fail their record_hash
+- **THEN** the bootloader SHALL halt with `Err: boot config corrupt, both slots`
+
+### Requirement: Atomic update via the inactive slot
+Updating the boot pointer SHALL: (1) compute the new record bytes (with `generation = max + 1` and the desired `active_slot`/`tentative` fields), (2) write the new record to the **inactive** slot (the one with the lower `generation`), (3) `flush()` to durable storage, (4) only then SHALL the bootloader's pick of "highest valid generation" select the new record. There SHALL be no in-place modification of the previously-active slot until the new slot is durably written.
+
+#### Scenario: Power loss before flush leaves previous slot intact
+- **WHEN** a write to the inactive slot is in progress and power is lost mid-write
+- **THEN** the previously-active slot SHALL remain unchanged on next boot
+- **AND** the bootloader SHALL select the previously-active slot via the highest-valid-generation rule
+
+#### Scenario: Power loss after flush of inactive slot
+- **WHEN** the inactive slot is fully written and flushed but power is lost before the OS resumes
+- **THEN** the next boot SHALL pick the new slot (highest valid generation)
+
+### Requirement: Atomicity invariant under arbitrary power loss
+After any sequence of writes to the boot config followed by an arbitrary power loss, the bootloader SHALL find at least one slot that is valid and whose `generation` is one of the two most recent generations ever written. Generation counters SHALL be monotonically increasing; values SHALL NEVER be reused. This invariant SHALL be modeled in Kani.
+
+#### Scenario: Kani harness covers all torn-write interleavings
+- **WHEN** the Kani harness runs `boot_config_atomic_update_under_power_loss`
+- **THEN** the proof SHALL hold for all valid bus-write granularities (per-byte, per-512-byte sector, per-4-KiB block)
+- **AND** the proof SHALL show at least one valid slot exists in every reachable post-state
+
+### Requirement: UEFI variable mirror
+On UEFI-capable arches (x86-64, AArch64-with-UEFI), the kernel SHALL also write the active slot pointer to a UEFI variable `SmallAIOSBoot-A3F7C2E0-FACE-4FFF-BBBB-000000000000`. The UEFI bootloader MAY read this variable to pick the slot without parsing GPT first. On disagreement between the variable and the partition, the partition SHALL win — the variable is a hint, not the truth.
+
+#### Scenario: UEFI variable matches partition after update
+- **WHEN** an A/B update completes successfully
+- **THEN** the UEFI variable SHALL be updated to match the new active slot
+- **AND** subsequent reads of the variable SHALL return the new value
+
+#### Scenario: Stale variable overruled by partition
+- **WHEN** the partition says active_slot=B and the UEFI variable says A (e.g., NVRAM corruption)
+- **THEN** the kernel SHALL boot from B and SHALL log `warn: UEFI boot var stale; rewriting`
+- **AND** SHALL rewrite the variable to match
+
+### Requirement: Watchdog + boot_success rollback
+After an A/B update, the new record SHALL be written with `tentative = 1, boot_success = 0`. A 60-s watchdog SHALL be armed at boot. The kernel SHALL call a new `boot_success` syscall after self-tests and the first successful login. `boot_success` SHALL clear `tentative` and set `boot_success = 1` on the active record (via the same atomic-write-to-inactive-slot path).
+
+If the watchdog fires before `boot_success` is called, the bootloader on the next boot SHALL observe `tentative=1, boot_success=0` and SHALL roll back to the previous slot (via choosing the second-highest valid generation), then SHALL invalidate the failed slot's record (set `valid=0`).
+
+The watchdog timeout SHALL be configurable via `mgmt/policy.toml` `fs.boot.watchdog_seconds` (default 60).
+
+#### Scenario: Successful boot calls boot_success
+- **WHEN** the new image self-tests pass and an operator logs in successfully
+- **THEN** the kernel SHALL invoke `boot_success`
+- **AND** the active record SHALL transition to `tentative=0, boot_success=1`
+
+#### Scenario: Watchdog fires triggers rollback
+- **WHEN** 60 s elapses without `boot_success` being called
+- **THEN** the watchdog SHALL trigger a hardware reset
+- **AND** on next boot the bootloader SHALL observe the tentative state and select the previous slot
+- **AND** the failed slot SHALL be marked `valid=0`
+
+#### Scenario: Watchdog timeout configurable
+- **WHEN** `fs.boot.watchdog_seconds = 30` is set in `mgmt/policy.toml`
+- **THEN** subsequent boots SHALL use a 30 s watchdog window

--- a/openspec/changes/embedded-filesystem-v1/specs/fs-block-device/spec.md
+++ b/openspec/changes/embedded-filesystem-v1/specs/fs-block-device/spec.md
@@ -1,0 +1,108 @@
+## ADDED Requirements
+
+### Requirement: BlockDevice trait
+The `fs` crate SHALL define a single `BlockDevice` trait used by every consumer (squashfs, F2FS, GPT parser, A/B boot, delta apply). The trait SHALL expose:
+
+```rust
+pub trait BlockDevice {
+    fn read_block(&self, lba: u64, buf: &mut [u8]) -> Result<(), BlockError>;
+    fn write_block(&mut self, lba: u64, buf: &[u8]) -> Result<(), BlockError>;
+    fn block_size_bytes(&self) -> u32;
+    fn block_count(&self) -> u64;
+    fn flush(&mut self) -> Result<(), BlockError>;
+}
+```
+
+`buf` length on read/write SHALL be a multiple of `block_size_bytes()`. Each implementation SHALL document its sector size and any device-specific alignment constraints.
+
+#### Scenario: Read returns exactly the requested block
+- **WHEN** `read_block(lba, buf)` is called with a `buf` of `block_size_bytes()`
+- **THEN** the call SHALL fill `buf` with the contents of `lba` and return `Ok(())`
+
+#### Scenario: Read with mis-sized buffer rejected
+- **WHEN** `read_block(lba, buf)` is called with a `buf` length that is not a multiple of `block_size_bytes()`
+- **THEN** the call SHALL return `Err(BlockError::Unaligned)` and SHALL NOT issue any I/O
+
+#### Scenario: Read past end of device rejected
+- **WHEN** `read_block(lba, buf)` is called with `lba >= block_count()`
+- **THEN** the call SHALL return `Err(BlockError::OutOfRange)`
+
+### Requirement: Typed BlockError enum
+Block I/O errors SHALL be represented by a typed `BlockError` enum:
+
+```rust
+pub enum BlockError {
+    MediaError,
+    NotPresent,
+    Timeout,
+    BadCrc,
+    Unaligned,
+    OutOfRange,
+    DeviceBusy,
+}
+```
+
+The enum SHALL be converted to POSIX-aligned errno (`-EIO`, `-ENXIO`, `-ETIMEDOUT`, `-EINVAL`, `-ENOSPC`, `-EBUSY`) at the syscall boundary by `posix-vfs`.
+
+#### Scenario: Timeout maps to ETIMEDOUT at syscall boundary
+- **WHEN** a block read times out after exhausting retries
+- **THEN** the internal API SHALL return `Err(BlockError::Timeout)`
+- **AND** any syscall surfaced via `posix-vfs` SHALL return `-ETIMEDOUT`
+
+#### Scenario: Bad CRC maps to EIO
+- **WHEN** the device reports a CRC failure on read
+- **THEN** the internal API SHALL return `Err(BlockError::BadCrc)`
+- **AND** the syscall boundary SHALL return `-EIO`
+
+### Requirement: Per-op timeout and retry policy
+Block reads SHALL have a default 250 ms per-op timeout and SHALL retry up to 3 times with exponential backoff (500 ms, 1 s, 2 s) before returning `BlockError::Timeout`. Block writes SHALL have a default 1 s per-op timeout with the same retry schedule. Timeouts and retry counts SHALL be configurable via `mgmt/policy.toml` keys `fs.block.read_timeout_ms`, `fs.block.write_timeout_ms`, `fs.block.retry_count`, `fs.block.retry_backoff_ms`.
+
+The fail-after-retries behavior SHALL NOT be configurable: an unattended appliance SHALL NEVER block indefinitely on a single bad sector.
+
+#### Scenario: Three retries then fail
+- **WHEN** a block read encounters transient failures and retry_count = 3
+- **THEN** the implementation SHALL retry 3 times with the configured backoff
+- **AND** the 4th failure SHALL return `Err(BlockError::Timeout)` to the caller
+
+#### Scenario: Indefinite retry rejected at config write
+- **WHEN** `mgmt/policy.toml` is written with `fs.block.retry_count = 0xFFFF_FFFF` or any "infinite" sentinel
+- **THEN** the validator SHALL reject the value with `-EINVAL`
+
+### Requirement: Per-arch BlockDevice implementations
+v1 SHALL ship four `BlockDevice` implementations:
+
+- `virtio-blk` — for QEMU x86-64 and aarch64 CI smoke tests.
+- `nvme` — for x86-64 bare-metal servers and USB-NVMe carriers.
+- `sdhci` (eMMC) — for the Jetson Orin Tegra234 BSP.
+- `ahci` — for legacy x86-64 SATA hardware.
+
+Each implementation SHALL pass the same generic conformance test suite (alignment, retry, error mapping) plus device-specific timing tests where applicable.
+
+#### Scenario: virtio-blk passes generic conformance
+- **WHEN** the conformance suite runs against a virtio-blk-backed device in QEMU
+- **THEN** all 30+ generic tests SHALL pass
+
+#### Scenario: NVMe passes generic conformance
+- **WHEN** the conformance suite runs against an NVMe device
+- **THEN** all 30+ generic tests SHALL pass
+
+#### Scenario: SDHCI eMMC passes generic conformance on Jetson
+- **WHEN** the conformance suite runs against a Jetson Orin's eMMC
+- **THEN** all 30+ generic tests SHALL pass
+
+### Requirement: Native 4 KiB block size with 512-byte fallback
+The `fs` crate SHALL operate natively at 4 KiB block size. Devices reporting 4 KiB physical / 4 KiB logical sectors SHALL be used directly. Devices reporting 512 B logical / 4 KiB physical (Advanced Format) SHALL be accessed in 4 KiB chunks aligned to the 8-LBA boundary. Devices reporting 512 B logical / 512 B physical SHALL be accessed via a slow-path emulation layer that bundles 8 logical sectors per 4 KiB FS block.
+
+#### Scenario: 4 KiB-native device used directly
+- **WHEN** the device reports `block_size_bytes() == 4096`
+- **THEN** FS reads SHALL issue 4 KiB I/O directly to the device
+
+#### Scenario: 512/4 KiB Advanced Format device aligned
+- **WHEN** the device reports 512 B logical / 4 KiB physical
+- **THEN** FS reads SHALL issue 4 KiB-aligned 8-LBA I/O
+- **AND** SHALL never split an FS block across two physical sectors
+
+#### Scenario: 512-byte legacy device emulated
+- **WHEN** the device reports 512 B logical / 512 B physical
+- **THEN** the emulation layer SHALL bundle 8 consecutive logical reads into one FS block read
+- **AND** SHALL log a one-time warning at mount about reduced performance

--- a/openspec/changes/embedded-filesystem-v1/specs/fs-delta-update/spec.md
+++ b/openspec/changes/embedded-filesystem-v1/specs/fs-delta-update/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: bsdiff delta applier
+The `fs` crate SHALL provide a clean-room `#![no_std]` Rust applier for the bsdiff binary-diff format. The applier SHALL accept a reference blob (the active squashfs) and a bsdiff patch payload, SHALL produce the new blob via the bsdiff streaming algorithm, and SHALL write the result to the inactive squashfs partition. No new external Rust crate dependencies SHALL be added in the production dep graph.
+
+#### Scenario: Apply produces expected blob
+- **WHEN** a known-good `(reference, patch, expected_output)` triple is processed
+- **THEN** the resulting bytes written to the inactive partition SHALL `cmp`-equal `expected_output` byte-for-byte
+
+#### Scenario: Truncated patch rejected
+- **WHEN** a bsdiff patch is truncated mid-stream
+- **THEN** the applier SHALL detect the truncation via length checks
+- **AND** SHALL return `Err: bsdiff patch truncated`
+- **AND** SHALL leave the inactive partition in an `unbootable` state (record marked `valid=0`)
+
+#### Scenario: Out-of-bounds offset rejected
+- **WHEN** a bsdiff control command references an out-of-range offset in the reference blob
+- **THEN** the applier SHALL return `Err: bsdiff offset out of range`
+- **AND** SHALL NOT proceed with downstream commands
+
+### Requirement: Pre-apply integrity checks
+Before any byte is written to the inactive partition, the delta-update flow SHALL verify:
+1. The ML-DSA-65 signature on the delta payload (signed by the SmallAIOS update-signing key) is valid.
+2. The reference-blob hash declared in the delta payload matches the SHA-3-256 of the active squashfs partition currently on disk.
+
+If either check fails, no inactive-partition writes SHALL occur and the flow SHALL return `Err: delta verification failed` with details of which check failed.
+
+#### Scenario: Forged delta rejected
+- **WHEN** a delta payload arrives with an invalid ML-DSA-65 signature
+- **THEN** verification SHALL fail before any disk write
+- **AND** SHALL append an audit record `delta_signature_invalid`
+
+#### Scenario: Wrong-version reference rejected
+- **WHEN** a delta payload's `reference_hash` does not match the active squashfs's actual hash
+- **THEN** verification SHALL fail with `Err: delta reference mismatch (expected <a>, found <b>)`
+- **AND** SHALL append an audit record naming both hashes
+
+### Requirement: Post-apply integrity checks
+After the bsdiff applier finishes writing to the inactive partition, the flow SHALL:
+1. Verify the SHA-3-256 manifest in the new partition's footer against every block in the partition.
+2. Verify the ML-DSA-65 signature in the footer over the manifest's hash array.
+
+If either check fails, the inactive-slot record SHALL be marked `valid=0` and the flow SHALL return `Err: post-apply verification failed`. The active slot SHALL remain in service.
+
+#### Scenario: Post-apply manifest mismatch fails closed
+- **WHEN** the post-apply per-block verify finds a single mismatched block
+- **THEN** the flow SHALL return `Err: manifest hash mismatch at block <n>`
+- **AND** the inactive-slot boot config record SHALL remain `valid=0`
+- **AND** the active slot SHALL continue serving inference normally
+
+#### Scenario: Post-apply signature verify
+- **WHEN** the manifest array hashes correctly but the ML-DSA-65 signature in the footer does not verify
+- **THEN** the flow SHALL return `Err: footer signature invalid`
+- **AND** the inactive-slot record SHALL remain `valid=0`
+
+### Requirement: Hand-off to remote-update-v1
+On successful pre + apply + post checks, the delta-update flow SHALL: (1) write the new boot config record (per `fs-ab-boot`) to the previously-inactive slot's record area with `active_slot` flipped, `tentative=1`, `boot_success=0`, and `generation = current_max + 1`; (2) emit an `update_staged` event for `remote-update-v1` to consume; (3) return `Ok(new_active_slot)`. The actual reboot SHALL be initiated by `remote-update-v1`, not the FS layer.
+
+#### Scenario: Successful staging hands off
+- **WHEN** all pre/apply/post checks pass
+- **THEN** the flow SHALL update the boot config to mark the new slot active+tentative
+- **AND** SHALL emit `update_staged{ new_slot, generation }`
+- **AND** SHALL NOT initiate the reboot itself
+
+#### Scenario: Audit record on staging
+- **WHEN** staging completes
+- **THEN** an audit record `update_staged` SHALL be appended with the new slot, generation, delta size, and the manifest hash

--- a/openspec/changes/embedded-filesystem-v1/specs/fs-f2fs-readwrite/spec.md
+++ b/openspec/changes/embedded-filesystem-v1/specs/fs-f2fs-readwrite/spec.md
@@ -1,0 +1,89 @@
+## ADDED Requirements
+
+### Requirement: F2FS read path
+The `fs` crate SHALL provide a clean-room `#![no_std]` Rust reader for the F2FS on-disk format matching the Linux 6.6 LTS feature set. The reader SHALL parse the superblock, the checkpoint journal, the SIT (Segment Information Table), the NAT (Node Address Table), the SSA (Segment Summary Area), and the data area per the F2FS specification. The reader SHALL successfully mount images produced by `mkfs.f2fs` from the matching `f2fs-tools` release and SHALL `cmp`-equal a byte-stream produced by Linux's F2FS driver reading the same image.
+
+#### Scenario: mkfs.f2fs image mounts
+- **WHEN** an image produced by `mkfs.f2fs` (from `f2fs-tools` matching Linux 6.6) is presented
+- **THEN** mount SHALL succeed and the root directory listing SHALL match what Linux F2FS reports
+
+#### Scenario: Linux-written file readable byte-for-byte
+- **WHEN** a file is created by Linux F2FS, then read by SmallAIOS
+- **THEN** the read bytes SHALL exactly match the bytes Linux wrote
+
+#### Scenario: Unknown mandatory feature bit rejected
+- **WHEN** the F2FS superblock declares an unknown mandatory feature bit
+- **THEN** mount SHALL fail with `Err: F2FS mandatory feature <bit> unsupported`
+- **AND** SHALL NOT proceed to a partial mount
+
+### Requirement: F2FS write path
+The `fs` crate SHALL provide a clean-room `#![no_std]` Rust writer for F2FS. The writer SHALL implement: file creation, directory creation, writes that extend a file, writes that overwrite existing blocks, file deletion, directory deletion, atomic rename, and `truncate`. Writes SHALL go through the SIT/NAT update machinery and SHALL produce on-disk state that Linux 6.6 F2FS can mount and read.
+
+#### Scenario: Write then Linux reads
+- **WHEN** SmallAIOS creates a file containing known bytes
+- **AND** the F2FS partition is then mounted on Linux 6.6
+- **THEN** Linux SHALL read back the same bytes
+
+#### Scenario: Atomic rename preserves consistency
+- **WHEN** SmallAIOS performs `rename(src, dst)` while another reader has `dst` open
+- **THEN** the open reader's file handle SHALL continue to refer to the original `dst` content
+- **AND** new opens of `dst` SHALL see `src`'s content
+
+#### Scenario: Truncate to zero
+- **WHEN** SmallAIOS truncates a 1 MiB file to 0 bytes
+- **THEN** subsequent reads SHALL return zero bytes
+- **AND** Linux re-mounting SHALL agree the file is 0 bytes
+
+### Requirement: fsync and checkpoint commit
+`fsync(fd)` SHALL force all dirty pages of `fd` and the corresponding NAT/SIT updates to disk via a checkpoint commit before returning. After successful `fsync`, the data SHALL be durable across an arbitrary power loss; Linux 6.6 reading the partition after the power cycle SHALL see the fsync'd state.
+
+A 5-second background timer SHALL trigger a checkpoint commit if any dirty data is pending and `fsync` has not been called.
+
+#### Scenario: fsync survives power loss
+- **WHEN** SmallAIOS writes a file, calls `fsync`, then the system loses power
+- **AND** the disk is read by Linux 6.6 after reboot
+- **THEN** the fsync'd file content SHALL be intact
+
+#### Scenario: Non-fsync data lost up to last checkpoint
+- **WHEN** SmallAIOS writes data without calling `fsync` and power is lost before any checkpoint
+- **THEN** the data MAY be absent on next mount
+- **AND** the filesystem SHALL still be consistent
+
+#### Scenario: 5-second timer commits idle dirty data
+- **WHEN** a write happens at time t and no `fsync` is called for 5 seconds
+- **THEN** at time t+5s a checkpoint commit SHALL flush the dirty data
+- **AND** subsequent power loss after t+5s SHALL preserve the data
+
+### Requirement: Garbage collection
+The F2FS writer SHALL implement segment-level garbage collection. GC SHALL run opportunistically when free segments fall below a threshold (default: 5% of total segments) and SHALL relocate live blocks from the most fragmented victim segment to a fresh segment, then mark the old segment free. GC SHALL be cooperative — it SHALL yield between block relocations so it does not stall foreground writes.
+
+#### Scenario: GC frees segments below threshold
+- **WHEN** free segments drop below 5%
+- **THEN** GC SHALL run and SHALL increase the free count
+- **AND** existing file data SHALL remain intact (verified post-GC `cmp` against pre-GC content)
+
+#### Scenario: GC yields to foreground writes
+- **WHEN** GC is running and a foreground write arrives
+- **THEN** GC SHALL release its work credit between block relocations
+- **AND** the foreground write SHALL not be starved
+
+### Requirement: VFS mount at `/data/`
+The F2FS partition SHALL be mounted at `/data/` in the VFS. The mount SHALL happen during kernel boot before `auth_login` (since `/data/auth/shadow` lives on this mount).
+
+#### Scenario: /data/ available before login
+- **WHEN** the kernel reaches the login prompt
+- **THEN** `/data/` SHALL already be mounted RW
+- **AND** `auth_login` SHALL be able to read `/data/auth/shadow`
+
+### Requirement: Format on first boot when physical presence asserted
+When the F2FS partition is unformatted and a `PhysicalPresenceProvider` indicator is asserted, the kernel SHALL run an in-process equivalent of `mkfs.f2fs` to format the partition, then SHALL append an audit record describing the format event (which provider asserted presence, the partition size, the resulting filesystem UUID).
+
+When the partition is unformatted and physical presence is **not** asserted, the kernel SHALL halt with a recovery hint pointing at the asserter mechanism for the current arch.
+
+#### Scenario: Format with presence asserted
+- **WHEN** the partition has no F2FS superblock and the GPIO presence pin is asserted
+- **THEN** the kernel SHALL format the partition, mount it, and append a `data_format` audit record
+
+#### Scenario: Halt without presence
+- **WHEN** the partition has no F2FS superblock and no presence provider asserts
+- **THEN** the kernel SHALL halt with `Err: /data/ unformatted; assert physical presence to format`

--- a/openspec/changes/embedded-filesystem-v1/specs/fs-integrity/spec.md
+++ b/openspec/changes/embedded-filesystem-v1/specs/fs-integrity/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: Mount-time manifest verification
+At squashfs mount time, the kernel SHALL: (1) read the manifest footer (per `fs-squashfs-readonly`), (2) verify the ML-DSA-65 signature in the footer over the manifest hash array using the SmallAIOS update-signing public key, (3) refuse the mount with `Err: squashfs signature invalid` if verification fails. No data block SHALL be served from the mount before the signature passes.
+
+#### Scenario: Valid signature mounts
+- **WHEN** the footer signature verifies against the embedded public key
+- **THEN** mount SHALL succeed and reads SHALL be served
+
+#### Scenario: Invalid signature rejected
+- **WHEN** the footer signature fails ML-DSA-65 verification
+- **THEN** mount SHALL fail with `Err: squashfs signature invalid`
+- **AND** an audit record `mount_signature_invalid` SHALL be appended
+
+### Requirement: Per-read SHA-3-256 block verification
+On every `read_block` from a squashfs mount, the FS layer SHALL compute the SHA-3-256 of the bytes read and SHALL compare against the manifest's recorded hash for that block. If the hashes do not match, the read SHALL return `Err(BlockError::BadCrc)` and SHALL NOT pass any byte of the corrupt block to the caller. The corruption event SHALL be appended to the audit log with the block number, expected hash, and observed hash.
+
+#### Scenario: Correct block passes through
+- **WHEN** a read returns bytes whose SHA-3-256 matches the manifest
+- **THEN** the bytes SHALL be returned to the caller
+- **AND** no audit record SHALL be appended
+
+#### Scenario: Corrupted block fails closed
+- **WHEN** a read returns bytes whose SHA-3-256 does NOT match the manifest entry
+- **THEN** the call SHALL return `Err(BlockError::BadCrc)`
+- **AND** zero bytes of the corrupt block SHALL be visible to the caller
+- **AND** an audit record `block_hash_mismatch` SHALL be appended
+
+#### Scenario: SHA-3-256 reused from existing security crate
+- **WHEN** the integrity layer hashes a block
+- **THEN** it SHALL call into the existing `security` crate's SHA-3-256 implementation
+- **AND** SHALL NOT introduce a separate hash implementation
+
+### Requirement: Both-slots-bad halt
+If both squashfs slots A and B fail their mount-time signature verification, the kernel SHALL refuse to mount `/models/`, SHALL print a recovery hint on the console, SHALL append a `both_slots_invalid` audit record, and SHALL continue boot far enough that login, audit, and `/data/` remain available so an operator can investigate. Inference SHALL be hard-disabled until at least one valid slot is restored.
+
+#### Scenario: Both slots invalid leaves system reachable
+- **WHEN** slot A and slot B both fail signature verification
+- **THEN** boot SHALL continue past mount with no `/models/` mounted
+- **AND** `auth_login` SHALL work normally
+- **AND** the operator SHALL be able to read the audit log and stage a recovery image
+
+#### Scenario: Inference disabled on both-bad
+- **WHEN** `/models/` is unmounted due to both-slots-bad
+- **THEN** any attempt to call `model_load` SHALL fail with `-EROFS` and a `system not in service` message
+- **AND** an audit record SHALL be appended for each attempt
+
+### Requirement: F2FS metadata CRC verification
+F2FS native CRC32C on the superblock, checkpoint, NAT, and SIT structures SHALL be checked on every read of these metadata blocks. CRC failure SHALL return `Err(BlockError::BadCrc)` and SHALL trigger fallback to the alternate copy of the metadata where F2FS provides one (e.g., the secondary superblock at fixed offset 1024 sectors).
+
+#### Scenario: Primary superblock corrupt falls through to secondary
+- **WHEN** the primary F2FS superblock CRC fails and the secondary CRC passes
+- **THEN** the mount SHALL proceed using the secondary
+- **AND** SHALL log a one-time warning
+
+#### Scenario: Both superblocks corrupt rejected
+- **WHEN** both F2FS superblocks fail CRC
+- **THEN** mount SHALL fail with `Err: F2FS superblocks corrupt`
+- **AND** the kernel SHALL halt with a recovery hint
+
+### Requirement: Application-layer checksums on /data/
+Files under `/data/` whose schema is owned by SmallAIOS SHALL carry application-layer integrity that does NOT rely on the filesystem alone. Specifically: the `/data/auth/shadow` file's PHC strings carry their own integrity (the Argon2id tag is implicit), the `/data/audit/log.jsonl` file is a SHA-3-256 hash chain (per `mgmt-audit-log`), and `/data/mgmt/policy.toml` SHALL include a SHA-3-256 fingerprint header that the loader checks before parsing.
+
+#### Scenario: policy.toml fingerprint valid
+- **WHEN** the loader reads `/data/mgmt/policy.toml`
+- **THEN** the loader SHALL recompute the SHA-3-256 over the body and compare against the header fingerprint
+- **AND** SHALL refuse the file with `Err: policy.toml fingerprint mismatch` if they differ
+
+#### Scenario: Audit chain verifies
+- **WHEN** the audit log is read and the chain head is validated
+- **THEN** every record's `prev_hash` SHALL match the previous record's `hash`
+- **AND** any mismatch SHALL be reported via the existing `mgmt-audit-log` chain-check mechanism

--- a/openspec/changes/embedded-filesystem-v1/specs/fs-partition-table/spec.md
+++ b/openspec/changes/embedded-filesystem-v1/specs/fs-partition-table/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: GPT partition table parser
+The `fs` crate SHALL parse the GUID Partition Table (GPT) per UEFI Specification 2.10 §5.3. Reads SHALL validate: protective-MBR signature, primary GPT header CRC32, partition entry array CRC32, header revision, and entry count bounds. The parser SHALL also read the secondary GPT (at the end of the device) and SHALL prefer it if the primary header is corrupt. v1 SHALL NOT support legacy MBR-only disks.
+
+#### Scenario: Valid GPT parses successfully
+- **WHEN** a device with a valid GPT is presented
+- **THEN** the parser SHALL return the array of partition entries with their type GUIDs, start LBAs, end LBAs, and names
+
+#### Scenario: Corrupt primary GPT falls through to secondary
+- **WHEN** the primary header CRC fails but the secondary header CRC is valid
+- **THEN** the parser SHALL read partition entries from the secondary location and SHALL log a one-time warning
+
+#### Scenario: Both primary and secondary corrupt rejected
+- **WHEN** both primary and secondary GPT headers fail their CRC checks
+- **THEN** the parser SHALL return `Err(BlockError::BadCrc)`
+- **AND** the kernel SHALL halt with a recovery hint
+
+#### Scenario: MBR-only disk rejected
+- **WHEN** a device with an MBR but no GPT signature is presented
+- **THEN** the parser SHALL refuse to mount and SHALL log "GPT required, MBR-only disk rejected"
+
+### Requirement: Protective MBR for tool compatibility
+On a freshly-formatted SmallAIOS disk, the GPT writer SHALL write a protective MBR (single MBR partition entry of type `0xEE` covering the disk) per the GPT specification. This SHALL ensure legacy partition-table tools see one large unknown-type partition rather than free space they might overwrite.
+
+#### Scenario: Protective MBR present after format
+- **WHEN** SmallAIOS formats a disk with the v1 layout
+- **THEN** the first 512 bytes SHALL contain a protective MBR with one partition of type `0xEE`
+
+### Requirement: v1 partition layout enforcement
+The v1 SmallAIOS GPT layout SHALL contain exactly five partitions in this order:
+
+| Idx | Type GUID                              | Size      | Purpose                          |
+|----:|----------------------------------------|-----------|----------------------------------|
+|   1 | EFI System Partition (`C12A7328-...`)  | 256 MiB   | UEFI bootloader + kernel image   |
+|   2 | SmallAIOS squashfs slot (`A3...A1`)    | 4 GiB     | `/models/` slot A                |
+|   3 | SmallAIOS squashfs slot (`A3...A2`)    | 4 GiB     | `/models/` slot B                |
+|   4 | Linux F2FS (`8DA63339-...`)            | remainder | `/data/`                         |
+|   5 | SmallAIOS boot config (`A3...B0`)      | 8 MiB     | A/B boot pointer (`fs-ab-boot`)  |
+
+The kernel SHALL refuse to mount if the layout does not match (correct partition types in the correct order).
+
+#### Scenario: Correct layout mounts
+- **WHEN** all five partitions exist with the expected types
+- **THEN** the kernel SHALL identify each partition and pass it to the appropriate driver
+
+#### Scenario: Missing F2FS partition rejected
+- **WHEN** partition #4 is absent or has the wrong type GUID
+- **THEN** the kernel SHALL halt with `Err: F2FS partition #4 missing`
+
+#### Scenario: Missing boot config partition rejected
+- **WHEN** partition #5 is absent
+- **THEN** the kernel SHALL halt with `Err: boot config partition #5 missing`
+
+### Requirement: SmallAIOS-specific partition type GUIDs
+SmallAIOS-specific partitions (squashfs slots, boot config) SHALL use SmallAIOS-registered partition type GUIDs:
+
+- Squashfs slot: `A3F7C2E0-FACE-4FFF-AAAA-000000000001` (slot A) and `A3F7C2E0-FACE-4FFF-AAAA-000000000002` (slot B)
+- Boot config: `A3F7C2E0-FACE-4FFF-BBBB-000000000000`
+
+These SHALL be documented in `docs/architecture.md` and SHALL NOT collide with any registered GUID in the `gdisk`/`parted` GUID database.
+
+#### Scenario: GUIDs documented
+- **WHEN** `docs/architecture.md` is read
+- **THEN** it SHALL contain the SmallAIOS partition type GUID table
+
+#### Scenario: Foreign GUID with same name rejected
+- **WHEN** a partition named `SmallAIOS Models A` has a non-SmallAIOS type GUID
+- **THEN** the kernel SHALL refuse to mount and SHALL log the type GUID mismatch

--- a/openspec/changes/embedded-filesystem-v1/specs/fs-squashfs-readonly/spec.md
+++ b/openspec/changes/embedded-filesystem-v1/specs/fs-squashfs-readonly/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: Squashfs 4.0 read-only reader
+The `fs` crate SHALL provide a clean-room `#![no_std]` Rust reader for the squashfs 4.0 on-disk format. The reader SHALL parse the superblock, the inode table, the directory table, the fragment table, the export table, and the ID/lookup tables per the squashfs 4.0 specification. The reader SHALL be read-only; any write attempt against a squashfs mount SHALL return `-EROFS`. The reader SHALL refuse to mount images of any other major version (1.x, 2.x, 3.x, or unknown future major versions ≥5).
+
+#### Scenario: 4.0 image mounts
+- **WHEN** a squashfs 4.0 image with no extended-feature bits is presented
+- **THEN** the mount SHALL succeed and the directory tree SHALL be readable
+
+#### Scenario: 3.x image rejected
+- **WHEN** a squashfs 3.x image is presented
+- **THEN** the mount SHALL fail with `Err: squashfs major version 3.x unsupported`
+
+#### Scenario: Unknown future major rejected
+- **WHEN** a squashfs image with major version 5 is presented
+- **THEN** the mount SHALL fail with `Err: squashfs major version 5 unsupported`
+- **AND** SHALL NOT silently fall through to a partial mount
+
+#### Scenario: Write to squashfs returns EROFS
+- **WHEN** any write syscall targets a path under `/models/`
+- **THEN** the syscall SHALL return `-EROFS`
+
+### Requirement: Compression algorithm support
+The squashfs reader SHALL decompress blocks using zstd, xz, gzip, and lz4. Each decoder SHALL be a clean-room `#![no_std]` Rust implementation; the zstd decoder SHALL be reused from the existing `compute` crate. Each decoder SHALL be tested against externally-produced reference images (one per algorithm produced by `mksquashfs -comp <alg>`) and SHALL `cmp`-equal the original input bytes after round-trip.
+
+#### Scenario: zstd decompression round-trip
+- **WHEN** a squashfs image produced by `mksquashfs -comp zstd` is read
+- **THEN** every file's contents SHALL match the original `cmp`-byte-for-byte
+
+#### Scenario: xz decompression round-trip
+- **WHEN** a squashfs image produced by `mksquashfs -comp xz` is read
+- **THEN** every file's contents SHALL match the original
+
+#### Scenario: gzip decompression round-trip
+- **WHEN** a squashfs image produced by `mksquashfs -comp gzip` is read
+- **THEN** every file's contents SHALL match the original
+
+#### Scenario: lz4 decompression round-trip
+- **WHEN** a squashfs image produced by `mksquashfs -comp lz4` is read
+- **THEN** every file's contents SHALL match the original
+
+#### Scenario: Unknown compression algorithm rejected
+- **WHEN** a squashfs image declares an unknown compression algorithm in its superblock
+- **THEN** mount SHALL fail with `Err: unsupported squashfs compression`
+
+### Requirement: Manifest footer with ML-DSA-65 signature
+A SmallAIOS-produced squashfs image SHALL have a sealed manifest footer appended after the squashfs's natural EOF. The footer SHALL contain: a magic number (`SmAIOSFS\0`), a version byte, a SHA-3-256 hash for every block in the image, the public-key fingerprint, an ML-DSA-65 signature over the hash array, and the footer length. The footer SHALL be 4-byte aligned to satisfy squashfs's trailing-padding tolerance so external `mount -t squashfs -o loop` continues to work.
+
+#### Scenario: External mount works
+- **WHEN** a SmallAIOS squashfs image (with footer) is mounted on stock Ubuntu via `mount -t squashfs -o loop`
+- **THEN** the mount SHALL succeed and contents SHALL be readable
+
+#### Scenario: SmallAIOS reads footer first
+- **WHEN** SmallAIOS opens a squashfs blob
+- **THEN** the implementation SHALL read the last `footer_length` bytes first to locate and validate the manifest before any block read is honored
+
+#### Scenario: Missing footer rejected by SmallAIOS
+- **WHEN** a squashfs image without the SmallAIOS footer is presented
+- **THEN** SmallAIOS SHALL refuse to mount it on `/models/` and SHALL log `Err: squashfs missing SmallAIOS manifest footer`
+- **AND** the same image SHALL still mount on stock Linux (manifest is SmallAIOS-only, not part of squashfs)
+
+### Requirement: VFS mount at `/models/`
+The active squashfs slot SHALL be mounted at `/models/` in the VFS. The mount SHALL happen during kernel boot, after the GPT parser has identified the active slot per `fs-ab-boot`, and before any service that depends on model files starts.
+
+#### Scenario: /models/ mounted on boot
+- **WHEN** the kernel finishes early init and the active slot has been determined
+- **THEN** `/models/` SHALL be mounted from the active squashfs slot
+- **AND** subsequent file opens under `/models/` SHALL succeed

--- a/openspec/changes/embedded-filesystem-v1/specs/kernel-syscalls/spec.md
+++ b/openspec/changes/embedded-filesystem-v1/specs/kernel-syscalls/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: New `boot_success` syscall
+The kernel SHALL expose a new `boot_success` syscall (number 48, after the auth syscalls 43–47 from `management-login-v1`). The syscall SHALL be callable only by `Role::Root`. Calling `boot_success` SHALL update the active boot config record (per `fs-ab-boot`) to clear `tentative` and set `boot_success = 1`. After successful return, the watchdog SHALL be disarmed.
+
+```text
+boot_success() -> 0 | -errno
+```
+
+The syscall SHALL be idempotent — calling it after the active record already shows `boot_success = 1` SHALL return `Ok(0)` without re-writing.
+
+#### Scenario: boot_success commits tentative slot
+- **WHEN** the active record has `tentative = 1, boot_success = 0`
+- **AND** Root calls `boot_success`
+- **THEN** the active record SHALL transition to `tentative = 0, boot_success = 1`
+- **AND** the watchdog SHALL be disarmed
+- **AND** an audit record `boot_success_committed` SHALL be appended
+
+#### Scenario: Idempotent on already-committed
+- **WHEN** Root calls `boot_success` on a record already at `boot_success = 1`
+- **THEN** the syscall SHALL return `Ok(0)` without touching the record
+
+#### Scenario: Non-Root denied
+- **WHEN** an Operator or Viewer calls `boot_success`
+- **THEN** the syscall SHALL return `-EPERM`
+- **AND** an audit record `DENY:boot_success` SHALL be appended
+
+## MODIFIED Requirements
+
+### Requirement: Updated documented syscall count
+The architecture documentation SHALL state the v1 syscall count as the prior count plus one (i.e., the post-`management-login-v1` count of "~51 syscalls" is updated to "~52 syscalls"). The new syscall number is stable: `boot_success = 48`.
+
+#### Scenario: Architecture doc reflects new count
+- **WHEN** `docs/architecture.md` is read
+- **THEN** it SHALL state the syscall count of 52
+- **AND** SHALL list `boot_success = 48` in the syscall table
+
+### Requirement: File syscalls operate on real backing
+Existing file syscalls (`open`, `read`, `write`, `fsync`, `rename`, `stat`, `unlink`, `mkdir`, `rmdir`) SHALL operate against the new on-disk mounts (`/models/` squashfs, `/data/` F2FS) via `posix-vfs`. The syscall ABI SHALL NOT change. Behavior on the in-memory mounts (`/dev/`, `/proc/self/`) SHALL be unchanged.
+
+#### Scenario: open(/data/x) creates a real file
+- **WHEN** `open("/data/x", O_CREAT | O_WRONLY)` is called
+- **THEN** the syscall SHALL return a valid fd
+- **AND** the file SHALL appear in F2FS metadata
+- **AND** SHALL persist across reboot if `fsync` is called
+
+#### Scenario: read(/models/x) reads from squashfs
+- **WHEN** `open("/models/some_model.onnx", O_RDONLY)` then `read(fd, ...)`
+- **THEN** the read SHALL return the squashfs-decompressed bytes
+
+#### Scenario: rename within /data/ is atomic
+- **WHEN** `rename("/data/auth/shadow.tmp", "/data/auth/shadow")` is called
+- **THEN** the syscall SHALL atomically replace the destination
+- **AND** the previous content SHALL not be visible to any future open

--- a/openspec/changes/embedded-filesystem-v1/specs/mgmt-config-layout/spec.md
+++ b/openspec/changes/embedded-filesystem-v1/specs/mgmt-config-layout/spec.md
@@ -1,0 +1,59 @@
+## MODIFIED Requirements
+
+### Requirement: Per-file permissions enforced against real F2FS inodes
+The per-file permission table introduced in `management-login-v1` SHALL be enforced against real F2FS inode mode bits, not the in-memory VFS placeholders. The "loader refuses mode laxer than declared" rule SHALL operate on the F2FS-recorded mode at open time.
+
+#### Scenario: F2FS mode 0644 on shadow rejected
+- **WHEN** `/data/auth/shadow` exists in F2FS with mode 0644 (declared 0600)
+- **THEN** the loader SHALL refuse to read it
+- **AND** SHALL treat the file as corrupt per `auth-shadow`'s boot-state requirement
+
+#### Scenario: F2FS mode 0600 on shadow accepted
+- **WHEN** `/data/auth/shadow` exists in F2FS with mode 0600
+- **THEN** the loader SHALL parse it normally
+
+## ADDED Requirements
+
+### Requirement: First-boot creation of /data/ directory tree
+On first boot of a freshly-formatted `/data/` partition, the kernel SHALL create the canonical directory tree with the declared permissions:
+
+```text
+/data/auth/         mode 0700
+/data/audit/        mode 0700
+/data/mgmt/         mode 0700
+/data/network/      mode 0755
+/data/update/       mode 0700
+/data/automotive/   mode 0700
+```
+
+Directory creation SHALL be atomic across the set: either the entire tree exists with the declared modes, or none does and the kernel halts.
+
+#### Scenario: Directories created on fresh /data/
+- **WHEN** the kernel formats `/data/` per `fs-f2fs-readwrite`'s first-boot path
+- **THEN** all six top-level directories SHALL exist with their declared modes
+- **AND** an audit record `data_tree_initialized` SHALL be appended
+
+#### Scenario: Partial tree on previous-boot crash auto-completes
+- **WHEN** boot finds `/data/auth/` but no `/data/audit/`
+- **THEN** the kernel SHALL create the missing directories with their declared modes
+- **AND** SHALL append a `data_tree_repaired` audit record
+
+### Requirement: Cache-budget configuration fields
+`mgmt/policy.toml` SHALL expose two new live-reload-able cache-budget fields:
+
+- `fs.cache.models_bytes` — LRU budget for the `/models/` mount, default 16 MiB.
+- `fs.cache.data_bytes` — LRU budget for the `/data/` mount, default 4 MiB.
+
+Both SHALL have a hard floor (4 MiB for models, 1 MiB for data); values below the floor SHALL be rejected with `-EINVAL` by the validator.
+
+#### Scenario: Default cache budgets present
+- **WHEN** a fresh `mgmt/policy.toml` is generated on first boot
+- **THEN** `fs.cache.models_bytes = 16777216` and `fs.cache.data_bytes = 4194304` SHALL be present
+
+#### Scenario: Below-floor budget rejected
+- **WHEN** an operator writes `fs.cache.models_bytes = 1048576` (below 4 MiB floor)
+- **THEN** the validator SHALL reject the write with `-EINVAL`
+
+#### Scenario: Live reload of cache budget
+- **WHEN** an operator writes a new `fs.cache.models_bytes` value
+- **THEN** the new budget SHALL apply to subsequent allocations without remount

--- a/openspec/changes/embedded-filesystem-v1/specs/posix-vfs/spec.md
+++ b/openspec/changes/embedded-filesystem-v1/specs/posix-vfs/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: On-disk mount points
+The VFS SHALL gain two on-disk mount points alongside the existing in-memory tree:
+
+- `/models/` — backed by the active squashfs slot (read-only, per `fs-squashfs-readonly`).
+- `/data/` — backed by the F2FS partition (read-write, per `fs-f2fs-readwrite`).
+
+The existing in-memory mounts (`/dev/`, `/proc/self/`) SHALL remain unchanged. Mount points SHALL be fixed in kernel code (compile-time constants); they SHALL NOT be overrideable from a config file in v1.
+
+#### Scenario: /models/ resolves to squashfs
+- **WHEN** any path under `/models/` is opened
+- **THEN** the open SHALL be routed to the squashfs reader for the active slot
+
+#### Scenario: /data/ resolves to F2FS
+- **WHEN** any path under `/data/` is opened
+- **THEN** the open SHALL be routed to the F2FS implementation
+
+### Requirement: BlockError to errno translation
+The VFS SHALL convert internal `BlockError` enum values (per `fs-block-device`) into POSIX-aligned errno at the syscall boundary:
+
+| BlockError | errno |
+|------------|-------|
+| MediaError | -EIO |
+| NotPresent | -ENXIO |
+| Timeout | -ETIMEDOUT |
+| BadCrc | -EIO |
+| Unaligned | -EINVAL |
+| OutOfRange | -EINVAL |
+| DeviceBusy | -EBUSY |
+
+#### Scenario: Block read timeout returns -ETIMEDOUT
+- **WHEN** a `read()` syscall on a `/models/` file triggers a `BlockError::Timeout`
+- **THEN** the syscall SHALL return `-ETIMEDOUT`
+
+#### Scenario: Block CRC failure returns -EIO
+- **WHEN** a `read()` syscall on a `/data/` file triggers a `BlockError::BadCrc`
+- **THEN** the syscall SHALL return `-EIO`
+
+## MODIFIED Requirements
+
+### Requirement: VFS write path returns real errors instead of EROFS
+The VFS SHALL no longer return `-EROFS` unconditionally on writes. Writes to the in-memory mounts (`/dev/`, `/proc/self/`) SHALL continue to return `-EROFS`. Writes to `/models/` SHALL return `-EROFS` (squashfs is read-only). Writes to `/data/` SHALL be passed through to the F2FS implementation and SHALL return whatever real errno the F2FS layer produces (`-ENOSPC`, `-EIO`, `-EACCES`, etc.) — including `Ok(0..)` on success.
+
+#### Scenario: Write to /models/ still returns -EROFS
+- **WHEN** any write syscall targets a path under `/models/`
+- **THEN** the syscall SHALL return `-EROFS`
+
+#### Scenario: Write to /dev/null succeeds (existing behavior)
+- **WHEN** a write targets `/dev/null`
+- **THEN** the syscall SHALL return `Ok(write_len)` per existing in-memory behavior
+
+#### Scenario: Write to /data/ returns real F2FS error
+- **WHEN** a write to `/data/audit/log.jsonl` exhausts free space
+- **THEN** the syscall SHALL return `-ENOSPC`
+- **AND** SHALL NOT return `-EROFS`
+
+#### Scenario: Successful write to /data/ persists
+- **WHEN** a write to `/data/auth/shadow` completes
+- **AND** `fsync` is called
+- **THEN** the syscall SHALL return `Ok(write_len)`
+- **AND** the bytes SHALL be durable across reboot

--- a/openspec/changes/embedded-filesystem-v1/tasks.md
+++ b/openspec/changes/embedded-filesystem-v1/tasks.md
@@ -1,0 +1,172 @@
+## 1. Phase 1 — `fs/` crate scaffold + `BlockDevice` trait
+
+- [ ] 1.1 Create `fs/` crate, `Cargo.toml`, register in workspace (23 → 24)
+- [ ] 1.2 `fs/src/lib.rs` — module structure, `#![no_std]` declaration
+- [ ] 1.3 `fs/src/block.rs` — `BlockDevice` trait, `BlockError` enum
+- [ ] 1.4 `fs/src/block/errno.rs` — `BlockError` → POSIX errno mapping
+- [ ] 1.5 Per-op timeout + 3-retry exponential backoff helper
+- [ ] 1.6 4 KiB / 512 B sector-size handling layer with emulation slow-path
+- [ ] 1.7 Generic conformance test suite (alignment, retry, error mapping)
+- [ ] 1.8 `arch/{x86_64,aarch64}/src/virtio_blk.rs` — `BlockDevice` impl
+- [ ] 1.9 Conformance suite passes against virtio-blk in QEMU CI
+- [ ] 1.10 Cyclic-dep check passes; clippy-D-warnings clean
+
+## 2. Phase 2 — GPT partition table
+
+- [ ] 2.1 `fs/src/gpt.rs` — clean-room GPT parser per UEFI 2.10 §5.3
+- [ ] 2.2 Primary + secondary header validation, fallback on primary corrupt
+- [ ] 2.3 Protective MBR writer (for fresh-format path)
+- [ ] 2.4 v1 partition layout enforcement (5-partition table, type GUID checks)
+- [ ] 2.5 SmallAIOS-specific type GUID allocation, documented in `docs/architecture.md`
+- [ ] 2.6 GPT parser fuzz harness
+- [ ] 2.7 Kani harness for parser bounds (no out-of-buffer reads on adversarial input)
+- [ ] 2.8 Tests against `parted`/`gdisk`-produced disks
+
+## 3. Phase 3 — Squashfs read path + manifest verification
+
+- [ ] 3.1 `fs/src/squashfs/superblock.rs` — squashfs 4.0 superblock parser
+- [ ] 3.2 `fs/src/squashfs/inodes.rs` — inode table reader
+- [ ] 3.3 `fs/src/squashfs/dirs.rs` — directory table reader
+- [ ] 3.4 `fs/src/squashfs/fragments.rs` — fragment table reader
+- [ ] 3.5 zstd decoder wired in from `compute`
+- [ ] 3.6 `fs/src/squashfs/xz.rs` — clean-room xz/lzma2 decoder
+- [ ] 3.7 `fs/src/squashfs/gzip.rs` — clean-room inflate decoder (RFC 1951)
+- [ ] 3.8 `fs/src/squashfs/lz4.rs` — clean-room lz4 block decoder
+- [ ] 3.9 Round-trip test against `mksquashfs -comp zstd` reference image
+- [ ] 3.10 Round-trip test against `mksquashfs -comp xz` reference image
+- [ ] 3.11 Round-trip test against `mksquashfs -comp gzip` reference image
+- [ ] 3.12 Round-trip test against `mksquashfs -comp lz4` reference image
+- [ ] 3.13 `fs/src/squashfs/manifest.rs` — appended footer parser + ML-DSA-65 verify
+- [ ] 3.14 Mount-time signature verification fail-closed
+- [ ] 3.15 Per-block SHA-3-256 verify on every read
+- [ ] 3.16 External interop CI: stock `mount -t squashfs -o loop` on Ubuntu LTS
+- [ ] 3.17 External interop CI: stock `mount -t squashfs -o loop` on Fedora current
+- [ ] 3.18 External interop CI: macOS via `squashfs-tools` from Homebrew
+
+## 4. Phase 4 — A/B boot pointer + bsdiff delta apply
+
+- [ ] 4.1 `fs/src/boot_config.rs` — `BootConfigRecord` struct + double-buffer layout
+- [ ] 4.2 Read both records, validate SHA-3-256 record_hash, pick highest valid generation
+- [ ] 4.3 Atomic update: write inactive slot → flush → done
+- [ ] 4.4 Kani harness for atomicity invariant under arbitrary partial writes
+- [ ] 4.5 UEFI variable mirror writer (x86-64 + aarch64-with-UEFI)
+- [ ] 4.6 Variable-vs-partition disagreement: partition wins, log warning, rewrite variable
+- [ ] 4.7 Watchdog arming on boot when `tentative=1`
+- [ ] 4.8 `fs/src/delta.rs` — clean-room bsdiff applier
+- [ ] 4.9 Pre-apply ML-DSA-65 signature verify on delta payload
+- [ ] 4.10 Pre-apply reference-blob hash check
+- [ ] 4.11 Bsdiff streaming apply to inactive partition
+- [ ] 4.12 Post-apply per-block SHA-3-256 manifest verify
+- [ ] 4.13 Post-apply ML-DSA-65 footer signature verify
+- [ ] 4.14 Hand-off event `update_staged{ new_slot, generation }` for `remote-update-v1`
+- [ ] 4.15 Coq proof of bsdiff applier correctness
+- [ ] 4.16 Property-based tests for bsdiff under truncated, scrambled, and oversized patches
+
+## CHECKPOINT A — Phases 1-4 ship as one PR into develop
+
+- [ ] CA.1 Behind cargo feature `fs-on-disk-mounts` (off by default)
+- [ ] CA.2 `cargo fmt --check`, `cargo clippy -- -D warnings`
+- [ ] CA.3 `cargo test --workspace` total ≥ 4700
+- [ ] CA.4 External interop CI green for squashfs on Ubuntu / Fedora / macOS
+- [ ] CA.5 Kani harnesses pass: GPT parser, A/B boot atomicity, bsdiff bounds
+- [ ] CA.6 PR opened against `develop` with summary covering Phases 1-4
+
+## 5. Phase 5 — F2FS read path
+
+- [ ] 5.1 `fs/src/f2fs/superblock.rs` — Linux 6.6 LTS feature-set superblock parser
+- [ ] 5.2 Primary/secondary superblock fallback on CRC failure
+- [ ] 5.3 `fs/src/f2fs/checkpoint.rs` — checkpoint journal reader
+- [ ] 5.4 `fs/src/f2fs/sit.rs` — Segment Information Table reader
+- [ ] 5.5 `fs/src/f2fs/nat.rs` — Node Address Table reader
+- [ ] 5.6 `fs/src/f2fs/ssa.rs` — Segment Summary Area reader
+- [ ] 5.7 `fs/src/f2fs/inode.rs` — F2FS inode parsing, extents, indirect pointers
+- [ ] 5.8 `fs/src/f2fs/dir.rs` — directory iteration
+- [ ] 5.9 `fs/src/f2fs/data.rs` — data block read path with cache integration
+- [ ] 5.10 Round-trip test: `mkfs.f2fs` populated by Linux → SmallAIOS reads → `cmp` byte-exact
+- [ ] 5.11 Unknown mandatory feature bit rejected with clear error
+- [ ] 5.12 F2FS metadata CRC32C verification on every metadata read
+- [ ] 5.13 NVMe `BlockDevice` impl (x86-64) with conformance + F2FS RO test
+- [ ] 5.14 SDHCI/eMMC `BlockDevice` impl (Jetson) with conformance + F2FS RO test on real Orin
+
+## 6. Phase 6 — Mount machinery + integrity layer
+
+- [ ] 6.1 Extend `posix-vfs` with `/models/` and `/data/` mount points
+- [ ] 6.2 Boot-time mount sequence: GPT → squashfs slot via boot config → F2FS
+- [ ] 6.3 Both-slots-bad halt path (login + audit + `/data/` still up)
+- [ ] 6.4 SPIN model proving no path under integrity failure leaks unverified bytes
+- [ ] 6.5 `fs/src/cache.rs` — per-mount LRU (16 MiB models, 4 MiB data, configurable)
+- [ ] 6.6 256 KiB write-coalescing buffer for `/data/`
+- [ ] 6.7 Cache-budget validators with hard floor (4 MiB / 1 MiB)
+- [ ] 6.8 `mgmt/policy.toml` `fs.cache.*`, `fs.block.*` fields with `#[reload("live")]` annotations
+
+## CHECKPOINT B — Phases 5-6 ship as one PR into develop
+
+- [ ] CB.1 `fs-on-disk-mounts` cargo feature still off by default — mounts still in-memory in production
+- [ ] CB.2 `cargo test --workspace` total ≥ 4900
+- [ ] CB.3 External interop CI green: `mount -t f2fs` on Ubuntu / Fedora reads SmallAIOS-produced images
+- [ ] CB.4 SPIN model verifies clean
+- [ ] CB.5 PR opened against `develop` with summary covering Phases 5-6
+
+## 7. Phase 7 — F2FS write path
+
+- [ ] 7.1 `fs/src/f2fs/write.rs` — file create, directory create, write extending
+- [ ] 7.2 NAT/SIT/SSA update path, log-structured allocation
+- [ ] 7.3 Atomic rename via journal
+- [ ] 7.4 truncate, unlink, rmdir
+- [ ] 7.5 Round-trip test: SmallAIOS writes → Linux 6.6 reads → `cmp` byte-exact
+- [ ] 7.6 Application-layer `policy.toml` SHA-3-256 fingerprint header
+- [ ] 7.7 Write-coalescing buffer integration
+
+## 8. Phase 8 — fsync + checkpoint commit
+
+- [ ] 8.1 `fs/src/f2fs/fsync.rs` — checkpoint commit on `fsync(fd)`
+- [ ] 8.2 5-second background commit timer (cooperative)
+- [ ] 8.3 Power-fail tests: kill-9 mid-write → reboot → verify last fsync'd offset intact
+- [ ] 8.4 TLA+ model `f2fs_checkpoint.tla` — checkpoint commit interleaving invariants
+- [ ] 8.5 First-boot format-on-physical-presence path
+- [ ] 8.6 First-boot `/data/` directory-tree creation with declared modes
+
+## 9. Phase 9 — F2FS garbage collection
+
+- [ ] 9.1 `fs/src/f2fs/gc.rs` — segment-level GC
+- [ ] 9.2 Threshold-driven trigger (free segments < 5%)
+- [ ] 9.3 Cooperative yielding so foreground writes are not starved
+- [ ] 9.4 Live-block relocation correctness tests (post-GC `cmp` against pre-GC)
+- [ ] 9.5 Property-based GC stress tests under random foreground workload
+
+## 10. Phase 10 — Boot success syscall + interop CI matrix
+
+- [ ] 10.1 Add `boot_success` syscall (number 48) — Root only, idempotent
+- [ ] 10.2 Watchdog arming + disarming wiring through `boot_success`
+- [ ] 10.3 Audit record `boot_success_committed` on commit
+- [ ] 10.4 End-to-end A/B update test: stage delta → reboot → boot_success → next boot
+- [ ] 10.5 End-to-end rollback test: stage delta → reboot → no boot_success → watchdog → previous slot
+- [ ] 10.6 Update `docs/architecture.md` syscall count to 52
+- [ ] 10.7 Interop CI: full matrix (Ubuntu LTS + Fedora current + macOS via FUSE) for both squashfs and F2FS
+- [ ] 10.8 Image-size regression check: F2FS write path stays within ≤ 200 KB compiled growth budget
+- [ ] 10.9 Boot footprint regression check: total binary ≤ 8.2 MB (vs prior 8.0 MB target)
+- [ ] 10.10 AHCI `BlockDevice` impl (legacy x86-64 SATA) — opportunistic; not a checkpoint blocker
+
+## CHECKPOINT C — Phases 7-10 ship as one PR into develop
+
+- [ ] CC.1 Flip `fs-on-disk-mounts` default to ON
+- [ ] CC.2 `cargo test --workspace` total ≥ 5100
+- [ ] CC.3 Full external interop matrix green
+- [ ] CC.4 Kani: GPT, A/B atomicity, delta pipeline pass
+- [ ] CC.5 TLA+: F2FS checkpoint model verifies clean
+- [ ] CC.6 SPIN: integrity fail-closed proof clean
+- [ ] CC.7 Coq: bsdiff applier proof checked
+- [ ] CC.8 PR opened against `develop` with summary covering Phases 7-10
+
+## 11. Cross-phase verification
+
+- [ ] 11.1 `cargo fmt --check`, `cargo clippy -- -D warnings`
+- [ ] 11.2 `cargo audit` advisory clean
+- [ ] 11.3 `cargo deny` license/advisory/ban clean
+- [ ] 11.4 `cargo geiger` shows no new unsafe outside well-justified arch / decoder code
+- [ ] 11.5 `cargo llvm-cov --fail-under-lines 80` passes (ratchet target 93%)
+- [ ] 11.6 Cyclic-dep check passes (workspace 23 → 24, all new edges respect Layer 1 → 0)
+- [ ] 11.7 `just arch-check` clean (module-level acyclicity)
+- [ ] 11.8 `openspec validate embedded-filesystem-v1 --strict` returns clean
+- [ ] 11.9 Zero CodeQL alerts on the new code (preserves baseline)
+- [ ] 11.10 Documentation updated: `docs/architecture.md` partition layout + GUIDs + syscall table; `docs/embedded-filesystem.md` operator runbook


### PR DESCRIPTION
## Summary

OpenSpec scaffolding for the on-disk filesystem substrate SmallAIOS needs to graduate from "the binary that runs in RAM" to "an attended appliance that persists state and survives power loss."

**Shape captured across 30 walkthrough questions:**
- New `fs/` Layer 1 crate (workspace 23 → 24).
- Read-only `/models/` on squashfs 4.0, A/B-partitioned, atomic whole-image swap with bsdiff block-level deltas applied to the inactive slot.
- Read-write `/data/` on F2FS matching Linux 6.6 LTS; phased read → write → fsync/checkpoint → GC.
- GPT partition table; protective MBR for tool compatibility; SmallAIOS-specific type GUIDs documented.
- Single `BlockDevice` trait; v1 impls for virtio-blk (CI), NVMe (x86), eMMC/SDHCI (Jetson), AHCI (legacy x86).
- Squashfs zstd + xz + gzip + lz4 decoders, all clean-room Rust `#![no_std]`.
- Sealed manifest footer with ML-DSA-65 signature appended after squashfs's natural EOF — still mounts cleanly with stock `mount -t squashfs -o loop`.
- Dedicated 8 MiB GPT partition for the A/B boot pointer with double-buffered records and Kani-modeled atomicity invariant.
- Watchdog timeout (60 s) + explicit `boot_success` syscall (#48) as the rollback trigger.
- bsdiff delta payloads with ML-DSA-65 signed pre/post integrity checks; Coq proof of the bsdiff applier.
- Per-PR external-interop CI on Ubuntu LTS + Fedora current + macOS via FUSE.
- ~600 new tests targeted (≥5100 total post-change).
- Formal coverage: Kani + TLA+ + SPIN + Coq.

**Spec deltas (7 new + 3 modified):**
- New: `fs-block-device`, `fs-partition-table`, `fs-squashfs-readonly`, `fs-f2fs-readwrite`, `fs-ab-boot`, `fs-delta-update`, `fs-integrity`
- Modified: `posix-vfs`, `kernel-syscalls`, `mgmt-config-layout`

`openspec validate embedded-filesystem-v1 --strict` is clean.

## Test plan

- [ ] `openspec validate embedded-filesystem-v1 --strict` returns clean (verified locally — ✅)
- [ ] PR title passes the conventional-commit semver check (`docs(...)` → `semver:none`)
- [ ] No production code changes; this is OpenSpec scaffolding only — implementation lands in three checkpoint PRs from agent-team worktrees off `develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)