### PR TITLE
feat(security): Blake2b + Argon2id (management-login-v1 phase 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,10 +39,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
@@ -51,10 +69,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -164,6 +200,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +273,27 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "either"
@@ -295,6 +361,16 @@ name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -488,6 +564,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,6 +641,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rayon"
@@ -885,6 +978,8 @@ dependencies = [
 name = "smallaios-security"
 version = "0.2.1"
 dependencies = [
+ "argon2",
+ "blake2",
  "smallaios-net",
 ]
 
@@ -894,6 +989,12 @@ version = "0.2.1"
 dependencies = [
  "smallaios-kernel",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -930,6 +1031,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,6 +1047,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/security/Cargo.toml
+++ b/security/Cargo.toml
@@ -20,5 +20,10 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }
 
 [dev-dependencies]
 smallaios-net = { path = "../net", features = ["quic"] }
+# Validation oracles for clean-room crypto. These crates MUST NOT enter the
+# production dep graph — they are only used in #[cfg(test)] KAT comparison
+# tests for Blake2b (RFC 7693) and Argon2id (RFC 9106).
+blake2 = "0.10"
+argon2 = "0.5"
 
 [dependencies]

--- a/security/src/argon2id.rs
+++ b/security/src/argon2id.rs
@@ -980,9 +980,9 @@ mod tests {
     #[test]
     fn phc_round_trip() {
         // Test-only fixtures, not production secrets.
+        // Use the absolute-minimum tier to keep tests fast.
         let password = b"correct horse battery staple"; // lgtm[rust/hard-coded-cryptographic-value] test fixture
         let salt = b"saltsalt12345678"; // lgtm[rust/hard-coded-cryptographic-value] test fixture
-        // Use the absolute-minimum tier to keep tests fast.
         let params = Argon2idParams {
             m_cost_kib: 8,
             t_cost: 1,

--- a/security/src/argon2id.rs
+++ b/security/src/argon2id.rs
@@ -1,0 +1,1119 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Argon2id — memory-hard password hashing (RFC 9106).
+//!
+//! Clean-room `#![no_std]` implementation of Argon2id (the hybrid Argon2
+//! variant: data-independent indexing for the first half-pass of the first
+//! pass, data-dependent indexing for the rest). Emits a 32-byte tag and a
+//! PHC-encoded string suitable for storage in `/data/auth/shadow`.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use smallaios_security::argon2id::{argon2id_hash, Argon2idParams};
+//!
+//! let salt = b"saltsaltsaltsalt"; // ≥ 8 bytes per RFC 9106 §3.1
+//! let tag = argon2id_hash(b"correct horse battery staple", salt,
+//!                          Argon2idParams::default_tier());
+//! ```
+//!
+//! # Per-tier defaults
+//!
+//! See [`Argon2idParams::tiny`], [`Argon2idParams::default_tier`],
+//! [`Argon2idParams::strong`]. The PHC string carries the parameters so
+//! verification is self-describing.
+//!
+//! # Implementation notes
+//!
+//! - Uses the [`crate::crypto::blake2b`] backend for `H` and `H'`.
+//! - Memory layout is a flat row-major `m_prime × 1024` block grid where
+//!   `m_prime = 4 * p_cost * floor(m_cost_kib / (4 * p_cost))` per RFC 9106
+//!   §3.2.
+//! - Indexing follows §3.4 — first half-pass of pass 0 is data-independent
+//!   (G2 stream); the rest is data-dependent (read from the previous block).
+//! - Per-arch SIMD (NEON / AVX2) shims are deferred to a follow-on phase.
+//!   Only the portable BLAMKA path is enabled here.
+//!
+//! # References
+//!
+//! - RFC 9106 — Argon2 Memory-Hard Function for Password Hashing and
+//!   Proof-of-Work Applications.
+//! - <https://github.com/P-H-C/phc-winner-argon2>
+
+#![allow(unused)]
+
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::fmt;
+
+use crate::crypto::blake2b::{Blake2b, BLAKE2B_OUT_MAX};
+use crate::crypto::constant_time::ct_eq;
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+/// Argon2 block size in bytes (RFC 9106 §3.1: B = 1024 bytes = 128 u64 lanes).
+pub const ARGON2_BLOCK_BYTES: usize = 1024;
+
+/// Argon2id type identifier (RFC 9106 §3.2 step 5).
+const ARGON2ID_TYPE: u32 = 2;
+
+/// Argon2 version (0x13 = 1.3, RFC 9106).
+const ARGON2_VERSION: u32 = 0x13;
+
+/// SYNC_POINTS — number of slices per lane per pass (RFC 9106 §3.4).
+const SYNC_POINTS: usize = 4;
+
+/// Output tag length used by the management-login API.
+pub const ARGON2ID_TAG_LEN: usize = 32;
+
+// ─── Errors ──────────────────────────────────────────────────────────────────
+
+/// Errors raised by Argon2id.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Error {
+    /// `m_cost_kib` is below the RFC 9106 minimum `8 * p_cost`.
+    InvalidMemory,
+    /// `t_cost` is below 1.
+    InvalidTime,
+    /// `p_cost` is 0 or > the RFC 9106 maximum (2^24 - 1).
+    InvalidLanes,
+    /// Salt length below the RFC 9106 minimum (8 bytes).
+    InvalidSalt,
+    /// Output tag length out of supported range (4..=64 bytes).
+    InvalidTagLength,
+    /// PHC string did not parse.
+    InvalidPhc,
+    /// Argon2 variant in PHC string is not `argon2id`.
+    UnsupportedVariant,
+    /// Argon2 version in PHC string is not 0x13.
+    UnsupportedVersion,
+    /// Base64 decoding failed.
+    Base64Decode,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidMemory => write!(f, "argon2id: m_cost too small"),
+            Self::InvalidTime => write!(f, "argon2id: t_cost must be >= 1"),
+            Self::InvalidLanes => write!(f, "argon2id: p_cost out of range"),
+            Self::InvalidSalt => write!(f, "argon2id: salt must be >= 8 bytes"),
+            Self::InvalidTagLength => write!(f, "argon2id: tag length out of range"),
+            Self::InvalidPhc => write!(f, "argon2id: malformed PHC string"),
+            Self::UnsupportedVariant => write!(f, "argon2id: variant not argon2id"),
+            Self::UnsupportedVersion => write!(f, "argon2id: unsupported version"),
+            Self::Base64Decode => write!(f, "argon2id: base64 decode failure"),
+        }
+    }
+}
+
+// ─── Parameters ──────────────────────────────────────────────────────────────
+
+/// Argon2id parameters per RFC 9106 §3.1.
+///
+/// - `m_cost_kib` — memory cost in kibibytes (1 KiB = 1024 bytes = 1 block).
+/// - `t_cost` — time cost: number of passes over the memory.
+/// - `p_cost` — parallelism / lane count.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Argon2idParams {
+    pub m_cost_kib: u32,
+    pub t_cost: u32,
+    pub p_cost: u32,
+}
+
+impl Argon2idParams {
+    /// `tiny` tier — 8 MiB / t=3 / p=1 — for ≤ 256 MiB-RAM x86 targets.
+    pub const fn tiny() -> Self {
+        Self {
+            m_cost_kib: 8 * 1024,
+            t_cost: 3,
+            p_cost: 1,
+        }
+    }
+
+    /// `default` tier — 64 MiB / t=3 / p=1 — typical container/VM target.
+    /// (Named `default_tier` rather than implementing `Default` to avoid
+    /// confusion with crypto callers that explicitly pick a tier.)
+    pub const fn default_tier() -> Self {
+        Self {
+            m_cost_kib: 64 * 1024,
+            t_cost: 3,
+            p_cost: 1,
+        }
+    }
+
+    /// `strong` tier — 128 MiB / t=4 / p=2 — Jetson-class targets.
+    pub const fn strong() -> Self {
+        Self {
+            m_cost_kib: 128 * 1024,
+            t_cost: 4,
+            p_cost: 2,
+        }
+    }
+
+    /// Validate the parameters per RFC 9106 §3.1.
+    fn validate(&self) -> Result<(), Error> {
+        if self.t_cost < 1 {
+            return Err(Error::InvalidTime);
+        }
+        if self.p_cost == 0 || self.p_cost > 0x00FF_FFFF {
+            return Err(Error::InvalidLanes);
+        }
+        if self.m_cost_kib < 8 * self.p_cost {
+            return Err(Error::InvalidMemory);
+        }
+        Ok(())
+    }
+}
+
+// Note: no `Default` impl — callers must pick a tier explicitly.
+
+// ─── Block ───────────────────────────────────────────────────────────────────
+
+/// 1024-byte Argon2 block, viewed as 128 little-endian u64 lanes.
+#[derive(Clone, Copy)]
+struct Block([u64; 128]);
+
+impl Block {
+    const fn zero() -> Self {
+        Block([0u64; 128])
+    }
+
+    fn from_bytes(b: &[u8]) -> Self {
+        debug_assert_eq!(b.len(), ARGON2_BLOCK_BYTES);
+        let mut lanes = [0u64; 128];
+        for i in 0..128 {
+            lanes[i] = u64::from_le_bytes(b[i * 8..i * 8 + 8].try_into().unwrap());
+        }
+        Block(lanes)
+    }
+
+    fn write_bytes(&self, out: &mut [u8]) {
+        debug_assert_eq!(out.len(), ARGON2_BLOCK_BYTES);
+        for i in 0..128 {
+            out[i * 8..i * 8 + 8].copy_from_slice(&self.0[i].to_le_bytes());
+        }
+    }
+
+    /// XOR `other` into `self` (in place).
+    fn xor_assign(&mut self, other: &Block) {
+        for i in 0..128 {
+            self.0[i] ^= other.0[i];
+        }
+    }
+
+    /// Copy `other` into `self`.
+    fn copy_from(&mut self, other: &Block) {
+        self.0 = other.0;
+    }
+}
+
+// ─── Variable-length hash H' (RFC 9106 §3.3) ─────────────────────────────────
+
+/// Variable-length hash function `H'` from RFC 9106 §3.3.
+///
+/// For `out_len <= 64`, `H'(X) = Blake2b_{out_len}(LE32(out_len) || X)`.
+/// For larger `out_len`, we chain Blake2b-512 outputs, taking the first 32
+/// bytes of each intermediate Blake2b-512 except the last block which
+/// emits the full remaining bytes (per the spec's V_i recursion).
+fn h_prime(out_len: u32, input: &[&[u8]], out: &mut [u8]) {
+    debug_assert_eq!(out.len(), out_len as usize);
+
+    let len_le = out_len.to_le_bytes();
+
+    if out_len as usize <= BLAKE2B_OUT_MAX {
+        let mut h = Blake2b::new(out_len as usize);
+        h.update(&len_le);
+        for chunk in input {
+            h.update(chunk);
+        }
+        let _ = h.finalize_into(out);
+        return;
+    }
+
+    // Long output: V_1 = Blake2b_512(LE32(T) || X). Subsequent V_{i} =
+    // Blake2b_512(V_{i-1}). Output is V_1[0..32] || V_2[0..32] || ... ||
+    // V_r where r is chosen so the total length matches `out_len`.
+    let mut v = [0u8; BLAKE2B_OUT_MAX];
+    {
+        let mut h = Blake2b::new(BLAKE2B_OUT_MAX);
+        h.update(&len_le);
+        for chunk in input {
+            h.update(chunk);
+        }
+        let _ = h.finalize_into(&mut v);
+    }
+
+    let mut written = 0usize;
+    // RFC 9106: 32-byte halves of the chain, with the last full Blake2b_512
+    // covering whatever remains. The number of intermediate iterations is
+    // r = ceil(out_len / 32) - 2.
+    let total = out_len as usize;
+    while written + BLAKE2B_OUT_MAX < total {
+        // Emit first 32 bytes of v.
+        out[written..written + 32].copy_from_slice(&v[..32]);
+        written += 32;
+        // Re-hash the full 64-byte v.
+        let mut h = Blake2b::new(BLAKE2B_OUT_MAX);
+        h.update(&v);
+        let _ = h.finalize_into(&mut v);
+    }
+    // Final block: emit the remaining bytes of v.
+    let rem = total - written;
+    out[written..].copy_from_slice(&v[..rem]);
+}
+
+// ─── BLAMKA / G compression (RFC 9106 §3.5–3.6) ──────────────────────────────
+
+/// BLAMKA mixing primitive (RFC 9106 §3.5).
+///
+/// Identical structure to Blake2's `G` but with the `+` operations replaced
+/// by `a + b + 2 * lower32(a) * lower32(b)`. Operates on four lanes of the
+/// 16-lane working state.
+#[inline(always)]
+fn blamka_g(state: &mut [u64; 16], a: usize, b: usize, c: usize, d: usize) {
+    fn fblamka(x: u64, y: u64) -> u64 {
+        let xy = (x & 0xFFFF_FFFF).wrapping_mul(y & 0xFFFF_FFFF);
+        x.wrapping_add(y).wrapping_add(2u64.wrapping_mul(xy))
+    }
+
+    state[a] = fblamka(state[a], state[b]);
+    state[d] = (state[d] ^ state[a]).rotate_right(32);
+    state[c] = fblamka(state[c], state[d]);
+    state[b] = (state[b] ^ state[c]).rotate_right(24);
+    state[a] = fblamka(state[a], state[b]);
+    state[d] = (state[d] ^ state[a]).rotate_right(16);
+    state[c] = fblamka(state[c], state[d]);
+    state[b] = (state[b] ^ state[c]).rotate_right(63);
+}
+
+/// Apply the round function `P` to a 16-lane (128-byte) row. RFC 9106 §3.6.
+#[inline(always)]
+fn blamka_round(s: &mut [u64; 16]) {
+    blamka_g(s, 0, 4, 8, 12);
+    blamka_g(s, 1, 5, 9, 13);
+    blamka_g(s, 2, 6, 10, 14);
+    blamka_g(s, 3, 7, 11, 15);
+
+    blamka_g(s, 0, 5, 10, 15);
+    blamka_g(s, 1, 6, 11, 12);
+    blamka_g(s, 2, 7, 8, 13);
+    blamka_g(s, 3, 4, 9, 14);
+}
+
+/// Argon2 compression `G(X, Y) -> Z`.
+///
+/// 1. R = X xor Y
+/// 2. Apply `P` row-wise (8 rows of 16 lanes), then column-wise (8 cols of
+///    16 lanes), to a temporary copy `Q` of `R`.
+/// 3. Z = R xor Q.
+fn argon2_g(x: &Block, y: &Block, out: &mut Block) {
+    // R = X xor Y
+    let mut r = [0u64; 128];
+    for (slot, (xv, yv)) in r.iter_mut().zip(x.0.iter().zip(y.0.iter())) {
+        *slot = *xv ^ *yv;
+    }
+
+    let mut q = r;
+
+    // Row passes: 8 rows × 16 lanes.
+    for row in 0..8 {
+        let off = row * 16;
+        let mut s: [u64; 16] = q[off..off + 16].try_into().unwrap();
+        blamka_round(&mut s);
+        q[off..off + 16].copy_from_slice(&s);
+    }
+
+    // Column passes: 8 columns × 16 lanes (each column is 8 rows × 2 lanes).
+    // Column j gathers lanes at positions {2j, 2j+1, 2j+16, 2j+17, ...}.
+    for col in 0..8 {
+        let mut s = [0u64; 16];
+        for k in 0..8 {
+            s[2 * k] = q[2 * col + 16 * k];
+            s[2 * k + 1] = q[2 * col + 1 + 16 * k];
+        }
+        blamka_round(&mut s);
+        for k in 0..8 {
+            q[2 * col + 16 * k] = s[2 * k];
+            q[2 * col + 1 + 16 * k] = s[2 * k + 1];
+        }
+    }
+
+    // Z = R xor Q
+    for i in 0..128 {
+        out.0[i] = r[i] ^ q[i];
+    }
+}
+
+// ─── Initial state H_0 (RFC 9106 §3.2 steps 4–5) ─────────────────────────────
+
+/// Compute the 64-byte H_0 seed used to initialize the first two columns
+/// of every lane. The hashed input is the concatenation:
+///
+/// LE32(p) || LE32(T) || LE32(m) || LE32(t) || LE32(v) || LE32(y) ||
+/// LE32(|P|) || P || LE32(|S|) || S || LE32(|K|) || K || LE32(|X|) || X
+fn h_zero(
+    pwd: &[u8],
+    salt: &[u8],
+    secret: &[u8],
+    associated: &[u8],
+    params: &Argon2idParams,
+    tag_len: u32,
+) -> [u8; BLAKE2B_OUT_MAX] {
+    let mut h = Blake2b::new(BLAKE2B_OUT_MAX);
+    h.update(&params.p_cost.to_le_bytes());
+    h.update(&tag_len.to_le_bytes());
+    h.update(&params.m_cost_kib.to_le_bytes());
+    h.update(&params.t_cost.to_le_bytes());
+    h.update(&ARGON2_VERSION.to_le_bytes());
+    h.update(&ARGON2ID_TYPE.to_le_bytes());
+    h.update(&(pwd.len() as u32).to_le_bytes());
+    h.update(pwd);
+    h.update(&(salt.len() as u32).to_le_bytes());
+    h.update(salt);
+    h.update(&(secret.len() as u32).to_le_bytes());
+    h.update(secret);
+    h.update(&(associated.len() as u32).to_le_bytes());
+    h.update(associated);
+    let mut out = [0u8; BLAKE2B_OUT_MAX];
+    let _ = h.finalize_into(&mut out);
+    out
+}
+
+// ─── Indexing helpers (RFC 9106 §3.4) ────────────────────────────────────────
+
+/// Compute `J1, J2` from a 64-bit pseudo-random value as specified in
+/// RFC 9106 §3.4.
+fn split_j(rand: u64) -> (u32, u32) {
+    let j1 = (rand & 0xFFFF_FFFF) as u32;
+    let j2 = (rand >> 32) as u32;
+    (j1, j2)
+}
+
+/// Position context passed to [`index_alpha`].
+struct Position {
+    pass: u32,
+    lane: u32,
+    slice: u32,
+    /// Column index within the segment.
+    index: u32,
+}
+
+/// Memory dimensions passed to [`index_alpha`].
+struct Dimensions {
+    lane_length: u32,
+    segment_length: u32,
+    p_cost: u32,
+}
+
+/// Determine the reference (lane, column) from `(J1, J2)` per RFC 9106 §3.4.2.
+fn index_alpha(pos: &Position, dim: &Dimensions, j1: u32, j2: u32) -> (u32, u32) {
+    // Step 1: select reference lane.
+    let ref_lane = if pos.pass == 0 && pos.slice == 0 {
+        // First slice of the first pass: must be the current lane.
+        pos.lane
+    } else {
+        j2 % dim.p_cost
+    };
+
+    // Step 2: number of reference blocks in the lane.
+    let ref_area_size = if pos.pass == 0 {
+        if pos.slice == 0 {
+            pos.index - 1
+        } else if ref_lane == pos.lane {
+            pos.slice * dim.segment_length + pos.index - 1
+        } else {
+            pos.slice * dim.segment_length - u32::from(pos.index == 0)
+        }
+    } else if ref_lane == pos.lane {
+        dim.lane_length - dim.segment_length + pos.index - 1
+    } else {
+        dim.lane_length - dim.segment_length - u32::from(pos.index == 0)
+    };
+
+    // Step 3: relative position within the reference area.
+    let mut rel = j1 as u64;
+    rel = (rel * rel) >> 32;
+    rel = (ref_area_size as u64 * rel) >> 32;
+    let rel = ref_area_size as u64 - 1 - rel;
+
+    // Step 4: starting position depends on pass.
+    let start_pos = if pos.pass != 0 && pos.slice != SYNC_POINTS as u32 - 1 {
+        ((pos.slice + 1) * dim.segment_length) as u64
+    } else {
+        0u64
+    };
+    let abs_pos = ((start_pos + rel) % dim.lane_length as u64) as u32;
+
+    (ref_lane, abs_pos)
+}
+
+// ─── Pseudo-random stream for data-independent indexing (Argon2id) ────────────
+
+/// Address-block generator for Argon2id's data-independent indexing.
+///
+/// RFC 9106 §3.4.1.2 and the phc-winner-argon2 reference: a fresh block of
+/// 128 64-bit pseudo-random values is generated by `G(0, G(0, IN))` where
+/// `IN` encodes `(pass, lane, slice, m', t, type, counter, 0...)` and
+/// `counter` increments every 128 values.
+///
+/// The values are *indexed* by the position `i` within the segment (i % 128),
+/// matching the reference. The internal `current_counter` tracks which input
+/// counter produced the cached address block.
+struct G2Stream {
+    pass: u64,
+    lane: u64,
+    slice: u64,
+    blocks_total: u64,
+    t_cost: u64,
+    /// Counter value of the last block we computed (0 means none yet).
+    current_counter: u64,
+    address: Block,
+}
+
+impl G2Stream {
+    fn new(pass: u32, lane: u32, slice: u32, blocks_total: u32, t_cost: u32) -> Self {
+        Self {
+            pass: pass as u64,
+            lane: lane as u64,
+            slice: slice as u64,
+            blocks_total: blocks_total as u64,
+            t_cost: t_cost as u64,
+            current_counter: 0,
+            address: Block::zero(),
+        }
+    }
+
+    /// Compute the address block for the given `counter` value (1-based) and
+    /// cache it.
+    fn fill_for_counter(&mut self, counter: u64) {
+        debug_assert!(counter >= 1);
+        if self.current_counter == counter {
+            return;
+        }
+
+        let mut input = Block::zero();
+        input.0[0] = self.pass;
+        input.0[1] = self.lane;
+        input.0[2] = self.slice;
+        input.0[3] = self.blocks_total;
+        input.0[4] = self.t_cost;
+        input.0[5] = ARGON2ID_TYPE as u64;
+        input.0[6] = counter;
+        // remaining lanes zero
+
+        let zero = Block::zero();
+        let mut tmp = Block::zero();
+        argon2_g(&zero, &input, &mut tmp);
+        argon2_g(&zero, &tmp, &mut self.address);
+        self.current_counter = counter;
+    }
+
+    /// Return the J value at position `i` within the segment.
+    fn j_at(&mut self, i: u32) -> u64 {
+        let counter = (i / 128) as u64 + 1;
+        self.fill_for_counter(counter);
+        self.address.0[(i % 128) as usize]
+    }
+}
+
+// ─── Memory fill (RFC 9106 §3.2 step 6, §3.4) ────────────────────────────────
+
+/// Argon2id memory matrix indexed as `mem[row]` where
+/// `row = lane * lane_length + col`.
+struct Memory {
+    blocks: Vec<Block>,
+    lane_length: u32,
+    segment_length: u32,
+    blocks_total: u32,
+    p_cost: u32,
+    t_cost: u32,
+}
+
+impl Memory {
+    fn new(params: &Argon2idParams) -> Self {
+        // Per RFC 9106 §3.2 step 2: m' = 4 * p * floor(m / 4p)
+        let blocks_total = 4 * params.p_cost * (params.m_cost_kib / (4 * params.p_cost));
+        let lane_length = blocks_total / params.p_cost;
+        let segment_length = lane_length / SYNC_POINTS as u32;
+
+        Self {
+            blocks: vec![Block::zero(); blocks_total as usize],
+            lane_length,
+            segment_length,
+            blocks_total,
+            p_cost: params.p_cost,
+            t_cost: params.t_cost,
+        }
+    }
+
+    fn at(&self, lane: u32, col: u32) -> &Block {
+        &self.blocks[(lane * self.lane_length + col) as usize]
+    }
+
+    fn at_mut(&mut self, lane: u32, col: u32) -> &mut Block {
+        &mut self.blocks[(lane * self.lane_length + col) as usize]
+    }
+
+    /// Initialize columns 0 and 1 of every lane (RFC 9106 §3.2 step 5).
+    fn init_first_two_columns(&mut self, h0: &[u8; BLAKE2B_OUT_MAX]) {
+        let mut buf = [0u8; ARGON2_BLOCK_BYTES];
+        for lane in 0..self.p_cost {
+            // B[i][0] = H'(H_0 || LE32(0) || LE32(i))
+            h_prime(
+                ARGON2_BLOCK_BYTES as u32,
+                &[h0, &0u32.to_le_bytes(), &lane.to_le_bytes()],
+                &mut buf,
+            );
+            *self.at_mut(lane, 0) = Block::from_bytes(&buf);
+
+            // B[i][1] = H'(H_0 || LE32(1) || LE32(i))
+            h_prime(
+                ARGON2_BLOCK_BYTES as u32,
+                &[h0, &1u32.to_le_bytes(), &lane.to_le_bytes()],
+                &mut buf,
+            );
+            *self.at_mut(lane, 1) = Block::from_bytes(&buf);
+        }
+    }
+
+    /// Fill a single segment `(pass, lane, slice)`. RFC 9106 §3.4.
+    fn fill_segment(&mut self, pass: u32, lane: u32, slice: u32) {
+        let data_independent = pass == 0 && slice < (SYNC_POINTS as u32) / 2;
+        let mut g2 = if data_independent {
+            Some(G2Stream::new(
+                pass,
+                lane,
+                slice,
+                self.blocks_total,
+                self.t_cost,
+            ))
+        } else {
+            None
+        };
+
+        // Starting column within this segment.
+        let start_col = if pass == 0 && slice == 0 { 2u32 } else { 0u32 };
+
+        for i in start_col..self.segment_length {
+            let curr_col = slice * self.segment_length + i;
+            let prev_col = if curr_col == 0 {
+                self.lane_length - 1
+            } else {
+                curr_col - 1
+            };
+
+            // Determine (J1, J2).
+            let (j1, j2) = if let Some(stream) = g2.as_mut() {
+                split_j(stream.j_at(i))
+            } else {
+                let prev = self.at(lane, prev_col);
+                split_j(prev.0[0])
+            };
+
+            let (ref_lane, ref_col) = index_alpha(
+                &Position {
+                    pass,
+                    lane,
+                    slice,
+                    index: i,
+                },
+                &Dimensions {
+                    lane_length: self.lane_length,
+                    segment_length: self.segment_length,
+                    p_cost: self.p_cost,
+                },
+                j1,
+                j2,
+            );
+
+            // Compute new block: G(B[lane][prev_col], B[ref_lane][ref_col]).
+            let prev_block = *self.at(lane, prev_col);
+            let ref_block = *self.at(ref_lane, ref_col);
+            let mut new_block = Block::zero();
+            argon2_g(&prev_block, &ref_block, &mut new_block);
+
+            if pass > 0 {
+                // Subsequent passes: XOR into existing block.
+                let curr = self.at_mut(lane, curr_col);
+                curr.xor_assign(&new_block);
+            } else {
+                *self.at_mut(lane, curr_col) = new_block;
+            }
+        }
+    }
+
+    /// Run all passes over the memory matrix. RFC 9106 §3.2 step 6.
+    fn fill(&mut self) {
+        for pass in 0..self.t_cost {
+            for slice in 0..SYNC_POINTS as u32 {
+                // RFC 9106 specifies lanes within a slice may be filled in
+                // parallel. Sequential is conformant; parallelism is a
+                // performance optimization deferred along with the SIMD
+                // shims (Q30).
+                for lane in 0..self.p_cost {
+                    self.fill_segment(pass, lane, slice);
+                }
+            }
+        }
+    }
+
+    /// Final block C = B[0][lane_length-1] xor ... xor B[p-1][lane_length-1].
+    fn finalize_block(&self) -> Block {
+        let mut c = *self.at(0, self.lane_length - 1);
+        for lane in 1..self.p_cost {
+            c.xor_assign(self.at(lane, self.lane_length - 1));
+        }
+        c
+    }
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/// Compute the Argon2id 32-byte tag.
+///
+/// `password` and `salt` are provided. RFC 9106 also accepts an optional
+/// secret (`K`) and associated data (`X`); the management-login API does
+/// not use either, so we pass empty slices. Use [`argon2id_hash_full`] for
+/// the full RFC 9106 surface.
+///
+/// # Panics
+///
+/// Panics if parameters are invalid. Use [`Argon2idParams::validate`] or
+/// [`argon2id_hash_full`] for a fallible variant.
+pub fn argon2id_hash(
+    password: &[u8],
+    salt: &[u8],
+    params: Argon2idParams,
+) -> [u8; ARGON2ID_TAG_LEN] {
+    argon2id_hash_full(password, salt, &[], &[], params, ARGON2ID_TAG_LEN)
+        .expect("argon2id: invalid parameters or salt length")
+        .try_into()
+        .expect("argon2id: tag length mismatch")
+}
+
+/// Full Argon2id surface (RFC 9106): password, salt, optional secret,
+/// optional associated data, parameters, and configurable tag length.
+pub fn argon2id_hash_full(
+    password: &[u8],
+    salt: &[u8],
+    secret: &[u8],
+    associated: &[u8],
+    params: Argon2idParams,
+    tag_len: usize,
+) -> Result<Vec<u8>, Error> {
+    if salt.len() < 8 {
+        return Err(Error::InvalidSalt);
+    }
+    if !(4..=BLAKE2B_OUT_MAX * 2).contains(&tag_len) {
+        return Err(Error::InvalidTagLength);
+    }
+    params.validate()?;
+
+    let h0 = h_zero(password, salt, secret, associated, &params, tag_len as u32);
+
+    let mut mem = Memory::new(&params);
+    mem.init_first_two_columns(&h0);
+    mem.fill();
+    let final_block = mem.finalize_block();
+
+    let mut final_bytes = [0u8; ARGON2_BLOCK_BYTES];
+    final_block.write_bytes(&mut final_bytes);
+
+    let mut tag = vec![0u8; tag_len];
+    h_prime(tag_len as u32, &[&final_bytes], &mut tag);
+    Ok(tag)
+}
+
+/// Verify a password against a PHC-formatted Argon2id hash.
+///
+/// Returns `Ok(true)` if the password matches, `Ok(false)` if it does not,
+/// or `Err` if the PHC string is malformed.
+pub fn argon2id_verify(password: &[u8], phc_string: &str) -> Result<bool, Error> {
+    let parsed = parse_phc(phc_string)?;
+    let tag = argon2id_hash_full(
+        password,
+        &parsed.salt,
+        &[],
+        &[],
+        parsed.params,
+        parsed.tag.len(),
+    )?;
+    Ok(ct_eq(&tag, &parsed.tag).to_bool())
+}
+
+/// Format an Argon2id PHC string per `phc-string-format` v1.0:
+///
+/// ```text
+/// $argon2id$v=19$m=<m>,t=<t>,p=<p>$<base64-salt>$<base64-tag>
+/// ```
+///
+/// Base64 is the unpadded variant (`=` removed) per the PHC spec.
+pub fn argon2id_format_phc(
+    salt: &[u8],
+    tag: &[u8; ARGON2ID_TAG_LEN],
+    params: Argon2idParams,
+) -> String {
+    let mut s = String::new();
+    s.push_str("$argon2id$v=19$m=");
+    push_u32(&mut s, params.m_cost_kib);
+    s.push_str(",t=");
+    push_u32(&mut s, params.t_cost);
+    s.push_str(",p=");
+    push_u32(&mut s, params.p_cost);
+    s.push('$');
+    push_b64(&mut s, salt);
+    s.push('$');
+    push_b64(&mut s, tag);
+    s
+}
+
+// ─── PHC parser ──────────────────────────────────────────────────────────────
+
+struct ParsedPhc {
+    params: Argon2idParams,
+    salt: Vec<u8>,
+    tag: Vec<u8>,
+}
+
+fn parse_phc(s: &str) -> Result<ParsedPhc, Error> {
+    // $argon2id$v=19$m=<m>,t=<t>,p=<p>$<salt>$<tag>
+    let mut parts = s.split('$');
+    if parts.next() != Some("") {
+        return Err(Error::InvalidPhc);
+    }
+    if parts.next() != Some("argon2id") {
+        return Err(Error::UnsupportedVariant);
+    }
+    let v_part = parts.next().ok_or(Error::InvalidPhc)?;
+    if v_part != "v=19" {
+        return Err(Error::UnsupportedVersion);
+    }
+    let pp = parts.next().ok_or(Error::InvalidPhc)?;
+    let salt_b64 = parts.next().ok_or(Error::InvalidPhc)?;
+    let tag_b64 = parts.next().ok_or(Error::InvalidPhc)?;
+    if parts.next().is_some() {
+        return Err(Error::InvalidPhc);
+    }
+
+    // Parse "m=<m>,t=<t>,p=<p>". Allow any field order for PHC compatibility.
+    let mut m: Option<u32> = None;
+    let mut t: Option<u32> = None;
+    let mut p: Option<u32> = None;
+    for kv in pp.split(',') {
+        let mut it = kv.splitn(2, '=');
+        let k = it.next().ok_or(Error::InvalidPhc)?;
+        let v = it.next().ok_or(Error::InvalidPhc)?;
+        let n: u32 = parse_u32(v).ok_or(Error::InvalidPhc)?;
+        match k {
+            "m" => m = Some(n),
+            "t" => t = Some(n),
+            "p" => p = Some(n),
+            _ => return Err(Error::InvalidPhc),
+        }
+    }
+
+    let params = Argon2idParams {
+        m_cost_kib: m.ok_or(Error::InvalidPhc)?,
+        t_cost: t.ok_or(Error::InvalidPhc)?,
+        p_cost: p.ok_or(Error::InvalidPhc)?,
+    };
+    params.validate()?;
+
+    let salt = b64_decode(salt_b64)?;
+    let tag = b64_decode(tag_b64)?;
+    if salt.len() < 8 {
+        return Err(Error::InvalidSalt);
+    }
+    if !(4..=BLAKE2B_OUT_MAX * 2).contains(&tag.len()) {
+        return Err(Error::InvalidTagLength);
+    }
+
+    Ok(ParsedPhc { params, salt, tag })
+}
+
+fn parse_u32(s: &str) -> Option<u32> {
+    if s.is_empty() {
+        return None;
+    }
+    let mut n: u32 = 0;
+    for c in s.chars() {
+        let d = c.to_digit(10)?;
+        n = n.checked_mul(10)?.checked_add(d)?;
+    }
+    Some(n)
+}
+
+fn push_u32(s: &mut String, mut n: u32) {
+    if n == 0 {
+        s.push('0');
+        return;
+    }
+    let mut buf = [0u8; 10];
+    let mut len = 0;
+    while n > 0 {
+        buf[len] = b'0' + (n % 10) as u8;
+        n /= 10;
+        len += 1;
+    }
+    for i in (0..len).rev() {
+        s.push(buf[i] as char);
+    }
+}
+
+// ─── Base64 (PHC unpadded) ───────────────────────────────────────────────────
+
+const B64_CHARS: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+fn push_b64(out: &mut String, input: &[u8]) {
+    let mut i = 0;
+    while i + 3 <= input.len() {
+        let n = ((input[i] as u32) << 16) | ((input[i + 1] as u32) << 8) | (input[i + 2] as u32);
+        out.push(B64_CHARS[((n >> 18) & 0x3F) as usize] as char);
+        out.push(B64_CHARS[((n >> 12) & 0x3F) as usize] as char);
+        out.push(B64_CHARS[((n >> 6) & 0x3F) as usize] as char);
+        out.push(B64_CHARS[(n & 0x3F) as usize] as char);
+        i += 3;
+    }
+    let rem = input.len() - i;
+    if rem == 1 {
+        let n = (input[i] as u32) << 16;
+        out.push(B64_CHARS[((n >> 18) & 0x3F) as usize] as char);
+        out.push(B64_CHARS[((n >> 12) & 0x3F) as usize] as char);
+    } else if rem == 2 {
+        let n = ((input[i] as u32) << 16) | ((input[i + 1] as u32) << 8);
+        out.push(B64_CHARS[((n >> 18) & 0x3F) as usize] as char);
+        out.push(B64_CHARS[((n >> 12) & 0x3F) as usize] as char);
+        out.push(B64_CHARS[((n >> 6) & 0x3F) as usize] as char);
+    }
+}
+
+fn b64_decode(s: &str) -> Result<Vec<u8>, Error> {
+    fn val(c: u8) -> Result<u8, Error> {
+        match c {
+            b'A'..=b'Z' => Ok(c - b'A'),
+            b'a'..=b'z' => Ok(c - b'a' + 26),
+            b'0'..=b'9' => Ok(c - b'0' + 52),
+            b'+' => Ok(62),
+            b'/' => Ok(63),
+            _ => Err(Error::Base64Decode),
+        }
+    }
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len() * 3 / 4);
+    let mut i = 0;
+    while i + 4 <= bytes.len() {
+        let a = val(bytes[i])?;
+        let b = val(bytes[i + 1])?;
+        let c = val(bytes[i + 2])?;
+        let d = val(bytes[i + 3])?;
+        let n = ((a as u32) << 18) | ((b as u32) << 12) | ((c as u32) << 6) | (d as u32);
+        out.push(((n >> 16) & 0xFF) as u8);
+        out.push(((n >> 8) & 0xFF) as u8);
+        out.push((n & 0xFF) as u8);
+        i += 4;
+    }
+    let rem = bytes.len() - i;
+    if rem == 1 {
+        return Err(Error::Base64Decode);
+    } else if rem == 2 {
+        let a = val(bytes[i])?;
+        let b = val(bytes[i + 1])?;
+        let n = ((a as u32) << 18) | ((b as u32) << 12);
+        out.push(((n >> 16) & 0xFF) as u8);
+    } else if rem == 3 {
+        let a = val(bytes[i])?;
+        let b = val(bytes[i + 1])?;
+        let c = val(bytes[i + 2])?;
+        let n = ((a as u32) << 18) | ((b as u32) << 12) | ((c as u32) << 6);
+        out.push(((n >> 16) & 0xFF) as u8);
+        out.push(((n >> 8) & 0xFF) as u8);
+    }
+    Ok(out)
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// RFC 9106 §5.3 Argon2id reference test vector.
+    ///
+    /// Parameters: t=3, m=32, p=4, version=0x13, type=Argon2id.
+    /// Password: 32 bytes of 0x01.
+    /// Salt: 16 bytes of 0x02.
+    /// Secret: 8 bytes of 0x03.
+    /// Associated data: 12 bytes of 0x04.
+    /// Tag length: 32.
+    /// Expected tag (RFC 9106 §5.3):
+    ///   0d 64 0d f5 8d 78 76 6c  08 c0 37 a3 4a 8b 53 c9
+    ///   d0 1e f0 45 2d 75 b6 5e  b5 25 20 e9 6b 01 e6 59
+    #[test]
+    fn rfc9106_section5_3_argon2id_kat() {
+        let password = [0x01u8; 32];
+        let salt = [0x02u8; 16];
+        let secret = [0x03u8; 8];
+        let ad = [0x04u8; 12];
+        let params = Argon2idParams {
+            m_cost_kib: 32,
+            t_cost: 3,
+            p_cost: 4,
+        };
+        let expected: [u8; 32] = [
+            0x0D, 0x64, 0x0D, 0xF5, 0x8D, 0x78, 0x76, 0x6C, 0x08, 0xC0, 0x37, 0xA3, 0x4A, 0x8B,
+            0x53, 0xC9, 0xD0, 0x1E, 0xF0, 0x45, 0x2D, 0x75, 0xB6, 0x5E, 0xB5, 0x25, 0x20, 0xE9,
+            0x6B, 0x01, 0xE6, 0x59,
+        ];
+        let tag = argon2id_hash_full(&password, &salt, &secret, &ad, params, 32).unwrap();
+        assert_eq!(tag.as_slice(), &expected[..]);
+    }
+
+    /// PHC round-trip: hash a password, format, parse, verify.
+    #[test]
+    fn phc_round_trip() {
+        let password = b"correct horse battery staple";
+        let salt = b"saltsalt12345678";
+        // Use the absolute-minimum tier to keep tests fast.
+        let params = Argon2idParams {
+            m_cost_kib: 8,
+            t_cost: 1,
+            p_cost: 1,
+        };
+        let tag = argon2id_hash(password, salt, params);
+        let phc = argon2id_format_phc(salt, &tag, params);
+
+        // Format check.
+        assert!(phc.starts_with("$argon2id$v=19$m=8,t=1,p=1$"));
+
+        // Verify success.
+        assert!(argon2id_verify(password, &phc).unwrap());
+
+        // Different password fails.
+        assert!(!argon2id_verify(b"wrong password", &phc).unwrap());
+    }
+
+    /// Tier constructors return valid parameters.
+    #[test]
+    fn tier_defaults_are_valid() {
+        Argon2idParams::tiny().validate().unwrap();
+        Argon2idParams::default_tier().validate().unwrap();
+        Argon2idParams::strong().validate().unwrap();
+    }
+
+    /// Salt < 8 bytes is rejected.
+    #[test]
+    fn short_salt_rejected() {
+        let params = Argon2idParams {
+            m_cost_kib: 8,
+            t_cost: 1,
+            p_cost: 1,
+        };
+        let r = argon2id_hash_full(b"pw", b"short", &[], &[], params, 32);
+        assert!(matches!(r, Err(Error::InvalidSalt)));
+    }
+
+    /// Cross-check against the upstream `argon2` crate (validation oracle).
+    /// Uses very small parameters to keep the test fast.
+    #[test]
+    fn argon2_oracle_matches() {
+        use argon2::{Algorithm, Argon2, Params, Version};
+
+        for &(m, t, p) in &[(8u32, 1u32, 1u32), (16, 2, 1), (32, 3, 2)] {
+            let password = b"oracle-test-password";
+            let salt = b"oracle-test-saltX"; // 17 bytes ≥ 8
+            let params = Argon2idParams {
+                m_cost_kib: m,
+                t_cost: t,
+                p_cost: p,
+            };
+            let mine = argon2id_hash(password, salt, params);
+
+            let oracle_params = Params::new(m, t, p, Some(32)).unwrap();
+            let oracle = Argon2::new(Algorithm::Argon2id, Version::V0x13, oracle_params);
+            let mut oracle_out = [0u8; 32];
+            oracle
+                .hash_password_into(password, salt, &mut oracle_out)
+                .unwrap();
+            assert_eq!(mine, oracle_out, "mismatch m={} t={} p={}", m, t, p);
+        }
+    }
+
+    /// PHC string from this implementation must verify under the upstream
+    /// `argon2` crate so the on-disk format is interoperable.
+    #[test]
+    fn phc_interoperates_with_oracle() {
+        use argon2::password_hash::{PasswordHash, PasswordVerifier};
+        use argon2::Argon2;
+
+        let password = b"interop-test";
+        let salt = b"interop-saltAAAAAAAA";
+        let params = Argon2idParams {
+            m_cost_kib: 16,
+            t_cost: 2,
+            p_cost: 1,
+        };
+        let tag = argon2id_hash(password, salt, params);
+        let phc = argon2id_format_phc(salt, &tag, params);
+
+        let parsed = PasswordHash::new(&phc).expect("oracle should parse our PHC");
+        let verifier = Argon2::default();
+        verifier
+            .verify_password(password, &parsed)
+            .expect("oracle should verify our PHC");
+    }
+
+    /// Parameter sweep for the portable path: small grid of (m, t, p)
+    /// must all complete without panicking and produce 32-byte tags.
+    #[test]
+    fn parameter_sweep() {
+        let password = b"sweep";
+        let salt = b"sweepsalt0000000";
+        for &m in &[8u32, 16, 32] {
+            for &t in &[1u32, 2] {
+                for &p in &[1u32, 2] {
+                    if m < 8 * p {
+                        continue;
+                    }
+                    let params = Argon2idParams {
+                        m_cost_kib: m,
+                        t_cost: t,
+                        p_cost: p,
+                    };
+                    let tag = argon2id_hash(password, salt, params);
+                    assert_eq!(tag.len(), 32);
+                }
+            }
+        }
+    }
+
+    /// Base64 round-trip without padding.
+    #[test]
+    fn b64_round_trip() {
+        for input in [&b""[..], b"f", b"fo", b"foo", b"foob", b"fooba", b"foobar"] {
+            let mut s = String::new();
+            push_b64(&mut s, input);
+            let decoded = b64_decode(&s).unwrap();
+            assert_eq!(&decoded[..], input);
+        }
+    }
+
+    /// PHC parser rejects malformed inputs.
+    #[test]
+    fn phc_parser_rejects_bad_inputs() {
+        assert!(matches!(
+            parse_phc("$argon2id$v=19$m=8,t=1,p=1$YWFhYWFhYWE"),
+            Err(Error::InvalidPhc)
+        ));
+        assert!(matches!(
+            parse_phc("$argon2i$v=19$m=8,t=1,p=1$YWFhYWFhYWE$abcd"),
+            Err(Error::UnsupportedVariant)
+        ));
+        assert!(matches!(
+            parse_phc("$argon2id$v=18$m=8,t=1,p=1$YWFhYWFhYWE$abcd"),
+            Err(Error::UnsupportedVersion)
+        ));
+    }
+}

--- a/security/src/argon2id.rs
+++ b/security/src/argon2id.rs
@@ -838,7 +838,8 @@ fn parse_u32(s: &str) -> Option<u32> {
     if s.is_empty() {
         return None;
     }
-    let mut n: u32 = 0; // lgtm[rust/hard-coded-cryptographic-value] integer accumulator, not a secret
+    // lgtm[rust/hard-coded-cryptographic-value] — integer accumulator, not a secret
+    let mut n: u32 = 0;
     for c in s.chars() {
         let d = c.to_digit(10)?;
         n = n.checked_mul(10)?.checked_add(d)?;
@@ -896,12 +897,18 @@ fn b64_decode(s: &str) -> Result<Vec<u8>, Error> {
     // RFC 4648 Table 1. CodeQL's `rust/hard-coded-cryptographic-value` rule
     // misclassifies these as cryptographic secrets; they are not.
     fn val(c: u8) -> Result<u8, Error> {
+        // lgtm[rust/hard-coded-cryptographic-value] — RFC 4648 base64 alphabet, not a secret
         match c {
-            b'A'..=b'Z' => Ok(c - b'A'), // lgtm[rust/hard-coded-cryptographic-value] RFC 4648 base64 alphabet, not a secret
-            b'a'..=b'z' => Ok(c - b'a' + 26), // lgtm[rust/hard-coded-cryptographic-value] RFC 4648 base64 alphabet, not a secret
-            b'0'..=b'9' => Ok(c - b'0' + 52), // lgtm[rust/hard-coded-cryptographic-value] RFC 4648 base64 alphabet, not a secret
-            b'+' => Ok(62), // lgtm[rust/hard-coded-cryptographic-value] RFC 4648 base64 alphabet, not a secret
-            b'/' => Ok(63), // lgtm[rust/hard-coded-cryptographic-value] RFC 4648 base64 alphabet, not a secret
+            // lgtm[rust/hard-coded-cryptographic-value] — RFC 4648 base64 alphabet, not a secret
+            b'A'..=b'Z' => Ok(c - b'A'),
+            // lgtm[rust/hard-coded-cryptographic-value] — RFC 4648 base64 alphabet, not a secret
+            b'a'..=b'z' => Ok(c - b'a' + 26),
+            // lgtm[rust/hard-coded-cryptographic-value] — RFC 4648 base64 alphabet, not a secret
+            b'0'..=b'9' => Ok(c - b'0' + 52),
+            // lgtm[rust/hard-coded-cryptographic-value] — RFC 4648 base64 alphabet, not a secret
+            b'+' => Ok(62),
+            // lgtm[rust/hard-coded-cryptographic-value] — RFC 4648 base64 alphabet, not a secret
+            b'/' => Ok(63),
             _ => Err(Error::Base64Decode),
         }
     }
@@ -958,10 +965,14 @@ mod tests {
     #[test]
     fn rfc9106_section5_3_argon2id_kat() {
         // RFC 9106 §5.3 reference vector — deterministic test fixtures, not production secrets.
-        let password = [0x01u8; 32]; // lgtm[rust/hard-coded-cryptographic-value] RFC 9106 §5.3 test vector
-        let salt = [0x02u8; 16]; // lgtm[rust/hard-coded-cryptographic-value] RFC 9106 §5.3 test vector
-        let secret = [0x03u8; 8]; // lgtm[rust/hard-coded-cryptographic-value] RFC 9106 §5.3 test vector
-        let ad = [0x04u8; 12]; // lgtm[rust/hard-coded-cryptographic-value] RFC 9106 §5.3 test vector
+        // lgtm[rust/hard-coded-cryptographic-value] — RFC 9106 §5.3 test vector
+        let password = [0x01u8; 32];
+        // lgtm[rust/hard-coded-cryptographic-value] — RFC 9106 §5.3 test vector
+        let salt = [0x02u8; 16];
+        // lgtm[rust/hard-coded-cryptographic-value] — RFC 9106 §5.3 test vector
+        let secret = [0x03u8; 8];
+        // lgtm[rust/hard-coded-cryptographic-value] — RFC 9106 §5.3 test vector
+        let ad = [0x04u8; 12];
         let params = Argon2idParams {
             m_cost_kib: 32,
             t_cost: 3,
@@ -981,8 +992,10 @@ mod tests {
     fn phc_round_trip() {
         // Test-only fixtures, not production secrets.
         // Use the absolute-minimum tier to keep tests fast.
-        let password = b"correct horse battery staple"; // lgtm[rust/hard-coded-cryptographic-value] test fixture
-        let salt = b"saltsalt12345678"; // lgtm[rust/hard-coded-cryptographic-value] test fixture
+        // lgtm[rust/hard-coded-cryptographic-value] — test fixture
+        let password = b"correct horse battery staple";
+        // lgtm[rust/hard-coded-cryptographic-value] — test fixture
+        let salt = b"saltsalt12345678";
         let params = Argon2idParams {
             m_cost_kib: 8,
             t_cost: 1,
@@ -998,7 +1011,8 @@ mod tests {
         assert!(argon2id_verify(password, &phc).unwrap());
 
         // Different password fails.
-        assert!(!argon2id_verify(b"wrong password", &phc).unwrap()); // lgtm[rust/hard-coded-cryptographic-value] negative-case test fixture
+        // lgtm[rust/hard-coded-cryptographic-value] — negative-case test fixture
+        assert!(!argon2id_verify(b"wrong password", &phc).unwrap());
     }
 
     /// Tier constructors return valid parameters.
@@ -1014,10 +1028,11 @@ mod tests {
     fn short_salt_rejected() {
         // Test-only Argon2id parameters, not a secret.
         let params = Argon2idParams {
-            m_cost_kib: 8, // lgtm[rust/hard-coded-cryptographic-value] test parameter
+            m_cost_kib: 8,
             t_cost: 1,
             p_cost: 1,
         };
+        // lgtm[rust/hard-coded-cryptographic-value] — short-salt negative-case test fixture
         let r = argon2id_hash_full(b"pw", b"short", &[], &[], params, 32);
         assert!(matches!(r, Err(Error::InvalidSalt)));
     }
@@ -1030,8 +1045,11 @@ mod tests {
 
         for &(m, t, p) in &[(8u32, 1u32, 1u32), (16, 2, 1), (32, 3, 2)] {
             // Oracle-comparison test fixtures, not production secrets.
-            let password = b"oracle-test-password"; // lgtm[rust/hard-coded-cryptographic-value] test fixture
-            let salt = b"oracle-test-saltX"; // 17 bytes ≥ 8 — lgtm[rust/hard-coded-cryptographic-value] test fixture
+            // lgtm[rust/hard-coded-cryptographic-value] — test fixture
+            let password = b"oracle-test-password";
+            // 17 bytes ≥ 8.
+            // lgtm[rust/hard-coded-cryptographic-value] — test fixture
+            let salt = b"oracle-test-saltX";
             let params = Argon2idParams {
                 m_cost_kib: m,
                 t_cost: t,
@@ -1057,8 +1075,10 @@ mod tests {
         use argon2::Argon2;
 
         // PHC interop test fixtures, not production secrets.
-        let password = b"interop-test"; // lgtm[rust/hard-coded-cryptographic-value] test fixture
-        let salt = b"interop-saltAAAAAAAA"; // lgtm[rust/hard-coded-cryptographic-value] test fixture
+        // lgtm[rust/hard-coded-cryptographic-value] — test fixture
+        let password = b"interop-test";
+        // lgtm[rust/hard-coded-cryptographic-value] — test fixture
+        let salt = b"interop-saltAAAAAAAA";
         let params = Argon2idParams {
             m_cost_kib: 16,
             t_cost: 2,
@@ -1079,8 +1099,10 @@ mod tests {
     #[test]
     fn parameter_sweep() {
         // Parameter-sweep test fixtures, not production secrets.
-        let password = b"sweep"; // lgtm[rust/hard-coded-cryptographic-value] test fixture
-        let salt = b"sweepsalt0000000"; // lgtm[rust/hard-coded-cryptographic-value] test fixture
+        // lgtm[rust/hard-coded-cryptographic-value] — test fixture
+        let password = b"sweep";
+        // lgtm[rust/hard-coded-cryptographic-value] — test fixture
+        let salt = b"sweepsalt0000000";
         for &m in &[8u32, 16, 32] {
             for &t in &[1u32, 2] {
                 for &p in &[1u32, 2] {

--- a/security/src/argon2id.rs
+++ b/security/src/argon2id.rs
@@ -838,7 +838,7 @@ fn parse_u32(s: &str) -> Option<u32> {
     if s.is_empty() {
         return None;
     }
-    let mut n: u32 = 0;
+    let mut n: u32 = 0; // lgtm[rust/hard-coded-cryptographic-value] integer accumulator, not a secret
     for c in s.chars() {
         let d = c.to_digit(10)?;
         n = n.checked_mul(10)?.checked_add(d)?;
@@ -891,13 +891,17 @@ fn push_b64(out: &mut String, input: &[u8]) {
 }
 
 fn b64_decode(s: &str) -> Result<Vec<u8>, Error> {
+    // The constants 26, 52, 62, 63 are the offsets of the four character
+    // ranges (A-Z, a-z, 0-9, +, /) in the standard base64 alphabet from
+    // RFC 4648 Table 1. CodeQL's `rust/hard-coded-cryptographic-value` rule
+    // misclassifies these as cryptographic secrets; they are not.
     fn val(c: u8) -> Result<u8, Error> {
         match c {
-            b'A'..=b'Z' => Ok(c - b'A'),
-            b'a'..=b'z' => Ok(c - b'a' + 26),
-            b'0'..=b'9' => Ok(c - b'0' + 52),
-            b'+' => Ok(62),
-            b'/' => Ok(63),
+            b'A'..=b'Z' => Ok(c - b'A'), // lgtm[rust/hard-coded-cryptographic-value] RFC 4648 base64 alphabet, not a secret
+            b'a'..=b'z' => Ok(c - b'a' + 26), // lgtm[rust/hard-coded-cryptographic-value] RFC 4648 base64 alphabet, not a secret
+            b'0'..=b'9' => Ok(c - b'0' + 52), // lgtm[rust/hard-coded-cryptographic-value] RFC 4648 base64 alphabet, not a secret
+            b'+' => Ok(62), // lgtm[rust/hard-coded-cryptographic-value] RFC 4648 base64 alphabet, not a secret
+            b'/' => Ok(63), // lgtm[rust/hard-coded-cryptographic-value] RFC 4648 base64 alphabet, not a secret
             _ => Err(Error::Base64Decode),
         }
     }
@@ -953,10 +957,11 @@ mod tests {
     ///   d0 1e f0 45 2d 75 b6 5e  b5 25 20 e9 6b 01 e6 59
     #[test]
     fn rfc9106_section5_3_argon2id_kat() {
-        let password = [0x01u8; 32];
-        let salt = [0x02u8; 16];
-        let secret = [0x03u8; 8];
-        let ad = [0x04u8; 12];
+        // RFC 9106 §5.3 reference vector — deterministic test fixtures, not production secrets.
+        let password = [0x01u8; 32]; // lgtm[rust/hard-coded-cryptographic-value] RFC 9106 §5.3 test vector
+        let salt = [0x02u8; 16]; // lgtm[rust/hard-coded-cryptographic-value] RFC 9106 §5.3 test vector
+        let secret = [0x03u8; 8]; // lgtm[rust/hard-coded-cryptographic-value] RFC 9106 §5.3 test vector
+        let ad = [0x04u8; 12]; // lgtm[rust/hard-coded-cryptographic-value] RFC 9106 §5.3 test vector
         let params = Argon2idParams {
             m_cost_kib: 32,
             t_cost: 3,
@@ -974,8 +979,9 @@ mod tests {
     /// PHC round-trip: hash a password, format, parse, verify.
     #[test]
     fn phc_round_trip() {
-        let password = b"correct horse battery staple";
-        let salt = b"saltsalt12345678";
+        // Test-only fixtures, not production secrets.
+        let password = b"correct horse battery staple"; // lgtm[rust/hard-coded-cryptographic-value] test fixture
+        let salt = b"saltsalt12345678"; // lgtm[rust/hard-coded-cryptographic-value] test fixture
         // Use the absolute-minimum tier to keep tests fast.
         let params = Argon2idParams {
             m_cost_kib: 8,
@@ -992,7 +998,7 @@ mod tests {
         assert!(argon2id_verify(password, &phc).unwrap());
 
         // Different password fails.
-        assert!(!argon2id_verify(b"wrong password", &phc).unwrap());
+        assert!(!argon2id_verify(b"wrong password", &phc).unwrap()); // lgtm[rust/hard-coded-cryptographic-value] negative-case test fixture
     }
 
     /// Tier constructors return valid parameters.
@@ -1006,8 +1012,9 @@ mod tests {
     /// Salt < 8 bytes is rejected.
     #[test]
     fn short_salt_rejected() {
+        // Test-only Argon2id parameters, not a secret.
         let params = Argon2idParams {
-            m_cost_kib: 8,
+            m_cost_kib: 8, // lgtm[rust/hard-coded-cryptographic-value] test parameter
             t_cost: 1,
             p_cost: 1,
         };
@@ -1022,8 +1029,9 @@ mod tests {
         use argon2::{Algorithm, Argon2, Params, Version};
 
         for &(m, t, p) in &[(8u32, 1u32, 1u32), (16, 2, 1), (32, 3, 2)] {
-            let password = b"oracle-test-password";
-            let salt = b"oracle-test-saltX"; // 17 bytes ≥ 8
+            // Oracle-comparison test fixtures, not production secrets.
+            let password = b"oracle-test-password"; // lgtm[rust/hard-coded-cryptographic-value] test fixture
+            let salt = b"oracle-test-saltX"; // 17 bytes ≥ 8 — lgtm[rust/hard-coded-cryptographic-value] test fixture
             let params = Argon2idParams {
                 m_cost_kib: m,
                 t_cost: t,
@@ -1048,8 +1056,9 @@ mod tests {
         use argon2::password_hash::{PasswordHash, PasswordVerifier};
         use argon2::Argon2;
 
-        let password = b"interop-test";
-        let salt = b"interop-saltAAAAAAAA";
+        // PHC interop test fixtures, not production secrets.
+        let password = b"interop-test"; // lgtm[rust/hard-coded-cryptographic-value] test fixture
+        let salt = b"interop-saltAAAAAAAA"; // lgtm[rust/hard-coded-cryptographic-value] test fixture
         let params = Argon2idParams {
             m_cost_kib: 16,
             t_cost: 2,
@@ -1069,8 +1078,9 @@ mod tests {
     /// must all complete without panicking and produce 32-byte tags.
     #[test]
     fn parameter_sweep() {
-        let password = b"sweep";
-        let salt = b"sweepsalt0000000";
+        // Parameter-sweep test fixtures, not production secrets.
+        let password = b"sweep"; // lgtm[rust/hard-coded-cryptographic-value] test fixture
+        let salt = b"sweepsalt0000000"; // lgtm[rust/hard-coded-cryptographic-value] test fixture
         for &m in &[8u32, 16, 32] {
             for &t in &[1u32, 2] {
                 for &p in &[1u32, 2] {

--- a/security/src/crypto/blake2b.rs
+++ b/security/src/crypto/blake2b.rs
@@ -1,0 +1,585 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Blake2b — cryptographic hash function (RFC 7693).
+//!
+//! Clean-room `#![no_std]` implementation of Blake2b. Variable digest length
+//! (1..=64 bytes), optional keyed mode, and full-parameter-block construction
+//! used by Argon2id (RFC 9106 §3.3, §3.4).
+//!
+//! The implementation follows RFC 7693 §3 closely. Each call to [`Blake2b`]
+//! processes input in 128-byte blocks; the final block is padded with zeros
+//! and finalized with the `f` flag set per the spec.
+//!
+//! # Examples
+//!
+//! Plain hash:
+//!
+//! ```ignore
+//! let mut h = Blake2b::new(64);
+//! h.update(b"abc");
+//! let digest = h.finalize();
+//! assert_eq!(digest.len(), 64);
+//! ```
+//!
+//! Keyed hash:
+//!
+//! ```ignore
+//! let mut h = Blake2b::new_keyed(b"my-key", 32);
+//! h.update(b"message");
+//! let mac = h.finalize();
+//! ```
+//!
+//! Full parameter block (used by Argon2id's variable-length hash `H'`):
+//!
+//! ```ignore
+//! let mut h = Blake2b::new_with_params(&Blake2bParams {
+//!     digest_length: 64,
+//!     key_length: 0,
+//!     fanout: 1,
+//!     depth: 1,
+//!     ..Default::default()
+//! });
+//! ```
+//!
+//! # References
+//!
+//! - RFC 7693: The BLAKE2 Cryptographic Hash and Message Authentication Code
+//! - <https://www.blake2.net/>
+
+#![allow(unused)]
+
+use core::fmt;
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+/// Maximum Blake2b digest length in bytes.
+pub const BLAKE2B_OUT_MAX: usize = 64;
+
+/// Blake2b block size in bytes.
+pub const BLAKE2B_BLOCK_BYTES: usize = 128;
+
+/// Maximum keyed-mode key length in bytes.
+pub const BLAKE2B_KEY_MAX: usize = 64;
+
+/// Initial value vector — first 64 bits of the fractional parts of the
+/// square roots of the first eight primes (2, 3, 5, 7, 11, 13, 17, 19).
+const IV: [u64; 8] = [
+    0x6a09_e667_f3bc_c908,
+    0xbb67_ae85_84ca_a73b,
+    0x3c6e_f372_fe94_f82b,
+    0xa54f_f53a_5f1d_36f1,
+    0x510e_527f_ade6_82d1,
+    0x9b05_688c_2b3e_6c1f,
+    0x1f83_d9ab_fb41_bd6b,
+    0x5be0_cd19_137e_2179,
+];
+
+/// SIGMA permutations for the message-word selection in `G`. RFC 7693 §2.7.
+const SIGMA: [[usize; 16]; 12] = [
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    [14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3],
+    [11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4],
+    [7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8],
+    [9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13],
+    [2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9],
+    [12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11],
+    [13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10],
+    [6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5],
+    [10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0],
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    [14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3],
+];
+
+/// Number of compression rounds for Blake2b.
+const ROUNDS: usize = 12;
+
+// ─── Errors ──────────────────────────────────────────────────────────────────
+
+/// Errors raised by Blake2b configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Blake2bError {
+    /// Output length out of the supported range (1..=64).
+    InvalidOutputLength,
+    /// Key length out of the supported range (0..=64).
+    InvalidKeyLength,
+}
+
+impl fmt::Display for Blake2bError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidOutputLength => write!(f, "blake2b: output length must be 1..=64"),
+            Self::InvalidKeyLength => write!(f, "blake2b: key length must be 0..=64"),
+        }
+    }
+}
+
+// ─── Parameter block ─────────────────────────────────────────────────────────
+
+/// Blake2b parameter block (RFC 7693 §2.5).
+///
+/// 64 bytes total. Plain mode uses `digest_length`/`key_length` only;
+/// Argon2id's `H'` uses the full structure to bind tree-mode parameters.
+#[derive(Debug, Clone, Copy)]
+pub struct Blake2bParams {
+    pub digest_length: u8,  // 0
+    pub key_length: u8,     // 1
+    pub fanout: u8,         // 2
+    pub depth: u8,          // 3
+    pub leaf_length: u32,   // 4..8
+    pub node_offset: u64,   // 8..16
+    pub node_depth: u8,     // 16
+    pub inner_length: u8,   // 17
+    pub reserved: [u8; 14], // 18..32
+    pub salt: [u8; 16],     // 32..48
+    pub personal: [u8; 16], // 48..64
+}
+
+impl Default for Blake2bParams {
+    fn default() -> Self {
+        Self {
+            digest_length: 64,
+            key_length: 0,
+            fanout: 1,
+            depth: 1,
+            leaf_length: 0,
+            node_offset: 0,
+            node_depth: 0,
+            inner_length: 0,
+            reserved: [0u8; 14],
+            salt: [0u8; 16],
+            personal: [0u8; 16],
+        }
+    }
+}
+
+impl Blake2bParams {
+    /// Serialize the parameter block to its 64-byte little-endian form so the
+    /// state can be initialized as `IV ^ params` per RFC 7693 §3.2.
+    fn as_bytes(&self) -> [u8; 64] {
+        let mut out = [0u8; 64];
+        out[0] = self.digest_length;
+        out[1] = self.key_length;
+        out[2] = self.fanout;
+        out[3] = self.depth;
+        out[4..8].copy_from_slice(&self.leaf_length.to_le_bytes());
+        out[8..16].copy_from_slice(&self.node_offset.to_le_bytes());
+        out[16] = self.node_depth;
+        out[17] = self.inner_length;
+        out[18..32].copy_from_slice(&self.reserved);
+        out[32..48].copy_from_slice(&self.salt);
+        out[48..64].copy_from_slice(&self.personal);
+        out
+    }
+}
+
+// ─── State ───────────────────────────────────────────────────────────────────
+
+/// Blake2b incremental hasher.
+#[derive(Clone)]
+pub struct Blake2b {
+    /// Chaining value `h[0..8]` per RFC 7693.
+    h: [u64; 8],
+    /// 128-bit message-byte counter `t`.
+    t: [u64; 2],
+    /// Current message buffer (one block at most).
+    buf: [u8; BLAKE2B_BLOCK_BYTES],
+    /// Bytes currently in `buf`.
+    buflen: usize,
+    /// Configured output length in bytes.
+    out_len: usize,
+}
+
+impl Blake2b {
+    /// Create a Blake2b hasher with `out_len` output bytes (1..=64).
+    ///
+    /// Equivalent to [`Blake2b::new_with_params`] with the default parameter
+    /// block and `digest_length = out_len`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `out_len` is 0 or > 64. Use [`Blake2b::try_new`] for a
+    /// non-panicking variant.
+    pub fn new(out_len: usize) -> Self {
+        Self::try_new(out_len).expect("blake2b: out_len must be 1..=64")
+    }
+
+    /// Fallible variant of [`Blake2b::new`].
+    pub fn try_new(out_len: usize) -> Result<Self, Blake2bError> {
+        if out_len == 0 || out_len > BLAKE2B_OUT_MAX {
+            return Err(Blake2bError::InvalidOutputLength);
+        }
+        let params = Blake2bParams {
+            digest_length: out_len as u8,
+            ..Blake2bParams::default()
+        };
+        Ok(Self::with_params(&params, &[]))
+    }
+
+    /// Keyed Blake2b (MAC mode) with a 0..=64-byte key.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `out_len` or `key.len()` are out of range. Use
+    /// [`Blake2b::try_new_keyed`] for a non-panicking variant.
+    pub fn new_keyed(key: &[u8], out_len: usize) -> Self {
+        Self::try_new_keyed(key, out_len).expect("blake2b: invalid out_len/key length")
+    }
+
+    /// Fallible variant of [`Blake2b::new_keyed`].
+    pub fn try_new_keyed(key: &[u8], out_len: usize) -> Result<Self, Blake2bError> {
+        if out_len == 0 || out_len > BLAKE2B_OUT_MAX {
+            return Err(Blake2bError::InvalidOutputLength);
+        }
+        if key.len() > BLAKE2B_KEY_MAX {
+            return Err(Blake2bError::InvalidKeyLength);
+        }
+        let params = Blake2bParams {
+            digest_length: out_len as u8,
+            key_length: key.len() as u8,
+            ..Blake2bParams::default()
+        };
+        Ok(Self::with_params(&params, key))
+    }
+
+    /// Construct a Blake2b instance with a fully specified parameter block.
+    ///
+    /// Caller must pass a key matching `params.key_length` (or `&[]` if
+    /// `key_length == 0`). The key is padded to a full block and consumed
+    /// before any user input. The non-keyed variants exposed via
+    /// [`Blake2b::new_with_params`] forward an empty key.
+    ///
+    /// # Panics
+    ///
+    /// Panics in debug builds if `params.digest_length` is out of range or
+    /// the key length does not match the parameter block.
+    pub fn new_with_params(params: &Blake2bParams) -> Self {
+        Self::with_params(params, &[])
+    }
+
+    /// Construct a Blake2b instance with a parameter block and an explicit
+    /// key matching `params.key_length`.
+    pub fn new_with_params_and_key(params: &Blake2bParams, key: &[u8]) -> Self {
+        Self::with_params(params, key)
+    }
+
+    /// Internal constructor used by all public entry points.
+    fn with_params(params: &Blake2bParams, key: &[u8]) -> Self {
+        debug_assert!(params.digest_length >= 1 && params.digest_length <= BLAKE2B_OUT_MAX as u8);
+        debug_assert_eq!(params.key_length as usize, key.len());
+        debug_assert!(key.len() <= BLAKE2B_KEY_MAX);
+
+        let pb = params.as_bytes();
+        let mut h = IV;
+        for i in 0..8 {
+            let word = u64::from_le_bytes(pb[i * 8..i * 8 + 8].try_into().unwrap());
+            h[i] ^= word;
+        }
+
+        let mut state = Self {
+            h,
+            t: [0u64; 2],
+            buf: [0u8; BLAKE2B_BLOCK_BYTES],
+            buflen: 0,
+            out_len: params.digest_length as usize,
+        };
+
+        // Keyed mode: prepend the zero-padded key as the first block.
+        if !key.is_empty() {
+            let mut block = [0u8; BLAKE2B_BLOCK_BYTES];
+            block[..key.len()].copy_from_slice(key);
+            state.update(&block);
+        }
+
+        state
+    }
+
+    /// Absorb `input` into the hash state.
+    pub fn update(&mut self, mut input: &[u8]) {
+        if input.is_empty() {
+            return;
+        }
+
+        // Fill the existing buffer first if it has bytes pending; we only
+        // compress when the *next* byte arrives, so we leave a full block
+        // unprocessed in the buffer.
+        if self.buflen > 0 {
+            let take = (BLAKE2B_BLOCK_BYTES - self.buflen).min(input.len());
+            self.buf[self.buflen..self.buflen + take].copy_from_slice(&input[..take]);
+            self.buflen += take;
+            input = &input[take..];
+
+            if input.is_empty() {
+                return;
+            }
+
+            // Buffer must be full at this point. Compress the buffered block
+            // and reset.
+            debug_assert_eq!(self.buflen, BLAKE2B_BLOCK_BYTES);
+            self.t_increment(BLAKE2B_BLOCK_BYTES as u64);
+            let block = self.buf;
+            self.compress(&block, false);
+            self.buflen = 0;
+        }
+
+        // Process whole blocks directly out of the input slice. Leave at
+        // least one byte over so finalize() always sees the last block.
+        while input.len() > BLAKE2B_BLOCK_BYTES {
+            self.t_increment(BLAKE2B_BLOCK_BYTES as u64);
+            let mut block = [0u8; BLAKE2B_BLOCK_BYTES];
+            block.copy_from_slice(&input[..BLAKE2B_BLOCK_BYTES]);
+            self.compress(&block, false);
+            input = &input[BLAKE2B_BLOCK_BYTES..];
+        }
+
+        // Stash the remainder.
+        self.buf[..input.len()].copy_from_slice(input);
+        self.buflen = input.len();
+    }
+
+    /// Finalize and write up to `out_len` bytes (the configured output
+    /// length) into `out`. Returns the number of bytes written.
+    pub fn finalize_into(mut self, out: &mut [u8]) -> usize {
+        let n = self.out_len.min(out.len());
+        // Pad the final block with zeros.
+        for byte in &mut self.buf[self.buflen..] {
+            *byte = 0;
+        }
+        self.t_increment(self.buflen as u64);
+        let block = self.buf;
+        self.compress(&block, true);
+        // Emit `out_len` bytes of state in little-endian.
+        let mut digest = [0u8; BLAKE2B_OUT_MAX];
+        for (i, lane) in self.h.iter().enumerate() {
+            digest[i * 8..i * 8 + 8].copy_from_slice(&lane.to_le_bytes());
+        }
+        out[..n].copy_from_slice(&digest[..n]);
+        n
+    }
+
+    /// Finalize and return the digest as a fixed-size array of length 64.
+    /// The valid bytes are the first `self.out_len`; the remaining bytes
+    /// are zero-padded.
+    pub fn finalize(self) -> [u8; BLAKE2B_OUT_MAX] {
+        let out_len = self.out_len;
+        let mut out = [0u8; BLAKE2B_OUT_MAX];
+        let _ = self.finalize_into(&mut out[..out_len]);
+        out
+    }
+
+    /// Return only the configured number of digest bytes as
+    /// `alloc::vec::Vec<u8>`. Callers that want zero-allocation should use
+    /// [`Blake2b::finalize_into`].
+    pub fn finalize_vec(self) -> alloc::vec::Vec<u8> {
+        let out_len = self.out_len;
+        let mut out = alloc::vec![0u8; out_len];
+        let _ = self.finalize_into(&mut out);
+        out
+    }
+
+    /// Return the configured output length (in bytes).
+    pub const fn output_length(&self) -> usize {
+        self.out_len
+    }
+
+    // ─── internals ──────────────────────────────────────────────────────────
+
+    /// Increment the 128-bit message-byte counter `t` by `n`.
+    fn t_increment(&mut self, n: u64) {
+        let (low, carry) = self.t[0].overflowing_add(n);
+        self.t[0] = low;
+        if carry {
+            self.t[1] = self.t[1].wrapping_add(1);
+        }
+    }
+
+    /// Compression function `F` (RFC 7693 §3.2). `final_block` sets the
+    /// `f0` finalization flag.
+    fn compress(&mut self, block: &[u8; BLAKE2B_BLOCK_BYTES], final_block: bool) {
+        // Decode 16 little-endian 64-bit message words.
+        let mut m = [0u64; 16];
+        for i in 0..16 {
+            m[i] = u64::from_le_bytes(block[i * 8..i * 8 + 8].try_into().unwrap());
+        }
+
+        // Initialize the working state v[0..16] = h[0..8] || IV[0..8].
+        let mut v = [0u64; 16];
+        v[..8].copy_from_slice(&self.h);
+        v[8..].copy_from_slice(&IV);
+
+        // Mix in the byte counter.
+        v[12] ^= self.t[0];
+        v[13] ^= self.t[1];
+
+        // Mix in the finalization flag for the last block.
+        if final_block {
+            v[14] = !v[14];
+        }
+
+        // 12 mixing rounds.
+        for s in SIGMA.iter().take(ROUNDS) {
+            mix(&mut v, 0, 4, 8, 12, m[s[0]], m[s[1]]);
+            mix(&mut v, 1, 5, 9, 13, m[s[2]], m[s[3]]);
+            mix(&mut v, 2, 6, 10, 14, m[s[4]], m[s[5]]);
+            mix(&mut v, 3, 7, 11, 15, m[s[6]], m[s[7]]);
+
+            mix(&mut v, 0, 5, 10, 15, m[s[8]], m[s[9]]);
+            mix(&mut v, 1, 6, 11, 12, m[s[10]], m[s[11]]);
+            mix(&mut v, 2, 7, 8, 13, m[s[12]], m[s[13]]);
+            mix(&mut v, 3, 4, 9, 14, m[s[14]], m[s[15]]);
+        }
+
+        // Update chaining value: h[i] = h[i] ^ v[i] ^ v[i+8].
+        for i in 0..8 {
+            self.h[i] ^= v[i] ^ v[i + 8];
+        }
+    }
+}
+
+/// Blake2b mixing function `G` (RFC 7693 §3.1).
+#[inline(always)]
+#[allow(clippy::too_many_arguments)]
+fn mix(v: &mut [u64; 16], a: usize, b: usize, c: usize, d: usize, x: u64, y: u64) {
+    v[a] = v[a].wrapping_add(v[b]).wrapping_add(x);
+    v[d] = (v[d] ^ v[a]).rotate_right(32);
+    v[c] = v[c].wrapping_add(v[d]);
+    v[b] = (v[b] ^ v[c]).rotate_right(24);
+
+    v[a] = v[a].wrapping_add(v[b]).wrapping_add(y);
+    v[d] = (v[d] ^ v[a]).rotate_right(16);
+    v[c] = v[c].wrapping_add(v[d]);
+    v[b] = (v[b] ^ v[c]).rotate_right(63);
+}
+
+// ─── Convenience top-level API ──────────────────────────────────────────────
+
+/// One-shot Blake2b: `out_len` digest bytes of `input`.
+pub fn blake2b(input: &[u8], out_len: usize) -> [u8; BLAKE2B_OUT_MAX] {
+    let mut h = Blake2b::new(out_len);
+    h.update(input);
+    h.finalize()
+}
+
+/// One-shot keyed Blake2b: `out_len` digest bytes of `input` with `key`.
+pub fn blake2b_keyed(key: &[u8], input: &[u8], out_len: usize) -> [u8; BLAKE2B_OUT_MAX] {
+    let mut h = Blake2b::new_keyed(key, out_len);
+    h.update(input);
+    h.finalize()
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    /// RFC 7693 Appendix A — Blake2b-512 of "abc".
+    #[test]
+    fn rfc7693_appendix_a_abc() {
+        let expected: [u8; 64] = [
+            0xBA, 0x80, 0xA5, 0x3F, 0x98, 0x1C, 0x4D, 0x0D, 0x6A, 0x27, 0x97, 0xB6, 0x9F, 0x12,
+            0xF6, 0xE9, 0x4C, 0x21, 0x2F, 0x14, 0x68, 0x5A, 0xC4, 0xB7, 0x4B, 0x12, 0xBB, 0x6F,
+            0xDB, 0xFF, 0xA2, 0xD1, 0x7D, 0x87, 0xC5, 0x39, 0x2A, 0xAB, 0x79, 0x2D, 0xC2, 0x52,
+            0xD5, 0xDE, 0x45, 0x33, 0xCC, 0x95, 0x18, 0xD3, 0x8A, 0xA8, 0xDB, 0xF1, 0x92, 0x5A,
+            0xB9, 0x23, 0x86, 0xED, 0xD4, 0x00, 0x99, 0x23,
+        ];
+        let actual = blake2b(b"abc", 64);
+        assert_eq!(&actual[..64], &expected[..]);
+    }
+
+    /// Empty-string vector — Blake2b-512 of "".
+    #[test]
+    fn empty_input_512() {
+        let expected: [u8; 64] = [
+            0x78, 0x6A, 0x02, 0xF7, 0x42, 0x01, 0x59, 0x03, 0xC6, 0xC6, 0xFD, 0x85, 0x25, 0x52,
+            0xD2, 0x72, 0x91, 0x2F, 0x47, 0x40, 0xE1, 0x58, 0x47, 0x61, 0x8A, 0x86, 0xE2, 0x17,
+            0xF7, 0x1F, 0x54, 0x19, 0xD2, 0x5E, 0x10, 0x31, 0xAF, 0xEE, 0x58, 0x53, 0x13, 0x89,
+            0x64, 0x44, 0x93, 0x4E, 0xB0, 0x4B, 0x90, 0x3A, 0x68, 0x5B, 0x14, 0x48, 0xB7, 0x55,
+            0xD5, 0x6F, 0x70, 0x1A, 0xFE, 0x9B, 0xE2, 0xCE,
+        ];
+        let actual = blake2b(b"", 64);
+        assert_eq!(&actual[..64], &expected[..]);
+    }
+
+    /// Variable output length — request 32 bytes vs 64 bytes.
+    /// The parameter block changes (digest_length differs), so the digests
+    /// are not simple truncations of one another.
+    #[test]
+    fn variable_output_length_changes_digest() {
+        let h32 = blake2b(b"abc", 32);
+        let h64 = blake2b(b"abc", 64);
+        assert_ne!(&h32[..32], &h64[..32]);
+    }
+
+    /// Incremental update should match one-shot for a non-trivial input.
+    #[test]
+    fn incremental_matches_one_shot() {
+        let big: Vec<u8> = (0..500u32).map(|i| (i & 0xFF) as u8).collect();
+        let one_shot = blake2b(&big, 64);
+        let mut h = Blake2b::new(64);
+        for chunk in big.chunks(37) {
+            h.update(chunk);
+        }
+        let inc = h.finalize();
+        assert_eq!(&one_shot[..], &inc[..]);
+    }
+
+    /// Block-boundary stress: input lengths around block multiples must match.
+    #[test]
+    fn block_boundary_stress() {
+        let buf: Vec<u8> = (0..512u32).map(|i| (i & 0xFF) as u8).collect();
+        for n in [0usize, 1, 64, 127, 128, 129, 200, 256, 257, 384, 511, 512] {
+            let one_shot = blake2b(&buf[..n], 64);
+            let mut h = Blake2b::new(64);
+            // Update in 1-byte increments to exercise the buffer code.
+            for b in &buf[..n] {
+                h.update(core::slice::from_ref(b));
+            }
+            let inc = h.finalize();
+            assert_eq!(&one_shot[..], &inc[..], "mismatch at n={}", n);
+        }
+    }
+
+    /// Out-of-range output length is rejected.
+    #[test]
+    fn out_of_range_output_length_rejected() {
+        assert!(Blake2b::try_new(0).is_err());
+        assert!(Blake2b::try_new(65).is_err());
+    }
+
+    /// Out-of-range key length is rejected.
+    #[test]
+    fn out_of_range_key_length_rejected() {
+        let big_key = [0u8; 65];
+        assert!(Blake2b::try_new_keyed(&big_key, 32).is_err());
+    }
+
+    /// Validation oracle: when the dev-only `blake2` crate is available,
+    /// compare against it for a sweep of message lengths and output sizes.
+    #[test]
+    fn blake2_oracle_matches_unkeyed() {
+        use blake2::digest::{Update, VariableOutput};
+        use blake2::Blake2bVar;
+
+        let buf: Vec<u8> = (0..1024u32).map(|i| (i & 0xFF) as u8).collect();
+        for n in [0usize, 1, 17, 64, 127, 128, 129, 256, 511, 512, 700, 1024] {
+            for out_len in [16usize, 32, 48, 64] {
+                let mut oracle = Blake2bVar::new(out_len).unwrap();
+                Update::update(&mut oracle, &buf[..n]);
+                let mut oracle_out = vec![0u8; out_len];
+                oracle.finalize_variable(&mut oracle_out).unwrap();
+
+                let mine = blake2b(&buf[..n], out_len);
+                assert_eq!(
+                    &mine[..out_len],
+                    oracle_out.as_slice(),
+                    "mismatch n={} out_len={}",
+                    n,
+                    out_len
+                );
+            }
+        }
+    }
+}

--- a/security/src/crypto/mod.rs
+++ b/security/src/crypto/mod.rs
@@ -5,6 +5,7 @@
 //!
 //! Implements post-quantum and classical cryptography:
 //! - SHA-3-256 and SHAKE256 (FIPS 202)
+//! - Blake2b (RFC 7693) — backend for Argon2id's variable-length hash
 //! - AES-256-GCM (FIPS 197 + SP 800-38D)
 //! - CSPRNG (SHAKE256-based, seeded from RDRAND/RNDR)
 //! - ML-KEM-768 (FIPS 203) — key encapsulation
@@ -13,6 +14,7 @@
 //! - Constant-time utilities
 
 pub mod aes_gcm;
+pub mod blake2b;
 pub mod constant_time;
 pub mod csprng;
 pub mod ed25519;

--- a/security/src/lib.rs
+++ b/security/src/lib.rs
@@ -22,6 +22,7 @@
 
 extern crate alloc;
 
+pub mod argon2id;
 pub mod audit;
 pub mod boundary;
 pub mod capability;

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -20,10 +20,6 @@ version = "0.1.6"
 criteria = "safe-to-run"
 
 [[exemptions.anstyle]]
-version = "1.0.13"
-criteria = "safe-to-run"
-
-[[exemptions.anstyle]]
 version = "1.0.14"
 criteria = "safe-to-run"
 
@@ -31,17 +27,33 @@ criteria = "safe-to-run"
 version = "1.0.102"
 criteria = "safe-to-run"
 
+[[exemptions.argon2]]
+version = "0.5.3"
+criteria = "safe-to-run"
+
 [[exemptions.autocfg]]
 version = "1.5.0"
+criteria = "safe-to-run"
+
+[[exemptions.base64ct]]
+version = "1.8.3"
 criteria = "safe-to-run"
 
 [[exemptions.bitflags]]
 version = "2.11.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.blake2]]
+version = "0.10.6"
+criteria = "safe-to-run"
+
 [[exemptions.block]]
 version = "0.1.6"
 criteria = "safe-to-deploy"
+
+[[exemptions.block-buffer]]
+version = "0.10.4"
+criteria = "safe-to-run"
 
 [[exemptions.bumpalo]]
 version = "3.20.2"
@@ -49,10 +61,6 @@ criteria = "safe-to-run"
 
 [[exemptions.cast]]
 version = "0.3.0"
-criteria = "safe-to-run"
-
-[[exemptions.cc]]
-version = "1.2.57"
 criteria = "safe-to-run"
 
 [[exemptions.cc]]
@@ -76,23 +84,11 @@ version = "0.2.2"
 criteria = "safe-to-run"
 
 [[exemptions.clap]]
-version = "4.5.60"
-criteria = "safe-to-run"
-
-[[exemptions.clap]]
 version = "4.6.0"
 criteria = "safe-to-run"
 
 [[exemptions.clap_builder]]
-version = "4.5.60"
-criteria = "safe-to-run"
-
-[[exemptions.clap_builder]]
 version = "4.6.0"
-criteria = "safe-to-run"
-
-[[exemptions.clap_lex]]
-version = "1.0.0"
 criteria = "safe-to-run"
 
 [[exemptions.clap_lex]]
@@ -110,6 +106,10 @@ criteria = "safe-to-deploy"
 [[exemptions.core-graphics-types]]
 version = "0.2.0"
 criteria = "safe-to-deploy"
+
+[[exemptions.cpufeatures]]
+version = "0.2.17"
+criteria = "safe-to-run"
 
 [[exemptions.criterion]]
 version = "0.8.2"
@@ -133,6 +133,14 @@ criteria = "safe-to-run"
 
 [[exemptions.crunchy]]
 version = "0.2.4"
+criteria = "safe-to-run"
+
+[[exemptions.crypto-common]]
+version = "0.1.7"
+criteria = "safe-to-run"
+
+[[exemptions.digest]]
+version = "0.10.7"
 criteria = "safe-to-run"
 
 [[exemptions.either]]
@@ -171,6 +179,10 @@ criteria = "safe-to-deploy"
 version = "0.3.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.generic-array]]
+version = "0.14.7"
+criteria = "safe-to-run"
+
 [[exemptions.getrandom]]
 version = "0.4.2"
 criteria = "safe-to-run"
@@ -204,15 +216,7 @@ version = "0.13.0"
 criteria = "safe-to-run"
 
 [[exemptions.itoa]]
-version = "1.0.17"
-criteria = "safe-to-run"
-
-[[exemptions.itoa]]
 version = "1.0.18"
-criteria = "safe-to-run"
-
-[[exemptions.js-sys]]
-version = "0.3.91"
 criteria = "safe-to-run"
 
 [[exemptions.js-sys]]
@@ -243,10 +247,6 @@ criteria = "safe-to-deploy"
 version = "2.8.0"
 criteria = "safe-to-run"
 
-[[exemptions.memmap2]]
-version = "0.9.10"
-criteria = "safe-to-deploy"
-
 [[exemptions.metal]]
 version = "0.33.0"
 criteria = "safe-to-deploy"
@@ -260,10 +260,6 @@ version = "0.2.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.once_cell]]
-version = "1.21.3"
-criteria = "safe-to-run"
-
-[[exemptions.once_cell]]
 version = "1.21.4"
 criteria = "safe-to-run"
 
@@ -273,6 +269,10 @@ criteria = "safe-to-run"
 
 [[exemptions.page_size]]
 version = "0.6.0"
+criteria = "safe-to-run"
+
+[[exemptions.password-hash]]
+version = "0.5.0"
 criteria = "safe-to-run"
 
 [[exemptions.paste]]
@@ -305,6 +305,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.r-efi]]
 version = "6.0.0"
+criteria = "safe-to-run"
+
+[[exemptions.rand_core]]
+version = "0.6.4"
 criteria = "safe-to-run"
 
 [[exemptions.rayon]]
@@ -363,6 +367,10 @@ criteria = "safe-to-run"
 version = "1.3.0"
 criteria = "safe-to-run"
 
+[[exemptions.subtle]]
+version = "2.6.1"
+criteria = "safe-to-run"
+
 [[exemptions.syn]]
 version = "2.0.117"
 criteria = "safe-to-deploy"
@@ -375,12 +383,20 @@ criteria = "safe-to-run"
 version = "1.2.1"
 criteria = "safe-to-run"
 
+[[exemptions.typenum]]
+version = "1.20.0"
+criteria = "safe-to-run"
+
 [[exemptions.unicode-ident]]
 version = "1.0.24"
 criteria = "safe-to-deploy"
 
 [[exemptions.unicode-xid]]
 version = "0.2.6"
+criteria = "safe-to-run"
+
+[[exemptions.version_check]]
+version = "0.9.5"
 criteria = "safe-to-run"
 
 [[exemptions.walkdir]]
@@ -396,15 +412,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 criteria = "safe-to-run"
 
 [[exemptions.wasm-bindgen]]
-version = "0.2.114"
-criteria = "safe-to-run"
-
-[[exemptions.wasm-bindgen]]
 version = "0.2.118"
-criteria = "safe-to-run"
-
-[[exemptions.wasm-bindgen-macro]]
-version = "0.2.114"
 criteria = "safe-to-run"
 
 [[exemptions.wasm-bindgen-macro]]
@@ -412,15 +420,7 @@ version = "0.2.118"
 criteria = "safe-to-run"
 
 [[exemptions.wasm-bindgen-macro-support]]
-version = "0.2.114"
-criteria = "safe-to-run"
-
-[[exemptions.wasm-bindgen-macro-support]]
 version = "0.2.118"
-criteria = "safe-to-run"
-
-[[exemptions.wasm-bindgen-shared]]
-version = "0.2.114"
 criteria = "safe-to-run"
 
 [[exemptions.wasm-bindgen-shared]]
@@ -437,10 +437,6 @@ criteria = "safe-to-run"
 
 [[exemptions.wasmparser]]
 version = "0.244.0"
-criteria = "safe-to-run"
-
-[[exemptions.web-sys]]
-version = "0.3.91"
 criteria = "safe-to-run"
 
 [[exemptions.web-sys]]
@@ -496,15 +492,7 @@ version = "0.244.0"
 criteria = "safe-to-run"
 
 [[exemptions.zerocopy]]
-version = "0.8.40"
-criteria = "safe-to-run"
-
-[[exemptions.zerocopy]]
 version = "0.8.48"
-criteria = "safe-to-run"
-
-[[exemptions.zerocopy-derive]]
-version = "0.8.40"
 criteria = "safe-to-run"
 
 [[exemptions.zerocopy-derive]]


### PR DESCRIPTION
## Summary

Phase 1 of `management-login-v1`. Clean-room `#![no_std]` Rust implementations of Blake2b (RFC 7693) and Argon2id (RFC 9106), tested against the published KAT vectors.

- `security/src/crypto/blake2b.rs` — 585 LOC. Variable output length 1..=64 bytes, keyed mode, parameter-block constructor used by Argon2id.
- `security/src/argon2id.rs` — 1,119 LOC. BLAMKA mixing, indexing (data-independent first half-pass per slice, data-dependent second), variable-length `H'`, PHC-encoded output.
- 17 new tests (8 Blake2b + 9 Argon2id) all green; total workspace `just test` runs at 4790 passing, 0 failing.

Per-tier defaults (`Argon2idParams::tiny()` / `default_tier()` / `strong()`) match `management-login-v1` Q26: `m=8/64/128 MiB`, `t=3/3/4`, `p=1/1/2`. The PHC string carries the parameters so verification reads them from the stored hash, not a global config.

The `argon2 = "0.5"` and `blake2 = "0.10"` crates appear in `[dev-dependencies]` only as RFC-vector validation oracles. **They are not in the production dep graph.**

## Deviations from spec (called out)

- `heapless::String<256>` → `alloc::string::String` for `argon2id_format_phc`. The `heapless` crate is not in the workspace; the prompt allowed this trade-off. Switching back is a one-line change if heapless is later adopted.
- `Default` constructor renamed `default_tier()` to force callers to pick a tier explicitly (avoids accidental defaulting at call sites).
- SIMD shims (NEON/AVX2) deferred to a later phase per the plan.

## Test plan

- [x] `just fmt-check` — clean.
- [x] `just clippy` (`-D warnings`) — clean.
- [x] `just test` — 4790 pass / 0 fail.
- [x] `cargo test -p smallaios-security --lib` — 882 pass / 0 fail.
- [x] `openspec validate management-login-v1 --strict` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Argon2id password hashing with configurable security tiers (tiny, default, strong)
  * Added Blake2b cryptographic hash algorithm
  * Both implementations are no_std compatible

* **Tests**
  * Added comprehensive test coverage including RFC reference vectors and interoperability verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->