### PR TITLE
docs(openspec): scaffold embedded-overlay-v1 (writable layer on /models/)

### DIFF
--- a/openspec/changes/embedded-overlay-v1/design.md
+++ b/openspec/changes/embedded-overlay-v1/design.md
@@ -1,0 +1,238 @@
+## Context
+
+`embedded-filesystem-v1` ships A/B whole-image squashfs swap as
+the only way to change `/models/`. That works for OS releases
+but it doesn't handle "operator drops a 200 MB ONNX into the
+running appliance without re-imaging the box." Whole-image swap
+for that case is wasteful and friction-y.
+
+This change introduces an OverlayFS-style writable layer mounted
+on top of the read-only squashfs `/models/`. It is a clean-room,
+SmallAIOS-specific design — not a port of Linux overlayfs. We
+pick the subset of overlayfs semantics that matter for the
+inference appliance and skip the rest (xattrs, char-device
+whiteouts, copy-up of large files, multi-layer overlays).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Two-layer merged view at `/models/`: lower = active squashfs
+  slot, upper = `/data/models-upper/` on F2FS.
+- Clean-room Rust `#![no_std]` merge logic in the existing `fs/`
+  crate (no new crate).
+- File-based whiteout (`<name>.whiteout`) and opaque-dir
+  (`<name>/.opaque`) markers — no xattrs, no char devices.
+- Persistence across A/B swaps: operator-added models survive
+  OS updates.
+- Conflict resolution rule: upper wins; lower-side changes
+  audit-logged, never silently merged.
+- New `model_add` (49) and `model_remove` (50) syscalls with
+  RBAC: Operator+ for add, Root for remove.
+- Per-file SHA-3-256 fingerprint sidecar (`<name>.sha3`) and
+  optional ML-DSA-65 signature sidecar (`<name>.sig`) controlled
+  by `fs.overlay.require_signed`.
+- Capacity cap (`fs.overlay.upper_max_bytes`, default 2 GiB).
+- ≥5250 total tests after change (~+150 new).
+- Formal coverage: Kani (merge precedence), SPIN (concurrent
+  add), TLA+ (overlay state machine).
+
+**Non-Goals (v1):**
+- Hard links across upper/lower.
+- POSIX `trusted.overlay.*` xattr compatibility.
+- Multi-layer overlays (lower-1 + lower-2 + upper).
+- copy-up of large lower files when modified.
+- Custom caching / pinning hints (block cache from
+  `embedded-filesystem-v1` covers reads).
+
+## Decisions
+
+The 15 questions resolved during the walkthrough.
+
+### Q1. Whiteout encoding
+
+**Decision:** Sidecar regular file `<name>.whiteout` next to
+where the hidden lower entry would be. Empty contents; mtime is
+the only metadata. Rejected reserved suffix at `model_add` time.
+Opaque-directory marker: `<dir>/.opaque` regular file, hides the
+entire lower-side subtree at that path.
+
+### Q2. ML-DSA-65 signing policy
+
+**Decision:** Configurable `fs.overlay.require_signed: bool`
+(default `false`). When `true`, every `model_load` from the
+upper SHALL find and verify a `<name>.sig` ML-DSA-65 signature
+over the file's SHA-3-256 fingerprint; missing or invalid sig
+returns `-EAUTH`. Verification happens at `model_load` time, not
+`model_add`, so flipping the policy on later rejects existing
+unsigned models without forcing re-upload.
+
+### Q3. Upper capacity cap default
+
+**Decision:** `fs.overlay.upper_max_bytes = 2147483648` (2 GiB).
+Configurable up to (`/data/` partition size − 1 GiB headroom for
+audit + config). Below-floor (`< 64 MiB`) rejected.
+
+### Q4. Audit cadence
+
+**Decision:** Every `model_add` and `model_remove` is audited
+with full context (`who`, `name`, `sha3`, `size`). Every shadow
+conflict detected at boot (upper has a name the new lower also
+has) appends one record per conflict per boot. Reads are not
+audited.
+
+### Q5. Whiteout removal RBAC
+
+**Decision:** Root only by default. Configurable knob
+`fs.overlay.allow_operator_unhide: bool` (default `false`)
+allows Operator to remove a whiteout. Audit record names the
+role and the affected entry.
+
+### Q6. Whiteout listing visibility
+
+**Decision:** Hidden — `readdir(/models)` skips entries with
+active whiteouts. Operator-facing diagnostic via the `model
+list --include-whiteouts` user-space CLI; the kernel-level
+listing remains POSIX-overlay-style hidden.
+
+### Q7. Boot-ordering / feature flag
+
+**Decision:** Behind cargo feature `fs-overlay-mounts`, default
+off. Mirrors `embedded-filesystem-v1`'s `fs-on-disk-mounts`
+pattern. While off, `/models/` continues to be a direct squashfs
+mount.
+
+### Q8. Test fixtures
+
+**Decision:** Synthetic — CI runs `mksquashfs` and `mkfs.f2fs`
+to produce small fixture images at every CI run. Keeps git
+history clean, reproducible from source, matches the existing
+`embedded-filesystem-v1` interop CI tooling.
+
+### Q9. Reserved name suffixes
+
+**Decision:** `model_add` rejects names ending in `.whiteout`,
+`.opaque`, `.sha3`, `.sig` with `-EINVAL` and a clear message.
+
+### Q10. `model_add` upload-fd source
+
+**Decision:** Any readable fd. Zenoh stream, pre-staged
+`/data/upload/...` file, or `/dev/null` (for empty-file tests)
+all work the same way: kernel reads bytes from the fd until EOF,
+hashes on the fly, writes to upper, writes sidecar.
+
+### Q11. Concurrent `model_add` of same name
+
+**Decision:** Per-name advisory lock in the kernel. Second
+concurrent `model_add` on a name already locked returns
+`-EBUSY` with a `Retry-After` hint. Lock released on success or
+failure of the first writer.
+
+### Q12. Phase ordering
+
+**Decision:** 6-phase bottom-up:
+1. Merge logic (read-only over synthetic upper+lower fixtures).
+2. Upper-layer write path on F2FS.
+3. `model_add` / `model_remove` syscalls.
+4. RBAC bindings + Zenoh admin verbs.
+5. SHA-3-256 fingerprint sidecars + optional ML-DSA-65 verify.
+6. Audit + capacity-cap enforcement + boot-time conflict
+   detection.
+
+### Q13. Test target
+
+**Decision:** ≥5250 total tests after change (~+150 new). Cover
+merge correctness, conflict-on-A/B-swap, capacity cap,
+signed-policy on/off, fingerprint mismatch fail-closed, RBAC
+matrix, concurrent-add lock, reserved-name reject, whiteout
+removal, audit emission.
+
+### Q14. Formal verification
+
+**Decision:** Kani (merge-lookup precedence invariant), SPIN
+(concurrent-add interleaving), TLA+ (overlay state machine
+covering add/remove/whiteout/A-B-swap interleavings). Maximum
+assurance, matching the rest of `fs/`.
+
+### Q15. PR strategy
+
+**Decision:** This change ships as **two** PRs:
+
+- **PR 1 (this PR):** scaffolding only — proposal, design,
+  specs, tasks. Merges to `develop` so agent teams can spawn
+  worktrees off develop and pick up the design.
+- **PR 2 (later):** implementation, behind the
+  `fs-overlay-mounts` cargo feature, single PR covering all 6
+  phases since the change is small enough to review cohesively.
+  Posts back to `develop` from a fresh `change/embedded-overlay-v1-impl`
+  branch.
+
+Note: Q15's "single PR once all 6 phases land" answer means the
+implementation lands in one cohesive merge — it does NOT block
+the scaffolding-PR-merging-now from going first. The wording in
+the question covered the implementation step; the scaffolding
+step is what we're delivering today.
+
+## Risks / Trade-offs
+
+- **[Risk] Merge logic correctness under directory iteration
+  with mixed upper/lower entries** — Mitigation: property-based
+  tests sweep all combinations; Kani harness proves the
+  precedence invariant.
+- **[Risk] Whiteout naming collision (operator literally adds
+  `foo.whiteout`)** — Mitigation: reserved-suffix rejection at
+  `model_add` (Q9) with a clear error.
+- **[Risk] Upper-layer growth blowing out `/data/`** —
+  Mitigation: capacity cap default 2 GiB (Q3), enforced at
+  write time, sized below the F2FS partition.
+- **[Risk] Concurrent-add race producing two half-written upper
+  files** — Mitigation: per-name advisory lock (Q11) prevents
+  it; SPIN model proves no two adds can both succeed.
+- **[Risk] Lower changes during A/B swap silently shadowing
+  operator's models** — Mitigation: boot-time conflict detection
+  (Q4) audits every conflict so the operator can review and
+  decide whether to un-hide the new lower version.
+- **[Risk] `fs.overlay.require_signed` default off leaves
+  unsigned models acceptable in default deployments** —
+  Mitigation: documented as the v1 trade-off; regulated
+  environments flip the policy on. Future v2 may flip the
+  default; flagged in `Open Questions`.
+
+## Migration Plan
+
+This change is purely additive:
+- Builds on `embedded-filesystem-v1`'s F2FS `/data/` mount and
+  squashfs A/B layout. No existing data layout changes.
+- First boot of an image carrying this change with the
+  `fs-overlay-mounts` feature enabled creates the empty
+  `/data/models-upper/` directory if absent (per the existing
+  `mgmt-config-layout` directory-tree-creation requirement).
+- An image without the feature enabled (or running on a system
+  that doesn't support it yet) sees `/models/` as a direct
+  squashfs mount, exactly as before.
+- No format on `/data/` is changed by this addition; an
+  operator can flip the feature flag in either direction
+  without re-formatting.
+
+## Open Questions
+
+All fifteen design walkthrough questions are resolved (Q1–Q15
+above).
+
+Items deferred to a future change with explicit decision:
+
+- **`fs.overlay.require_signed` default flip to `true`** — v1
+  defaults off for friction-free dev/test workflows. v2 may
+  default on once a model-signing tooling story is documented
+  in the runbook.
+- **Multi-layer overlay (lower-1 + lower-2 + upper)** — out of
+  scope. If a use case appears (e.g., per-customer models on
+  top of base + tenant-specific models on top of that), capture
+  as `embedded-overlay-v2`.
+- **Hard links across upper/lower** — explicit non-goal in v1.
+  Linux overlayfs supports them via xattr-tracked origin; not
+  worth the xattr machinery for our use case.
+- **copy-up on modify** — out of scope. Operators add new files
+  rather than editing squashfs files. Writes that require
+  copy-up of an existing lower file return `-EROFS` with a
+  message instructing the operator to `model_add` under a new
+  name.

--- a/openspec/changes/embedded-overlay-v1/proposal.md
+++ b/openspec/changes/embedded-overlay-v1/proposal.md
@@ -1,0 +1,249 @@
+## Why
+
+`embedded-filesystem-v1` ships A/B whole-image squashfs swap as
+the only way to change `/models/`. That works for the
+periodic-update cadence of OS releases, but it doesn't handle the
+"operator drops a 200 MB ONNX model into the running appliance
+without re-imaging the box" workflow. Whole-image swap for that
+case is wasteful (gigabytes of unchanged base image written for
+a small per-deployment delta) and friction-y (operators want
+`cp model.onnx /models/custom/` semantics, not "produce a fresh
+squashfs delta and stage it through the update pipeline").
+
+This change introduces an OverlayFS-style writable layer mounted
+on top of the read-only squashfs `/models/`. Adding, replacing,
+or hiding a model becomes a normal POSIX write to the upper
+layer; the base squashfs remains unchanged and continues to be
+A/B-swappable per `embedded-filesystem-v1`.
+
+The implementation is **clean-room Rust, `#![no_std]`** —
+matching the rest of the project's fs stack. It is **not** a port
+of the Linux kernel's overlayfs; it is an in-tree
+SmallAIOS-specific design that picks the subset of overlayfs
+semantics that matter for the inference appliance use case and
+leaves the rest out.
+
+## What Changes
+
+### Two-layer mount at `/models/`
+
+`/models/` becomes a merged view of two underlying mounts:
+
+```text
+/models/                  (visible)
+  ├── lower/              (RO squashfs from active A/B slot)
+  │   ├── llama-3.onnx
+  │   └── whisper.onnx
+  └── upper/              (RW F2FS subdir at /data/models-upper/)
+      ├── custom-tuned.onnx       ← operator-added
+      └── llama-3.onnx.whiteout   ← marker that hides lower's llama-3
+```
+
+Reads consult the upper first, then the lower. Writes go
+exclusively to the upper. Whiteout markers in the upper hide
+lower entries.
+
+### Whiteout & opaque-directory semantics
+
+A whiteout SHALL be encoded as a regular file `<name>.whiteout`
+in the upper layer (not as a special inode type — F2FS has no
+character-device support in our `#![no_std]` write path, and we
+don't want to introduce one for this).
+
+An opaque directory (operator wants to completely shadow a
+lower-layer directory) SHALL be marked by a `.opaque` regular
+file in the corresponding upper directory.
+
+This is a deliberate divergence from Linux overlayfs, which uses
+character-device whiteouts and `trusted.overlay.opaque` xattrs.
+The simplification trades some POSIX-overlayfs interop for a much
+smaller implementation and zero xattr dependency.
+
+### Upper layer storage on `/data/`
+
+The upper layer's backing storage SHALL be a subdirectory of the
+existing F2FS `/data/` partition: `/data/models-upper/`. No new
+partition is added. The kernel SHALL ensure the directory exists
+on first boot (per `embedded-filesystem-v1`'s
+directory-tree-creation requirement) with mode 0700 owned by
+kernel.
+
+### Persistence across A/B swaps
+
+The upper layer SHALL persist across A/B swaps of the lower
+squashfs. Operator-added models survive OS updates. The
+`embedded-filesystem-v1` boot sequence already mounts `/data/`
+before `/models/`, so the upper is available when the merged
+mount happens.
+
+### Conflict resolution on lower-side changes
+
+When an A/B swap brings in a new lower squashfs that contains a
+file the upper already shadows (e.g., the operator added a custom
+`llama-3.onnx` to the upper and the new base image also has
+`llama-3.onnx`), the upper's version SHALL continue to win. No
+automatic merge or "lower changed, what now" prompt; the
+operator's explicit action takes precedence over implicit OS
+updates. An audit record SHALL flag the conflict at boot so the
+operator can review.
+
+### RBAC integration
+
+Adding a model SHALL require `Role::Operator` or `Role::Root`
+(matches `model_load` permissions from `management-login-v1`).
+Whiting out or removing an upper-layer entry SHALL require
+`Role::Root` (this is destructive across reboots and SHOULD be a
+deliberate admin action).
+
+### Capacity and quota
+
+The upper layer SHALL have a configurable size cap
+(`fs.overlay.upper_max_bytes`, default 2 GiB) enforced at write
+time. Exceeding the cap SHALL fail writes with `-ENOSPC` so a
+runaway uploader does not exhaust `/data/`. The cap SHALL count
+toward the F2FS `/data/` partition's overall budget.
+
+### Integrity for upper-layer files
+
+Files added to the upper SHALL gain a SHA-3-256 fingerprint
+recorded in a sidecar `<name>.sha3` file written atomically with
+the model file. Loading any model from `/models/` (whether from
+lower or upper) SHALL hash-verify before the bytes flow into the
+ONNX runtime. The lower's per-block hashes (from
+`embedded-filesystem-v1`) cover the squashfs side; the upper's
+per-file fingerprints cover the operator-added side.
+
+ML-DSA-65 signing of upper-layer files SHALL be optional in v1
+(behind `fs.overlay.require_signed = bool`, default `false`).
+Operators in regulated environments can flip the policy on; the
+verifier expects a `<name>.sig` sidecar with an ML-DSA-65
+signature over the model file's SHA-3-256 fingerprint.
+
+### `model_add` / `model_remove` syscalls
+
+Two new syscalls in the kernel's auth-gated table (numbers 49 and
+50, after `boot_success = 48` from `embedded-filesystem-v1`):
+
+```text
+model_add(name_ptr, name_len, contents_fd) -> 0 | -errno
+   -- Operator+
+model_remove(name_ptr, name_len) -> 0 | -errno
+   -- Root only
+```
+
+`model_add` reads from the supplied fd (typically a network
+upload), writes to `/data/models-upper/<name>`, computes the
+SHA-3-256, writes the sidecar fingerprint, and (if signed-policy
+is on) verifies the signature. `model_remove` writes the
+appropriate whiteout / removes the upper entry.
+
+### Capabilities
+
+#### New Capabilities
+- `fs-overlay-mount`: two-layer merge view at `/models/`, lookup
+  precedence (upper → lower), whiteout / opaque-dir markers,
+  POSIX read semantics across the merged tree.
+- `fs-overlay-write`: write path to the upper layer, conflict
+  resolution rules, audit-record-on-shadow, capacity cap
+  enforcement.
+- `fs-overlay-integrity`: SHA-3-256 fingerprint sidecars,
+  optional ML-DSA-65 signature verification, fail-closed read
+  on hash mismatch.
+- `fs-overlay-syscalls`: `model_add`, `model_remove`, RBAC
+  bindings.
+
+#### Modified Capabilities
+- `posix-vfs` (from `embedded-filesystem-v1`): the `/models/`
+  mount becomes a merged view rather than a direct squashfs
+  mount.
+- `kernel-syscalls`: adds `model_add` (49), `model_remove` (50);
+  bumps documented count.
+- `mgmt-config-layout` (from `management-login-v1` /
+  `embedded-filesystem-v1`): adds `fs.overlay.*` configuration
+  fields with `#[reload("live")]` annotations.
+
+## Impact
+
+- **Code:**
+  - `fs/src/overlay.rs` — merge logic, whiteout/opaque scanning,
+    upper-priority lookup.
+  - `fs/src/overlay/write.rs` — upper-layer write path,
+    capacity-cap enforcement, audit record on lower-shadow.
+  - `fs/src/overlay/integrity.rs` — SHA-3-256 fingerprint sidecar
+    writer + verifier, optional ML-DSA-65 signature check.
+  - `kernel/src/syscalls/model.rs` — `model_add`, `model_remove`
+    syscalls.
+  - `container/src/bin/model.rs` — user-space `model add` /
+    `model remove` CLI.
+  - `mgmt/src/config.rs` — new `fs.overlay.*` fields.
+- **Tests:** ~150 new tests targeted: merge correctness (upper
+  shadows lower, lower visible when upper absent, whiteout
+  hides lower, opaque-dir hides whole subtree), conflict
+  resolution on A/B swap (operator-added file persists across
+  swap), capacity-cap behavior, signed-policy on/off,
+  fingerprint mismatch fail-closed, RBAC enforcement
+  (Operator can add, Operator cannot remove, Viewer cannot
+  add). Aim to keep the post-`embedded-filesystem-v1` baseline
+  of `≥5100` growing to `≥5250`.
+- **Boot footprint:** Negligible — overlay merge logic is small
+  (~1 kLOC), no new decompressors, no new on-disk format. Reuses
+  existing F2FS write path for the upper.
+- **External interop:** The upper layer is a normal F2FS
+  subdirectory under `/data/models-upper/`. A recovery laptop
+  mounting the F2FS partition sees the operator-added files
+  directly. The merged view at `/models/` is a SmallAIOS-runtime
+  construct only; external readers see lower (squashfs) and
+  upper (F2FS) separately, which is the right behavior for
+  recovery.
+- **Downstream:** Unblocks the "operator drops in a custom model"
+  workflow without forcing it through the OS update pipeline.
+  Independent from `remote-update-v1` (the A/B swap mechanism).
+- **Dependencies:** No new external Rust crates. Reuses
+  `security` (SHA-3, ML-DSA-65) and the F2FS write path.
+- **Risks:**
+  1. Merge logic correctness under directory iteration with
+     mixed upper/lower entries. Property-based tests sweep this.
+  2. Whiteout naming collision — a real model literally named
+     `foo.whiteout` would be ambiguous. Mitigation: reject names
+     ending in `.whiteout`, `.opaque`, `.sha3`, `.sig` at
+     `model_add` time with `-EINVAL` and a clear message.
+  3. Upper-layer growth blowing out `/data/` if cap not enforced.
+     Capacity cap (Q from walkthrough) is the answer.
+
+## Out of scope for v1 (flagged)
+
+- Hard links across upper/lower (Linux overlayfs supports
+  these via xattr-tracked origin; we deliberately don't).
+- POSIX `trusted.overlay.*` xattr compatibility — our markers
+  are file-based.
+- Multi-layer overlays (lower-1 + lower-2 + upper). v1 is
+  strictly two layers.
+- copy-up of large lower files when modified (Linux overlayfs
+  copies the whole file on first write). Our model is "operator
+  adds new files" not "operator edits squashfs files." Reject
+  writes that would require copy-up of an existing lower file
+  with `-EROFS` and a clear message; if the operator wants a
+  modified version, they `model_add` it under a new name.
+- Caching / pinning hints. The block cache from
+  `embedded-filesystem-v1` covers reads.
+
+## Open Questions
+
+1. Whiteout encoding — sidecar file (`<name>.whiteout`),
+   directory entry naming convention, or both?
+2. Should `model_add` accept signed-only at the syscall level,
+   or always allow upload and verify-on-load?
+3. Capacity cap default — 2 GiB, percentage of `/data/`, or
+   operator-mandatory at first boot?
+4. Audit cadence — every `model_add` and every shadow conflict
+   on A/B swap, or only the conflicts?
+5. Whiteout removal — does removing a whiteout (un-hiding a
+   lower file) require Root, or Operator like other adds?
+6. Should the merged `/models/` view show whiteout markers as
+   "missing" or as a special `.whiteouts/` virtual subdirectory
+   for diagnostics?
+7. Boot ordering — should the overlay mount be deferred behind
+   a feature flag like `embedded-filesystem-v1`'s
+   `fs-on-disk-mounts`?
+8. Test fixture strategy — synthetic squashfs + F2FS images
+   built in CI, or a small set of golden images committed?

--- a/openspec/changes/embedded-overlay-v1/specs/fs-overlay-integrity/spec.md
+++ b/openspec/changes/embedded-overlay-v1/specs/fs-overlay-integrity/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: SHA-3-256 fingerprint sidecar
+Every successful `model_add` SHALL produce a sidecar file `<name>.sha3` in the upper layer containing the hex-encoded SHA-3-256 of the model file's bytes. The sidecar SHALL be written atomically alongside the model file (staged + renamed in the same `model_add` transaction). Reads from `/models/` SHALL hash-verify the upper-layer file against the sidecar before bytes flow into ONNX runtime; mismatch SHALL fail closed with `-EIO`.
+
+#### Scenario: Sidecar produced on add
+- **WHEN** `model_add("foo.onnx", fd)` succeeds with content of length N
+- **THEN** `/data/models-upper/foo.onnx.sha3` SHALL contain the hex-encoded SHA-3-256 of those N bytes
+
+#### Scenario: Mismatch fails closed
+- **WHEN** `/data/models-upper/foo.onnx` is corrupted post-add (single byte flipped)
+- **AND** ONNX runtime calls `read("/models/foo.onnx", ...)`
+- **THEN** the read SHALL return `-EIO` after the hash check
+- **AND** zero bytes of corrupted content SHALL be visible to ONNX runtime
+- **AND** an audit record `model_hash_mismatch` SHALL be appended
+
+#### Scenario: Missing sidecar fails closed
+- **WHEN** an upper-layer model file exists without the corresponding `.sha3` sidecar
+- **THEN** reads SHALL return `-EIO` with reason `missing fingerprint sidecar`
+- **AND** an audit record SHALL be appended
+
+### Requirement: Optional ML-DSA-65 signature sidecar
+When `fs.overlay.require_signed = true`, every `model_load` from the upper layer SHALL find and verify a `<name>.sig` sidecar containing an ML-DSA-65 signature over the file's SHA-3-256 fingerprint, signed by the SmallAIOS model-signing key. Missing sidecar SHALL return `-EAUTH`. Invalid signature SHALL return `-EAUTH` and append an audit record. When `fs.overlay.require_signed = false` (default), the sidecar SHALL be ignored (verification still runs if a sig is present, but is non-fatal on mismatch).
+
+#### Scenario: Required-signed missing rejected
+- **WHEN** `fs.overlay.require_signed = true` and `/data/models-upper/foo.onnx.sig` is absent
+- **AND** ONNX runtime calls `model_load("/models/foo.onnx")`
+- **THEN** the load SHALL fail with `-EAUTH`
+- **AND** an audit record `model_load_unsigned` SHALL be appended
+
+#### Scenario: Required-signed invalid rejected
+- **WHEN** `fs.overlay.require_signed = true` and the sig sidecar fails ML-DSA-65 verification
+- **THEN** the load SHALL fail with `-EAUTH`
+- **AND** an audit record `model_signature_invalid` SHALL be appended
+
+#### Scenario: Default-off allows unsigned
+- **WHEN** `fs.overlay.require_signed = false` and a model has no sig sidecar
+- **THEN** the load SHALL succeed (subject to fingerprint verify)
+
+#### Scenario: Policy flip rejects existing unsigned
+- **WHEN** an unsigned model exists in the upper
+- **AND** an operator flips `fs.overlay.require_signed` to `true`
+- **THEN** subsequent `model_load` of that model SHALL fail with `-EAUTH`
+- **AND** the file remains in place — re-uploading with a sig restores access
+
+### Requirement: Lower-layer integrity unchanged
+Files read from the lower (squashfs) layer SHALL continue to use `embedded-filesystem-v1`'s per-block SHA-3-256 manifest verification. The overlay SHALL NOT add any second-layer hash check on top of the lower; the manifest is sufficient. The merged read path SHALL apply the appropriate verification per-source.
+
+#### Scenario: Lower file uses block-level manifest
+- **WHEN** a read targets a lower-only file
+- **THEN** verification SHALL be the per-block SHA-3-256 manifest check from `embedded-filesystem-v1`
+- **AND** the overlay SHALL NOT add a second check
+
+#### Scenario: Upper file uses sidecar fingerprint
+- **WHEN** a read targets an upper-layer file
+- **THEN** verification SHALL be the file-level SHA-3-256 sidecar check
+- **AND** the lower's manifest SHALL NOT be consulted for this file

--- a/openspec/changes/embedded-overlay-v1/specs/fs-overlay-mount/spec.md
+++ b/openspec/changes/embedded-overlay-v1/specs/fs-overlay-mount/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: Two-layer merged mount at /models/
+When the `fs-overlay-mounts` cargo feature is enabled, `/models/` SHALL present a merged view of two underlying mounts: a read-only **lower** layer backed by the active squashfs slot (per `embedded-filesystem-v1`'s `fs-squashfs-readonly`) and a read-write **upper** layer backed by `/data/models-upper/` on F2FS (per `embedded-filesystem-v1`'s `fs-f2fs-readwrite`). When the feature is disabled, `/models/` SHALL continue to be a direct squashfs mount with no upper layer.
+
+#### Scenario: Feature off behaves identically to embedded-filesystem-v1
+- **WHEN** the kernel is built without `fs-overlay-mounts`
+- **THEN** `/models/` SHALL be a direct squashfs mount
+- **AND** all writes SHALL return `-EROFS`
+- **AND** behavior SHALL be byte-identical to `embedded-filesystem-v1`
+
+#### Scenario: Feature on creates merged view
+- **WHEN** the kernel is built with `fs-overlay-mounts`
+- **AND** `/data/models-upper/` exists
+- **THEN** `/models/` SHALL present the merged view
+- **AND** `readdir(/models)` SHALL return the union of upper and lower entries (with upper-wins precedence and whiteouts honored)
+
+### Requirement: Upper-wins lookup precedence
+Path lookup under `/models/` SHALL consult the upper layer first. If the upper has a regular file at the requested path, that file SHALL be returned. If the upper has a whiteout marker `<name>.whiteout` at the parent path, the lookup SHALL return `-ENOENT`. Otherwise the lookup SHALL fall through to the lower layer.
+
+#### Scenario: Upper file shadows lower file
+- **WHEN** `/data/models-upper/llama-3.onnx` exists with content X
+- **AND** the lower squashfs has `llama-3.onnx` with content Y
+- **THEN** `read("/models/llama-3.onnx")` SHALL return X
+
+#### Scenario: Lower visible when upper absent
+- **WHEN** `/data/models-upper/` has no entry for `whisper.onnx`
+- **AND** the lower squashfs has `whisper.onnx`
+- **THEN** `read("/models/whisper.onnx")` SHALL return the lower's content
+
+#### Scenario: Whiteout hides lower
+- **WHEN** `/data/models-upper/llama-3.onnx.whiteout` exists
+- **AND** the lower squashfs has `llama-3.onnx`
+- **THEN** `open("/models/llama-3.onnx", O_RDONLY)` SHALL return `-ENOENT`
+- **AND** `readdir("/models/")` SHALL NOT list `llama-3.onnx`
+
+#### Scenario: Opaque dir hides whole subtree
+- **WHEN** `/data/models-upper/custom/.opaque` exists
+- **AND** the lower has files under `custom/`
+- **THEN** the lower entries under `custom/` SHALL NOT be visible
+- **AND** only upper entries under `/data/models-upper/custom/` SHALL be listed
+
+### Requirement: Whiteouts and opaque markers are file-based
+Whiteout markers SHALL be regular empty files named `<name>.whiteout` placed at the parent path. Opaque-directory markers SHALL be regular empty files named `.opaque` placed inside the subdirectory whose lower-side contents are to be hidden. The implementation SHALL NOT use POSIX xattrs, character-device whiteouts, or any other mechanism beyond regular files.
+
+#### Scenario: Empty whiteout file enough to hide
+- **WHEN** an empty file `/data/models-upper/foo.onnx.whiteout` exists
+- **THEN** lower-layer `foo.onnx` SHALL be hidden
+- **AND** the whiteout file's contents (zero bytes) SHALL not be inspected
+
+#### Scenario: Non-empty whiteout still functional
+- **WHEN** the whiteout file contains arbitrary bytes (e.g., comment text)
+- **THEN** the file's mere presence SHALL still hide the lower entry
+- **AND** the bytes SHALL be ignored
+
+### Requirement: Reserved-suffix names rejected
+The merge layer and `model_add` syscall SHALL reject names ending in `.whiteout`, `.opaque`, `.sha3`, or `.sig` with `-EINVAL` and a user-readable message naming the conflicting suffix. This ensures operator-supplied names cannot collide with overlay-internal markers.
+
+#### Scenario: Reserved suffix on add
+- **WHEN** `model_add("foo.whiteout", ...)` is called
+- **THEN** the syscall SHALL return `-EINVAL`
+- **AND** the audit record SHALL note the rejected suffix
+
+#### Scenario: Reserved suffix on direct write
+- **WHEN** an Operator attempts `open("/data/models-upper/foo.opaque", O_CREAT)`
+- **THEN** the operation SHALL be rejected at the VFS write boundary

--- a/openspec/changes/embedded-overlay-v1/specs/fs-overlay-syscalls/spec.md
+++ b/openspec/changes/embedded-overlay-v1/specs/fs-overlay-syscalls/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: model_add syscall
+The kernel SHALL expose a new `model_add` syscall (number 49) callable by `Role::Operator` and `Role::Root`. Signature:
+
+```text
+model_add(name_ptr, name_len, contents_fd, expected_size) -> 0 | -errno
+```
+
+Behavior: validates `name` against the reserved-suffix list, acquires the per-name advisory lock, opens `<name>.tmp` in `/data/models-upper/`, copies bytes from `contents_fd` until EOF, computes SHA-3-256 on the fly, enforces the capacity cap (using `expected_size` for pre-flight when non-zero, else current cumulative bytes), writes the `<name>.sha3` sidecar, optionally writes `<name>.sig` if signed-policy is on (signature provided as a follow-on field of the protocol), `fsync`s, atomically `rename`s over `<name>`, releases the lock, appends an audit record `model_added`.
+
+#### Scenario: Operator successfully adds a model
+- **WHEN** an Operator calls `model_add("custom.onnx", fd, 50_000_000)`
+- **THEN** the syscall SHALL return `Ok(0)` after copying 50 MB from `fd`
+- **AND** `/models/custom.onnx` SHALL serve the new bytes
+- **AND** the audit ring SHALL contain `model_added{ who, name, sha3, size }`
+
+#### Scenario: Viewer denied
+- **WHEN** a Viewer calls `model_add(...)`
+- **THEN** the syscall SHALL return `-EPERM`
+- **AND** an audit `DENY:model_add` SHALL be appended
+
+#### Scenario: Reserved suffix rejected
+- **WHEN** an Operator calls `model_add("foo.whiteout", ...)`
+- **THEN** the syscall SHALL return `-EINVAL` with the suffix-reserved message
+- **AND** SHALL NOT acquire the per-name lock
+
+### Requirement: model_remove syscall
+The kernel SHALL expose a new `model_remove` syscall (number 50) callable by `Role::Root` only. Signature:
+
+```text
+model_remove(name_ptr, name_len, mode: u8) -> 0 | -errno
+```
+
+`mode` selects the removal kind:
+- `0` — Remove an upper-layer entry only (an operator-added file). If the lower has the same name, it becomes visible after removal.
+- `1` — Hide a lower-layer entry by writing the whiteout marker. The lower entry remains on disk but is invisible from `/models/`.
+- `2` — Remove a whiteout (un-hide), restoring lower visibility. Subject to `fs.overlay.allow_operator_unhide` policy.
+
+#### Scenario: Root removes upper file
+- **WHEN** Root calls `model_remove("custom.onnx", 0)` and the upper has `custom.onnx`
+- **THEN** the upper file and its `.sha3`/`.sig` sidecars SHALL be deleted
+- **AND** an audit `model_removed{ who, name, mode=0 }` SHALL be appended
+
+#### Scenario: Root hides lower file
+- **WHEN** Root calls `model_remove("llama-3.onnx", 1)` and the lower has `llama-3.onnx`
+- **THEN** `<name>.whiteout` SHALL be written to the upper
+- **AND** the audit record SHALL be `model_hidden{ who, name }`
+
+#### Scenario: Operator denied remove
+- **WHEN** an Operator calls `model_remove(...)` with any mode
+- **THEN** the syscall SHALL return `-EPERM`
+- **AND** an audit `DENY:model_remove` SHALL be appended
+
+#### Scenario: Operator may unhide if policy permits
+- **WHEN** `fs.overlay.allow_operator_unhide = true` is set
+- **AND** an Operator calls `model_remove("foo.onnx", 2)`
+- **THEN** the syscall SHALL succeed and the whiteout SHALL be deleted
+- **AND** an audit record SHALL name the role and entry
+
+### Requirement: Boot-time conflict detection
+On every boot after a successful A/B swap into a new lower squashfs, the kernel SHALL scan the upper layer and SHALL append one audit record `overlay_conflict` for each upper entry that shadows a name now present in the new lower. The audit record SHALL include the name, the lower's SHA-3-256 (from the squashfs manifest), and the upper's SHA-3-256 (from the sidecar). No automatic resolution SHALL be attempted — the operator's upper continues to win.
+
+#### Scenario: Newly-shadowing entry audited at boot
+- **WHEN** before A/B swap the upper has `custom.onnx` and the lower has no `custom.onnx`
+- **AND** an A/B swap brings in a new lower that has `custom.onnx`
+- **THEN** on first boot of the new image an audit record `overlay_conflict{ name=custom.onnx, lower_sha3, upper_sha3 }` SHALL be appended
+
+#### Scenario: Pre-existing conflict not re-audited
+- **WHEN** an upper-shadow conflict was audited on a prior boot and neither upper nor lower has changed
+- **THEN** the conflict SHALL NOT be re-appended on subsequent boots

--- a/openspec/changes/embedded-overlay-v1/specs/fs-overlay-write/spec.md
+++ b/openspec/changes/embedded-overlay-v1/specs/fs-overlay-write/spec.md
@@ -1,0 +1,80 @@
+## ADDED Requirements
+
+### Requirement: Upper-layer write path
+Write operations under `/models/` SHALL be directed exclusively to the upper layer at `/data/models-upper/`. Lower-layer (squashfs) entries SHALL never be modified. Writes that would require modification of an existing lower-layer file (e.g., `truncate("/models/llama-3.onnx")` where `llama-3.onnx` is in the lower) SHALL return `-EROFS` with a user-readable message instructing the operator to `model_add` under a new name.
+
+#### Scenario: Write to upper-only file succeeds
+- **WHEN** an Operator writes to `/models/custom-tuned.onnx` (no lower entry)
+- **THEN** the write SHALL go to `/data/models-upper/custom-tuned.onnx`
+- **AND** the lower squashfs SHALL be untouched
+
+#### Scenario: Write to lower-only file rejected
+- **WHEN** an Operator attempts to truncate `/models/llama-3.onnx` (lower-only)
+- **THEN** the syscall SHALL return `-EROFS`
+- **AND** the message SHALL instruct using `model_add` under a new name
+
+### Requirement: Per-name advisory lock during model_add
+The kernel SHALL hold a per-name advisory lock during `model_add`. A second concurrent `model_add` for the same name SHALL return `-EBUSY` and SHALL include a `Retry-After` hint of 1 second. The lock SHALL be released on success, on failure, or on the writing fd being closed without completing.
+
+#### Scenario: Concurrent add on same name rejected
+- **WHEN** Operator A's `model_add("foo.onnx", ...)` is in progress
+- **AND** Operator B issues `model_add("foo.onnx", ...)` simultaneously
+- **THEN** B's syscall SHALL return `-EBUSY` with `Retry-After: 1`
+- **AND** A's add SHALL proceed unaffected
+
+#### Scenario: Concurrent add on different names allowed
+- **WHEN** Operator A's `model_add("foo.onnx", ...)` is in progress
+- **AND** Operator B issues `model_add("bar.onnx", ...)`
+- **THEN** both adds SHALL proceed in parallel
+
+#### Scenario: Lock released on writer-side abort
+- **WHEN** Operator A's `model_add` aborts mid-write (Zenoh source disconnects)
+- **THEN** the per-name lock SHALL be released
+- **AND** any pending bytes in the upper SHALL be unlinked
+- **AND** Operator B's subsequent `model_add` for the same name SHALL succeed
+
+### Requirement: Atomic write via stage-and-rename
+Each `model_add` SHALL stage to `<name>.tmp` in the upper layer, write the SHA-3-256 fingerprint sidecar (`<name>.sha3`) and optional ML-DSA-65 signature sidecar (`<name>.sig`), `fsync` the model file, then atomically `rename` over the final name. A crash before the rename SHALL leave no partially-visible model under `/models/`.
+
+#### Scenario: Crash before rename leaves no visible file
+- **WHEN** `model_add` writes bytes to `<name>.tmp` and the system crashes
+- **THEN** on next boot `/models/<name>` SHALL not be visible (only the lower entry, if any)
+- **AND** the orphan `<name>.tmp` SHALL be removed during boot cleanup
+
+#### Scenario: Successful add visible after rename
+- **WHEN** `model_add` completes the rename
+- **THEN** `/models/<name>` SHALL serve the new bytes immediately
+- **AND** `fsync(fd)` on the rename SHALL have made the change durable
+
+### Requirement: Capacity cap enforcement
+The total bytes occupied by `/data/models-upper/` SHALL be tracked and SHALL NOT exceed `fs.overlay.upper_max_bytes` (default 2 GiB; floor 64 MiB; ceiling = `/data/` partition size − 1 GiB headroom). Writes that would exceed the cap SHALL return `-ENOSPC`. The check SHALL include the in-progress staged file's expected size when known (operator-declared via the `model_add` ABI).
+
+#### Scenario: Write within cap succeeds
+- **WHEN** the upper holds 1 GiB and a 500 MiB add arrives (cap 2 GiB)
+- **THEN** the add SHALL succeed
+- **AND** subsequent reads SHALL return the new bytes
+
+#### Scenario: Write exceeding cap rejected
+- **WHEN** the upper holds 1.8 GiB and a 500 MiB add arrives (cap 2 GiB)
+- **THEN** the add SHALL return `-ENOSPC` after the first ~200 MiB
+- **AND** the staged tmp file SHALL be unlinked
+- **AND** an audit record `model_add_capacity_exceeded` SHALL be appended
+
+#### Scenario: Cap below floor rejected at config time
+- **WHEN** an operator writes `fs.overlay.upper_max_bytes = 32 MiB`
+- **THEN** the validator SHALL reject with `-EINVAL`
+- **AND** the previous value SHALL remain in effect
+
+### Requirement: Whiteout removal RBAC
+Removing a whiteout marker (un-hiding a lower-layer entry) SHALL require `Role::Root` by default. When `fs.overlay.allow_operator_unhide = true`, `Role::Operator` MAY also remove whiteouts. Adding or modifying whiteouts SHALL always require Root via `model_remove`.
+
+#### Scenario: Operator cannot remove whiteout by default
+- **WHEN** an Operator calls `model_unhide("foo.onnx")` and the policy is default
+- **THEN** the syscall SHALL return `-EPERM`
+- **AND** an audit `DENY:model_unhide` SHALL be appended
+
+#### Scenario: Operator unhides when policy permits
+- **WHEN** `fs.overlay.allow_operator_unhide = true` is set
+- **AND** an Operator calls `model_unhide("foo.onnx")`
+- **THEN** the syscall SHALL succeed (subject to other preconditions)
+- **AND** the audit record SHALL name the role and entry

--- a/openspec/changes/embedded-overlay-v1/specs/kernel-syscalls/spec.md
+++ b/openspec/changes/embedded-overlay-v1/specs/kernel-syscalls/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: model_add and model_remove syscalls
+The kernel SHALL expose two new syscalls:
+
+```text
+model_add(name_ptr, name_len, contents_fd, expected_size) -> 0 | -errno
+   number 49 — Operator+
+model_remove(name_ptr, name_len, mode: u8) -> 0 | -errno
+   number 50 — Root only
+```
+
+These syscalls implement the operator-facing API for the overlay layer specified in `fs-overlay-syscalls`. They SHALL participate in the existing `min_role` capability system from `auth-roles`.
+
+#### Scenario: model_add ABI matches existing convention
+- **WHEN** `model_add` is invoked
+- **THEN** arguments SHALL pass via the existing kernel syscall convention
+- **AND** the return value SHALL be 0 on success or a negative POSIX errno on failure
+
+#### Scenario: model_remove ABI matches existing convention
+- **WHEN** `model_remove` is invoked
+- **THEN** arguments SHALL pass via the existing kernel syscall convention
+- **AND** the return value SHALL be 0 on success or a negative POSIX errno on failure
+
+## MODIFIED Requirements
+
+### Requirement: Documented syscall count after overlay
+The architecture documentation SHALL state the v1-with-overlay syscall count as the prior count plus two (i.e., the post-`embedded-filesystem-v1` count of "~52 syscalls" is updated to "~54 syscalls"). New syscall numbers are stable: `model_add = 49`, `model_remove = 50`.
+
+#### Scenario: Architecture doc reflects new count
+- **WHEN** `docs/architecture.md` is read
+- **THEN** it SHALL state the syscall count of 54
+- **AND** SHALL list `model_add = 49` and `model_remove = 50` in the syscall table

--- a/openspec/changes/embedded-overlay-v1/specs/mgmt-config-layout/spec.md
+++ b/openspec/changes/embedded-overlay-v1/specs/mgmt-config-layout/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: /data/models-upper/ directory
+On first boot of an image carrying the `fs-overlay-mounts` feature enabled, the kernel SHALL ensure `/data/models-upper/` exists with mode 0700 owned by kernel. The directory SHALL be created atomically alongside the rest of the `/data/` tree per the existing first-boot directory-tree-creation requirement.
+
+#### Scenario: Directory created on first boot with overlay feature
+- **WHEN** the kernel formats `/data/` per `embedded-filesystem-v1`
+- **AND** the `fs-overlay-mounts` cargo feature is enabled
+- **THEN** `/data/models-upper/` SHALL exist with mode 0700
+- **AND** an audit record `overlay_upper_initialized` SHALL be appended
+
+#### Scenario: Directory not created without feature
+- **WHEN** the kernel formats `/data/` and the overlay feature is disabled
+- **THEN** `/data/models-upper/` SHALL NOT be created
+- **AND** the absence SHALL not block boot
+
+### Requirement: fs.overlay.* configuration fields
+`mgmt/policy.toml` SHALL expose the following live-reload-able fields when the overlay feature is enabled:
+
+- `fs.overlay.upper_max_bytes` — capacity cap, default 2 GiB. Floor 64 MiB; ceiling = `/data/` partition size − 1 GiB headroom.
+- `fs.overlay.require_signed` — boolean, default `false`. When `true`, every `model_load` from upper requires a valid `<name>.sig` ML-DSA-65 signature.
+- `fs.overlay.allow_operator_unhide` — boolean, default `false`. When `true`, `Role::Operator` MAY remove whiteouts via `model_remove(_, 2)`.
+
+All three fields SHALL carry `#[reload("live")]` so changes apply without remount.
+
+#### Scenario: Default cap present in fresh policy
+- **WHEN** a fresh `mgmt/policy.toml` is generated
+- **THEN** `fs.overlay.upper_max_bytes = 2147483648` SHALL be present
+- **AND** `fs.overlay.require_signed = false`, `fs.overlay.allow_operator_unhide = false` SHALL be present
+
+#### Scenario: Cap below floor rejected
+- **WHEN** an operator writes `fs.overlay.upper_max_bytes = 33554432` (32 MiB, below 64 MiB floor)
+- **THEN** the validator SHALL reject with `-EINVAL`
+
+#### Scenario: Live reload of require_signed
+- **WHEN** an operator writes `fs.overlay.require_signed = true`
+- **THEN** subsequent `model_load` calls SHALL begin enforcing signed requirement immediately
+- **AND** no remount of `/models/` SHALL be required
+
+## MODIFIED Requirements
+
+### Requirement: Per-file permission table extended
+The per-file permission declaration table SHALL include an entry for the overlay sidecar files in `/data/models-upper/`. Sidecars (`<name>.sha3`, `<name>.sig`) SHALL be mode 0600 owned by kernel; main model files SHALL be mode 0640 (group-readable for the inference runtime). Whiteout markers (`<name>.whiteout`, `<name>/.opaque`) SHALL be mode 0600.
+
+#### Scenario: Sidecar mode 0600
+- **WHEN** `model_add` writes `<name>.sha3` and `<name>.sig`
+- **THEN** the resulting files SHALL have mode 0600
+
+#### Scenario: Model file mode 0640
+- **WHEN** `model_add` completes
+- **THEN** the resulting `<name>` SHALL have mode 0640
+- **AND** the inference runtime (running as the appropriate group) SHALL be able to read it

--- a/openspec/changes/embedded-overlay-v1/specs/posix-vfs/spec.md
+++ b/openspec/changes/embedded-overlay-v1/specs/posix-vfs/spec.md
@@ -1,0 +1,18 @@
+## MODIFIED Requirements
+
+### Requirement: /models/ becomes a merged view when overlay feature is enabled
+With the `fs-overlay-mounts` cargo feature enabled, the `/models/` mount point SHALL no longer be a direct squashfs mount. It SHALL instead be a merged view backed by the overlay implementation in `fs-overlay-mount`. The lower layer SHALL be the active squashfs slot per `embedded-filesystem-v1`'s A/B selection. The upper layer SHALL be `/data/models-upper/` on F2FS.
+
+When the `fs-overlay-mounts` feature is disabled, the existing `embedded-filesystem-v1` behavior SHALL apply unchanged: `/models/` is a direct squashfs mount, all writes return `-EROFS`.
+
+#### Scenario: Overlay-enabled merged view
+- **WHEN** the kernel is built with `fs-overlay-mounts`
+- **THEN** lookups under `/models/` SHALL apply upper-wins precedence
+- **AND** writes to upper-only or new files SHALL succeed
+- **AND** writes to lower-only files SHALL return `-EROFS` with the model_add hint
+
+#### Scenario: Overlay-disabled compatibility
+- **WHEN** the kernel is built without `fs-overlay-mounts`
+- **THEN** `/models/` SHALL behave exactly as in `embedded-filesystem-v1`
+- **AND** any write SHALL return `-EROFS`
+- **AND** no upper-layer code SHALL execute

--- a/openspec/changes/embedded-overlay-v1/tasks.md
+++ b/openspec/changes/embedded-overlay-v1/tasks.md
@@ -1,0 +1,98 @@
+## 1. Phase 1 — Merge logic (read-only)
+
+- [ ] 1.1 `fs/src/overlay/mod.rs` — module skeleton, `#![no_std]`, gated by `fs-overlay-mounts` cargo feature
+- [ ] 1.2 `fs/src/overlay/lookup.rs` — upper-wins precedence resolver
+- [ ] 1.3 Whiteout detection (`<name>.whiteout` regular file)
+- [ ] 1.4 Opaque-directory detection (`<dir>/.opaque` regular file)
+- [ ] 1.5 Reserved-suffix rejection (`.whiteout`, `.opaque`, `.sha3`, `.sig`)
+- [ ] 1.6 `readdir` merging (union of upper + lower entries minus whiteouts/opaque hides)
+- [ ] 1.7 Synthetic fixture builder: CI script that runs `mksquashfs` + `mkfs.f2fs` to produce small lower + upper images
+- [ ] 1.8 Property-based tests sweep all upper/lower content combinations
+- [ ] 1.9 Kani harness for the merge-lookup precedence invariant
+- [ ] 1.10 TLA+ model `overlay_state.tla` — add/remove/whiteout/A-B-swap interleavings
+
+## 2. Phase 2 — Upper-layer write path
+
+- [ ] 2.1 `fs/src/overlay/write.rs` — write routing (upper-only, lower-only-rejected)
+- [ ] 2.2 Stage-and-rename atomic write helper
+- [ ] 2.3 Per-name advisory lock (`HashMap<&str, OverlayLock>` keyed by name)
+- [ ] 2.4 Concurrent-add `-EBUSY` path
+- [ ] 2.5 Aborted-add cleanup (orphan `<name>.tmp` removal on writer-fd close)
+- [ ] 2.6 SPIN model proving no two concurrent adds for the same name both succeed
+- [ ] 2.7 Boot-cleanup pass: on mount, remove any orphan `<name>.tmp` from `/data/models-upper/`
+- [ ] 2.8 Tests: stage-rename atomicity, per-name lock, concurrent on different names allowed
+
+## 3. Phase 3 — model_add / model_remove syscalls
+
+- [ ] 3.1 Add `model_add` syscall (49) per `kernel-syscalls`
+- [ ] 3.2 Add `model_remove` syscall (50) per `kernel-syscalls`
+- [ ] 3.3 Hook into existing `min_role` capability dispatch
+- [ ] 3.4 SHA-3-256 fingerprint sidecar writer integrated with `model_add`
+- [ ] 3.5 Optional ML-DSA-65 signature sidecar (always written when payload provides one; validity checked at load time per integrity spec)
+- [ ] 3.6 `model_remove` mode 0/1/2 (delete-upper / hide-lower / unhide)
+- [ ] 3.7 `passwd`-style user-space CLI: `container/src/bin/model.rs` wrapping `model_add` + `model_remove`
+- [ ] 3.8 Tests for ABI conformance and per-mode behavior
+
+## 4. Phase 4 — RBAC + Zenoh admin verbs
+
+- [ ] 4.1 Operator + Root permitted on `model_add`
+- [ ] 4.2 Root only permitted on `model_remove` (modes 0, 1)
+- [ ] 4.3 `model_remove` mode 2 (unhide) gated on `fs.overlay.allow_operator_unhide`
+- [ ] 4.4 Zenoh admin verbs: `smallaios/admin/model/add`, `smallaios/admin/model/remove`
+- [ ] 4.5 Streaming upload over Zenoh queryable for `model_add` payloads
+- [ ] 4.6 Tests across the RBAC matrix (every role × every verb)
+- [ ] 4.7 Audit `DENY:model_add` / `DENY:model_remove` records on RBAC failure
+
+## 5. Phase 5 — Integrity layer
+
+- [ ] 5.1 SHA-3-256 verify on every read of an upper file (per `fs-overlay-integrity`)
+- [ ] 5.2 Missing-sidecar fail-closed
+- [ ] 5.3 ML-DSA-65 signature verify when `require_signed = true`
+- [ ] 5.4 Default-off mode (signature ignored if not required, even when present)
+- [ ] 5.5 Audit records on hash mismatch and signature failure
+- [ ] 5.6 Property-based fuzz on corrupted sidecars (truncated, malformed hex, wrong-length signature)
+
+## 6. Phase 6 — Audit + cap enforcement + boot conflict
+
+- [ ] 6.1 Capacity-cap pre-flight on `model_add` (using `expected_size` when provided)
+- [ ] 6.2 Capacity-cap mid-flight (running cumulative bytes vs cap)
+- [ ] 6.3 `-ENOSPC` on cap violation; staged tmp file unlinked
+- [ ] 6.4 Audit `model_add_capacity_exceeded` with declared/actual bytes
+- [ ] 6.5 Boot-time conflict scan: walk upper, check each non-whiteout name against lower
+- [ ] 6.6 One audit record per new conflict per boot (no re-audit if already-audited)
+- [ ] 6.7 `mgmt/policy.toml` fields wired with `#[reload("live")]`
+- [ ] 6.8 First-boot `/data/models-upper/` directory creation
+
+## CHECKPOINT — Single PR into `develop` once all 6 phases land
+
+This change ships as **two PRs**:
+
+- **PR 1 (this PR — scaffolding only):** proposal.md, design.md, the 7 spec deltas (4 new + 3 modified), tasks.md. Merges to `develop` so agent teams can spawn worktrees off develop and pick up the design.
+- **PR 2 (later — implementation):** all 6 phases in one cohesive merge, behind the default-off `fs-overlay-mounts` cargo feature.
+
+The scaffolding (PR 1) gating list:
+
+- [ ] CA.1 `openspec validate embedded-overlay-v1 --strict` returns clean
+- [ ] CA.2 PR title follows conventional-commit semver convention
+- [ ] CA.3 No production code changes (scaffolding only)
+- [ ] CA.4 Documentation references `embedded-filesystem-v1` as the foundation
+
+The implementation (PR 2) gating list:
+
+- [ ] CB.1 Behind cargo feature `fs-overlay-mounts`, default off
+- [ ] CB.2 `cargo fmt --check`, `cargo clippy -- -D warnings`
+- [ ] CB.3 `cargo test --workspace` total ≥ 5250 (post-`embedded-filesystem-v1` baseline + ~150)
+- [ ] CB.4 Kani harness for merge-lookup precedence passes
+- [ ] CB.5 SPIN concurrent-add interleaving model verifies clean
+- [ ] CB.6 TLA+ overlay-state model verifies clean
+- [ ] CB.7 Cyclic-dep check passes (no new edges; reuses `fs/` and `security/`)
+- [ ] CB.8 `cargo audit` / `cargo deny` clean
+
+## 7. Cross-phase verification
+
+- [ ] 7.1 Documentation updates: `docs/architecture.md` syscall table 49/50; new `docs/embedded-overlay.md` operator runbook (model_add / model_remove flows)
+- [ ] 7.2 Image-size regression check: overlay code stays ≤ 30 KB compiled growth budget
+- [ ] 7.3 Reserved-suffix CI lint to catch accidental introduction of conflicting test fixture names
+- [ ] 7.4 Update SmallAIOS user-space CLI tools to know about `/models/` upper layer (for `model list --include-whiteouts`)
+- [ ] 7.5 First-boot `/data/models-upper/` directory creation tested on a fresh GPT image
+- [ ] 7.6 Round-trip with external `mount -t f2fs`: external reader sees `/data/models-upper/` contents directly (operator-added files visible from a recovery laptop)


### PR DESCRIPTION
## Summary

OverlayFS-style writable layer mounted on top of the read-only squashfs `/models/` from `embedded-filesystem-v1`. Operators can drop in a custom model via `model_add` syscall without re-imaging the box; the base squashfs remains unchanged and continues to be A/B-swappable.

**Shape captured across 15 walkthrough questions:**
- Two-layer mount: lower = active squashfs slot, upper = `/data/models-upper/` on F2FS.
- Whiteouts are file-based (`<name>.whiteout`); opaque dirs are `<dir>/.opaque` markers. No xattrs, no char-device whiteouts (clean-room SmallAIOS-specific design, not a Linux overlayfs port).
- Upper-wins lookup precedence; lower visible only when upper has no entry and no whiteout.
- New syscalls: `model_add` (49, Operator+) and `model_remove` (50, Root). Bumps documented count 52 → 54.
- Per-name advisory lock during `model_add`; concurrent adds on same name return `-EBUSY`.
- Stage-and-rename atomic write; orphan tmp cleanup at boot.
- SHA-3-256 fingerprint sidecar (`<name>.sha3`) on every add; optional ML-DSA-65 signature sidecar (`<name>.sig`) controlled by `fs.overlay.require_signed` (default off, configurable).
- Capacity cap `fs.overlay.upper_max_bytes` (default 2 GiB).
- Reserved-suffix rejection: `.whiteout`, `.opaque`, `.sha3`, `.sig`.
- Boot-time conflict detection: every upper entry that shadows a name in the new lower after A/B swap appends one audit record per boot.
- Behind `fs-overlay-mounts` cargo feature (default off); feature-off behavior is byte-identical to `embedded-filesystem-v1`.
- ~150 new tests (≥5250 total post-change).
- Formal: Kani (merge precedence), SPIN (concurrent add), TLA+ (overlay state machine).

**Spec deltas (4 new + 3 modified):**
- New: `fs-overlay-mount`, `fs-overlay-write`, `fs-overlay-integrity`, `fs-overlay-syscalls`
- Modified: `posix-vfs`, `kernel-syscalls`, `mgmt-config-layout`

`openspec validate embedded-overlay-v1 --strict` is clean.

## Test plan

- [ ] `openspec validate embedded-overlay-v1 --strict` returns clean (verified locally — ✅)
- [ ] PR title passes the conventional-commit semver check (`docs(...)` → `semver:none`)
- [ ] No production code changes; this is OpenSpec scaffolding only — implementation lands in a follow-on PR from an agent-team worktree off `develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive design specifications for a filesystem overlay feature enabling writable model management with integrity verification, capacity limits, and role-based access controls.
  * Documented new model administration syscalls, mount behavior, configuration options, audit requirements, and multi-phase implementation plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->