### PR TITLE
feat(fs): BlockDevice + virtio-blk + sector emulation (embedded-filesystem-v1 phase 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,6 +692,7 @@ name = "smallaios-arch-aarch64"
 version = "0.2.1"
 dependencies = [
  "smallaios-arch-nvidia",
+ "smallaios-fs",
  "smallaios-kernel",
  "smallaios-onnx-rt",
 ]
@@ -739,6 +740,7 @@ dependencies = [
 name = "smallaios-arch-x86_64"
 version = "0.2.1"
 dependencies = [
+ "smallaios-fs",
  "smallaios-kernel",
 ]
 

--- a/arch/aarch64/Cargo.toml
+++ b/arch/aarch64/Cargo.toml
@@ -37,8 +37,12 @@ tegra-x1 = ["smallaios-onnx-rt", "smallaios-arch-nvidia"]
 # sub-PRs of `unikernel-orin-bringup-v1`. Distinct from `arch/nvidia`'s
 # `tegra-orin` (Orin userspace CUDA) by design.
 tegra234 = []
+# virtio-blk MMIO driver — `BlockDevice` impl over the modern (1.0+)
+# virtio-blk transport. Built on by `embedded-filesystem-v1` Phase 1.
+fs-block-virtio = ["dep:smallaios-fs", "smallaios-fs/fs-on-disk-mounts", "smallaios-fs/fs-block-virtio"]
 
 [dependencies]
 smallaios-kernel = { path = "../../kernel" }
 smallaios-onnx-rt = { path = "../../onnx-rt", optional = true, default-features = false, features = ["cpu"] }
 smallaios-arch-nvidia = { path = "../nvidia", optional = true, default-features = false, features = ["tegra"] }
+smallaios-fs = { path = "../../fs", optional = true }

--- a/arch/aarch64/src/lib.rs
+++ b/arch/aarch64/src/lib.rs
@@ -30,6 +30,8 @@ pub mod paging;
 pub mod platform;
 pub mod syscall;
 pub mod uart;
+#[cfg(feature = "fs-block-virtio")]
+pub mod virtio_blk;
 
 #[cfg(feature = "tegra-x1")]
 pub mod image_header;

--- a/arch/aarch64/src/virtio_blk.rs
+++ b/arch/aarch64/src/virtio_blk.rs
@@ -1,0 +1,589 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! virtio-blk-modern (1.0+) MMIO driver implementing
+//! [`smallaios_fs::block::BlockDevice`].
+//!
+//! This is the QEMU CI surface for the on-disk filesystem stack. The
+//! driver targets the standardized virtio-MMIO transport — QEMU's
+//! `-device virtio-blk-device,drive=...` exposes its registers via a
+//! 0x200-byte MMIO window that this module pokes directly.
+//!
+//! The implementation is intentionally minimal:
+//!
+//! - Single virtqueue (#0) — virtio-blk has one request queue.
+//! - Submit-and-wait per request (no interrupt or async; this is the
+//!   smoke-test path).
+//! - Three request types: `VIRTIO_BLK_T_IN`, `VIRTIO_BLK_T_OUT`,
+//!   `VIRTIO_BLK_T_FLUSH`.
+//! - Modern device path only (no legacy device support).
+//!
+//! Owned by `embedded-filesystem-v1` Phase 1.
+//!
+//! ## Safety
+//!
+//! The driver assumes the caller has identified a virtio-MMIO window
+//! at `mmio_base` corresponding to a virtio-blk device (DeviceID = 2,
+//! Magic = "virt"). The caller passes a physically-contiguous,
+//! identity-mapped DMA region for the descriptor/avail/used rings.
+//! The driver MUST NOT be used after the underlying device is
+//! reset/hot-removed.
+
+#![cfg(feature = "fs-block-virtio")]
+// Some MMIO register offsets and feature bits are documented for
+// completeness so the module reads as a reference for the
+// `embedded-filesystem-v1` follow-on phases (NVMe, AHCI, SDHCI). The
+// current submit-and-wait path doesn't use all of them yet.
+#![allow(dead_code)]
+
+use core::cell::UnsafeCell;
+use core::ptr::{read_volatile, write_volatile};
+use core::sync::atomic::{compiler_fence, fence, Ordering};
+
+use smallaios_fs::block::{check_buf_alignment, check_lba_in_range, BlockDevice, BlockError};
+
+// ─── virtio-MMIO register offsets (modern, virtio v1.0+) ────────────────────
+// Reference: virtio v1.2 spec § 4.2.2 "MMIO Device Register Layout".
+
+/// Magic value 0x74726976 ("virt" little-endian).
+const REG_MAGIC: usize = 0x000;
+/// Device version (must be 2 for virtio v1.0+).
+const REG_VERSION: usize = 0x004;
+/// Subsystem device ID (2 = block).
+const REG_DEVICE_ID: usize = 0x008;
+const REG_VENDOR_ID: usize = 0x00C;
+const REG_DEVICE_FEATURES: usize = 0x010;
+const REG_DEVICE_FEATURES_SEL: usize = 0x014;
+const REG_DRIVER_FEATURES: usize = 0x020;
+const REG_DRIVER_FEATURES_SEL: usize = 0x024;
+const REG_QUEUE_SEL: usize = 0x030;
+const REG_QUEUE_NUM_MAX: usize = 0x034;
+const REG_QUEUE_NUM: usize = 0x038;
+const REG_QUEUE_READY: usize = 0x044;
+const REG_QUEUE_NOTIFY: usize = 0x050;
+const REG_INTERRUPT_STATUS: usize = 0x060;
+const REG_INTERRUPT_ACK: usize = 0x064;
+const REG_STATUS: usize = 0x070;
+const REG_QUEUE_DESC_LOW: usize = 0x080;
+const REG_QUEUE_DESC_HIGH: usize = 0x084;
+const REG_QUEUE_AVAIL_LOW: usize = 0x090;
+const REG_QUEUE_AVAIL_HIGH: usize = 0x094;
+const REG_QUEUE_USED_LOW: usize = 0x0A0;
+const REG_QUEUE_USED_HIGH: usize = 0x0A4;
+const REG_CONFIG: usize = 0x100;
+
+const VIRTIO_MMIO_MAGIC: u32 = 0x7472_6976;
+const VIRTIO_DEVICE_ID_BLOCK: u32 = 2;
+
+// virtio-blk feature bits.
+const VIRTIO_BLK_F_FLUSH: u32 = 9;
+const VIRTIO_F_VERSION_1: u32 = 32;
+
+// Status register bits.
+const STATUS_ACKNOWLEDGE: u32 = 1;
+const STATUS_DRIVER: u32 = 2;
+const STATUS_DRIVER_OK: u32 = 4;
+const STATUS_FEATURES_OK: u32 = 8;
+const STATUS_FAILED: u32 = 0x80;
+
+// Descriptor flags.
+const VRING_DESC_F_NEXT: u16 = 0x1;
+const VRING_DESC_F_WRITE: u16 = 0x2;
+
+// virtio-blk request types.
+const VIRTIO_BLK_T_IN: u32 = 0;
+const VIRTIO_BLK_T_OUT: u32 = 1;
+const VIRTIO_BLK_T_FLUSH: u32 = 4;
+
+// virtio-blk request status codes.
+const VIRTIO_BLK_S_OK: u8 = 0;
+const VIRTIO_BLK_S_IOERR: u8 = 1;
+const VIRTIO_BLK_S_UNSUPP: u8 = 2;
+
+// Default queue size — keep small; this is the smoke-test path.
+const QUEUE_SIZE: u16 = 16;
+
+// virtio-blk hard-coded sector size (per the spec § 5.2).
+const VIRTIO_BLK_SECTOR_SIZE: u32 = 512;
+
+// ─── On-the-wire ring structures ────────────────────────────────────────────
+
+/// Descriptor in the descriptor table.
+#[repr(C, align(16))]
+#[derive(Clone, Copy, Default)]
+struct VringDesc {
+    addr: u64,
+    len: u32,
+    flags: u16,
+    next: u16,
+}
+
+/// Available ring header + entries (split-virtqueue).
+#[repr(C, align(2))]
+struct VringAvail {
+    flags: u16,
+    idx: u16,
+    ring: [u16; QUEUE_SIZE as usize],
+    used_event: u16,
+}
+
+/// Used ring entry.
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+struct VringUsedElem {
+    id: u32,
+    len: u32,
+}
+
+/// Used ring (split-virtqueue).
+#[repr(C, align(4))]
+struct VringUsed {
+    flags: u16,
+    idx: u16,
+    ring: [VringUsedElem; QUEUE_SIZE as usize],
+    avail_event: u16,
+}
+
+/// virtio-blk request header (sent on the device-readable descriptor).
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+struct VirtioBlkReqHeader {
+    ty: u32,
+    reserved: u32,
+    sector: u64,
+}
+
+/// virtio-blk readable config space header (subset).
+#[repr(C)]
+struct VirtioBlkConfig {
+    capacity_low: u32,  // sectors, low 32 bits
+    capacity_high: u32, // sectors, high 32 bits
+}
+
+// ─── Driver state ───────────────────────────────────────────────────────────
+
+/// Storage for one virtqueue. Allocated in identity-mapped, contiguous,
+/// aligned DMA memory by the caller via [`VirtioBlk::new`].
+#[repr(C, align(4096))]
+pub struct QueueStorage {
+    descs: [VringDesc; QUEUE_SIZE as usize],
+    avail: VringAvail,
+    used: VringUsed,
+    /// Per-request scratch: 3 descriptors per request (header / data /
+    /// status), one slot per descriptor index.
+    headers: [VirtioBlkReqHeader; QUEUE_SIZE as usize],
+    statuses: [u8; QUEUE_SIZE as usize],
+}
+
+impl QueueStorage {
+    /// Construct an empty queue storage block. MUST live in
+    /// identity-mapped DMA memory.
+    pub const fn new() -> Self {
+        Self {
+            descs: [VringDesc {
+                addr: 0,
+                len: 0,
+                flags: 0,
+                next: 0,
+            }; QUEUE_SIZE as usize],
+            avail: VringAvail {
+                flags: 0,
+                idx: 0,
+                ring: [0; QUEUE_SIZE as usize],
+                used_event: 0,
+            },
+            used: VringUsed {
+                flags: 0,
+                idx: 0,
+                ring: [VringUsedElem { id: 0, len: 0 }; QUEUE_SIZE as usize],
+                avail_event: 0,
+            },
+            headers: [VirtioBlkReqHeader {
+                ty: 0,
+                reserved: 0,
+                sector: 0,
+            }; QUEUE_SIZE as usize],
+            statuses: [0; QUEUE_SIZE as usize],
+        }
+    }
+}
+
+impl Default for QueueStorage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Interior-mutable state of the virtio-blk driver.
+///
+/// `BlockDevice::read_block` takes `&self` per the trait contract, but
+/// the virtio request submission necessarily mutates the rings and
+/// the `last_used_idx` watermark. We wrap that mutable state in an
+/// `UnsafeCell` and rely on the caller to externally serialize access
+/// (the driver is `!Sync` — see [`VirtioBlk`]). Concretely: every
+/// SmallAIOS mount path owns its `VirtioBlk` from a single executor
+/// task / IRQ context.
+struct VirtioBlkInner {
+    queue: &'static mut QueueStorage,
+    /// Last-seen `used.idx` value, used to detect new completions.
+    last_used_idx: u16,
+}
+
+/// virtio-blk-modern MMIO driver.
+///
+/// `!Sync`: callers must serialize access externally (e.g. one device
+/// per mount, accessed from the mount's owning executor task).
+pub struct VirtioBlk {
+    mmio_base: usize,
+    inner: UnsafeCell<VirtioBlkInner>,
+    /// Capacity in 512-byte sectors as reported by the device.
+    capacity_sectors: u64,
+    /// Whether the device supports `VIRTIO_BLK_T_FLUSH`.
+    has_flush: bool,
+}
+
+// `VirtioBlk` is intentionally `!Sync`. The `UnsafeCell` already makes
+// it `!Sync`, and we do not provide a manual `unsafe impl Sync`. The
+// `Send` bound is also conservative: in practice the driver moves
+// between executor tasks freely as long as serialized, but we leave
+// that to the kernel scheduler.
+
+impl VirtioBlk {
+    /// Probe an MMIO window. Returns `Some(())` if the magic + device
+    /// ID match a virtio-blk-modern device.
+    ///
+    /// # Safety
+    /// `mmio_base` must point to a 0x200-byte MMIO window mapped for
+    /// volatile access.
+    pub unsafe fn probe(mmio_base: usize) -> bool {
+        let magic = read_volatile((mmio_base + REG_MAGIC) as *const u32);
+        if magic != VIRTIO_MMIO_MAGIC {
+            return false;
+        }
+        let version = read_volatile((mmio_base + REG_VERSION) as *const u32);
+        if version != 2 {
+            return false;
+        }
+        let dev_id = read_volatile((mmio_base + REG_DEVICE_ID) as *const u32);
+        dev_id == VIRTIO_DEVICE_ID_BLOCK
+    }
+
+    /// Initialize a virtio-blk device.
+    ///
+    /// # Safety
+    /// - `mmio_base` must be a virtio-blk-modern MMIO window
+    ///   ([`probe`](Self::probe) returned true).
+    /// - `queue` must live in identity-mapped, DMA-coherent memory
+    ///   for the lifetime of the `VirtioBlk`.
+    /// - The caller must externally serialize access to the driver
+    ///   (`VirtioBlk` is `!Sync`).
+    pub unsafe fn new(
+        mmio_base: usize,
+        queue: &'static mut QueueStorage,
+    ) -> Result<Self, BlockError> {
+        // 1. Reset the device.
+        write_reg(mmio_base, REG_STATUS, 0);
+
+        // 2. Set ACKNOWLEDGE | DRIVER.
+        write_reg(mmio_base, REG_STATUS, STATUS_ACKNOWLEDGE);
+        write_reg(mmio_base, REG_STATUS, STATUS_ACKNOWLEDGE | STATUS_DRIVER);
+
+        // 3. Read device features (low 32 + high 32).
+        write_reg(mmio_base, REG_DEVICE_FEATURES_SEL, 0);
+        let dev_feat_lo = read_reg(mmio_base, REG_DEVICE_FEATURES);
+        write_reg(mmio_base, REG_DEVICE_FEATURES_SEL, 1);
+        let dev_feat_hi = read_reg(mmio_base, REG_DEVICE_FEATURES);
+
+        // We need VIRTIO_F_VERSION_1 (bit 32 in the high half) to
+        // operate in modern mode.
+        let want_version_1 = 1u32 << (VIRTIO_F_VERSION_1 - 32);
+        if dev_feat_hi & want_version_1 == 0 {
+            write_reg(mmio_base, REG_STATUS, STATUS_FAILED);
+            return Err(BlockError::NotPresent);
+        }
+
+        // Optional: VIRTIO_BLK_F_FLUSH (bit 9 in the low half).
+        let has_flush = (dev_feat_lo & (1u32 << VIRTIO_BLK_F_FLUSH)) != 0;
+
+        // Negotiate features: only VERSION_1 (+ FLUSH if available).
+        let drv_feat_lo = if has_flush {
+            1u32 << VIRTIO_BLK_F_FLUSH
+        } else {
+            0
+        };
+        let drv_feat_hi = want_version_1;
+        write_reg(mmio_base, REG_DRIVER_FEATURES_SEL, 0);
+        write_reg(mmio_base, REG_DRIVER_FEATURES, drv_feat_lo);
+        write_reg(mmio_base, REG_DRIVER_FEATURES_SEL, 1);
+        write_reg(mmio_base, REG_DRIVER_FEATURES, drv_feat_hi);
+
+        // 4. Set FEATURES_OK and re-read to confirm.
+        write_reg(
+            mmio_base,
+            REG_STATUS,
+            STATUS_ACKNOWLEDGE | STATUS_DRIVER | STATUS_FEATURES_OK,
+        );
+        let status = read_reg(mmio_base, REG_STATUS);
+        if status & STATUS_FEATURES_OK == 0 {
+            write_reg(mmio_base, REG_STATUS, status | STATUS_FAILED);
+            return Err(BlockError::NotPresent);
+        }
+
+        // 5. Set up virtqueue 0.
+        write_reg(mmio_base, REG_QUEUE_SEL, 0);
+        let max = read_reg(mmio_base, REG_QUEUE_NUM_MAX);
+        if max == 0 {
+            write_reg(mmio_base, REG_STATUS, status | STATUS_FAILED);
+            return Err(BlockError::NotPresent);
+        }
+        let q_num = if max < QUEUE_SIZE as u32 {
+            max as u16
+        } else {
+            QUEUE_SIZE
+        };
+        write_reg(mmio_base, REG_QUEUE_NUM, q_num as u32);
+
+        // Program ring physical addresses (identity-mapped → virt == phys).
+        let desc_addr = queue.descs.as_ptr() as u64;
+        let avail_addr = (&queue.avail as *const _) as u64;
+        let used_addr = (&queue.used as *const _) as u64;
+        write_reg(mmio_base, REG_QUEUE_DESC_LOW, desc_addr as u32);
+        write_reg(mmio_base, REG_QUEUE_DESC_HIGH, (desc_addr >> 32) as u32);
+        write_reg(mmio_base, REG_QUEUE_AVAIL_LOW, avail_addr as u32);
+        write_reg(mmio_base, REG_QUEUE_AVAIL_HIGH, (avail_addr >> 32) as u32);
+        write_reg(mmio_base, REG_QUEUE_USED_LOW, used_addr as u32);
+        write_reg(mmio_base, REG_QUEUE_USED_HIGH, (used_addr >> 32) as u32);
+
+        // Mark queue ready.
+        write_reg(mmio_base, REG_QUEUE_READY, 1);
+
+        // 6. Read capacity from device-config space.
+        let cfg = (mmio_base + REG_CONFIG) as *const VirtioBlkConfig;
+        let cap_lo = read_volatile(&(*cfg).capacity_low) as u64;
+        let cap_hi = read_volatile(&(*cfg).capacity_high) as u64;
+        let capacity_sectors = (cap_hi << 32) | cap_lo;
+
+        // 7. DRIVER_OK → device is live.
+        write_reg(
+            mmio_base,
+            REG_STATUS,
+            STATUS_ACKNOWLEDGE | STATUS_DRIVER | STATUS_FEATURES_OK | STATUS_DRIVER_OK,
+        );
+
+        Ok(Self {
+            mmio_base,
+            inner: UnsafeCell::new(VirtioBlkInner {
+                queue,
+                last_used_idx: 0,
+            }),
+            capacity_sectors,
+            has_flush,
+        })
+    }
+
+    /// Submit a request and busy-wait for completion.
+    ///
+    /// Single-queue, three-descriptor chain layout:
+    /// - desc[0]: header (device-readable)
+    /// - desc[1]: data buffer (device-writable for IN, device-readable for OUT)
+    /// - desc[2]: status byte (device-writable)
+    ///
+    /// For FLUSH there is no data buffer, so the chain is two
+    /// descriptors (header + status).
+    ///
+    /// # Safety
+    /// - Caller guarantees `data` (if `Some`) is identity-mapped DMA
+    ///   memory for the duration of the call.
+    /// - Caller guarantees no other thread/task is calling
+    ///   `submit_and_wait` on this `VirtioBlk` concurrently
+    ///   (`VirtioBlk` is `!Sync`).
+    unsafe fn submit_and_wait(
+        &self,
+        req_type: u32,
+        sector: u64,
+        data: Option<(*mut u8, usize, bool)>, // (ptr, len, is_write_to_device)
+    ) -> Result<(), BlockError> {
+        // SAFETY: `VirtioBlk` is `!Sync` and the caller serializes
+        // access. We hold the only active `&mut VirtioBlkInner` for
+        // the duration of this call.
+        let inner: &mut VirtioBlkInner = &mut *self.inner.get();
+
+        // Use slot 0 deterministically — this is single-threaded
+        // submit-and-wait; we never have more than one in flight.
+        let slot = 0usize;
+
+        // Populate header.
+        inner.queue.headers[slot] = VirtioBlkReqHeader {
+            ty: req_type,
+            reserved: 0,
+            sector,
+        };
+        inner.queue.statuses[slot] = 0xFFu8; // sentinel "not yet written by device"
+
+        // Build descriptor chain.
+        let header_addr = (&inner.queue.headers[slot] as *const _) as u64;
+        let status_addr = (&inner.queue.statuses[slot] as *const _) as u64;
+
+        match data {
+            Some((data_ptr, data_len, write_to_device)) => {
+                // 3-descriptor chain.
+                inner.queue.descs[0] = VringDesc {
+                    addr: header_addr,
+                    len: core::mem::size_of::<VirtioBlkReqHeader>() as u32,
+                    flags: VRING_DESC_F_NEXT,
+                    next: 1,
+                };
+                let mut data_flags = VRING_DESC_F_NEXT;
+                if write_to_device {
+                    // VIRTIO_BLK_T_IN means the *device* writes the buffer
+                    // (it's reading from disk, writing into our memory).
+                    data_flags |= VRING_DESC_F_WRITE;
+                }
+                inner.queue.descs[1] = VringDesc {
+                    addr: data_ptr as u64,
+                    len: data_len as u32,
+                    flags: data_flags,
+                    next: 2,
+                };
+                inner.queue.descs[2] = VringDesc {
+                    addr: status_addr,
+                    len: 1,
+                    flags: VRING_DESC_F_WRITE,
+                    next: 0,
+                };
+            }
+            None => {
+                // FLUSH: 2-descriptor chain (header + status).
+                inner.queue.descs[0] = VringDesc {
+                    addr: header_addr,
+                    len: core::mem::size_of::<VirtioBlkReqHeader>() as u32,
+                    flags: VRING_DESC_F_NEXT,
+                    next: 1,
+                };
+                inner.queue.descs[1] = VringDesc {
+                    addr: status_addr,
+                    len: 1,
+                    flags: VRING_DESC_F_WRITE,
+                    next: 0,
+                };
+            }
+        }
+
+        // Publish to the available ring.
+        let avail_idx = inner.queue.avail.idx;
+        inner.queue.avail.ring[(avail_idx as usize) & (QUEUE_SIZE as usize - 1)] = 0; // head desc index
+                                                                                      // Memory barrier: ensure descriptor writes are visible before
+                                                                                      // we publish the new avail.idx.
+        fence(Ordering::Release);
+        inner.queue.avail.idx = avail_idx.wrapping_add(1);
+        // Another barrier before the device-visible notify.
+        fence(Ordering::Release);
+
+        // Notify queue 0.
+        write_reg(self.mmio_base, REG_QUEUE_NOTIFY, 0);
+
+        // Busy-wait for used.idx to advance. In CI this returns within
+        // microseconds; the production retry-policy wraps this call
+        // and converts hangs to BlockError::Timeout.
+        let target = inner.last_used_idx.wrapping_add(1);
+        let mut spins: u64 = 0;
+        while read_volatile(&inner.queue.used.idx) != target {
+            core::hint::spin_loop();
+            spins = spins.wrapping_add(1);
+            // Fail-safe: 100M spins ~ a few hundred ms on a modern CPU.
+            // The retry layer handles real timeouts; this is only here
+            // so a totally-wedged device surfaces an error.
+            if spins > 100_000_000 {
+                return Err(BlockError::Timeout);
+            }
+        }
+        inner.last_used_idx = target;
+
+        // Memory barrier before reading device-written status.
+        fence(Ordering::Acquire);
+        compiler_fence(Ordering::Acquire);
+
+        let status = read_volatile(&inner.queue.statuses[slot]);
+        match status {
+            VIRTIO_BLK_S_OK => Ok(()),
+            VIRTIO_BLK_S_IOERR => Err(BlockError::MediaError),
+            VIRTIO_BLK_S_UNSUPP => Err(BlockError::NotPresent),
+            // 0xFF means the device never wrote — treat as media error.
+            _ => Err(BlockError::MediaError),
+        }
+    }
+
+    /// Capacity in 512-byte sectors as reported by the device.
+    pub fn capacity_sectors(&self) -> u64 {
+        self.capacity_sectors
+    }
+
+    /// `true` if the device negotiated `VIRTIO_BLK_F_FLUSH`.
+    pub fn supports_flush(&self) -> bool {
+        self.has_flush
+    }
+}
+
+impl BlockDevice for VirtioBlk {
+    fn read_block(&self, lba: u64, buf: &mut [u8]) -> Result<(), BlockError> {
+        check_buf_alignment(buf.len(), VIRTIO_BLK_SECTOR_SIZE)?;
+        check_lba_in_range(
+            lba,
+            buf.len(),
+            VIRTIO_BLK_SECTOR_SIZE,
+            self.capacity_sectors,
+        )?;
+        let ptr = buf.as_mut_ptr();
+        let len = buf.len();
+        // SAFETY: VirtioBlk is `!Sync`; the caller ensures no
+        // concurrent submit_and_wait. The buffer is borrowed
+        // exclusively (&mut [u8]) for the duration of the call.
+        unsafe { self.submit_and_wait(VIRTIO_BLK_T_IN, lba, Some((ptr, len, true))) }
+    }
+
+    fn write_block(&mut self, lba: u64, buf: &[u8]) -> Result<(), BlockError> {
+        check_buf_alignment(buf.len(), VIRTIO_BLK_SECTOR_SIZE)?;
+        check_lba_in_range(
+            lba,
+            buf.len(),
+            VIRTIO_BLK_SECTOR_SIZE,
+            self.capacity_sectors,
+        )?;
+        let ptr = buf.as_ptr() as *mut u8;
+        let len = buf.len();
+        // SAFETY: same as read_block above; data buffer is read-only
+        // by the device for VIRTIO_BLK_T_OUT.
+        unsafe { self.submit_and_wait(VIRTIO_BLK_T_OUT, lba, Some((ptr, len, false))) }
+    }
+
+    fn block_size_bytes(&self) -> u32 {
+        VIRTIO_BLK_SECTOR_SIZE
+    }
+
+    fn block_count(&self) -> u64 {
+        self.capacity_sectors
+    }
+
+    fn flush(&mut self) -> Result<(), BlockError> {
+        if !self.has_flush {
+            // Spec § 5.2.6.2: "The device MAY support the
+            // VIRTIO_BLK_T_FLUSH command [...] If the device does not
+            // negotiate VIRTIO_BLK_F_FLUSH, the driver MUST NOT issue
+            // a flush." Treat as a successful no-op.
+            return Ok(());
+        }
+        unsafe { self.submit_and_wait(VIRTIO_BLK_T_FLUSH, 0, None) }
+    }
+}
+
+// ─── Volatile MMIO accessors ────────────────────────────────────────────────
+
+#[inline(always)]
+unsafe fn write_reg(base: usize, off: usize, val: u32) {
+    write_volatile((base + off) as *mut u32, val);
+}
+
+#[inline(always)]
+unsafe fn read_reg(base: usize, off: usize) -> u32 {
+    read_volatile((base + off) as *const u32)
+}

--- a/arch/x86_64/Cargo.toml
+++ b/arch/x86_64/Cargo.toml
@@ -17,6 +17,10 @@ path = "src/main.rs"
 
 [features]
 default = []
+# virtio-blk MMIO driver — `BlockDevice` impl over the modern (1.0+)
+# virtio-blk transport. Built on by `embedded-filesystem-v1` Phase 1.
+fs-block-virtio = ["dep:smallaios-fs", "smallaios-fs/fs-on-disk-mounts", "smallaios-fs/fs-block-virtio"]
 
 [dependencies]
 smallaios-kernel = { path = "../../kernel" }
+smallaios-fs = { path = "../../fs", optional = true }

--- a/arch/x86_64/src/lib.rs
+++ b/arch/x86_64/src/lib.rs
@@ -17,6 +17,8 @@ pub mod interrupts;
 pub mod paging;
 pub mod serial;
 pub mod syscall;
+#[cfg(feature = "fs-block-virtio")]
+pub mod virtio_blk;
 
 use core::panic::PanicInfo;
 

--- a/arch/x86_64/src/virtio_blk.rs
+++ b/arch/x86_64/src/virtio_blk.rs
@@ -1,0 +1,589 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! virtio-blk-modern (1.0+) MMIO driver implementing
+//! [`smallaios_fs::block::BlockDevice`].
+//!
+//! This is the QEMU CI surface for the on-disk filesystem stack. The
+//! driver targets the standardized virtio-MMIO transport — QEMU's
+//! `-device virtio-blk-device,drive=...` exposes its registers via a
+//! 0x200-byte MMIO window that this module pokes directly.
+//!
+//! The implementation is intentionally minimal:
+//!
+//! - Single virtqueue (#0) — virtio-blk has one request queue.
+//! - Submit-and-wait per request (no interrupt or async; this is the
+//!   smoke-test path).
+//! - Three request types: `VIRTIO_BLK_T_IN`, `VIRTIO_BLK_T_OUT`,
+//!   `VIRTIO_BLK_T_FLUSH`.
+//! - Modern device path only (no legacy device support).
+//!
+//! Owned by `embedded-filesystem-v1` Phase 1.
+//!
+//! ## Safety
+//!
+//! The driver assumes the caller has identified a virtio-MMIO window
+//! at `mmio_base` corresponding to a virtio-blk device (DeviceID = 2,
+//! Magic = "virt"). The caller passes a physically-contiguous,
+//! identity-mapped DMA region for the descriptor/avail/used rings.
+//! The driver MUST NOT be used after the underlying device is
+//! reset/hot-removed.
+
+#![cfg(feature = "fs-block-virtio")]
+// Some MMIO register offsets and feature bits are documented for
+// completeness so the module reads as a reference for the
+// `embedded-filesystem-v1` follow-on phases (NVMe, AHCI, SDHCI). The
+// current submit-and-wait path doesn't use all of them yet.
+#![allow(dead_code)]
+
+use core::cell::UnsafeCell;
+use core::ptr::{read_volatile, write_volatile};
+use core::sync::atomic::{compiler_fence, fence, Ordering};
+
+use smallaios_fs::block::{check_buf_alignment, check_lba_in_range, BlockDevice, BlockError};
+
+// ─── virtio-MMIO register offsets (modern, virtio v1.0+) ────────────────────
+// Reference: virtio v1.2 spec § 4.2.2 "MMIO Device Register Layout".
+
+/// Magic value 0x74726976 ("virt" little-endian).
+const REG_MAGIC: usize = 0x000;
+/// Device version (must be 2 for virtio v1.0+).
+const REG_VERSION: usize = 0x004;
+/// Subsystem device ID (2 = block).
+const REG_DEVICE_ID: usize = 0x008;
+const REG_VENDOR_ID: usize = 0x00C;
+const REG_DEVICE_FEATURES: usize = 0x010;
+const REG_DEVICE_FEATURES_SEL: usize = 0x014;
+const REG_DRIVER_FEATURES: usize = 0x020;
+const REG_DRIVER_FEATURES_SEL: usize = 0x024;
+const REG_QUEUE_SEL: usize = 0x030;
+const REG_QUEUE_NUM_MAX: usize = 0x034;
+const REG_QUEUE_NUM: usize = 0x038;
+const REG_QUEUE_READY: usize = 0x044;
+const REG_QUEUE_NOTIFY: usize = 0x050;
+const REG_INTERRUPT_STATUS: usize = 0x060;
+const REG_INTERRUPT_ACK: usize = 0x064;
+const REG_STATUS: usize = 0x070;
+const REG_QUEUE_DESC_LOW: usize = 0x080;
+const REG_QUEUE_DESC_HIGH: usize = 0x084;
+const REG_QUEUE_AVAIL_LOW: usize = 0x090;
+const REG_QUEUE_AVAIL_HIGH: usize = 0x094;
+const REG_QUEUE_USED_LOW: usize = 0x0A0;
+const REG_QUEUE_USED_HIGH: usize = 0x0A4;
+const REG_CONFIG: usize = 0x100;
+
+const VIRTIO_MMIO_MAGIC: u32 = 0x7472_6976;
+const VIRTIO_DEVICE_ID_BLOCK: u32 = 2;
+
+// virtio-blk feature bits.
+const VIRTIO_BLK_F_FLUSH: u32 = 9;
+const VIRTIO_F_VERSION_1: u32 = 32;
+
+// Status register bits.
+const STATUS_ACKNOWLEDGE: u32 = 1;
+const STATUS_DRIVER: u32 = 2;
+const STATUS_DRIVER_OK: u32 = 4;
+const STATUS_FEATURES_OK: u32 = 8;
+const STATUS_FAILED: u32 = 0x80;
+
+// Descriptor flags.
+const VRING_DESC_F_NEXT: u16 = 0x1;
+const VRING_DESC_F_WRITE: u16 = 0x2;
+
+// virtio-blk request types.
+const VIRTIO_BLK_T_IN: u32 = 0;
+const VIRTIO_BLK_T_OUT: u32 = 1;
+const VIRTIO_BLK_T_FLUSH: u32 = 4;
+
+// virtio-blk request status codes.
+const VIRTIO_BLK_S_OK: u8 = 0;
+const VIRTIO_BLK_S_IOERR: u8 = 1;
+const VIRTIO_BLK_S_UNSUPP: u8 = 2;
+
+// Default queue size — keep small; this is the smoke-test path.
+const QUEUE_SIZE: u16 = 16;
+
+// virtio-blk hard-coded sector size (per the spec § 5.2).
+const VIRTIO_BLK_SECTOR_SIZE: u32 = 512;
+
+// ─── On-the-wire ring structures ────────────────────────────────────────────
+
+/// Descriptor in the descriptor table.
+#[repr(C, align(16))]
+#[derive(Clone, Copy, Default)]
+struct VringDesc {
+    addr: u64,
+    len: u32,
+    flags: u16,
+    next: u16,
+}
+
+/// Available ring header + entries (split-virtqueue).
+#[repr(C, align(2))]
+struct VringAvail {
+    flags: u16,
+    idx: u16,
+    ring: [u16; QUEUE_SIZE as usize],
+    used_event: u16,
+}
+
+/// Used ring entry.
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+struct VringUsedElem {
+    id: u32,
+    len: u32,
+}
+
+/// Used ring (split-virtqueue).
+#[repr(C, align(4))]
+struct VringUsed {
+    flags: u16,
+    idx: u16,
+    ring: [VringUsedElem; QUEUE_SIZE as usize],
+    avail_event: u16,
+}
+
+/// virtio-blk request header (sent on the device-readable descriptor).
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+struct VirtioBlkReqHeader {
+    ty: u32,
+    reserved: u32,
+    sector: u64,
+}
+
+/// virtio-blk readable config space header (subset).
+#[repr(C)]
+struct VirtioBlkConfig {
+    capacity_low: u32,  // sectors, low 32 bits
+    capacity_high: u32, // sectors, high 32 bits
+}
+
+// ─── Driver state ───────────────────────────────────────────────────────────
+
+/// Storage for one virtqueue. Allocated in identity-mapped, contiguous,
+/// aligned DMA memory by the caller via [`VirtioBlk::new`].
+#[repr(C, align(4096))]
+pub struct QueueStorage {
+    descs: [VringDesc; QUEUE_SIZE as usize],
+    avail: VringAvail,
+    used: VringUsed,
+    /// Per-request scratch: 3 descriptors per request (header / data /
+    /// status), one slot per descriptor index.
+    headers: [VirtioBlkReqHeader; QUEUE_SIZE as usize],
+    statuses: [u8; QUEUE_SIZE as usize],
+}
+
+impl QueueStorage {
+    /// Construct an empty queue storage block. MUST live in
+    /// identity-mapped DMA memory.
+    pub const fn new() -> Self {
+        Self {
+            descs: [VringDesc {
+                addr: 0,
+                len: 0,
+                flags: 0,
+                next: 0,
+            }; QUEUE_SIZE as usize],
+            avail: VringAvail {
+                flags: 0,
+                idx: 0,
+                ring: [0; QUEUE_SIZE as usize],
+                used_event: 0,
+            },
+            used: VringUsed {
+                flags: 0,
+                idx: 0,
+                ring: [VringUsedElem { id: 0, len: 0 }; QUEUE_SIZE as usize],
+                avail_event: 0,
+            },
+            headers: [VirtioBlkReqHeader {
+                ty: 0,
+                reserved: 0,
+                sector: 0,
+            }; QUEUE_SIZE as usize],
+            statuses: [0; QUEUE_SIZE as usize],
+        }
+    }
+}
+
+impl Default for QueueStorage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Interior-mutable state of the virtio-blk driver.
+///
+/// `BlockDevice::read_block` takes `&self` per the trait contract, but
+/// the virtio request submission necessarily mutates the rings and
+/// the `last_used_idx` watermark. We wrap that mutable state in an
+/// `UnsafeCell` and rely on the caller to externally serialize access
+/// (the driver is `!Sync` — see [`VirtioBlk`]). Concretely: every
+/// SmallAIOS mount path owns its `VirtioBlk` from a single executor
+/// task / IRQ context.
+struct VirtioBlkInner {
+    queue: &'static mut QueueStorage,
+    /// Last-seen `used.idx` value, used to detect new completions.
+    last_used_idx: u16,
+}
+
+/// virtio-blk-modern MMIO driver.
+///
+/// `!Sync`: callers must serialize access externally (e.g. one device
+/// per mount, accessed from the mount's owning executor task).
+pub struct VirtioBlk {
+    mmio_base: usize,
+    inner: UnsafeCell<VirtioBlkInner>,
+    /// Capacity in 512-byte sectors as reported by the device.
+    capacity_sectors: u64,
+    /// Whether the device supports `VIRTIO_BLK_T_FLUSH`.
+    has_flush: bool,
+}
+
+// `VirtioBlk` is intentionally `!Sync`. The `UnsafeCell` already makes
+// it `!Sync`, and we do not provide a manual `unsafe impl Sync`. The
+// `Send` bound is also conservative: in practice the driver moves
+// between executor tasks freely as long as serialized, but we leave
+// that to the kernel scheduler.
+
+impl VirtioBlk {
+    /// Probe an MMIO window. Returns `Some(())` if the magic + device
+    /// ID match a virtio-blk-modern device.
+    ///
+    /// # Safety
+    /// `mmio_base` must point to a 0x200-byte MMIO window mapped for
+    /// volatile access.
+    pub unsafe fn probe(mmio_base: usize) -> bool {
+        let magic = read_volatile((mmio_base + REG_MAGIC) as *const u32);
+        if magic != VIRTIO_MMIO_MAGIC {
+            return false;
+        }
+        let version = read_volatile((mmio_base + REG_VERSION) as *const u32);
+        if version != 2 {
+            return false;
+        }
+        let dev_id = read_volatile((mmio_base + REG_DEVICE_ID) as *const u32);
+        dev_id == VIRTIO_DEVICE_ID_BLOCK
+    }
+
+    /// Initialize a virtio-blk device.
+    ///
+    /// # Safety
+    /// - `mmio_base` must be a virtio-blk-modern MMIO window
+    ///   ([`probe`](Self::probe) returned true).
+    /// - `queue` must live in identity-mapped, DMA-coherent memory
+    ///   for the lifetime of the `VirtioBlk`.
+    /// - The caller must externally serialize access to the driver
+    ///   (`VirtioBlk` is `!Sync`).
+    pub unsafe fn new(
+        mmio_base: usize,
+        queue: &'static mut QueueStorage,
+    ) -> Result<Self, BlockError> {
+        // 1. Reset the device.
+        write_reg(mmio_base, REG_STATUS, 0);
+
+        // 2. Set ACKNOWLEDGE | DRIVER.
+        write_reg(mmio_base, REG_STATUS, STATUS_ACKNOWLEDGE);
+        write_reg(mmio_base, REG_STATUS, STATUS_ACKNOWLEDGE | STATUS_DRIVER);
+
+        // 3. Read device features (low 32 + high 32).
+        write_reg(mmio_base, REG_DEVICE_FEATURES_SEL, 0);
+        let dev_feat_lo = read_reg(mmio_base, REG_DEVICE_FEATURES);
+        write_reg(mmio_base, REG_DEVICE_FEATURES_SEL, 1);
+        let dev_feat_hi = read_reg(mmio_base, REG_DEVICE_FEATURES);
+
+        // We need VIRTIO_F_VERSION_1 (bit 32 in the high half) to
+        // operate in modern mode.
+        let want_version_1 = 1u32 << (VIRTIO_F_VERSION_1 - 32);
+        if dev_feat_hi & want_version_1 == 0 {
+            write_reg(mmio_base, REG_STATUS, STATUS_FAILED);
+            return Err(BlockError::NotPresent);
+        }
+
+        // Optional: VIRTIO_BLK_F_FLUSH (bit 9 in the low half).
+        let has_flush = (dev_feat_lo & (1u32 << VIRTIO_BLK_F_FLUSH)) != 0;
+
+        // Negotiate features: only VERSION_1 (+ FLUSH if available).
+        let drv_feat_lo = if has_flush {
+            1u32 << VIRTIO_BLK_F_FLUSH
+        } else {
+            0
+        };
+        let drv_feat_hi = want_version_1;
+        write_reg(mmio_base, REG_DRIVER_FEATURES_SEL, 0);
+        write_reg(mmio_base, REG_DRIVER_FEATURES, drv_feat_lo);
+        write_reg(mmio_base, REG_DRIVER_FEATURES_SEL, 1);
+        write_reg(mmio_base, REG_DRIVER_FEATURES, drv_feat_hi);
+
+        // 4. Set FEATURES_OK and re-read to confirm.
+        write_reg(
+            mmio_base,
+            REG_STATUS,
+            STATUS_ACKNOWLEDGE | STATUS_DRIVER | STATUS_FEATURES_OK,
+        );
+        let status = read_reg(mmio_base, REG_STATUS);
+        if status & STATUS_FEATURES_OK == 0 {
+            write_reg(mmio_base, REG_STATUS, status | STATUS_FAILED);
+            return Err(BlockError::NotPresent);
+        }
+
+        // 5. Set up virtqueue 0.
+        write_reg(mmio_base, REG_QUEUE_SEL, 0);
+        let max = read_reg(mmio_base, REG_QUEUE_NUM_MAX);
+        if max == 0 {
+            write_reg(mmio_base, REG_STATUS, status | STATUS_FAILED);
+            return Err(BlockError::NotPresent);
+        }
+        let q_num = if max < QUEUE_SIZE as u32 {
+            max as u16
+        } else {
+            QUEUE_SIZE
+        };
+        write_reg(mmio_base, REG_QUEUE_NUM, q_num as u32);
+
+        // Program ring physical addresses (identity-mapped → virt == phys).
+        let desc_addr = queue.descs.as_ptr() as u64;
+        let avail_addr = (&queue.avail as *const _) as u64;
+        let used_addr = (&queue.used as *const _) as u64;
+        write_reg(mmio_base, REG_QUEUE_DESC_LOW, desc_addr as u32);
+        write_reg(mmio_base, REG_QUEUE_DESC_HIGH, (desc_addr >> 32) as u32);
+        write_reg(mmio_base, REG_QUEUE_AVAIL_LOW, avail_addr as u32);
+        write_reg(mmio_base, REG_QUEUE_AVAIL_HIGH, (avail_addr >> 32) as u32);
+        write_reg(mmio_base, REG_QUEUE_USED_LOW, used_addr as u32);
+        write_reg(mmio_base, REG_QUEUE_USED_HIGH, (used_addr >> 32) as u32);
+
+        // Mark queue ready.
+        write_reg(mmio_base, REG_QUEUE_READY, 1);
+
+        // 6. Read capacity from device-config space.
+        let cfg = (mmio_base + REG_CONFIG) as *const VirtioBlkConfig;
+        let cap_lo = read_volatile(&(*cfg).capacity_low) as u64;
+        let cap_hi = read_volatile(&(*cfg).capacity_high) as u64;
+        let capacity_sectors = (cap_hi << 32) | cap_lo;
+
+        // 7. DRIVER_OK → device is live.
+        write_reg(
+            mmio_base,
+            REG_STATUS,
+            STATUS_ACKNOWLEDGE | STATUS_DRIVER | STATUS_FEATURES_OK | STATUS_DRIVER_OK,
+        );
+
+        Ok(Self {
+            mmio_base,
+            inner: UnsafeCell::new(VirtioBlkInner {
+                queue,
+                last_used_idx: 0,
+            }),
+            capacity_sectors,
+            has_flush,
+        })
+    }
+
+    /// Submit a request and busy-wait for completion.
+    ///
+    /// Single-queue, three-descriptor chain layout:
+    /// - desc[0]: header (device-readable)
+    /// - desc[1]: data buffer (device-writable for IN, device-readable for OUT)
+    /// - desc[2]: status byte (device-writable)
+    ///
+    /// For FLUSH there is no data buffer, so the chain is two
+    /// descriptors (header + status).
+    ///
+    /// # Safety
+    /// - Caller guarantees `data` (if `Some`) is identity-mapped DMA
+    ///   memory for the duration of the call.
+    /// - Caller guarantees no other thread/task is calling
+    ///   `submit_and_wait` on this `VirtioBlk` concurrently
+    ///   (`VirtioBlk` is `!Sync`).
+    unsafe fn submit_and_wait(
+        &self,
+        req_type: u32,
+        sector: u64,
+        data: Option<(*mut u8, usize, bool)>, // (ptr, len, is_write_to_device)
+    ) -> Result<(), BlockError> {
+        // SAFETY: `VirtioBlk` is `!Sync` and the caller serializes
+        // access. We hold the only active `&mut VirtioBlkInner` for
+        // the duration of this call.
+        let inner: &mut VirtioBlkInner = &mut *self.inner.get();
+
+        // Use slot 0 deterministically — this is single-threaded
+        // submit-and-wait; we never have more than one in flight.
+        let slot = 0usize;
+
+        // Populate header.
+        inner.queue.headers[slot] = VirtioBlkReqHeader {
+            ty: req_type,
+            reserved: 0,
+            sector,
+        };
+        inner.queue.statuses[slot] = 0xFFu8; // sentinel "not yet written by device"
+
+        // Build descriptor chain.
+        let header_addr = (&inner.queue.headers[slot] as *const _) as u64;
+        let status_addr = (&inner.queue.statuses[slot] as *const _) as u64;
+
+        match data {
+            Some((data_ptr, data_len, write_to_device)) => {
+                // 3-descriptor chain.
+                inner.queue.descs[0] = VringDesc {
+                    addr: header_addr,
+                    len: core::mem::size_of::<VirtioBlkReqHeader>() as u32,
+                    flags: VRING_DESC_F_NEXT,
+                    next: 1,
+                };
+                let mut data_flags = VRING_DESC_F_NEXT;
+                if write_to_device {
+                    // VIRTIO_BLK_T_IN means the *device* writes the buffer
+                    // (it's reading from disk, writing into our memory).
+                    data_flags |= VRING_DESC_F_WRITE;
+                }
+                inner.queue.descs[1] = VringDesc {
+                    addr: data_ptr as u64,
+                    len: data_len as u32,
+                    flags: data_flags,
+                    next: 2,
+                };
+                inner.queue.descs[2] = VringDesc {
+                    addr: status_addr,
+                    len: 1,
+                    flags: VRING_DESC_F_WRITE,
+                    next: 0,
+                };
+            }
+            None => {
+                // FLUSH: 2-descriptor chain (header + status).
+                inner.queue.descs[0] = VringDesc {
+                    addr: header_addr,
+                    len: core::mem::size_of::<VirtioBlkReqHeader>() as u32,
+                    flags: VRING_DESC_F_NEXT,
+                    next: 1,
+                };
+                inner.queue.descs[1] = VringDesc {
+                    addr: status_addr,
+                    len: 1,
+                    flags: VRING_DESC_F_WRITE,
+                    next: 0,
+                };
+            }
+        }
+
+        // Publish to the available ring.
+        let avail_idx = inner.queue.avail.idx;
+        inner.queue.avail.ring[(avail_idx as usize) & (QUEUE_SIZE as usize - 1)] = 0; // head desc index
+                                                                                      // Memory barrier: ensure descriptor writes are visible before
+                                                                                      // we publish the new avail.idx.
+        fence(Ordering::Release);
+        inner.queue.avail.idx = avail_idx.wrapping_add(1);
+        // Another barrier before the device-visible notify.
+        fence(Ordering::Release);
+
+        // Notify queue 0.
+        write_reg(self.mmio_base, REG_QUEUE_NOTIFY, 0);
+
+        // Busy-wait for used.idx to advance. In CI this returns within
+        // microseconds; the production retry-policy wraps this call
+        // and converts hangs to BlockError::Timeout.
+        let target = inner.last_used_idx.wrapping_add(1);
+        let mut spins: u64 = 0;
+        while read_volatile(&inner.queue.used.idx) != target {
+            core::hint::spin_loop();
+            spins = spins.wrapping_add(1);
+            // Fail-safe: 100M spins ~ a few hundred ms on a modern CPU.
+            // The retry layer handles real timeouts; this is only here
+            // so a totally-wedged device surfaces an error.
+            if spins > 100_000_000 {
+                return Err(BlockError::Timeout);
+            }
+        }
+        inner.last_used_idx = target;
+
+        // Memory barrier before reading device-written status.
+        fence(Ordering::Acquire);
+        compiler_fence(Ordering::Acquire);
+
+        let status = read_volatile(&inner.queue.statuses[slot]);
+        match status {
+            VIRTIO_BLK_S_OK => Ok(()),
+            VIRTIO_BLK_S_IOERR => Err(BlockError::MediaError),
+            VIRTIO_BLK_S_UNSUPP => Err(BlockError::NotPresent),
+            // 0xFF means the device never wrote — treat as media error.
+            _ => Err(BlockError::MediaError),
+        }
+    }
+
+    /// Capacity in 512-byte sectors as reported by the device.
+    pub fn capacity_sectors(&self) -> u64 {
+        self.capacity_sectors
+    }
+
+    /// `true` if the device negotiated `VIRTIO_BLK_F_FLUSH`.
+    pub fn supports_flush(&self) -> bool {
+        self.has_flush
+    }
+}
+
+impl BlockDevice for VirtioBlk {
+    fn read_block(&self, lba: u64, buf: &mut [u8]) -> Result<(), BlockError> {
+        check_buf_alignment(buf.len(), VIRTIO_BLK_SECTOR_SIZE)?;
+        check_lba_in_range(
+            lba,
+            buf.len(),
+            VIRTIO_BLK_SECTOR_SIZE,
+            self.capacity_sectors,
+        )?;
+        let ptr = buf.as_mut_ptr();
+        let len = buf.len();
+        // SAFETY: VirtioBlk is `!Sync`; the caller ensures no
+        // concurrent submit_and_wait. The buffer is borrowed
+        // exclusively (&mut [u8]) for the duration of the call.
+        unsafe { self.submit_and_wait(VIRTIO_BLK_T_IN, lba, Some((ptr, len, true))) }
+    }
+
+    fn write_block(&mut self, lba: u64, buf: &[u8]) -> Result<(), BlockError> {
+        check_buf_alignment(buf.len(), VIRTIO_BLK_SECTOR_SIZE)?;
+        check_lba_in_range(
+            lba,
+            buf.len(),
+            VIRTIO_BLK_SECTOR_SIZE,
+            self.capacity_sectors,
+        )?;
+        let ptr = buf.as_ptr() as *mut u8;
+        let len = buf.len();
+        // SAFETY: same as read_block above; data buffer is read-only
+        // by the device for VIRTIO_BLK_T_OUT.
+        unsafe { self.submit_and_wait(VIRTIO_BLK_T_OUT, lba, Some((ptr, len, false))) }
+    }
+
+    fn block_size_bytes(&self) -> u32 {
+        VIRTIO_BLK_SECTOR_SIZE
+    }
+
+    fn block_count(&self) -> u64 {
+        self.capacity_sectors
+    }
+
+    fn flush(&mut self) -> Result<(), BlockError> {
+        if !self.has_flush {
+            // Spec § 5.2.6.2: "The device MAY support the
+            // VIRTIO_BLK_T_FLUSH command [...] If the device does not
+            // negotiate VIRTIO_BLK_F_FLUSH, the driver MUST NOT issue
+            // a flush." Treat as a successful no-op.
+            return Ok(());
+        }
+        unsafe { self.submit_and_wait(VIRTIO_BLK_T_FLUSH, 0, None) }
+    }
+}
+
+// ─── Volatile MMIO accessors ────────────────────────────────────────────────
+
+#[inline(always)]
+unsafe fn write_reg(base: usize, off: usize, val: u32) {
+    write_volatile((base + off) as *mut u32, val);
+}
+
+#[inline(always)]
+unsafe fn read_reg(base: usize, off: usize) -> u32 {
+    read_volatile((base + off) as *const u32)
+}

--- a/fs/src/block/errno.rs
+++ b/fs/src/block/errno.rs
@@ -1,0 +1,115 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! POSIX errno conversion for [`BlockError`](super::BlockError).
+//!
+//! Per `embedded-filesystem-v1` spec `fs-block-device`:
+//!
+//! | `BlockError`            | POSIX errno |
+//! |-------------------------|-------------|
+//! | `MediaError`, `BadCrc`  | `-EIO`      |
+//! | `NotPresent`            | `-ENXIO`    |
+//! | `Timeout`               | `-ETIMEDOUT`|
+//! | `Unaligned`, `OutOfRange` | `-EINVAL` |
+//! | `DeviceBusy`            | `-EBUSY`    |
+//!
+//! These errno values are surfaced to userspace by `posix-vfs` at the
+//! syscall boundary in Phase 6. They are negated (Linux-style negative
+//! return) by syscall dispatchers; this module returns the *positive*
+//! integer for callers that want a raw errno.
+
+use super::BlockError;
+
+/// `EIO` — I/O error.
+pub const EIO: i32 = 5;
+/// `ENXIO` — no such device or address.
+pub const ENXIO: i32 = 6;
+/// `EBUSY` — device or resource busy.
+pub const EBUSY: i32 = 16;
+/// `EINVAL` — invalid argument.
+pub const EINVAL: i32 = 22;
+/// `ENOSPC` — no space left on device.
+pub const ENOSPC: i32 = 28;
+/// `ETIMEDOUT` — connection / operation timed out.
+pub const ETIMEDOUT: i32 = 110;
+
+/// Map a [`BlockError`] to a positive POSIX errno.
+///
+/// Callers that want the Linux negative-errno convention should
+/// negate the result.
+#[inline]
+pub const fn block_error_to_errno(err: BlockError) -> i32 {
+    match err {
+        BlockError::MediaError | BlockError::BadCrc => EIO,
+        BlockError::NotPresent => ENXIO,
+        BlockError::Timeout => ETIMEDOUT,
+        BlockError::Unaligned | BlockError::OutOfRange => EINVAL,
+        BlockError::DeviceBusy => EBUSY,
+    }
+}
+
+/// Map a [`BlockError`] to a Linux-style negative errno
+/// (`-EIO`, `-ETIMEDOUT`, ...).
+///
+/// This is the form `posix-vfs` returns from syscalls.
+#[inline]
+pub const fn block_error_to_negative_errno(err: BlockError) -> i32 {
+    -block_error_to_errno(err)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn media_error_maps_to_eio() {
+        assert_eq!(block_error_to_errno(BlockError::MediaError), EIO);
+        assert_eq!(block_error_to_negative_errno(BlockError::MediaError), -EIO);
+    }
+
+    #[test]
+    fn bad_crc_maps_to_eio() {
+        assert_eq!(block_error_to_errno(BlockError::BadCrc), EIO);
+    }
+
+    #[test]
+    fn not_present_maps_to_enxio() {
+        assert_eq!(block_error_to_errno(BlockError::NotPresent), ENXIO);
+    }
+
+    #[test]
+    fn timeout_maps_to_etimedout() {
+        assert_eq!(block_error_to_errno(BlockError::Timeout), ETIMEDOUT);
+        assert_eq!(
+            block_error_to_negative_errno(BlockError::Timeout),
+            -ETIMEDOUT
+        );
+    }
+
+    #[test]
+    fn unaligned_maps_to_einval() {
+        assert_eq!(block_error_to_errno(BlockError::Unaligned), EINVAL);
+    }
+
+    #[test]
+    fn out_of_range_maps_to_einval() {
+        assert_eq!(block_error_to_errno(BlockError::OutOfRange), EINVAL);
+    }
+
+    #[test]
+    fn device_busy_maps_to_ebusy() {
+        assert_eq!(block_error_to_errno(BlockError::DeviceBusy), EBUSY);
+    }
+
+    #[test]
+    fn errno_constants_match_linux() {
+        // Cross-check against the canonical Linux x86-64 / aarch64
+        // errno table. These constants must not drift.
+        assert_eq!(EIO, 5);
+        assert_eq!(ENXIO, 6);
+        assert_eq!(EBUSY, 16);
+        assert_eq!(EINVAL, 22);
+        assert_eq!(ENOSPC, 28);
+        assert_eq!(ETIMEDOUT, 110);
+    }
+}

--- a/fs/src/block/mock.rs
+++ b/fs/src/block/mock.rs
@@ -1,0 +1,321 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! In-memory mock [`BlockDevice`] for tests and CI.
+//!
+//! `MockBlockDevice` keeps a single contiguous backing buffer and
+//! services reads/writes by `memcpy`. It also has injectable failure
+//! modes so the conformance suite can drive the retry path:
+//!
+//! - [`MockBlockDevice::set_transient_failures`] makes the next *N*
+//!   read/write calls return [`BlockError::DeviceBusy`] (transient).
+//! - [`MockBlockDevice::set_permanent_failure`] makes every subsequent
+//!   call return the chosen error.
+//! - [`MockBlockDevice::set_bad_crc_block`] flags one specific LBA as
+//!   producing [`BlockError::BadCrc`] on read.
+//!
+//! The mock is `#![no_std]`-friendly: it uses `alloc::vec::Vec` and
+//! `core::cell::RefCell` for interior mutability so the trait methods
+//! can keep `&self` semantics where the spec requires it.
+
+use core::cell::RefCell;
+
+use super::{check_buf_alignment, check_lba_in_range, BlockDevice, BlockError};
+
+/// Internal mutable state of [`MockBlockDevice`].
+///
+/// Wrapped in `RefCell` so reads (which take `&self`) can still
+/// decrement counters and read-out injected errors.
+#[derive(Debug)]
+struct State {
+    storage: alloc::vec::Vec<u8>,
+    block_size_bytes: u32,
+    block_count: u64,
+    transient_failures_remaining: u32,
+    permanent_failure: Option<BlockError>,
+    bad_crc_blocks: alloc::vec::Vec<u64>,
+    flush_count: u32,
+    read_count: u32,
+    write_count: u32,
+}
+
+/// In-memory mock [`BlockDevice`] for tests.
+///
+/// Construct with [`new`](Self::new) (zero-initialized backing) or
+/// [`with_pattern`](Self::with_pattern) (fill with `lba_byte * 251` so
+/// each block has a distinct fingerprint).
+#[derive(Debug)]
+pub struct MockBlockDevice {
+    state: RefCell<State>,
+}
+
+impl MockBlockDevice {
+    /// Construct a mock with `block_count` zero-initialized blocks of
+    /// `block_size_bytes`.
+    pub fn new(block_size_bytes: u32, block_count: u64) -> Self {
+        let total = (block_size_bytes as usize)
+            .checked_mul(block_count as usize)
+            .expect("mock device too large for usize");
+        Self {
+            state: RefCell::new(State {
+                storage: alloc::vec![0u8; total],
+                block_size_bytes,
+                block_count,
+                transient_failures_remaining: 0,
+                permanent_failure: None,
+                bad_crc_blocks: alloc::vec::Vec::new(),
+                flush_count: 0,
+                read_count: 0,
+                write_count: 0,
+            }),
+        }
+    }
+
+    /// Construct a mock pre-filled with a deterministic pattern so
+    /// each block has unique contents (`byte_i = (block_index +
+    /// offset_in_block) % 251`).
+    pub fn with_pattern(block_size_bytes: u32, block_count: u64) -> Self {
+        let dev = Self::new(block_size_bytes, block_count);
+        {
+            let mut state = dev.state.borrow_mut();
+            for blk in 0..block_count {
+                for off in 0..block_size_bytes as usize {
+                    let byte = ((blk as usize).wrapping_add(off) % 251) as u8;
+                    let idx = blk as usize * block_size_bytes as usize + off;
+                    state.storage[idx] = byte;
+                }
+            }
+        }
+        dev
+    }
+
+    /// Inject `n` transient failures into the next `n` read/write
+    /// calls. Each surfaces as [`BlockError::DeviceBusy`] (which is
+    /// classified as retryable by [`crate::block::retry`]).
+    pub fn set_transient_failures(&self, n: u32) {
+        self.state.borrow_mut().transient_failures_remaining = n;
+    }
+
+    /// Inject a permanent failure: every subsequent read/write returns
+    /// this error until cleared.
+    pub fn set_permanent_failure(&self, err: BlockError) {
+        self.state.borrow_mut().permanent_failure = Some(err);
+    }
+
+    /// Clear any injected permanent failure.
+    pub fn clear_permanent_failure(&self) {
+        self.state.borrow_mut().permanent_failure = None;
+    }
+
+    /// Mark `lba` as producing [`BlockError::BadCrc`] on read until
+    /// cleared with [`clear_bad_crc_blocks`](Self::clear_bad_crc_blocks).
+    pub fn set_bad_crc_block(&self, lba: u64) {
+        self.state.borrow_mut().bad_crc_blocks.push(lba);
+    }
+
+    /// Clear all CRC-bad markers.
+    pub fn clear_bad_crc_blocks(&self) {
+        self.state.borrow_mut().bad_crc_blocks.clear();
+    }
+
+    /// Flush call count (test introspection).
+    pub fn flush_count(&self) -> u32 {
+        self.state.borrow().flush_count
+    }
+
+    /// Successful-read call count (test introspection).
+    pub fn read_count(&self) -> u32 {
+        self.state.borrow().read_count
+    }
+
+    /// Successful-write call count (test introspection).
+    pub fn write_count(&self) -> u32 {
+        self.state.borrow().write_count
+    }
+
+    /// Pre-load specific bytes at an LBA for deterministic-content
+    /// tests.
+    pub fn preload(&self, lba: u64, data: &[u8]) {
+        let mut state = self.state.borrow_mut();
+        let bs = state.block_size_bytes as usize;
+        assert!(
+            data.len().is_multiple_of(bs),
+            "preload buf must be block-aligned"
+        );
+        let start = lba as usize * bs;
+        let end = start + data.len();
+        state.storage[start..end].copy_from_slice(data);
+    }
+
+    /// Read raw bytes for inspection (does NOT count toward
+    /// [`read_count`](Self::read_count)).
+    pub fn snapshot(&self, lba: u64, len: usize) -> alloc::vec::Vec<u8> {
+        let state = self.state.borrow();
+        let bs = state.block_size_bytes as usize;
+        let start = lba as usize * bs;
+        state.storage[start..start + len].to_vec()
+    }
+}
+
+impl BlockDevice for MockBlockDevice {
+    fn read_block(&self, lba: u64, buf: &mut [u8]) -> Result<(), BlockError> {
+        let mut state = self.state.borrow_mut();
+        check_buf_alignment(buf.len(), state.block_size_bytes)?;
+        check_lba_in_range(lba, buf.len(), state.block_size_bytes, state.block_count)?;
+
+        if let Some(err) = state.permanent_failure {
+            return Err(err);
+        }
+        if state.transient_failures_remaining > 0 {
+            state.transient_failures_remaining -= 1;
+            return Err(BlockError::DeviceBusy);
+        }
+        // Bad-CRC injection — applies to any block in the I/O range.
+        let blocks = (buf.len() / state.block_size_bytes as usize) as u64;
+        for cur in lba..lba + blocks {
+            if state.bad_crc_blocks.contains(&cur) {
+                return Err(BlockError::BadCrc);
+            }
+        }
+
+        let bs = state.block_size_bytes as usize;
+        let start = lba as usize * bs;
+        let end = start + buf.len();
+        buf.copy_from_slice(&state.storage[start..end]);
+        state.read_count += 1;
+        Ok(())
+    }
+
+    fn write_block(&mut self, lba: u64, buf: &[u8]) -> Result<(), BlockError> {
+        let mut state = self.state.borrow_mut();
+        check_buf_alignment(buf.len(), state.block_size_bytes)?;
+        check_lba_in_range(lba, buf.len(), state.block_size_bytes, state.block_count)?;
+
+        if let Some(err) = state.permanent_failure {
+            return Err(err);
+        }
+        if state.transient_failures_remaining > 0 {
+            state.transient_failures_remaining -= 1;
+            return Err(BlockError::DeviceBusy);
+        }
+
+        let bs = state.block_size_bytes as usize;
+        let start = lba as usize * bs;
+        let end = start + buf.len();
+        state.storage[start..end].copy_from_slice(buf);
+        state.write_count += 1;
+        Ok(())
+    }
+
+    fn block_size_bytes(&self) -> u32 {
+        self.state.borrow().block_size_bytes
+    }
+
+    fn block_count(&self) -> u64 {
+        self.state.borrow().block_count
+    }
+
+    fn flush(&mut self) -> Result<(), BlockError> {
+        let mut state = self.state.borrow_mut();
+        if let Some(err) = state.permanent_failure {
+            return Err(err);
+        }
+        state.flush_count += 1;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pattern_fill_distinct_blocks() {
+        let dev = MockBlockDevice::with_pattern(512, 4);
+        let b0 = dev.snapshot(0, 512);
+        let b1 = dev.snapshot(1, 512);
+        let b2 = dev.snapshot(2, 512);
+        let b3 = dev.snapshot(3, 512);
+        assert_ne!(b0, b1);
+        assert_ne!(b1, b2);
+        assert_ne!(b2, b3);
+    }
+
+    #[test]
+    fn read_returns_stored_bytes() {
+        let dev = MockBlockDevice::with_pattern(512, 4);
+        let expected = dev.snapshot(2, 512);
+        let mut got = alloc::vec![0u8; 512];
+        dev.read_block(2, &mut got).unwrap();
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn transient_failure_decrements() {
+        let mut dev = MockBlockDevice::new(512, 4);
+        dev.set_transient_failures(2);
+        let mut buf = alloc::vec![0u8; 512];
+        assert_eq!(dev.read_block(0, &mut buf), Err(BlockError::DeviceBusy));
+        assert_eq!(dev.read_block(0, &mut buf), Err(BlockError::DeviceBusy));
+        assert!(dev.read_block(0, &mut buf).is_ok());
+        // Same for writes.
+        dev.set_transient_failures(1);
+        assert_eq!(
+            dev.write_block(0, &alloc::vec![0u8; 512]),
+            Err(BlockError::DeviceBusy)
+        );
+        assert!(dev.write_block(0, &alloc::vec![0u8; 512]).is_ok());
+    }
+
+    #[test]
+    fn permanent_failure_persists() {
+        let dev = MockBlockDevice::new(512, 4);
+        dev.set_permanent_failure(BlockError::MediaError);
+        let mut buf = alloc::vec![0u8; 512];
+        assert_eq!(dev.read_block(0, &mut buf), Err(BlockError::MediaError));
+        assert_eq!(dev.read_block(0, &mut buf), Err(BlockError::MediaError));
+        dev.clear_permanent_failure();
+        assert!(dev.read_block(0, &mut buf).is_ok());
+    }
+
+    #[test]
+    fn bad_crc_injection() {
+        let dev = MockBlockDevice::new(512, 4);
+        dev.set_bad_crc_block(2);
+        let mut buf = alloc::vec![0u8; 512];
+        assert!(dev.read_block(0, &mut buf).is_ok());
+        assert!(dev.read_block(1, &mut buf).is_ok());
+        assert_eq!(dev.read_block(2, &mut buf), Err(BlockError::BadCrc));
+        assert!(dev.read_block(3, &mut buf).is_ok());
+    }
+
+    #[test]
+    fn flush_increments_counter() {
+        let mut dev = MockBlockDevice::new(512, 4);
+        assert_eq!(dev.flush_count(), 0);
+        dev.flush().unwrap();
+        dev.flush().unwrap();
+        assert_eq!(dev.flush_count(), 2);
+    }
+
+    #[test]
+    fn unaligned_read_rejected() {
+        let dev = MockBlockDevice::new(512, 4);
+        let mut buf = alloc::vec![0u8; 513];
+        assert_eq!(dev.read_block(0, &mut buf), Err(BlockError::Unaligned));
+    }
+
+    #[test]
+    fn out_of_range_read_rejected() {
+        let dev = MockBlockDevice::new(512, 4);
+        let mut buf = alloc::vec![0u8; 512];
+        assert_eq!(dev.read_block(4, &mut buf), Err(BlockError::OutOfRange));
+        assert_eq!(dev.read_block(5, &mut buf), Err(BlockError::OutOfRange));
+    }
+
+    #[test]
+    fn capacity_bytes_works() {
+        let dev = MockBlockDevice::new(4096, 16);
+        assert_eq!(dev.capacity_bytes(), 65536);
+    }
+}

--- a/fs/src/block/mod.rs
+++ b/fs/src/block/mod.rs
@@ -1,0 +1,264 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Block-device abstraction for SmallAIOS on-disk filesystems.
+//!
+//! This module defines the single `BlockDevice` trait used by every
+//! consumer of block I/O in the `fs` crate (squashfs, F2FS, GPT parser,
+//! A/B boot pointer, delta apply pipeline). The trait is intentionally
+//! minimal:
+//!
+//! ```ignore
+//! pub trait BlockDevice {
+//!     fn read_block(&self, lba: u64, buf: &mut [u8]) -> Result<(), BlockError>;
+//!     fn write_block(&mut self, lba: u64, buf: &[u8]) -> Result<(), BlockError>;
+//!     fn block_size_bytes(&self) -> u32;
+//!     fn block_count(&self) -> u64;
+//!     fn flush(&mut self) -> Result<(), BlockError>;
+//! }
+//! ```
+//!
+//! The crate operates **natively at 4 KiB block size**. Devices that
+//! report a different logical/physical sector size are wrapped by an
+//! emulation layer in [`sector`] so consumers always see 4 KiB blocks.
+//!
+//! Errors are typed (`BlockError`) and converted to POSIX errno values
+//! at the syscall boundary by [`errno::block_error_to_errno`]. The
+//! retry policy (per-op timeout + 3-retry exponential backoff) is in
+//! [`retry`]; fail-after-retries is non-configurable so an unattended
+//! appliance never wedges on a single bad sector.
+//!
+//! Owned by `embedded-filesystem-v1` Phase 1.
+
+pub mod errno;
+pub mod retry;
+pub mod sector;
+
+pub mod mock;
+
+// Convenience re-exports so `use smallaios_fs::block::block_error_to_errno`
+// works without an extra `errno::` segment.
+pub use errno::{block_error_to_errno, block_error_to_negative_errno};
+
+use core::fmt;
+
+/// Native filesystem block size used by the SmallAIOS `fs` crate.
+///
+/// The squashfs reader, F2FS reader/writer, GPT parser, A/B boot
+/// pointer, and delta apply pipeline all express their I/O in terms
+/// of this value. Underlying block devices that report a different
+/// logical/physical sector size are wrapped by [`sector`] so callers
+/// always see 4 KiB blocks.
+pub const FS_BLOCK_SIZE_BYTES: u32 = 4096;
+
+/// Block-device trait implemented by every per-arch driver.
+///
+/// `BlockDevice` is the only abstraction layer between the on-disk
+/// filesystem code and the underlying transport (virtio-blk, NVMe,
+/// SDHCI/eMMC, AHCI). Each implementation documents its own native
+/// sector size; consumers that always want 4 KiB blocks should wrap
+/// the device with [`sector::SectorAdapter`].
+///
+/// # Alignment
+///
+/// `buf` length on `read_block`/`write_block` MUST be a multiple of
+/// [`block_size_bytes`](Self::block_size_bytes). Otherwise the call
+/// returns [`BlockError::Unaligned`] without issuing any I/O.
+///
+/// # Bounds
+///
+/// `lba >= block_count()` returns [`BlockError::OutOfRange`].
+pub trait BlockDevice {
+    /// Read one or more contiguous logical blocks starting at `lba`.
+    ///
+    /// `buf.len()` MUST be a non-zero multiple of
+    /// [`block_size_bytes`](Self::block_size_bytes).
+    fn read_block(&self, lba: u64, buf: &mut [u8]) -> Result<(), BlockError>;
+
+    /// Write one or more contiguous logical blocks starting at `lba`.
+    ///
+    /// `buf.len()` MUST be a non-zero multiple of
+    /// [`block_size_bytes`](Self::block_size_bytes).
+    fn write_block(&mut self, lba: u64, buf: &[u8]) -> Result<(), BlockError>;
+
+    /// Logical block size of this device in bytes.
+    ///
+    /// For most modern devices this is 4096. Devices that expose 512 B
+    /// logical sectors (Advanced Format with 512e, or pre-AF legacy
+    /// drives) report 512 here and rely on [`sector::SectorAdapter`]
+    /// to translate FS-level 4 KiB I/O.
+    fn block_size_bytes(&self) -> u32;
+
+    /// Number of logical blocks on the device.
+    fn block_count(&self) -> u64;
+
+    /// Force any in-flight writes to non-volatile media.
+    ///
+    /// On virtio-blk this issues `VIRTIO_BLK_T_FLUSH`. On NVMe it
+    /// issues a Flush command. On SDHCI/eMMC it issues
+    /// `CMD_FLUSH_CACHE`.
+    fn flush(&mut self) -> Result<(), BlockError>;
+
+    /// Total logical capacity in bytes.
+    ///
+    /// Default implementation: `block_size_bytes * block_count`.
+    fn capacity_bytes(&self) -> u64 {
+        self.block_count()
+            .saturating_mul(self.block_size_bytes() as u64)
+    }
+}
+
+/// Typed block-I/O errors.
+///
+/// Mapped to POSIX errno at the syscall boundary by
+/// [`errno::block_error_to_errno`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BlockError {
+    /// Hardware reported a media-level read/write failure (CRC bit
+    /// already accounted as `BadCrc`, this is the catch-all for ECC
+    /// uncorrectable, sector relocation failures, etc.).
+    MediaError,
+    /// The device is not present (hot-removed, never enumerated, or
+    /// transport went down).
+    NotPresent,
+    /// Per-op timeout fired and all retries are exhausted.
+    Timeout,
+    /// Read completed but the device-reported integrity check
+    /// (CRC32C, T10-DIF, NVMe metadata, etc.) failed.
+    BadCrc,
+    /// `buf.len()` is not a multiple of `block_size_bytes()`, OR
+    /// the LBA is misaligned for this transport.
+    Unaligned,
+    /// `lba >= block_count()` or the I/O extends past end-of-device.
+    OutOfRange,
+    /// The transport returned a "device busy" / queue-full code that
+    /// is not transient enough to retry inside this op.
+    DeviceBusy,
+}
+
+impl fmt::Display for BlockError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            BlockError::MediaError => "media error",
+            BlockError::NotPresent => "device not present",
+            BlockError::Timeout => "timeout after retries",
+            BlockError::BadCrc => "bad CRC",
+            BlockError::Unaligned => "unaligned buffer or LBA",
+            BlockError::OutOfRange => "LBA out of range",
+            BlockError::DeviceBusy => "device busy",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Validate that a buffer length is a non-zero multiple of the
+/// device's logical block size.
+///
+/// Used by every `BlockDevice` implementation in this crate as the
+/// first check in `read_block` / `write_block`. Returns
+/// `Err(BlockError::Unaligned)` for `buf.len() == 0`,
+/// `buf.len() % block_size_bytes != 0`.
+#[inline]
+pub fn check_buf_alignment(buf_len: usize, block_size_bytes: u32) -> Result<(), BlockError> {
+    if buf_len == 0 {
+        return Err(BlockError::Unaligned);
+    }
+    let bs = block_size_bytes as usize;
+    if bs == 0 || !buf_len.is_multiple_of(bs) {
+        return Err(BlockError::Unaligned);
+    }
+    Ok(())
+}
+
+/// Validate that an I/O of `(buf.len() / block_size_bytes)` blocks
+/// starting at `lba` fits within the device.
+#[inline]
+pub fn check_lba_in_range(
+    lba: u64,
+    buf_len: usize,
+    block_size_bytes: u32,
+    block_count: u64,
+) -> Result<(), BlockError> {
+    if block_count == 0 {
+        return Err(BlockError::OutOfRange);
+    }
+    if lba >= block_count {
+        return Err(BlockError::OutOfRange);
+    }
+    let blocks = (buf_len / block_size_bytes as usize) as u64;
+    let last = lba.checked_add(blocks).ok_or(BlockError::OutOfRange)?;
+    if last > block_count {
+        return Err(BlockError::OutOfRange);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn buf_alignment_zero_rejected() {
+        assert_eq!(check_buf_alignment(0, 4096), Err(BlockError::Unaligned));
+    }
+
+    #[test]
+    fn buf_alignment_misaligned_rejected() {
+        assert_eq!(check_buf_alignment(4097, 4096), Err(BlockError::Unaligned));
+        assert_eq!(check_buf_alignment(512, 4096), Err(BlockError::Unaligned));
+        assert_eq!(check_buf_alignment(8193, 4096), Err(BlockError::Unaligned));
+    }
+
+    #[test]
+    fn buf_alignment_aligned_accepted() {
+        assert!(check_buf_alignment(4096, 4096).is_ok());
+        assert!(check_buf_alignment(8192, 4096).is_ok());
+        assert!(check_buf_alignment(512, 512).is_ok());
+        assert!(check_buf_alignment(4096, 512).is_ok());
+    }
+
+    #[test]
+    fn lba_at_or_past_end_rejected() {
+        assert_eq!(
+            check_lba_in_range(100, 4096, 4096, 100),
+            Err(BlockError::OutOfRange)
+        );
+        assert_eq!(
+            check_lba_in_range(101, 4096, 4096, 100),
+            Err(BlockError::OutOfRange)
+        );
+    }
+
+    #[test]
+    fn lba_in_range_ok() {
+        assert!(check_lba_in_range(0, 4096, 4096, 100).is_ok());
+        assert!(check_lba_in_range(99, 4096, 4096, 100).is_ok());
+        // 8 KiB starting at lba 98 covers lba 98 and 99 — fits
+        assert!(check_lba_in_range(98, 8192, 4096, 100).is_ok());
+    }
+
+    #[test]
+    fn lba_extends_past_end_rejected() {
+        // 8 KiB starting at lba 99 needs lba 99 and 100, only 99 exists
+        assert_eq!(
+            check_lba_in_range(99, 8192, 4096, 100),
+            Err(BlockError::OutOfRange)
+        );
+    }
+
+    #[test]
+    fn empty_device_rejects_any_lba() {
+        assert_eq!(
+            check_lba_in_range(0, 4096, 4096, 0),
+            Err(BlockError::OutOfRange)
+        );
+    }
+
+    #[test]
+    fn block_error_display() {
+        use core::fmt::Write;
+        let mut buf = alloc::string::String::new();
+        write!(buf, "{}", BlockError::Timeout).unwrap();
+        assert!(buf.contains("timeout"));
+    }
+}

--- a/fs/src/block/retry.rs
+++ b/fs/src/block/retry.rs
@@ -1,0 +1,453 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-op timeout + bounded-retry policy for block I/O.
+//!
+//! Per the spec (`embedded-filesystem-v1::fs-block-device`):
+//!
+//! - **Read** default per-op timeout is **250 ms**, retry schedule is
+//!   **500 ms / 1 s / 2 s** (3 retries), then `Err(Timeout)`.
+//! - **Write** default per-op timeout is **1 s**, same retry schedule
+//!   (3 retries), then `Err(Timeout)`.
+//! - Configurable via `mgmt/policy.toml` keys
+//!   `fs.block.read_timeout_ms`, `fs.block.write_timeout_ms`,
+//!   `fs.block.retry_count`, `fs.block.retry_backoff_ms`.
+//! - **Fail-after-retries is non-configurable.** An unattended
+//!   appliance must NEVER block indefinitely on a single bad sector;
+//!   "infinite retry" sentinels (`u32::MAX`, `0xFFFF_FFFF`) are
+//!   rejected by [`RetryPolicy::validate`] with [`PolicyError::Indefinite`]
+//!   and surfaced to userspace as `-EINVAL`.
+//!
+//! Wave 0's `mgmt/` is empty — the `from_config()` helper here is a
+//! stub that returns `default()` for now; `management-login-v1`
+//! Phase 5 wires it to the real `Config` struct.
+
+use super::BlockError;
+
+/// Default read per-op timeout, in milliseconds.
+pub const DEFAULT_READ_TIMEOUT_MS: u32 = 250;
+
+/// Default write per-op timeout, in milliseconds.
+pub const DEFAULT_WRITE_TIMEOUT_MS: u32 = 1000;
+
+/// Default retry count (3 attempts beyond the initial one).
+pub const DEFAULT_RETRY_COUNT: u32 = 3;
+
+/// Default exponential-backoff schedule, in milliseconds.
+///
+/// `[500, 1000, 2000]` = first retry waits 500 ms, second 1 s, third
+/// 2 s. The schedule has at most [`DEFAULT_RETRY_COUNT`] entries; if
+/// `retry_count` is configured higher than the schedule length, the
+/// last value is reused for the additional retries.
+pub const DEFAULT_RETRY_BACKOFF_MS: [u32; 3] = [500, 1000, 2000];
+
+/// Sentinel value rejected by [`RetryPolicy::validate`].
+///
+/// The spec is explicit: an unattended appliance must never block
+/// indefinitely on a single bad sector. Configuration writes
+/// containing this value (or any retry count above
+/// [`MAX_ALLOWED_RETRY_COUNT`]) are rejected with `-EINVAL`.
+pub const RETRY_COUNT_INFINITE_SENTINEL: u32 = u32::MAX;
+
+/// Hard upper bound on `retry_count`. Higher values are rejected at
+/// configuration time as effectively-infinite (an unattended appliance
+/// must never wedge).
+///
+/// Sized so that with the maximum allowed backoff, a single failed I/O
+/// can stall for at most a few minutes — well short of the watchdog.
+pub const MAX_ALLOWED_RETRY_COUNT: u32 = 16;
+
+/// Hard upper bound on `retry_backoff_ms` entries.
+///
+/// 30 s per backoff step + 16 retries = ~8 min worst case. Beyond this
+/// the operator should investigate hardware rather than configure
+/// longer backoff.
+pub const MAX_ALLOWED_BACKOFF_MS: u32 = 30_000;
+
+/// Hard upper bound on per-op timeout. 30 s per attempt is already
+/// extreme for any reasonable transport.
+pub const MAX_ALLOWED_TIMEOUT_MS: u32 = 30_000;
+
+/// Errors returned by [`RetryPolicy::validate`].
+///
+/// Each variant maps to `-EINVAL` at the syscall boundary
+/// (configuration write).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PolicyError {
+    /// `retry_count` is `u32::MAX` or otherwise an "infinite retry"
+    /// sentinel. Rejected to keep an unattended appliance from
+    /// wedging.
+    Indefinite,
+    /// `retry_count` exceeds [`MAX_ALLOWED_RETRY_COUNT`].
+    RetryCountTooHigh,
+    /// A backoff entry exceeds [`MAX_ALLOWED_BACKOFF_MS`], or the
+    /// list is empty when `retry_count > 0`.
+    BackoffOutOfRange,
+    /// Per-op timeout exceeds [`MAX_ALLOWED_TIMEOUT_MS`] or is zero.
+    TimeoutOutOfRange,
+}
+
+/// Per-op timeout + retry schedule for a block-I/O operation.
+///
+/// Two well-known constructors give the spec defaults:
+/// [`RetryPolicy::default_read`] (250 ms timeout) and
+/// [`RetryPolicy::default_write`] (1 s timeout). The retry schedule
+/// is the same for both (`500 / 1000 / 2000` ms).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetryPolicy {
+    /// Per-attempt timeout, in milliseconds. Zero is invalid.
+    pub timeout_ms: u32,
+    /// Number of retries beyond the initial attempt. The total number
+    /// of attempts is `retry_count + 1`. Capped by
+    /// [`MAX_ALLOWED_RETRY_COUNT`].
+    pub retry_count: u32,
+    /// Exponential-backoff schedule, in milliseconds. If
+    /// `retry_count > backoff_ms.len()`, the last value is reused for
+    /// the additional retries.
+    pub backoff_ms: alloc::vec::Vec<u32>,
+}
+
+impl RetryPolicy {
+    /// Spec defaults for **read** operations: 250 ms per-op timeout,
+    /// 3 retries with `[500, 1000, 2000]` ms backoff.
+    pub fn default_read() -> Self {
+        Self {
+            timeout_ms: DEFAULT_READ_TIMEOUT_MS,
+            retry_count: DEFAULT_RETRY_COUNT,
+            backoff_ms: DEFAULT_RETRY_BACKOFF_MS.to_vec(),
+        }
+    }
+
+    /// Spec defaults for **write** operations: 1 s per-op timeout,
+    /// 3 retries with `[500, 1000, 2000]` ms backoff.
+    pub fn default_write() -> Self {
+        Self {
+            timeout_ms: DEFAULT_WRITE_TIMEOUT_MS,
+            retry_count: DEFAULT_RETRY_COUNT,
+            backoff_ms: DEFAULT_RETRY_BACKOFF_MS.to_vec(),
+        }
+    }
+
+    /// Stub for the `mgmt::Config` integration. Wave 0's `mgmt` crate
+    /// is empty; once `management-login-v1` Phase 5 lands, this
+    /// reads the four `fs.block.*` keys and applies them on top of
+    /// the spec defaults.
+    ///
+    /// For now: returns the spec defaults for the requested operation
+    /// kind.
+    pub fn from_config(kind: PolicyKind) -> Self {
+        match kind {
+            PolicyKind::Read => Self::default_read(),
+            PolicyKind::Write => Self::default_write(),
+        }
+    }
+
+    /// Validate this policy against the non-configurable safety
+    /// invariants. Called by `mgmt`'s config validator on every
+    /// `policy.toml` write.
+    pub fn validate(&self) -> Result<(), PolicyError> {
+        if self.retry_count == RETRY_COUNT_INFINITE_SENTINEL {
+            return Err(PolicyError::Indefinite);
+        }
+        if self.retry_count > MAX_ALLOWED_RETRY_COUNT {
+            return Err(PolicyError::RetryCountTooHigh);
+        }
+        if self.timeout_ms == 0 || self.timeout_ms > MAX_ALLOWED_TIMEOUT_MS {
+            return Err(PolicyError::TimeoutOutOfRange);
+        }
+        if self.retry_count > 0 && self.backoff_ms.is_empty() {
+            return Err(PolicyError::BackoffOutOfRange);
+        }
+        for &b in &self.backoff_ms {
+            if b > MAX_ALLOWED_BACKOFF_MS {
+                return Err(PolicyError::BackoffOutOfRange);
+            }
+        }
+        Ok(())
+    }
+
+    /// Backoff to wait before retry attempt `n` (1-indexed).
+    ///
+    /// `n=1` is the first retry; for `n >= backoff_ms.len()` returns
+    /// the last entry. Returns `0` if `backoff_ms` is empty.
+    pub fn backoff_for_retry(&self, n: u32) -> u32 {
+        if self.backoff_ms.is_empty() {
+            return 0;
+        }
+        if n == 0 {
+            return 0;
+        }
+        let idx = ((n - 1) as usize).min(self.backoff_ms.len() - 1);
+        self.backoff_ms[idx]
+    }
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self::default_read()
+    }
+}
+
+/// Whether to use the read or write defaults in
+/// [`RetryPolicy::from_config`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PolicyKind {
+    Read,
+    Write,
+}
+
+/// Outcome of running a single attempt inside [`run_with_retries`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttemptOutcome {
+    /// Success — return immediately.
+    Success,
+    /// Failure that should be retried (transient transport error,
+    /// timeout, busy).
+    Retry,
+    /// Failure that should NOT be retried (alignment, bounds,
+    /// permanent media error).
+    Permanent(BlockError),
+}
+
+/// Run a block-I/O attempt with bounded retries.
+///
+/// `attempt` is invoked up to `1 + policy.retry_count` times. Between
+/// attempts it sleeps for `policy.backoff_for_retry(n)` ms via the
+/// caller-provided `sleep_ms` callback (no global timer dependency).
+///
+/// On exhaustion the helper returns `Err(BlockError::Timeout)`,
+/// regardless of which transient error variant the underlying device
+/// reported, because the spec's contract with userspace is
+/// "fail-after-retries === ETIMEDOUT".
+pub fn run_with_retries<F, S>(
+    policy: &RetryPolicy,
+    mut attempt: F,
+    mut sleep_ms: S,
+) -> Result<(), BlockError>
+where
+    F: FnMut(u32) -> AttemptOutcome,
+    S: FnMut(u32),
+{
+    let total_attempts = policy.retry_count.saturating_add(1);
+    for n in 0..total_attempts {
+        match attempt(n) {
+            AttemptOutcome::Success => return Ok(()),
+            AttemptOutcome::Permanent(err) => return Err(err),
+            AttemptOutcome::Retry => {
+                // After the last attempt, fall through to Timeout.
+                if n + 1 < total_attempts {
+                    let backoff = policy.backoff_for_retry(n + 1);
+                    if backoff > 0 {
+                        sleep_ms(backoff);
+                    }
+                }
+            }
+        }
+    }
+    Err(BlockError::Timeout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::cell::Cell;
+
+    #[test]
+    fn read_defaults_match_spec() {
+        let p = RetryPolicy::default_read();
+        assert_eq!(p.timeout_ms, 250);
+        assert_eq!(p.retry_count, 3);
+        assert_eq!(p.backoff_ms, [500, 1000, 2000]);
+    }
+
+    #[test]
+    fn write_defaults_match_spec() {
+        let p = RetryPolicy::default_write();
+        assert_eq!(p.timeout_ms, 1000);
+        assert_eq!(p.retry_count, 3);
+        assert_eq!(p.backoff_ms, [500, 1000, 2000]);
+    }
+
+    #[test]
+    fn from_config_returns_defaults_for_now() {
+        assert_eq!(
+            RetryPolicy::from_config(PolicyKind::Read),
+            RetryPolicy::default_read()
+        );
+        assert_eq!(
+            RetryPolicy::from_config(PolicyKind::Write),
+            RetryPolicy::default_write()
+        );
+    }
+
+    #[test]
+    fn validate_accepts_defaults() {
+        assert!(RetryPolicy::default_read().validate().is_ok());
+        assert!(RetryPolicy::default_write().validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_infinite_sentinel() {
+        let p = RetryPolicy {
+            timeout_ms: 250,
+            retry_count: RETRY_COUNT_INFINITE_SENTINEL,
+            backoff_ms: alloc::vec![500],
+        };
+        assert_eq!(p.validate(), Err(PolicyError::Indefinite));
+    }
+
+    #[test]
+    fn validate_rejects_too_many_retries() {
+        let p = RetryPolicy {
+            timeout_ms: 250,
+            retry_count: MAX_ALLOWED_RETRY_COUNT + 1,
+            backoff_ms: alloc::vec![500],
+        };
+        assert_eq!(p.validate(), Err(PolicyError::RetryCountTooHigh));
+    }
+
+    #[test]
+    fn validate_rejects_zero_timeout() {
+        let p = RetryPolicy {
+            timeout_ms: 0,
+            retry_count: 0,
+            backoff_ms: alloc::vec![],
+        };
+        assert_eq!(p.validate(), Err(PolicyError::TimeoutOutOfRange));
+    }
+
+    #[test]
+    fn validate_rejects_huge_timeout() {
+        let p = RetryPolicy {
+            timeout_ms: MAX_ALLOWED_TIMEOUT_MS + 1,
+            retry_count: 0,
+            backoff_ms: alloc::vec![],
+        };
+        assert_eq!(p.validate(), Err(PolicyError::TimeoutOutOfRange));
+    }
+
+    #[test]
+    fn validate_rejects_huge_backoff() {
+        let p = RetryPolicy {
+            timeout_ms: 250,
+            retry_count: 1,
+            backoff_ms: alloc::vec![MAX_ALLOWED_BACKOFF_MS + 1],
+        };
+        assert_eq!(p.validate(), Err(PolicyError::BackoffOutOfRange));
+    }
+
+    #[test]
+    fn validate_rejects_empty_backoff_with_retries() {
+        let p = RetryPolicy {
+            timeout_ms: 250,
+            retry_count: 3,
+            backoff_ms: alloc::vec![],
+        };
+        assert_eq!(p.validate(), Err(PolicyError::BackoffOutOfRange));
+    }
+
+    #[test]
+    fn backoff_schedule_clamps_to_last_entry() {
+        let p = RetryPolicy::default_read();
+        assert_eq!(p.backoff_for_retry(1), 500);
+        assert_eq!(p.backoff_for_retry(2), 1000);
+        assert_eq!(p.backoff_for_retry(3), 2000);
+        // beyond the schedule reuses the last
+        assert_eq!(p.backoff_for_retry(4), 2000);
+        assert_eq!(p.backoff_for_retry(99), 2000);
+    }
+
+    #[test]
+    fn run_with_retries_succeeds_on_first_try() {
+        let p = RetryPolicy::default_read();
+        let calls = Cell::new(0u32);
+        let res = run_with_retries(
+            &p,
+            |_| {
+                calls.set(calls.get() + 1);
+                AttemptOutcome::Success
+            },
+            |_| panic!("must not sleep"),
+        );
+        assert!(res.is_ok());
+        assert_eq!(calls.get(), 1);
+    }
+
+    #[test]
+    fn run_with_retries_three_retries_then_timeout() {
+        let p = RetryPolicy::default_read();
+        let calls = Cell::new(0u32);
+        let sleeps: core::cell::RefCell<alloc::vec::Vec<u32>> =
+            core::cell::RefCell::new(alloc::vec::Vec::new());
+        let res = run_with_retries(
+            &p,
+            |_| {
+                calls.set(calls.get() + 1);
+                AttemptOutcome::Retry
+            },
+            |ms| sleeps.borrow_mut().push(ms),
+        );
+        // 1 initial + 3 retries = 4 calls
+        assert_eq!(calls.get(), 4);
+        // Sleeps happen between attempts: 3 of them
+        assert_eq!(*sleeps.borrow(), alloc::vec![500u32, 1000, 2000]);
+        assert_eq!(res, Err(BlockError::Timeout));
+    }
+
+    #[test]
+    fn run_with_retries_permanent_error_returned_immediately() {
+        let p = RetryPolicy::default_read();
+        let calls = Cell::new(0u32);
+        let res = run_with_retries(
+            &p,
+            |_| {
+                calls.set(calls.get() + 1);
+                AttemptOutcome::Permanent(BlockError::OutOfRange)
+            },
+            |_| panic!("must not sleep on permanent error"),
+        );
+        assert_eq!(calls.get(), 1);
+        assert_eq!(res, Err(BlockError::OutOfRange));
+    }
+
+    #[test]
+    fn run_with_retries_success_on_third_attempt() {
+        let p = RetryPolicy::default_read();
+        let calls = Cell::new(0u32);
+        let res = run_with_retries(
+            &p,
+            |_| {
+                let n = calls.get() + 1;
+                calls.set(n);
+                if n < 3 {
+                    AttemptOutcome::Retry
+                } else {
+                    AttemptOutcome::Success
+                }
+            },
+            |_| {},
+        );
+        assert!(res.is_ok());
+        assert_eq!(calls.get(), 3);
+    }
+
+    #[test]
+    fn run_with_retries_zero_retries_one_attempt() {
+        let p = RetryPolicy {
+            timeout_ms: 100,
+            retry_count: 0,
+            backoff_ms: alloc::vec![],
+        };
+        let calls = Cell::new(0u32);
+        let res = run_with_retries(
+            &p,
+            |_| {
+                calls.set(calls.get() + 1);
+                AttemptOutcome::Retry
+            },
+            |_| panic!("must not sleep when retry_count == 0"),
+        );
+        assert_eq!(calls.get(), 1);
+        assert_eq!(res, Err(BlockError::Timeout));
+    }
+}

--- a/fs/src/block/sector.rs
+++ b/fs/src/block/sector.rs
@@ -1,0 +1,319 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! 4 KiB-native FS access over devices that report 4 KiB or 512 B
+//! sectors.
+//!
+//! The SmallAIOS `fs` crate operates natively at 4 KiB
+//! ([`crate::block::FS_BLOCK_SIZE_BYTES`]). Underlying block devices,
+//! however, fall into one of three categories per spec Q23:
+//!
+//! 1. **4 KiB native** (`logical == physical == 4096`). FS reads and
+//!    writes pass through directly.
+//! 2. **Advanced Format / 512e** (`logical == 512`, `physical == 4096`).
+//!    The device exposes 512-byte LBAs but the underlying media works
+//!    in 4 KiB physical sectors. FS reads issue 8-LBA-aligned 4 KiB
+//!    I/O so we never split a logical FS block across two physical
+//!    sectors.
+//! 3. **Legacy 512 / 512** (`logical == physical == 512`). The
+//!    emulation layer bundles 8 consecutive logical sectors per FS
+//!    block. A one-time warning is logged at mount because this is
+//!    the slow path on modern hardware.
+//!
+//! All three modes are wrapped uniformly by [`SectorAdapter`], which
+//! itself implements [`BlockDevice`] with a fixed
+//! [`FS_BLOCK_SIZE_BYTES`] block size. Code above the adapter
+//! (squashfs, F2FS, GPT parser, A/B boot) never sees 512-byte LBAs.
+
+use super::{
+    check_buf_alignment, check_lba_in_range, BlockDevice, BlockError, FS_BLOCK_SIZE_BYTES,
+};
+
+/// LBA-multiplier from a 512 B logical sector to a 4 KiB FS block.
+pub const LEGACY_SECTORS_PER_FS_BLOCK: u32 = 8;
+
+/// Sector mode reported by [`SectorAdapter::mode`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SectorMode {
+    /// Logical and physical sector are both 4 KiB. Direct passthrough.
+    Native4K,
+    /// 512 B logical / 4 KiB physical. FS issues 4 KiB-aligned 8-LBA I/O.
+    AdvancedFormat512e,
+    /// 512 B logical / 512 B physical. Slow-path emulation: bundle 8
+    /// logical sectors per FS block. Warned about at mount.
+    Legacy512,
+}
+
+impl SectorMode {
+    /// Pick the appropriate mode from the device-reported `logical`
+    /// and `physical` sector sizes.
+    ///
+    /// Rules:
+    /// - `logical == 4096`, `physical == 4096` → `Native4K`
+    /// - `logical == 512`, `physical == 4096` → `AdvancedFormat512e`
+    /// - `logical == 512`, `physical == 512`  → `Legacy512`
+    /// - any other combination → `None` (unsupported)
+    pub fn from_sizes(logical: u32, physical: u32) -> Option<Self> {
+        match (logical, physical) {
+            (4096, 4096) => Some(Self::Native4K),
+            (512, 4096) => Some(Self::AdvancedFormat512e),
+            (512, 512) => Some(Self::Legacy512),
+            _ => None,
+        }
+    }
+
+    /// `true` when the FS block size requires bundling several
+    /// logical sectors per FS block.
+    pub fn needs_bundling(self) -> bool {
+        matches!(self, Self::AdvancedFormat512e | Self::Legacy512)
+    }
+
+    /// `true` when this mode is the legacy 512/512 slow-path that
+    /// SHOULD log a one-time warning at mount per the spec.
+    pub fn is_legacy_slow_path(self) -> bool {
+        matches!(self, Self::Legacy512)
+    }
+}
+
+/// Wraps any [`BlockDevice`] and presents a 4 KiB FS-block interface.
+///
+/// Use [`SectorAdapter::new`] to construct from an underlying device
+/// plus the device-reported physical sector size.
+pub struct SectorAdapter<D: BlockDevice> {
+    inner: D,
+    mode: SectorMode,
+    /// FS-level block count (capacity_bytes / 4 KiB). Pre-computed so
+    /// `block_count` is O(1) and we never overflow inside the trait
+    /// bounds checks.
+    fs_block_count: u64,
+}
+
+impl<D: BlockDevice> SectorAdapter<D> {
+    /// Construct a new adapter.
+    ///
+    /// `physical_sector_bytes` is the device-reported *physical* sector
+    /// size (which may differ from `inner.block_size_bytes()`, the
+    /// logical sector size, for Advanced Format devices).
+    ///
+    /// Returns `None` if the (logical, physical) combination is not
+    /// one of the three supported modes.
+    pub fn new(inner: D, physical_sector_bytes: u32) -> Option<Self> {
+        let logical = inner.block_size_bytes();
+        let mode = SectorMode::from_sizes(logical, physical_sector_bytes)?;
+        let inner_capacity_blocks = inner.block_count();
+        let fs_block_count = match mode {
+            SectorMode::Native4K => inner_capacity_blocks,
+            SectorMode::AdvancedFormat512e | SectorMode::Legacy512 => {
+                inner_capacity_blocks / LEGACY_SECTORS_PER_FS_BLOCK as u64
+            }
+        };
+        Some(Self {
+            inner,
+            mode,
+            fs_block_count,
+        })
+    }
+
+    /// Return the operating mode of this adapter.
+    pub fn mode(&self) -> SectorMode {
+        self.mode
+    }
+
+    /// Borrow the underlying device.
+    pub fn inner(&self) -> &D {
+        &self.inner
+    }
+
+    /// Mutable-borrow the underlying device.
+    pub fn inner_mut(&mut self) -> &mut D {
+        &mut self.inner
+    }
+
+    /// Translate an FS-level LBA to the underlying-device LBA.
+    fn fs_lba_to_inner_lba(&self, fs_lba: u64) -> u64 {
+        match self.mode {
+            SectorMode::Native4K => fs_lba,
+            SectorMode::AdvancedFormat512e | SectorMode::Legacy512 => {
+                fs_lba.saturating_mul(LEGACY_SECTORS_PER_FS_BLOCK as u64)
+            }
+        }
+    }
+}
+
+impl<D: BlockDevice> BlockDevice for SectorAdapter<D> {
+    fn read_block(&self, fs_lba: u64, buf: &mut [u8]) -> Result<(), BlockError> {
+        check_buf_alignment(buf.len(), FS_BLOCK_SIZE_BYTES)?;
+        check_lba_in_range(fs_lba, buf.len(), FS_BLOCK_SIZE_BYTES, self.fs_block_count)?;
+        let inner_lba = self.fs_lba_to_inner_lba(fs_lba);
+        // Buffer length is already a multiple of 4 KiB, which is also
+        // a multiple of 512 — so passes the inner alignment check.
+        self.inner.read_block(inner_lba, buf)
+    }
+
+    fn write_block(&mut self, fs_lba: u64, buf: &[u8]) -> Result<(), BlockError> {
+        check_buf_alignment(buf.len(), FS_BLOCK_SIZE_BYTES)?;
+        check_lba_in_range(fs_lba, buf.len(), FS_BLOCK_SIZE_BYTES, self.fs_block_count)?;
+        let inner_lba = self.fs_lba_to_inner_lba(fs_lba);
+        self.inner.write_block(inner_lba, buf)
+    }
+
+    fn block_size_bytes(&self) -> u32 {
+        FS_BLOCK_SIZE_BYTES
+    }
+
+    fn block_count(&self) -> u64 {
+        self.fs_block_count
+    }
+
+    fn flush(&mut self) -> Result<(), BlockError> {
+        self.inner.flush()
+    }
+}
+
+/// One-time warning hook for the 512/512 legacy slow path.
+///
+/// Wave 0 has no logging crate yet; this is a thin abstraction so the
+/// mount code can register a callback once the audit-ring lands.
+/// Default impl is a no-op.
+pub trait LegacyPathWarner {
+    /// Called exactly once when a 512/512 legacy device is mounted.
+    fn warn_legacy_slow_path(&self) {}
+}
+
+/// Helper that wraps the adapter constructor and emits the one-time
+/// legacy-path warning if applicable.
+pub fn new_with_warning<D: BlockDevice, W: LegacyPathWarner>(
+    inner: D,
+    physical_sector_bytes: u32,
+    warner: &W,
+) -> Option<SectorAdapter<D>> {
+    let adapter = SectorAdapter::new(inner, physical_sector_bytes)?;
+    if adapter.mode().is_legacy_slow_path() {
+        warner.warn_legacy_slow_path();
+    }
+    Some(adapter)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block::mock::MockBlockDevice;
+
+    #[test]
+    fn sector_mode_from_sizes() {
+        assert_eq!(
+            SectorMode::from_sizes(4096, 4096),
+            Some(SectorMode::Native4K)
+        );
+        assert_eq!(
+            SectorMode::from_sizes(512, 4096),
+            Some(SectorMode::AdvancedFormat512e)
+        );
+        assert_eq!(
+            SectorMode::from_sizes(512, 512),
+            Some(SectorMode::Legacy512)
+        );
+        assert_eq!(SectorMode::from_sizes(1024, 4096), None);
+        assert_eq!(SectorMode::from_sizes(4096, 512), None);
+    }
+
+    #[test]
+    fn native_4k_passthrough() {
+        // 16 blocks * 4 KiB = 64 KiB device.
+        let mock = MockBlockDevice::new(4096, 16);
+        let adapter = SectorAdapter::new(mock, 4096).unwrap();
+        assert_eq!(adapter.mode(), SectorMode::Native4K);
+        assert_eq!(adapter.block_size_bytes(), 4096);
+        assert_eq!(adapter.block_count(), 16);
+    }
+
+    #[test]
+    fn advanced_format_512e_aligns_to_8_lbas() {
+        // 128 logical sectors of 512 = 64 KiB device, exposes 16 FS blocks.
+        let mock = MockBlockDevice::new(512, 128);
+        let adapter = SectorAdapter::new(mock, 4096).unwrap();
+        assert_eq!(adapter.mode(), SectorMode::AdvancedFormat512e);
+        assert_eq!(adapter.block_size_bytes(), 4096);
+        assert_eq!(adapter.block_count(), 16);
+        // Internal LBA mapping multiplies by 8.
+        assert_eq!(adapter.fs_lba_to_inner_lba(0), 0);
+        assert_eq!(adapter.fs_lba_to_inner_lba(1), 8);
+        assert_eq!(adapter.fs_lba_to_inner_lba(15), 120);
+    }
+
+    #[test]
+    fn legacy_512_marks_slow_path() {
+        let mock = MockBlockDevice::new(512, 128);
+        let adapter = SectorAdapter::new(mock, 512).unwrap();
+        assert_eq!(adapter.mode(), SectorMode::Legacy512);
+        assert!(adapter.mode().is_legacy_slow_path());
+        assert_eq!(adapter.block_count(), 16);
+    }
+
+    #[test]
+    fn unaligned_buf_rejected_at_adapter() {
+        let mock = MockBlockDevice::new(4096, 16);
+        let adapter = SectorAdapter::new(mock, 4096).unwrap();
+        let mut buf = alloc::vec![0u8; 4097];
+        assert_eq!(adapter.read_block(0, &mut buf), Err(BlockError::Unaligned));
+    }
+
+    #[test]
+    fn out_of_range_rejected_at_adapter() {
+        let mock = MockBlockDevice::new(4096, 16);
+        let adapter = SectorAdapter::new(mock, 4096).unwrap();
+        let mut buf = alloc::vec![0u8; 4096];
+        assert_eq!(
+            adapter.read_block(16, &mut buf),
+            Err(BlockError::OutOfRange)
+        );
+    }
+
+    #[test]
+    fn legacy_path_warning_fires_once() {
+        use core::cell::Cell;
+
+        struct CountingWarner(Cell<u32>);
+        impl LegacyPathWarner for CountingWarner {
+            fn warn_legacy_slow_path(&self) {
+                self.0.set(self.0.get() + 1);
+            }
+        }
+
+        let warner = CountingWarner(Cell::new(0));
+        let _adapter = new_with_warning(MockBlockDevice::new(512, 128), 512, &warner).unwrap();
+        assert_eq!(warner.0.get(), 1);
+        // No second adapter constructed → no second warning. The "once"
+        // contract is at the call site (mount only fires this once); the
+        // helper itself emits at construction.
+    }
+
+    #[test]
+    fn non_legacy_path_no_warning() {
+        use core::cell::Cell;
+
+        struct CountingWarner(Cell<u32>);
+        impl LegacyPathWarner for CountingWarner {
+            fn warn_legacy_slow_path(&self) {
+                self.0.set(self.0.get() + 1);
+            }
+        }
+
+        let warner = CountingWarner(Cell::new(0));
+        let _adapter = new_with_warning(MockBlockDevice::new(4096, 16), 4096, &warner).unwrap();
+        assert_eq!(warner.0.get(), 0);
+        let _adapter = new_with_warning(MockBlockDevice::new(512, 128), 4096, &warner).unwrap();
+        assert_eq!(warner.0.get(), 0);
+    }
+
+    #[test]
+    fn read_then_write_via_adapter_roundtrips() {
+        let mock = MockBlockDevice::new(512, 128);
+        let mut adapter = SectorAdapter::new(mock, 4096).unwrap();
+        let pattern: alloc::vec::Vec<u8> = (0..4096).map(|i| (i % 251) as u8).collect();
+        adapter.write_block(3, &pattern).unwrap();
+        let mut readback = alloc::vec![0u8; 4096];
+        adapter.read_block(3, &mut readback).unwrap();
+        assert_eq!(readback, pattern);
+    }
+}

--- a/fs/src/lib.rs
+++ b/fs/src/lib.rs
@@ -36,6 +36,8 @@
 #![no_std]
 #![forbid(unsafe_code)]
 
+extern crate alloc;
+
 // ─── Module skeleton ─────────────────────────────────────────────────────────
 //
 // Each `pub mod` is gated by its owning cargo feature. Modules contain
@@ -46,7 +48,7 @@
 ///
 /// Filled by `embedded-filesystem-v1` Phase 1.
 #[cfg(feature = "fs-on-disk-mounts")]
-pub mod block {}
+pub mod block;
 
 /// GPT partition table parser + protective-MBR writer + v1 layout
 /// enforcement.

--- a/fs/tests/block_conformance.rs
+++ b/fs/tests/block_conformance.rs
@@ -1,0 +1,596 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Generic conformance suite for any [`BlockDevice`] implementation.
+//!
+//! Per `embedded-filesystem-v1::fs-block-device` spec, every per-arch
+//! driver SHALL pass this suite. The suite runs against:
+//!
+//! - The in-memory `MockBlockDevice` (always — exercised by every CI
+//!   run of `cargo test -p smallaios-fs --features fs-on-disk-mounts`).
+//! - The virtio-blk driver (added under `fs-block-virtio` once the
+//!   QEMU-side test harness lands; see Phase 1 follow-on tickets).
+//!
+//! The suite uses a minimal Rust-host runner: each test is a top-level
+//! `#[test]` fn so `cargo test` picks them up. The file lives at
+//! `fs/tests/block_conformance.rs` so it is compiled as an integration
+//! test (separate binary).
+
+#![cfg(feature = "fs-on-disk-mounts")]
+
+extern crate alloc;
+
+use core::cell::RefCell;
+
+use smallaios_fs::block::{
+    block_error_to_errno, block_error_to_negative_errno, check_buf_alignment, check_lba_in_range,
+    mock::MockBlockDevice,
+    retry::{
+        run_with_retries, AttemptOutcome, PolicyError, PolicyKind, RetryPolicy,
+        DEFAULT_READ_TIMEOUT_MS, DEFAULT_RETRY_BACKOFF_MS, DEFAULT_RETRY_COUNT,
+        DEFAULT_WRITE_TIMEOUT_MS, MAX_ALLOWED_RETRY_COUNT, RETRY_COUNT_INFINITE_SENTINEL,
+    },
+    sector::{LegacyPathWarner, SectorAdapter, SectorMode},
+    BlockDevice, BlockError, FS_BLOCK_SIZE_BYTES,
+};
+
+// ─── Trait-level scenarios from spec ───────────────────────────────────────
+
+/// Spec scenario: "Read returns exactly the requested block".
+#[test]
+fn read_returns_exactly_the_requested_block() {
+    let dev = MockBlockDevice::with_pattern(4096, 16);
+    let expected = dev.snapshot(7, 4096);
+
+    let mut buf = alloc::vec![0u8; 4096];
+    dev.read_block(7, &mut buf).unwrap();
+
+    assert_eq!(buf, expected);
+    assert_eq!(buf.len(), 4096);
+}
+
+/// Spec scenario: "Read with mis-sized buffer rejected".
+#[test]
+fn read_with_mis_sized_buffer_rejected_unaligned() {
+    let dev = MockBlockDevice::new(4096, 16);
+
+    // Length not a multiple of 4096 → Unaligned.
+    let mut bad = alloc::vec![0u8; 4095];
+    assert_eq!(dev.read_block(0, &mut bad), Err(BlockError::Unaligned));
+
+    let mut bad = alloc::vec![0u8; 4097];
+    assert_eq!(dev.read_block(0, &mut bad), Err(BlockError::Unaligned));
+
+    // Zero-length is also unaligned (no I/O issued).
+    let mut empty: alloc::vec::Vec<u8> = alloc::vec::Vec::new();
+    assert_eq!(dev.read_block(0, &mut empty), Err(BlockError::Unaligned));
+
+    // Reads do NOT increment the success counter on rejection.
+    assert_eq!(dev.read_count(), 0);
+}
+
+/// Spec scenario: "Write with mis-sized buffer rejected".
+#[test]
+fn write_with_mis_sized_buffer_rejected_unaligned() {
+    let mut dev = MockBlockDevice::new(4096, 16);
+    let bad = alloc::vec![0u8; 4095];
+    assert_eq!(dev.write_block(0, &bad), Err(BlockError::Unaligned));
+
+    let bad = alloc::vec![0u8; 4097];
+    assert_eq!(dev.write_block(0, &bad), Err(BlockError::Unaligned));
+
+    let bad: alloc::vec::Vec<u8> = alloc::vec::Vec::new();
+    assert_eq!(dev.write_block(0, &bad), Err(BlockError::Unaligned));
+    assert_eq!(dev.write_count(), 0);
+}
+
+/// Spec scenario: "Read past end of device rejected".
+#[test]
+fn read_past_end_of_device_rejected_outofrange() {
+    let dev = MockBlockDevice::new(4096, 4);
+    let mut buf = alloc::vec![0u8; 4096];
+
+    // lba == block_count
+    assert_eq!(dev.read_block(4, &mut buf), Err(BlockError::OutOfRange));
+    // lba > block_count
+    assert_eq!(dev.read_block(5, &mut buf), Err(BlockError::OutOfRange));
+    assert_eq!(
+        dev.read_block(u64::MAX, &mut buf),
+        Err(BlockError::OutOfRange)
+    );
+}
+
+/// Spec scenario: "Read extending past end rejected".
+#[test]
+fn multi_block_read_extending_past_end_rejected() {
+    let dev = MockBlockDevice::new(4096, 4);
+    let mut buf = alloc::vec![0u8; 8192]; // 2 blocks
+                                          // lba 3 + 2 blocks = covers 3 and 4, but only 0..3 exist → OutOfRange
+    assert_eq!(dev.read_block(3, &mut buf), Err(BlockError::OutOfRange));
+}
+
+/// Spec scenario: "Write past end of device rejected".
+#[test]
+fn write_past_end_of_device_rejected_outofrange() {
+    let mut dev = MockBlockDevice::new(4096, 4);
+    let buf = alloc::vec![0u8; 4096];
+    assert_eq!(dev.write_block(4, &buf), Err(BlockError::OutOfRange));
+}
+
+/// Multi-block read: 2 contiguous 4 KiB blocks come back as one slab.
+#[test]
+fn multi_block_read_concatenates_storage() {
+    let dev = MockBlockDevice::with_pattern(4096, 4);
+    let mut buf = alloc::vec![0u8; 8192];
+    dev.read_block(1, &mut buf).unwrap();
+
+    let expected_first = dev.snapshot(1, 4096);
+    let expected_second = dev.snapshot(2, 4096);
+    assert_eq!(&buf[..4096], &expected_first[..]);
+    assert_eq!(&buf[4096..], &expected_second[..]);
+}
+
+/// Round-trip: write then read returns the same bytes.
+#[test]
+fn write_then_read_roundtrip() {
+    let mut dev = MockBlockDevice::new(4096, 4);
+    let pattern: alloc::vec::Vec<u8> = (0u32..4096).map(|i| (i % 251) as u8).collect();
+    dev.write_block(2, &pattern).unwrap();
+
+    let mut readback = alloc::vec![0u8; 4096];
+    dev.read_block(2, &mut readback).unwrap();
+    assert_eq!(readback, pattern);
+}
+
+// ─── Errno mapping spec scenarios ──────────────────────────────────────────
+
+/// Spec scenario: "Timeout maps to ETIMEDOUT at syscall boundary".
+#[test]
+fn timeout_maps_to_etimedout_at_syscall_boundary() {
+    assert_eq!(block_error_to_errno(BlockError::Timeout), 110);
+    assert_eq!(block_error_to_negative_errno(BlockError::Timeout), -110);
+}
+
+/// Spec scenario: "Bad CRC maps to EIO".
+#[test]
+fn bad_crc_maps_to_eio() {
+    assert_eq!(block_error_to_errno(BlockError::BadCrc), 5);
+    assert_eq!(block_error_to_negative_errno(BlockError::BadCrc), -5);
+}
+
+/// Bad CRC observed end-to-end: drive injects, errno conversion fires.
+#[test]
+fn bad_crc_block_observable_end_to_end() {
+    let dev = MockBlockDevice::new(4096, 4);
+    dev.set_bad_crc_block(2);
+
+    let mut buf = alloc::vec![0u8; 4096];
+    let err = dev.read_block(2, &mut buf).unwrap_err();
+    assert_eq!(err, BlockError::BadCrc);
+    assert_eq!(block_error_to_negative_errno(err), -5); // -EIO
+}
+
+/// MediaError surfaces as -EIO (not -EINVAL or anything else).
+#[test]
+fn media_error_maps_to_eio_at_syscall_boundary() {
+    let dev = MockBlockDevice::new(4096, 4);
+    dev.set_permanent_failure(BlockError::MediaError);
+
+    let mut buf = alloc::vec![0u8; 4096];
+    let err = dev.read_block(0, &mut buf).unwrap_err();
+    assert_eq!(err, BlockError::MediaError);
+    assert_eq!(block_error_to_negative_errno(err), -5);
+}
+
+/// NotPresent surfaces as -ENXIO.
+#[test]
+fn not_present_maps_to_enxio_at_syscall_boundary() {
+    let dev = MockBlockDevice::new(4096, 4);
+    dev.set_permanent_failure(BlockError::NotPresent);
+
+    let mut buf = alloc::vec![0u8; 4096];
+    let err = dev.read_block(0, &mut buf).unwrap_err();
+    assert_eq!(err, BlockError::NotPresent);
+    assert_eq!(block_error_to_negative_errno(err), -6);
+}
+
+/// DeviceBusy surfaces as -EBUSY.
+#[test]
+fn device_busy_maps_to_ebusy_at_syscall_boundary() {
+    let dev = MockBlockDevice::new(4096, 4);
+    dev.set_permanent_failure(BlockError::DeviceBusy);
+
+    let mut buf = alloc::vec![0u8; 4096];
+    let err = dev.read_block(0, &mut buf).unwrap_err();
+    assert_eq!(err, BlockError::DeviceBusy);
+    assert_eq!(block_error_to_negative_errno(err), -16);
+}
+
+/// Unaligned surfaces as -EINVAL.
+#[test]
+fn unaligned_maps_to_einval_at_syscall_boundary() {
+    let dev = MockBlockDevice::new(4096, 4);
+    let mut buf = alloc::vec![0u8; 4097];
+    let err = dev.read_block(0, &mut buf).unwrap_err();
+    assert_eq!(err, BlockError::Unaligned);
+    assert_eq!(block_error_to_negative_errno(err), -22);
+}
+
+/// OutOfRange surfaces as -EINVAL.
+#[test]
+fn out_of_range_maps_to_einval_at_syscall_boundary() {
+    let dev = MockBlockDevice::new(4096, 4);
+    let mut buf = alloc::vec![0u8; 4096];
+    let err = dev.read_block(4, &mut buf).unwrap_err();
+    assert_eq!(err, BlockError::OutOfRange);
+    assert_eq!(block_error_to_negative_errno(err), -22);
+}
+
+// ─── Retry policy spec scenarios ───────────────────────────────────────────
+
+/// Spec scenario: "Three retries then fail".
+#[test]
+fn three_retries_then_fail_with_timeout() {
+    let policy = RetryPolicy::default_read();
+    let calls = core::cell::Cell::new(0u32);
+    let sleeps: RefCell<alloc::vec::Vec<u32>> = RefCell::new(alloc::vec::Vec::new());
+
+    let result = run_with_retries(
+        &policy,
+        |_| {
+            calls.set(calls.get() + 1);
+            AttemptOutcome::Retry
+        },
+        |ms| sleeps.borrow_mut().push(ms),
+    );
+
+    // 1 initial attempt + 3 retries = 4 total attempts.
+    assert_eq!(calls.get(), 4);
+    // The 4th failure surfaces as Timeout per the spec.
+    assert_eq!(result, Err(BlockError::Timeout));
+    // Backoff schedule: 500 / 1000 / 2000.
+    assert_eq!(*sleeps.borrow(), alloc::vec![500u32, 1000, 2000]);
+}
+
+/// Spec scenario: "Indefinite retry rejected at config write" — the
+/// validator returns `-EINVAL`.
+#[test]
+fn indefinite_retry_rejected_at_config_write() {
+    let policy = RetryPolicy {
+        timeout_ms: 250,
+        retry_count: RETRY_COUNT_INFINITE_SENTINEL,
+        backoff_ms: alloc::vec![500],
+    };
+    assert_eq!(policy.validate(), Err(PolicyError::Indefinite));
+
+    // PolicyError → -EINVAL at the syscall boundary.
+    let err_code: i32 = match policy.validate() {
+        Err(PolicyError::Indefinite) => -22,
+        Err(_) => -22,
+        Ok(_) => 0,
+    };
+    assert_eq!(err_code, -22);
+}
+
+/// Even values higher than the explicit sentinel but above the cap
+/// are rejected (defense in depth).
+#[test]
+fn retry_count_above_cap_rejected() {
+    let policy = RetryPolicy {
+        timeout_ms: 250,
+        retry_count: MAX_ALLOWED_RETRY_COUNT + 1,
+        backoff_ms: alloc::vec![500],
+    };
+    assert_eq!(policy.validate(), Err(PolicyError::RetryCountTooHigh));
+}
+
+/// Default read policy matches spec values.
+#[test]
+fn default_read_policy_matches_spec() {
+    let p = RetryPolicy::default_read();
+    assert_eq!(p.timeout_ms, DEFAULT_READ_TIMEOUT_MS);
+    assert_eq!(p.timeout_ms, 250);
+    assert_eq!(p.retry_count, DEFAULT_RETRY_COUNT);
+    assert_eq!(p.retry_count, 3);
+    assert_eq!(p.backoff_ms, DEFAULT_RETRY_BACKOFF_MS.to_vec());
+}
+
+/// Default write policy matches spec values.
+#[test]
+fn default_write_policy_matches_spec() {
+    let p = RetryPolicy::default_write();
+    assert_eq!(p.timeout_ms, DEFAULT_WRITE_TIMEOUT_MS);
+    assert_eq!(p.timeout_ms, 1000);
+    assert_eq!(p.retry_count, 3);
+    assert_eq!(p.backoff_ms, [500u32, 1000, 2000].to_vec());
+}
+
+/// Retry helper: success on retry attempt 2 returns Ok with no further
+/// attempts.
+#[test]
+fn retry_succeeds_on_second_attempt() {
+    let policy = RetryPolicy::default_read();
+    let calls = core::cell::Cell::new(0u32);
+    let sleeps: RefCell<alloc::vec::Vec<u32>> = RefCell::new(alloc::vec::Vec::new());
+
+    let result = run_with_retries(
+        &policy,
+        |_| {
+            let n = calls.get() + 1;
+            calls.set(n);
+            if n < 2 {
+                AttemptOutcome::Retry
+            } else {
+                AttemptOutcome::Success
+            }
+        },
+        |ms| sleeps.borrow_mut().push(ms),
+    );
+    assert!(result.is_ok());
+    assert_eq!(calls.get(), 2);
+    // One backoff before retry #1.
+    assert_eq!(*sleeps.borrow(), alloc::vec![500u32]);
+}
+
+/// Retry helper: permanent error short-circuits.
+#[test]
+fn retry_permanent_error_short_circuits() {
+    let policy = RetryPolicy::default_read();
+    let calls = core::cell::Cell::new(0u32);
+    let result = run_with_retries(
+        &policy,
+        |_| {
+            calls.set(calls.get() + 1);
+            AttemptOutcome::Permanent(BlockError::OutOfRange)
+        },
+        |_| panic!("must not sleep on permanent error"),
+    );
+    assert_eq!(calls.get(), 1);
+    assert_eq!(result, Err(BlockError::OutOfRange));
+}
+
+/// `from_config` is wired and returns spec defaults today.
+#[test]
+fn retry_policy_from_config_returns_defaults() {
+    assert_eq!(
+        RetryPolicy::from_config(PolicyKind::Read),
+        RetryPolicy::default_read()
+    );
+    assert_eq!(
+        RetryPolicy::from_config(PolicyKind::Write),
+        RetryPolicy::default_write()
+    );
+}
+
+/// End-to-end: device rejects the first 3 reads with DeviceBusy then
+/// succeeds. Combined with the default retry policy, the wrapper
+/// returns Ok.
+#[test]
+fn retry_wrapper_recovers_from_transient_failures() {
+    let dev = MockBlockDevice::with_pattern(4096, 4);
+    dev.set_transient_failures(3);
+
+    let policy = RetryPolicy::default_read();
+    let mut buf = alloc::vec![0u8; 4096];
+
+    let result = run_with_retries(
+        &policy,
+        |_| match dev.read_block(0, &mut buf) {
+            Ok(()) => AttemptOutcome::Success,
+            Err(BlockError::DeviceBusy) | Err(BlockError::Timeout) => AttemptOutcome::Retry,
+            Err(e) => AttemptOutcome::Permanent(e),
+        },
+        |_| {},
+    );
+    assert!(result.is_ok());
+    assert_eq!(buf, dev.snapshot(0, 4096));
+}
+
+/// End-to-end: device fails the first 4 reads (initial + 3 retries
+/// exhaust). Wrapper returns Timeout.
+#[test]
+fn retry_wrapper_returns_timeout_after_exhausting_retries() {
+    let dev = MockBlockDevice::new(4096, 4);
+    dev.set_transient_failures(10);
+
+    let policy = RetryPolicy::default_read();
+    let mut buf = alloc::vec![0u8; 4096];
+
+    let result = run_with_retries(
+        &policy,
+        |_| match dev.read_block(0, &mut buf) {
+            Ok(()) => AttemptOutcome::Success,
+            Err(BlockError::DeviceBusy) | Err(BlockError::Timeout) => AttemptOutcome::Retry,
+            Err(e) => AttemptOutcome::Permanent(e),
+        },
+        |_| {},
+    );
+    assert_eq!(result, Err(BlockError::Timeout));
+    assert_eq!(block_error_to_negative_errno(BlockError::Timeout), -110);
+}
+
+// ─── Sector-size spec scenarios ────────────────────────────────────────────
+
+/// Spec scenario: "4 KiB-native device used directly".
+#[test]
+fn fourk_native_device_used_directly() {
+    let dev = MockBlockDevice::with_pattern(4096, 16);
+    let adapter = SectorAdapter::new(dev, 4096).unwrap();
+
+    assert_eq!(adapter.mode(), SectorMode::Native4K);
+    assert_eq!(adapter.block_size_bytes(), FS_BLOCK_SIZE_BYTES);
+    assert_eq!(adapter.block_count(), 16);
+
+    let expected = adapter.inner().snapshot(7, 4096);
+    let mut buf = alloc::vec![0u8; 4096];
+    adapter.read_block(7, &mut buf).unwrap();
+    assert_eq!(buf, expected);
+}
+
+/// Spec scenario: "512/4 KiB Advanced Format device aligned".
+#[test]
+fn advanced_format_512e_device_aligned_to_4k() {
+    // 128 * 512 = 64 KiB → exposes 16 FS blocks.
+    let dev = MockBlockDevice::with_pattern(512, 128);
+    let adapter = SectorAdapter::new(dev, 4096).unwrap();
+
+    assert_eq!(adapter.mode(), SectorMode::AdvancedFormat512e);
+    assert_eq!(adapter.block_size_bytes(), FS_BLOCK_SIZE_BYTES);
+    assert_eq!(adapter.block_count(), 16);
+
+    // FS block 0 must read inner LBAs 0..8; FS block 5 reads 40..48.
+    let mut fs_block = alloc::vec![0u8; 4096];
+    adapter.read_block(5, &mut fs_block).unwrap();
+
+    let inner_chunk = adapter.inner().snapshot(40, 4096);
+    assert_eq!(fs_block, inner_chunk);
+}
+
+/// Spec scenario: "512-byte legacy device emulated".
+#[test]
+fn legacy_512_device_emulated_with_warning() {
+    use core::cell::Cell;
+
+    struct CountingWarner(Cell<u32>);
+    impl LegacyPathWarner for CountingWarner {
+        fn warn_legacy_slow_path(&self) {
+            self.0.set(self.0.get() + 1);
+        }
+    }
+
+    let dev = MockBlockDevice::with_pattern(512, 128);
+    let warner = CountingWarner(Cell::new(0));
+    let adapter = smallaios_fs::block::sector::new_with_warning(dev, 512, &warner).unwrap();
+
+    assert_eq!(adapter.mode(), SectorMode::Legacy512);
+    assert!(adapter.mode().is_legacy_slow_path());
+    // The warning fired exactly once at construction.
+    assert_eq!(warner.0.get(), 1);
+
+    // FS-level reads still bundle 8 logical sectors per FS block.
+    let mut buf = alloc::vec![0u8; 4096];
+    adapter.read_block(0, &mut buf).unwrap();
+    assert_eq!(buf.len(), 4096);
+}
+
+/// FS reads SHALL never split across two physical sectors on
+/// Advanced Format devices.
+#[test]
+fn fs_block_never_splits_physical_sector_on_advanced_format() {
+    // 16 FS blocks via 128 * 512 logical sectors.
+    let dev = MockBlockDevice::with_pattern(512, 128);
+    let adapter = SectorAdapter::new(dev, 4096).unwrap();
+
+    // Probe every FS block — verify each FS block's contents come from
+    // an aligned 8-LBA window (lba * 8 .. lba * 8 + 8) of the inner
+    // device, NEVER from a misaligned offset.
+    for fs_lba in 0..adapter.block_count() {
+        let mut buf = alloc::vec![0u8; 4096];
+        adapter.read_block(fs_lba, &mut buf).unwrap();
+
+        let aligned_start = (fs_lba * 8) as usize * 512;
+        let inner_storage = adapter
+            .inner()
+            .snapshot(0, adapter.inner().block_count() as usize * 512);
+        assert_eq!(
+            buf,
+            &inner_storage[aligned_start..aligned_start + 4096],
+            "FS block {fs_lba} did not align to inner LBA {}",
+            fs_lba * 8
+        );
+    }
+}
+
+/// Unsupported sector-size combinations are rejected.
+#[test]
+fn unsupported_sector_combinations_rejected() {
+    // 2 KiB logical / 4 KiB physical — not supported.
+    let dev = MockBlockDevice::new(2048, 32);
+    assert!(SectorAdapter::new(dev, 4096).is_none());
+
+    // 4 KiB logical / 512 B physical — nonsensical.
+    let dev = MockBlockDevice::new(4096, 16);
+    assert!(SectorAdapter::new(dev, 512).is_none());
+
+    // 8 KiB logical — none of the three supported modes.
+    let dev = MockBlockDevice::new(8192, 8);
+    assert!(SectorAdapter::new(dev, 8192).is_none());
+}
+
+/// Adapter rejects unaligned FS-level buffers.
+#[test]
+fn adapter_rejects_misaligned_fs_buffer() {
+    let dev = MockBlockDevice::new(512, 128);
+    let adapter = SectorAdapter::new(dev, 4096).unwrap();
+    let mut buf = alloc::vec![0u8; 4097];
+    assert_eq!(adapter.read_block(0, &mut buf), Err(BlockError::Unaligned));
+}
+
+/// Adapter rejects FS-level out-of-range LBAs.
+#[test]
+fn adapter_rejects_out_of_range_fs_lba() {
+    let dev = MockBlockDevice::new(512, 128);
+    let adapter = SectorAdapter::new(dev, 4096).unwrap();
+    let mut buf = alloc::vec![0u8; 4096];
+    assert_eq!(
+        adapter.read_block(16, &mut buf),
+        Err(BlockError::OutOfRange)
+    );
+}
+
+/// Round-trip via the legacy 512/512 emulation slow path: writes also
+/// bundle 8 logical sectors per FS block.
+#[test]
+fn legacy_512_roundtrip_through_adapter() {
+    let dev = MockBlockDevice::new(512, 128);
+    let mut adapter = SectorAdapter::new(dev, 512).unwrap();
+    assert_eq!(adapter.mode(), SectorMode::Legacy512);
+
+    let pattern: alloc::vec::Vec<u8> = (0u32..4096)
+        .map(|i| (i.wrapping_mul(7) % 251) as u8)
+        .collect();
+    adapter.write_block(11, &pattern).unwrap();
+    let mut readback = alloc::vec![0u8; 4096];
+    adapter.read_block(11, &mut readback).unwrap();
+    assert_eq!(readback, pattern);
+}
+
+// ─── Helpers for module-level invariants ────────────────────────────────────
+
+/// `check_buf_alignment` is the canonical helper used by every per-arch
+/// driver. Verify its contract.
+#[test]
+fn buf_alignment_helper_contract() {
+    assert!(check_buf_alignment(4096, 4096).is_ok());
+    assert!(check_buf_alignment(8192, 4096).is_ok());
+    assert!(check_buf_alignment(512, 512).is_ok());
+
+    assert_eq!(check_buf_alignment(0, 4096), Err(BlockError::Unaligned));
+    assert_eq!(check_buf_alignment(1, 4096), Err(BlockError::Unaligned));
+    assert_eq!(check_buf_alignment(4097, 4096), Err(BlockError::Unaligned));
+}
+
+/// `check_lba_in_range` is the canonical bounds helper.
+#[test]
+fn lba_in_range_helper_contract() {
+    assert!(check_lba_in_range(0, 4096, 4096, 4).is_ok());
+    assert!(check_lba_in_range(3, 4096, 4096, 4).is_ok());
+    assert_eq!(
+        check_lba_in_range(4, 4096, 4096, 4),
+        Err(BlockError::OutOfRange)
+    );
+    assert_eq!(
+        check_lba_in_range(0, 4096, 4096, 0),
+        Err(BlockError::OutOfRange)
+    );
+}
+
+/// Flush is reachable through the trait and propagates errors.
+#[test]
+fn flush_propagates_permanent_failure() {
+    let mut dev = MockBlockDevice::new(4096, 4);
+    dev.set_permanent_failure(BlockError::MediaError);
+    assert_eq!(dev.flush(), Err(BlockError::MediaError));
+    dev.clear_permanent_failure();
+    assert!(dev.flush().is_ok());
+}


### PR DESCRIPTION
## Summary

Phase 1 of `embedded-filesystem-v1`. Wires up the bottom of the new `fs/` crate.

- `fs/src/block/{mod,errno,retry,sector,mock}.rs` — 1,472 LOC.
  - `BlockDevice` trait + typed `BlockError` enum.
  - POSIX-aligned errno conversion (`-EIO` / `-ENXIO` / `-ETIMEDOUT` / `-EINVAL` / `-EBUSY`).
  - Per-op timeout + 3-retry exponential backoff (250 ms / 1 s defaults; 500ms/1s/2s backoff). **Fail-after-retries is non-configurable** per the spec: an unattended appliance must never wedge on a bad sector.
  - Native 4 KiB sector size; 512/4 KiB Advanced-Format alignment; 512/512 legacy emulation slow-path with one-time mount warning.
  - `MockBlockDevice` with injectable transient/permanent failures and bad-CRC blocks for downstream phases' tests.
- `arch/x86_64/src/virtio_blk.rs` + `arch/aarch64/src/virtio_blk.rs` — 1,178 LOC. virtio-blk-modern (1.0+) MMIO, single virtqueue, submit-and-wait, `VIRTIO_BLK_T_IN/OUT/FLUSH`. Driver is `!Sync`; assumes external serialization.
- `fs/tests/block_conformance.rs` — 596 LOC, **37 conformance tests** covering every spec scenario.
- 87 fs tests passing total (50 unit + 37 conformance).

Behind cargo features `fs-on-disk-mounts` (master switch, default off) and `fs-block-virtio`. Default builds get zero new code linked. NVMe / SDHCI / AHCI drivers and the GPT parser come in subsequent phases.

## Deviations from spec (called out)

- `RetryPolicy::from_config(PolicyKind)` returns spec defaults rather than reading from `mgmt/policy.toml` — Wave 0's `mgmt/` is empty. The validator (`RetryPolicy::validate`) is fully implemented and ready for `management-login-v1` Phase 5 to call.
- `MockBlockDevice` is always-on (not test-gated). Downstream phases (squashfs, GPT, F2FS) will all want it; gating made the integration test crate fail to link.
- virtio-blk uses `UnsafeCell` interior mutability to satisfy the `read_block(&self, ...)` trait signature. Driver is `!Sync` by construction, documented in module doccomments.

## Test plan

- [x] `just fmt-check` — clean.
- [x] `just clippy` (`-D warnings`) — clean.
- [x] `just test` (full workspace) — passes; 87 new fs tests on top of baseline.
- [x] `cargo test -p smallaios-fs --features fs-on-disk-mounts,fs-block-virtio --lib --tests` — 87/87 pass.
- [x] `openspec validate embedded-filesystem-v1 --strict` — clean.
- [x] `just build-kernel-arm` (default features) — succeeds.
- [x] Bare-metal arch lib builds for x86_64-unknown-none and aarch64-unknown-none with `--features fs-block-virtio` — succeed.

`just build-kernel-x86` has a pre-existing linker overlap on `x86_64/linker.ld` that pre-dates this branch and is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)