### PR TITLE
feat(auth): shadow parser + role enum + tier selection (management-login-v1 phase 2)

### DIFF
--- a/auth/src/atomic_write.rs
+++ b/auth/src/atomic_write.rs
@@ -1,0 +1,383 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Atomic shadow-file rewrite — `stage → fsync → rename`.
+//!
+//! Spec: `openspec/changes/management-login-v1/specs/auth-shadow/spec.md`
+//! Requirement "Atomic shadow rewrite".
+//!
+//! Every write to `/data/auth/shadow` SHALL stage to `<path>.tmp`, `fsync`
+//! the staged file, then `rename` atomically over the target. The rename is
+//! the only operation visible to other readers; partial writes SHALL never
+//! appear at the canonical path. On crash mid-rename, the next boot SHALL
+//! see the original `<path>` intact and the orphan `<path>.tmp` cleared
+//! before any login is permitted.
+//!
+//! ## Status
+//!
+//! This module defines the [`AtomicWriter`] trait and ships two
+//! implementations:
+//!
+//! - [`TestAtomicWriter`] — in-memory, used by unit tests in this crate
+//!   and downstream callers (kernel session-table tests, console-login).
+//!   It models the staging/rename machinery so the contract is exercised.
+//! - [`KernelAtomicWriter`] — production stub. Returns
+//!   [`AtomicWriteError::NotImplemented`] until `embedded-filesystem-v1`
+//!   Phase 7 lands the F2FS read-write path.
+//!
+//! When F2FS RW arrives, the kernel impl will be wired through to a
+//! `vfs::write_atomic` syscall. The trait surface is stable now so the
+//! shadow-file persistence path (Phases 3-4) can ship against the test
+//! impl and be re-targeted by feature-flag in Phase 7.
+
+use alloc::collections::BTreeMap;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::cell::RefCell;
+use core::fmt;
+
+/// Errors raised by [`AtomicWriter`] implementations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AtomicWriteError {
+    /// The production [`KernelAtomicWriter`] is not yet wired through to a
+    /// real F2FS read-write path. Returned until `embedded-filesystem-v1`
+    /// Phase 7 ships.
+    NotImplemented,
+    /// Backing storage I/O error (test impl uses this for crash-fault
+    /// injection).
+    Io(&'static str),
+    /// The path is empty or otherwise unusable.
+    InvalidPath,
+}
+
+impl fmt::Display for AtomicWriteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotImplemented => write!(
+                f,
+                "auth: KernelAtomicWriter requires embedded-filesystem-v1 Phase 7"
+            ),
+            Self::Io(s) => write!(f, "auth: atomic-write I/O error: {s}"),
+            Self::InvalidPath => write!(f, "auth: atomic-write invalid path"),
+        }
+    }
+}
+
+/// Atomic file rewrite contract for the shadow file (and other
+/// crash-safety-critical management state).
+///
+/// Implementations SHALL:
+///
+/// 1. Stage the new contents to a sibling path derived from `path` — by
+///    convention, `<path>.tmp`.
+/// 2. Flush staged contents to durable storage (`fsync` semantics).
+/// 3. Atomically rename the staged file over `path`.
+///
+/// Readers observing `path` SHALL never see a partially-written record.
+pub trait AtomicWriter {
+    /// Atomically replace the file at `path` with `contents`. On error the
+    /// file at `path` SHALL be left untouched.
+    fn write_atomic(&self, path: &str, contents: &[u8]) -> Result<(), AtomicWriteError>;
+
+    /// Remove any orphan `<path>.tmp` siblings under `parent_dir` left over
+    /// from an interrupted rewrite. Called once at boot before any login is
+    /// permitted, per the "Crash mid-rename leaves shadow intact" scenario.
+    fn cleanup_orphan_tmp(&self, parent_dir: &str) -> Result<(), AtomicWriteError>;
+}
+
+// ─── Test implementation ─────────────────────────────────────────────────────
+
+/// In-memory [`AtomicWriter`] that simulates the `stage → fsync → rename`
+/// machinery. Used by unit tests in this crate and by downstream tests in
+/// `kernel/`, `peripheral/`, and `mgmt/`.
+///
+/// The simulator separately tracks `path` (the canonical file) and
+/// `<path>.tmp` (the staging file). The rename step swaps them in a single
+/// atomic step that other readers cannot interrupt.
+///
+/// Crash-injection helpers ([`TestAtomicWriter::inject_crash_after_stage`])
+/// model a power-fail between fsync and rename, leaving an orphan tmp file
+/// to be cleaned up by [`AtomicWriter::cleanup_orphan_tmp`].
+pub struct TestAtomicWriter {
+    inner: RefCell<TestAtomicWriterInner>,
+}
+
+struct TestAtomicWriterInner {
+    files: BTreeMap<String, Vec<u8>>,
+    crash_after_stage: bool,
+    crash_during_io: bool,
+}
+
+impl Default for TestAtomicWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TestAtomicWriter {
+    /// Construct an empty in-memory writer.
+    pub fn new() -> Self {
+        Self {
+            inner: RefCell::new(TestAtomicWriterInner {
+                files: BTreeMap::new(),
+                crash_after_stage: false,
+                crash_during_io: false,
+            }),
+        }
+    }
+
+    /// Install a pre-existing file (e.g., a "previous-boot" shadow) at
+    /// `path` for tests.
+    pub fn seed(&self, path: &str, contents: &[u8]) {
+        let mut g = self.inner.borrow_mut();
+        g.files.insert(path.to_string(), contents.to_vec());
+    }
+
+    /// Read the current contents at `path` — for assertion.
+    pub fn read(&self, path: &str) -> Option<Vec<u8>> {
+        self.inner.borrow().files.get(path).cloned()
+    }
+
+    /// Return `true` iff a staged `<path>.tmp` sibling exists. Used by
+    /// crash-recovery tests.
+    pub fn has_staged(&self, path: &str) -> bool {
+        let tmp = staging_path(path);
+        self.inner.borrow().files.contains_key(&tmp)
+    }
+
+    /// Inject a "crash" after the stage+fsync but before the rename. The
+    /// next [`AtomicWriter::write_atomic`] call SHALL leave `<path>.tmp`
+    /// populated and `<path>` untouched, then return
+    /// [`AtomicWriteError::Io`].
+    pub fn inject_crash_after_stage(&self) {
+        self.inner.borrow_mut().crash_after_stage = true;
+    }
+
+    /// Inject a "crash" during the staging write. The next write SHALL
+    /// fail before any rename; the staged tmp may be partially written
+    /// (test simulates this as removing both staged and target).
+    pub fn inject_crash_during_io(&self) {
+        self.inner.borrow_mut().crash_during_io = true;
+    }
+}
+
+impl AtomicWriter for TestAtomicWriter {
+    fn write_atomic(&self, path: &str, contents: &[u8]) -> Result<(), AtomicWriteError> {
+        if path.is_empty() {
+            return Err(AtomicWriteError::InvalidPath);
+        }
+
+        let mut g = self.inner.borrow_mut();
+
+        if g.crash_during_io {
+            // Simulate a crash *during* the stage write — the staged tmp
+            // is half-formed, target is untouched.
+            g.crash_during_io = false;
+            return Err(AtomicWriteError::Io("crash during stage"));
+        }
+
+        // Step 1: stage to `<path>.tmp`.
+        let tmp = staging_path(path);
+        g.files.insert(tmp.clone(), contents.to_vec());
+
+        if g.crash_after_stage {
+            // Simulate a power-fail between fsync and rename.
+            g.crash_after_stage = false;
+            return Err(AtomicWriteError::Io("crash after stage"));
+        }
+
+        // Step 2 (implicit): fsync — modeled by the in-memory commit above.
+        // Step 3: atomic rename.
+        if let Some(staged) = g.files.remove(&tmp) {
+            g.files.insert(path.to_string(), staged);
+        }
+        Ok(())
+    }
+
+    fn cleanup_orphan_tmp(&self, parent_dir: &str) -> Result<(), AtomicWriteError> {
+        let mut g = self.inner.borrow_mut();
+        let prefix = if parent_dir.is_empty() {
+            String::new()
+        } else if parent_dir.ends_with('/') {
+            parent_dir.to_string()
+        } else {
+            // dir + '/'
+            let mut p = String::from(parent_dir);
+            p.push('/');
+            p
+        };
+        let to_remove: Vec<String> = g
+            .files
+            .keys()
+            .filter(|k| k.starts_with(&prefix) && k.ends_with(".tmp"))
+            .cloned()
+            .collect();
+        for k in to_remove {
+            g.files.remove(&k);
+        }
+        Ok(())
+    }
+}
+
+/// Compute the staging path for `<path>` per the rewrite convention.
+fn staging_path(path: &str) -> String {
+    let mut tmp = String::from(path);
+    tmp.push_str(".tmp");
+    tmp
+}
+
+// ─── Production stub ─────────────────────────────────────────────────────────
+
+/// Production [`AtomicWriter`] — currently a stub. Returns
+/// [`AtomicWriteError::NotImplemented`] until `embedded-filesystem-v1`
+/// Phase 7 lands the F2FS read-write VFS path.
+///
+/// The constructor is `const fn` so the type can be embedded in static
+/// contexts without paying allocation up front.
+pub struct KernelAtomicWriter {
+    _private: (),
+}
+
+impl Default for KernelAtomicWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl KernelAtomicWriter {
+    /// Construct the production writer. Wire-up to F2FS lands in
+    /// `embedded-filesystem-v1` Phase 7.
+    pub const fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+impl AtomicWriter for KernelAtomicWriter {
+    fn write_atomic(&self, _path: &str, _contents: &[u8]) -> Result<(), AtomicWriteError> {
+        Err(AtomicWriteError::NotImplemented)
+    }
+
+    fn cleanup_orphan_tmp(&self, _parent_dir: &str) -> Result<(), AtomicWriteError> {
+        Err(AtomicWriteError::NotImplemented)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SHADOW_PATH: &str = "/data/auth/shadow";
+
+    #[test]
+    fn round_trip_replaces_target() {
+        let w = TestAtomicWriter::new();
+        w.write_atomic(SHADOW_PATH, b"hello").unwrap();
+        assert_eq!(w.read(SHADOW_PATH).as_deref(), Some(&b"hello"[..]));
+
+        w.write_atomic(SHADOW_PATH, b"world").unwrap();
+        assert_eq!(w.read(SHADOW_PATH).as_deref(), Some(&b"world"[..]));
+
+        // No leftover staged tmp visible on success.
+        assert!(!w.has_staged(SHADOW_PATH));
+    }
+
+    #[test]
+    fn rejects_empty_path() {
+        let w = TestAtomicWriter::new();
+        assert_eq!(w.write_atomic("", b"x"), Err(AtomicWriteError::InvalidPath));
+    }
+
+    #[test]
+    fn crash_after_stage_leaves_target_intact_and_staged_visible() {
+        // Spec: "Crash mid-rename leaves shadow intact"
+        let w = TestAtomicWriter::new();
+        w.seed(SHADOW_PATH, b"original");
+
+        w.inject_crash_after_stage();
+        let result = w.write_atomic(SHADOW_PATH, b"new-contents");
+        assert!(matches!(result, Err(AtomicWriteError::Io(_))));
+
+        // Target untouched.
+        assert_eq!(
+            w.read(SHADOW_PATH).as_deref(),
+            Some(&b"original"[..]),
+            "target file SHALL be untouched after crash mid-rename"
+        );
+
+        // Orphan tmp visible until cleanup.
+        assert!(
+            w.has_staged(SHADOW_PATH),
+            "staged tmp SHALL remain after crash"
+        );
+
+        // Boot-time cleanup removes it.
+        w.cleanup_orphan_tmp("/data/auth").unwrap();
+        assert!(
+            !w.has_staged(SHADOW_PATH),
+            "cleanup_orphan_tmp SHALL remove orphan staged file"
+        );
+
+        // Target is still the original.
+        assert_eq!(w.read(SHADOW_PATH).as_deref(), Some(&b"original"[..]));
+    }
+
+    #[test]
+    fn crash_during_io_leaves_target_and_staged_clean() {
+        let w = TestAtomicWriter::new();
+        w.seed(SHADOW_PATH, b"original");
+
+        w.inject_crash_during_io();
+        let result = w.write_atomic(SHADOW_PATH, b"new-contents");
+        assert!(matches!(result, Err(AtomicWriteError::Io(_))));
+
+        // Original is intact, no staged file was created.
+        assert_eq!(w.read(SHADOW_PATH).as_deref(), Some(&b"original"[..]));
+        assert!(!w.has_staged(SHADOW_PATH));
+    }
+
+    #[test]
+    fn cleanup_orphan_tmp_is_idempotent() {
+        let w = TestAtomicWriter::new();
+        w.cleanup_orphan_tmp("/data/auth").unwrap();
+        w.cleanup_orphan_tmp("/data/auth").unwrap();
+    }
+
+    #[test]
+    fn cleanup_orphan_tmp_only_removes_tmp_siblings() {
+        let w = TestAtomicWriter::new();
+        w.seed("/data/auth/shadow", b"keep me");
+        w.seed("/data/auth/shadow.tmp", b"orphan");
+        w.seed("/data/auth/policy.toml", b"keep me too");
+
+        w.cleanup_orphan_tmp("/data/auth").unwrap();
+
+        assert_eq!(
+            w.read("/data/auth/shadow").as_deref(),
+            Some(&b"keep me"[..])
+        );
+        assert_eq!(
+            w.read("/data/auth/policy.toml").as_deref(),
+            Some(&b"keep me too"[..])
+        );
+        assert!(w.read("/data/auth/shadow.tmp").is_none());
+    }
+
+    #[test]
+    fn kernel_writer_is_not_implemented() {
+        let w = KernelAtomicWriter::new();
+        assert_eq!(
+            w.write_atomic(SHADOW_PATH, b"x"),
+            Err(AtomicWriteError::NotImplemented)
+        );
+        assert_eq!(
+            w.cleanup_orphan_tmp("/data/auth"),
+            Err(AtomicWriteError::NotImplemented)
+        );
+    }
+
+    #[test]
+    fn staging_path_appends_dot_tmp() {
+        assert_eq!(staging_path("/data/auth/shadow"), "/data/auth/shadow.tmp");
+        assert_eq!(staging_path(""), ".tmp");
+    }
+}

--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -17,11 +17,11 @@
 //!
 //! ## Status
 //!
-//! This is a Wave 0 **skeleton**. Implementation is scheduled as
-//! `management-login-v1` Phases 1–10:
+//! Implementation is sequenced as `management-login-v1` Phases 1–10:
 //!
-//! 1. Argon2id KDF (in `security`) + KAT vectors.
-//! 2. `auth/` crate scaffold (this file) + shadow parser + role enum.
+//! 1. Argon2id KDF (in `security`) + KAT vectors. **Landed.**
+//! 2. `auth/` crate scaffold (this file) + shadow parser + role enum
+//!    + tier auto-selection + atomic-write trait. **This phase.**
 //! 3. Kernel auth syscalls + session table.
 //! 4. Console-login (TTY first-boot, login, lockout, idle sweep).
 //! 5. `mgmt/` crate scaffold + `Config` + `ConfigSurface` trait.
@@ -30,29 +30,30 @@
 //! 8. Zenoh telemetry keyspace.
 //! 9. TOTP (RFC 6238) + `totp_setup` syscall.
 //! 10. Audit chain + signed checkpoints + denial audit.
-//!
-//! Each phase ships as a separate PR per the agent-team plan.
 
 #![no_std]
 #![forbid(unsafe_code)]
 
-// ─── Module skeleton ─────────────────────────────────────────────────────────
-//
-// These `pub mod` declarations are intentionally empty stubs in Wave 0.
-// The `management-login-v1` implementation agent fills them per phase.
-// Empty modules keep the public-API surface stable so downstream crates
-// (`mgmt`, `ipc`, `container`) can name `auth::role::Role` etc. before
-// the bodies land.
+extern crate alloc;
+
+// ─── Phase 2 modules ─────────────────────────────────────────────────────────
 
 /// Three-role taxonomy: `Root`, `Operator`, `Viewer`.
-///
-/// Filled by `management-login-v1` Phase 2.
-pub mod role {}
+pub mod role;
 
 /// Shadow file format, parser, and atomic-rewrite helper.
-///
-/// Filled by `management-login-v1` Phase 2.
-pub mod shadow {}
+pub mod shadow;
+
+/// Atomic shadow-rewrite trait (`stage → fsync → rename`) plus an
+/// in-memory test impl and a `KernelAtomicWriter` stub awaiting
+/// `embedded-filesystem-v1` Phase 7 (F2FS RW).
+pub mod atomic_write;
+
+/// Argon2id per-tier parameter selection from available RAM.
+pub mod tier;
+
+// ─── Future-phase scaffolding (kept as empty stubs so downstream crates
+//      can name them once the bodies land) ────────────────────────────────────
 
 /// Kernel session table API surface.
 ///
@@ -69,3 +70,12 @@ pub mod token {}
 ///
 /// Filled by `management-login-v1` Phase 4.
 pub mod console {}
+
+// ─── Re-exports ──────────────────────────────────────────────────────────────
+
+pub use role::{Role, RoleError};
+pub use shadow::{
+    parse_file, parse_record, serialize_file, serialize_record, verify_file_permissions,
+    ShadowEntry, ShadowError, FLAG_MUST_CHANGE_PASSWORD,
+};
+pub use tier::select_tier;

--- a/auth/src/role.rs
+++ b/auth/src/role.rs
@@ -1,0 +1,146 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Three-role taxonomy: `Root`, `Operator`, `Viewer`.
+//!
+//! Spec: `openspec/changes/management-login-v1/specs/auth-roles/spec.md`.
+//!
+//! The role enum is a `#[repr(u8)]` enum so it can cross the syscall ABI as a
+//! raw `u8`. Values 0..=2 are valid in v1; 3..=255 are reserved for future
+//! roles and SHALL be rejected with `-EINVAL` per spec Requirement
+//! "Three-role taxonomy".
+
+use core::fmt;
+
+/// Three-role taxonomy for SmallAIOS v1.
+///
+/// `Root` (0) — full access: account management, model load/unload,
+/// system power, audit, all config namespaces.
+///
+/// `Operator` (1) — model lifecycle and read-only access to logs/metrics.
+///
+/// `Viewer` (2) — read-only telemetry. May not load models or change config.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Role {
+    /// Full access. The bootstrap account; created at first-boot.
+    Root = 0,
+    /// Model lifecycle + read-only audit/metrics.
+    Operator = 1,
+    /// Read-only telemetry.
+    Viewer = 2,
+}
+
+/// Errors raised by [`Role`] decoding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RoleError {
+    /// Wire-format byte does not correspond to a known role. Future roles
+    /// may legitimately appear here on a downgrade — callers SHALL reject
+    /// with `-EINVAL`.
+    Unknown(u8),
+    /// String form did not match `"root"`, `"operator"`, or `"viewer"`.
+    UnknownName,
+}
+
+impl fmt::Display for RoleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unknown(n) => write!(f, "auth: unknown role byte 0x{n:02x}"),
+            Self::UnknownName => write!(f, "auth: unknown role name"),
+        }
+    }
+}
+
+impl Role {
+    /// Decode a `u8` into a [`Role`]. Reject 3..=255 with
+    /// [`RoleError::Unknown`].
+    pub const fn from_u8(n: u8) -> Result<Self, RoleError> {
+        match n {
+            0 => Ok(Role::Root),
+            1 => Ok(Role::Operator),
+            2 => Ok(Role::Viewer),
+            _ => Err(RoleError::Unknown(n)),
+        }
+    }
+
+    /// Encode a [`Role`] back to its wire-format byte.
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+
+    /// Lower-case role name as stored in `/data/auth/shadow`'s `role=` field.
+    pub const fn name(self) -> &'static str {
+        match self {
+            Role::Root => "root",
+            Role::Operator => "operator",
+            Role::Viewer => "viewer",
+        }
+    }
+
+    /// Parse a role name as it appears in the shadow file (`root`,
+    /// `operator`, `viewer`). Case-sensitive per spec.
+    pub fn from_name(name: &str) -> Result<Self, RoleError> {
+        match name {
+            "root" => Ok(Role::Root),
+            "operator" => Ok(Role::Operator),
+            "viewer" => Ok(Role::Viewer),
+            _ => Err(RoleError::UnknownName),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_u8_accepts_known_values() {
+        assert_eq!(Role::from_u8(0), Ok(Role::Root));
+        assert_eq!(Role::from_u8(1), Ok(Role::Operator));
+        assert_eq!(Role::from_u8(2), Ok(Role::Viewer));
+    }
+
+    #[test]
+    fn from_u8_rejects_unknown_values() {
+        assert_eq!(Role::from_u8(3), Err(RoleError::Unknown(3)));
+        assert_eq!(Role::from_u8(7), Err(RoleError::Unknown(7)));
+        assert_eq!(Role::from_u8(255), Err(RoleError::Unknown(255)));
+    }
+
+    #[test]
+    fn as_u8_round_trips_for_every_known_value() {
+        for n in 0u8..=2 {
+            let r = Role::from_u8(n).unwrap();
+            assert_eq!(r.as_u8(), n);
+        }
+    }
+
+    #[test]
+    fn name_matches_shadow_field_convention() {
+        assert_eq!(Role::Root.name(), "root");
+        assert_eq!(Role::Operator.name(), "operator");
+        assert_eq!(Role::Viewer.name(), "viewer");
+    }
+
+    #[test]
+    fn from_name_accepts_canonical_strings() {
+        assert_eq!(Role::from_name("root"), Ok(Role::Root));
+        assert_eq!(Role::from_name("operator"), Ok(Role::Operator));
+        assert_eq!(Role::from_name("viewer"), Ok(Role::Viewer));
+    }
+
+    #[test]
+    fn from_name_is_case_sensitive() {
+        assert_eq!(Role::from_name("Root"), Err(RoleError::UnknownName));
+        assert_eq!(Role::from_name("ROOT"), Err(RoleError::UnknownName));
+        assert_eq!(Role::from_name(""), Err(RoleError::UnknownName));
+        assert_eq!(Role::from_name("admin"), Err(RoleError::UnknownName));
+    }
+
+    #[test]
+    fn name_round_trip() {
+        for r in [Role::Root, Role::Operator, Role::Viewer] {
+            assert_eq!(Role::from_name(r.name()), Ok(r));
+        }
+    }
+}

--- a/auth/src/shadow.rs
+++ b/auth/src/shadow.rs
@@ -1,0 +1,690 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shadow file format — parser, serializer, file-mode check.
+//!
+//! Spec: `openspec/changes/management-login-v1/specs/auth-shadow/spec.md`
+//!
+//! ## Canonical record format
+//!
+//! ```text
+//! username:$argon2id$v=19$m=<m>,t=<t>,p=<p>$<base64-salt>$<base64-tag>:role=<root|operator|viewer>:flags=<u32>:last_changed=<unix-day>:totp_secret=<base32-or-empty>:lockout_until=<unix-or-zero>
+//! ```
+//!
+//! ## Forward-compatibility rule
+//!
+//! Parsers SHALL ignore unknown trailing fields. Any additional `key=value`
+//! field after `lockout_until=` is preserved verbatim in
+//! [`ShadowEntry::trailing_unknown_fields`] and round-tripped on rewrite,
+//! so a future feature flag (e.g. `mfa_kind=fido2`) does not break older
+//! readers.
+//!
+//! ## File-mode defense in depth
+//!
+//! [`verify_file_permissions`] rejects any mode laxer than 0600. The
+//! caller (kernel boot path) supplies the mode bits read from the
+//! filesystem; this module performs the policy check so the boot logic
+//! can stay independent of the `fs/` crate's metadata API.
+
+use crate::role::{Role, RoleError};
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::fmt;
+
+// ─── Bit flags ────────────────────────────────────────────────────────────────
+
+/// Bit 0 of [`ShadowEntry::flags`] — when set, the kernel SHALL only honor
+/// `auth_change_password`, `auth_whoami`, and `auth_logout` until the user
+/// rotates the password. See `auth-roles` spec "must-change-password
+/// gating".
+pub const FLAG_MUST_CHANGE_PASSWORD: u32 = 0x0000_0001;
+
+// ─── Errors ───────────────────────────────────────────────────────────────────
+
+/// Errors raised by shadow-file parsing/serialization or permission checks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ShadowError {
+    /// Record had fewer mandatory colon-separated segments than required.
+    Truncated,
+    /// PHC string did not start with `$argon2id$` or otherwise failed
+    /// shape validation.
+    MalformedPhc,
+    /// `role=…` field carried an unknown role string.
+    UnknownRole,
+    /// A mandatory key=value field was missing or its key was wrong.
+    MissingField(&'static str),
+    /// A numeric field (`flags`, `last_changed`, `lockout_until`) failed
+    /// to parse as the expected integer type.
+    InvalidInteger(&'static str),
+    /// A duplicate `key=` was seen in the trailing-fields section.
+    DuplicateField(&'static str),
+    /// Username was empty.
+    EmptyUsername,
+    /// Username contained a forbidden character (`:`, NUL, or `\n`).
+    InvalidUsername,
+    /// File mode was laxer than 0600 — the loader SHALL refuse to read it.
+    PermissionTooLax(u32),
+    /// File contained a record whose line was empty (other than trailing
+    /// blank lines).
+    EmptyRecord,
+}
+
+impl fmt::Display for ShadowError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Truncated => write!(f, "auth/shadow: truncated record"),
+            Self::MalformedPhc => write!(f, "auth/shadow: malformed PHC string"),
+            Self::UnknownRole => write!(f, "auth/shadow: unknown role name"),
+            Self::MissingField(k) => write!(f, "auth/shadow: missing field `{k}`"),
+            Self::InvalidInteger(k) => write!(f, "auth/shadow: invalid integer for `{k}`"),
+            Self::DuplicateField(k) => write!(f, "auth/shadow: duplicate field `{k}`"),
+            Self::EmptyUsername => write!(f, "auth/shadow: empty username"),
+            Self::InvalidUsername => write!(f, "auth/shadow: invalid character in username"),
+            Self::PermissionTooLax(m) => {
+                write!(f, "auth/shadow: mode 0o{m:o} laxer than 0600")
+            }
+            Self::EmptyRecord => write!(f, "auth/shadow: empty record"),
+        }
+    }
+}
+
+impl From<RoleError> for ShadowError {
+    fn from(_: RoleError) -> Self {
+        ShadowError::UnknownRole
+    }
+}
+
+// ─── Record ───────────────────────────────────────────────────────────────────
+
+/// A single parsed shadow-file record.
+///
+/// Round-trip invariant: after `serialize_record(parse_record(line))?` the
+/// resulting string SHALL equal `line` exactly, including any unknown
+/// trailing fields. This is verified by tests in this module and is
+/// required by the "Round-trip parse and serialize" spec scenario.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShadowEntry {
+    /// Username — printable, no `:` / `\n` / NUL.
+    pub username: String,
+    /// PHC-encoded Argon2id hash — the entire `$argon2id$…` string.
+    pub phc: String,
+    /// Role for capability gating.
+    pub role: Role,
+    /// Bit-flag set: bit 0 = `must_change_password_on_login`, others
+    /// reserved.
+    pub flags: u32,
+    /// Day on which the password was last changed (Unix days since epoch,
+    /// `floor(unix_seconds / 86_400)`).
+    pub last_changed_unix_day: u32,
+    /// Optional TOTP shared secret. `None` means TOTP not enrolled. The
+    /// field stores the *decoded* secret bytes; the on-disk format is
+    /// RFC 4648 base32 without padding (or empty).
+    pub totp_secret: Option<Vec<u8>>,
+    /// Lockout deadline as Unix seconds (`0` ⇒ not locked out).
+    pub lockout_until_unix: u64,
+    /// Forward-compat: any `key=value` field appearing after
+    /// `lockout_until=` is preserved verbatim and rewritten on
+    /// serialization. Each entry is the raw `key=value` string (no
+    /// surrounding colons).
+    pub trailing_unknown_fields: Vec<String>,
+}
+
+// ─── Permission check ─────────────────────────────────────────────────────────
+
+/// Refuse to read a shadow file whose mode is laxer than 0600.
+///
+/// Per spec "Shadow file permission defense": only the owner-read and
+/// owner-write bits MAY be set. Any group or world bits, or non-owner
+/// special bits, SHALL trigger [`ShadowError::PermissionTooLax`].
+///
+/// `mode` is the POSIX mode field as seen by `fstat(2)`'s `st_mode &
+/// 0o777`. Callers SHALL strip the file-type nibble before passing.
+pub fn verify_file_permissions(mode: u32) -> Result<(), ShadowError> {
+    // Reject any group or world bits. Bits 077 cover g_rwx + o_rwx.
+    if mode & 0o077 != 0 {
+        return Err(ShadowError::PermissionTooLax(mode));
+    }
+    Ok(())
+}
+
+// ─── Parsing ──────────────────────────────────────────────────────────────────
+
+/// Parse a single shadow-file record (one line, no trailing newline).
+pub fn parse_record(line: &str) -> Result<ShadowEntry, ShadowError> {
+    if line.is_empty() {
+        return Err(ShadowError::EmptyRecord);
+    }
+
+    // Layout:
+    //   username : phc : role=… : flags=… : last_changed=… : totp_secret=… : lockout_until=… [: extra]*
+    //
+    // The PHC string itself has *internal* `$`s but no `:`s, so `:` is a
+    // safe separator.
+    let mut parts = line.split(':');
+
+    let username = parts.next().ok_or(ShadowError::Truncated)?;
+    validate_username(username)?;
+
+    let phc = parts.next().ok_or(ShadowError::Truncated)?;
+    if !phc.starts_with("$argon2id$") {
+        return Err(ShadowError::MalformedPhc);
+    }
+    // Sanity-check the canonical PHC shape: 5 `$` segments after the
+    // leading `$`. We don't run the argon2id verifier here — that is
+    // applied at login time. We just require the string be parseable.
+    let phc_dollar_segments = phc.matches('$').count();
+    if phc_dollar_segments != 5 {
+        return Err(ShadowError::MalformedPhc);
+    }
+
+    // Mandatory key=value fields, in canonical order. We accept any order
+    // for forward-compat readers, but enforce all four are present.
+    let mut role: Option<Role> = None;
+    let mut flags: Option<u32> = None;
+    let mut last_changed: Option<u32> = None;
+    let mut totp_secret: Option<Option<Vec<u8>>> = None;
+    let mut lockout_until: Option<u64> = None;
+    let mut trailing: Vec<String> = Vec::new();
+
+    for kv in parts {
+        let (k, v) = split_key_value(kv)?;
+        match k {
+            "role" => {
+                if role.is_some() {
+                    return Err(ShadowError::DuplicateField("role"));
+                }
+                role = Some(Role::from_name(v)?);
+            }
+            "flags" => {
+                if flags.is_some() {
+                    return Err(ShadowError::DuplicateField("flags"));
+                }
+                flags = Some(parse_u32(v).ok_or(ShadowError::InvalidInteger("flags"))?);
+            }
+            "last_changed" => {
+                if last_changed.is_some() {
+                    return Err(ShadowError::DuplicateField("last_changed"));
+                }
+                last_changed =
+                    Some(parse_u32(v).ok_or(ShadowError::InvalidInteger("last_changed"))?);
+            }
+            "totp_secret" => {
+                if totp_secret.is_some() {
+                    return Err(ShadowError::DuplicateField("totp_secret"));
+                }
+                totp_secret = Some(if v.is_empty() {
+                    None
+                } else {
+                    Some(base32_decode(v)?)
+                });
+            }
+            "lockout_until" => {
+                if lockout_until.is_some() {
+                    return Err(ShadowError::DuplicateField("lockout_until"));
+                }
+                lockout_until =
+                    Some(parse_u64(v).ok_or(ShadowError::InvalidInteger("lockout_until"))?);
+            }
+            _ => {
+                // Forward-compat: preserve verbatim.
+                trailing.push(kv.to_string());
+            }
+        }
+    }
+
+    Ok(ShadowEntry {
+        username: username.to_string(),
+        phc: phc.to_string(),
+        role: role.ok_or(ShadowError::MissingField("role"))?,
+        flags: flags.ok_or(ShadowError::MissingField("flags"))?,
+        last_changed_unix_day: last_changed.ok_or(ShadowError::MissingField("last_changed"))?,
+        totp_secret: totp_secret.ok_or(ShadowError::MissingField("totp_secret"))?,
+        lockout_until_unix: lockout_until.ok_or(ShadowError::MissingField("lockout_until"))?,
+        trailing_unknown_fields: trailing,
+    })
+}
+
+/// Parse an entire shadow file into a vector of entries. Empty lines are
+/// silently skipped (so a trailing newline is harmless).
+pub fn parse_file(content: &str) -> Result<Vec<ShadowEntry>, ShadowError> {
+    let mut out = Vec::new();
+    for line in content.split('\n') {
+        if line.is_empty() {
+            continue;
+        }
+        out.push(parse_record(line)?);
+    }
+    Ok(out)
+}
+
+// ─── Serialization ────────────────────────────────────────────────────────────
+
+/// Serialize a single record back to the canonical line form. The trailing
+/// `\n` is not included.
+pub fn serialize_record(entry: &ShadowEntry) -> String {
+    let mut out = String::new();
+    out.push_str(&entry.username);
+    out.push(':');
+    out.push_str(&entry.phc);
+    out.push_str(":role=");
+    out.push_str(entry.role.name());
+    out.push_str(":flags=");
+    push_u32(&mut out, entry.flags);
+    out.push_str(":last_changed=");
+    push_u32(&mut out, entry.last_changed_unix_day);
+    out.push_str(":totp_secret=");
+    if let Some(secret) = entry.totp_secret.as_ref() {
+        push_base32(&mut out, secret);
+    }
+    out.push_str(":lockout_until=");
+    push_u64(&mut out, entry.lockout_until_unix);
+    for extra in &entry.trailing_unknown_fields {
+        out.push(':');
+        out.push_str(extra);
+    }
+    out
+}
+
+/// Serialize a slice of entries into a shadow-file body. A trailing
+/// newline is appended so the file is terminated per Unix convention.
+pub fn serialize_file(entries: &[ShadowEntry]) -> String {
+    let mut out = String::new();
+    for entry in entries {
+        out.push_str(&serialize_record(entry));
+        out.push('\n');
+    }
+    out
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+fn validate_username(u: &str) -> Result<(), ShadowError> {
+    if u.is_empty() {
+        return Err(ShadowError::EmptyUsername);
+    }
+    for b in u.bytes() {
+        if b == b':' || b == 0 || b == b'\n' {
+            return Err(ShadowError::InvalidUsername);
+        }
+    }
+    Ok(())
+}
+
+fn split_key_value(kv: &str) -> Result<(&str, &str), ShadowError> {
+    let idx = kv.find('=').ok_or(ShadowError::Truncated)?;
+    let (k, rest) = kv.split_at(idx);
+    if k.is_empty() {
+        return Err(ShadowError::Truncated);
+    }
+    Ok((k, &rest[1..]))
+}
+
+fn parse_u32(s: &str) -> Option<u32> {
+    if s.is_empty() {
+        return None;
+    }
+    let mut acc: u32 = 0;
+    for b in s.bytes() {
+        if !b.is_ascii_digit() {
+            return None;
+        }
+        acc = acc.checked_mul(10)?.checked_add((b - b'0') as u32)?;
+    }
+    Some(acc)
+}
+
+fn parse_u64(s: &str) -> Option<u64> {
+    if s.is_empty() {
+        return None;
+    }
+    let mut acc: u64 = 0;
+    for b in s.bytes() {
+        if !b.is_ascii_digit() {
+            return None;
+        }
+        acc = acc.checked_mul(10)?.checked_add((b - b'0') as u64)?;
+    }
+    Some(acc)
+}
+
+fn push_u32(out: &mut String, n: u32) {
+    if n == 0 {
+        out.push('0');
+        return;
+    }
+    let mut buf = [0u8; 10];
+    let mut i = buf.len();
+    let mut m = n;
+    while m > 0 {
+        i -= 1;
+        buf[i] = b'0' + (m % 10) as u8;
+        m /= 10;
+    }
+    // SAFETY: only ASCII digits written.
+    out.push_str(core::str::from_utf8(&buf[i..]).unwrap());
+}
+
+fn push_u64(out: &mut String, n: u64) {
+    if n == 0 {
+        out.push('0');
+        return;
+    }
+    let mut buf = [0u8; 20];
+    let mut i = buf.len();
+    let mut m = n;
+    while m > 0 {
+        i -= 1;
+        buf[i] = b'0' + (m % 10) as u8;
+        m /= 10;
+    }
+    out.push_str(core::str::from_utf8(&buf[i..]).unwrap());
+}
+
+// ─── Base32 (RFC 4648, no padding) ────────────────────────────────────────────
+
+// RFC 4648 §6 base32 alphabet. The 32 letters A..=Z plus digits 2..=7,
+// in canonical order. Used both for the on-disk TOTP secret encoding and
+// for round-tripping; this is a public-facing alphabet, not a secret.
+//
+// lgtm[rust/hard-coded-cryptographic-value] — RFC 4648 §6 base32 alphabet, not a secret
+const BASE32_ALPHABET: &[u8; 32] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+fn base32_decode(s: &str) -> Result<Vec<u8>, ShadowError> {
+    // Reject padding `=` to keep the field length canonical.
+    if s.contains('=') {
+        return Err(ShadowError::InvalidInteger("totp_secret"));
+    }
+    let mut out: Vec<u8> = Vec::with_capacity(s.len() * 5 / 8);
+    let mut buffer: u32 = 0;
+    let mut bits: u32 = 0;
+    for ch in s.bytes() {
+        let v: u32 = match ch {
+            b'A'..=b'Z' => (ch - b'A') as u32,
+            b'a'..=b'z' => (ch - b'a') as u32,
+            b'2'..=b'7' => (ch - b'2' + 26) as u32,
+            _ => return Err(ShadowError::InvalidInteger("totp_secret")),
+        };
+        buffer = (buffer << 5) | v;
+        bits += 5;
+        if bits >= 8 {
+            bits -= 8;
+            out.push(((buffer >> bits) & 0xFF) as u8);
+        }
+    }
+    // Any leftover `bits` are zero padding from a non-multiple-of-8 secret
+    // length, which is allowed by RFC 4648 §6 when no `=` padding is used.
+    Ok(out)
+}
+
+fn push_base32(out: &mut String, bytes: &[u8]) {
+    let mut buffer: u32 = 0;
+    let mut bits: u32 = 0;
+    for &b in bytes {
+        buffer = (buffer << 8) | (b as u32);
+        bits += 8;
+        while bits >= 5 {
+            bits -= 5;
+            let idx = ((buffer >> bits) & 0x1F) as usize;
+            out.push(BASE32_ALPHABET[idx] as char);
+        }
+    }
+    if bits > 0 {
+        let idx = ((buffer << (5 - bits)) & 0x1F) as usize;
+        out.push(BASE32_ALPHABET[idx] as char);
+    }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Synthetic, fixture-only PHC string. The salt and tag bytes here are
+    // *not* secret — they exist solely as a parser oracle.
+    //
+    // lgtm[rust/hard-coded-cryptographic-value] — synthetic test fixture, not a real credential
+    const SAMPLE_PHC: &str =
+        "$argon2id$v=19$m=8192,t=3,p=1$YWFhYWFhYWFhYWFhYWFhYQ$YWJjZGVmZ2hpamtsbW5vcA";
+
+    fn sample_entry() -> ShadowEntry {
+        ShadowEntry {
+            username: "root".to_string(),
+            phc: SAMPLE_PHC.to_string(),
+            role: Role::Root,
+            flags: FLAG_MUST_CHANGE_PASSWORD,
+            last_changed_unix_day: 19_852,
+            totp_secret: None,
+            lockout_until_unix: 0,
+            trailing_unknown_fields: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn round_trip_basic_record() {
+        let entry = sample_entry();
+        let line = serialize_record(&entry);
+        let parsed = parse_record(&line).unwrap();
+        assert_eq!(parsed, entry);
+    }
+
+    #[test]
+    fn round_trip_with_totp_secret() {
+        // Synthetic 20-byte secret (RFC 6238 typical length). Not used to
+        // exfiltrate any real credential — purely a round-trip oracle.
+        //
+        // lgtm[rust/hard-coded-cryptographic-value] — synthetic test fixture, not a real credential
+        let secret: Vec<u8> = (0u8..20).collect();
+        let mut entry = sample_entry();
+        entry.totp_secret = Some(secret.clone());
+        let line = serialize_record(&entry);
+        let parsed = parse_record(&line).unwrap();
+        assert_eq!(parsed.totp_secret, Some(secret));
+        assert_eq!(parsed, entry);
+    }
+
+    #[test]
+    fn forward_compatible_unknown_trailing_field_preserved() {
+        // Spec scenario: "Forward-compatible parse"
+        let entry = sample_entry();
+        let mut line = serialize_record(&entry);
+        line.push_str(":mfa_kind=fido2");
+        line.push_str(":hardened=true");
+
+        let parsed = parse_record(&line).unwrap();
+        assert_eq!(
+            parsed.trailing_unknown_fields,
+            ["mfa_kind=fido2", "hardened=true"]
+        );
+
+        // Round-trip preserves them verbatim.
+        let reserialized = serialize_record(&parsed);
+        assert_eq!(reserialized, line);
+    }
+
+    #[test]
+    fn reject_malformed_phc_missing_prefix() {
+        // Spec scenario: "Reject malformed PHC string"
+        let bad = "root:$bcrypt$abc:role=root:flags=0:last_changed=0:totp_secret=:lockout_until=0";
+        assert_eq!(parse_record(bad), Err(ShadowError::MalformedPhc));
+    }
+
+    #[test]
+    fn reject_malformed_phc_truncated() {
+        let bad =
+            "root:$argon2id$abc:role=root:flags=0:last_changed=0:totp_secret=:lockout_until=0";
+        assert_eq!(parse_record(bad), Err(ShadowError::MalformedPhc));
+    }
+
+    #[test]
+    fn reject_unknown_role() {
+        let line = alloc::format!(
+            "root:{}:role=admin:flags=0:last_changed=0:totp_secret=:lockout_until=0",
+            SAMPLE_PHC
+        );
+        assert_eq!(parse_record(&line), Err(ShadowError::UnknownRole));
+    }
+
+    #[test]
+    fn reject_truncated_record() {
+        // Only the username, no PHC.
+        assert_eq!(parse_record("root"), Err(ShadowError::Truncated));
+    }
+
+    #[test]
+    fn reject_missing_required_field_lockout_until() {
+        let line = alloc::format!(
+            "root:{}:role=root:flags=0:last_changed=0:totp_secret=",
+            SAMPLE_PHC
+        );
+        assert_eq!(
+            parse_record(&line),
+            Err(ShadowError::MissingField("lockout_until"))
+        );
+    }
+
+    #[test]
+    fn reject_invalid_integer() {
+        let line = alloc::format!(
+            "root:{}:role=root:flags=notanumber:last_changed=0:totp_secret=:lockout_until=0",
+            SAMPLE_PHC
+        );
+        assert_eq!(
+            parse_record(&line),
+            Err(ShadowError::InvalidInteger("flags"))
+        );
+    }
+
+    #[test]
+    fn reject_empty_username() {
+        let line = alloc::format!(
+            ":{}:role=root:flags=0:last_changed=0:totp_secret=:lockout_until=0",
+            SAMPLE_PHC
+        );
+        assert_eq!(parse_record(&line), Err(ShadowError::EmptyUsername));
+    }
+
+    #[test]
+    fn reject_duplicate_field() {
+        let line = alloc::format!(
+            "root:{}:role=root:flags=0:flags=1:last_changed=0:totp_secret=:lockout_until=0",
+            SAMPLE_PHC
+        );
+        assert_eq!(
+            parse_record(&line),
+            Err(ShadowError::DuplicateField("flags"))
+        );
+    }
+
+    #[test]
+    fn parse_file_handles_multiple_records_and_blank_lines() {
+        let entry = sample_entry();
+        let mut file = serialize_record(&entry);
+        file.push('\n');
+        file.push('\n'); // blank line in the middle
+        let mut other = entry.clone();
+        other.username = "operator-1".to_string();
+        other.role = Role::Operator;
+        file.push_str(&serialize_record(&other));
+        file.push('\n');
+
+        let parsed = parse_file(&file).unwrap();
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].username, "root");
+        assert_eq!(parsed[1].username, "operator-1");
+        assert_eq!(parsed[1].role, Role::Operator);
+    }
+
+    #[test]
+    fn serialize_file_round_trips() {
+        let entry_a = sample_entry();
+        let mut entry_b = entry_a.clone();
+        entry_b.username = "viewer-bob".to_string();
+        entry_b.role = Role::Viewer;
+        entry_b.flags = 0;
+        entry_b.lockout_until_unix = 1_700_000_000;
+
+        let body = serialize_file(&[entry_a.clone(), entry_b.clone()]);
+        let parsed = parse_file(&body).unwrap();
+        assert_eq!(parsed, alloc::vec![entry_a, entry_b]);
+    }
+
+    #[test]
+    fn verify_file_permissions_accepts_0600() {
+        // Spec scenario: "Mode 0600 shadow accepted"
+        assert!(verify_file_permissions(0o600).is_ok());
+        // Read-only is also fine — the loader doesn't write.
+        assert!(verify_file_permissions(0o400).is_ok());
+    }
+
+    #[test]
+    fn verify_file_permissions_rejects_0644() {
+        // Spec scenario: "Mode 0644 shadow rejected"
+        assert_eq!(
+            verify_file_permissions(0o644),
+            Err(ShadowError::PermissionTooLax(0o644))
+        );
+    }
+
+    #[test]
+    fn verify_file_permissions_rejects_any_group_or_world_bit() {
+        for laxer in [0o604, 0o620, 0o640, 0o660, 0o666, 0o777] {
+            assert_eq!(
+                verify_file_permissions(laxer),
+                Err(ShadowError::PermissionTooLax(laxer)),
+                "mode 0o{laxer:o} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_username_rejected() {
+        let line = alloc::format!(
+            "ro\not:{}:role=root:flags=0:last_changed=0:totp_secret=:lockout_until=0",
+            SAMPLE_PHC
+        );
+        assert_eq!(parse_record(&line), Err(ShadowError::InvalidUsername));
+    }
+
+    #[test]
+    fn flag_bit_zero_is_must_change() {
+        // Cross-check the named constant against the spec wording.
+        assert_eq!(FLAG_MUST_CHANGE_PASSWORD, 0x0000_0001);
+    }
+
+    #[test]
+    fn base32_round_trip_smoke() {
+        // RFC 4648 §10 test vectors, base32 form (no padding).
+        let cases: &[(&[u8], &str)] = &[
+            (b"", ""),
+            (b"f", "MY"),
+            (b"fo", "MZXQ"),
+            (b"foo", "MZXW6"),
+            (b"foob", "MZXW6YQ"),
+            (b"fooba", "MZXW6YTB"),
+            (b"foobar", "MZXW6YTBOI"),
+        ];
+        for (raw, encoded) in cases {
+            let mut got = String::new();
+            push_base32(&mut got, raw);
+            assert_eq!(&got, encoded, "encode failed for {raw:?}");
+            assert_eq!(
+                base32_decode(encoded).unwrap(),
+                raw.to_vec(),
+                "decode failed for {encoded}"
+            );
+        }
+    }
+
+    #[test]
+    fn base32_decode_rejects_padding_and_garbage() {
+        assert!(base32_decode("MY=").is_err());
+        assert!(base32_decode("M!Y").is_err());
+        assert!(base32_decode("0189").is_err()); // '0' / '1' not in alphabet
+    }
+
+    #[test]
+    fn empty_record_rejected() {
+        assert_eq!(parse_record(""), Err(ShadowError::EmptyRecord));
+    }
+}

--- a/auth/src/tier.rs
+++ b/auth/src/tier.rs
@@ -1,0 +1,105 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Argon2id per-tier parameter selection from available RAM.
+//!
+//! Spec: `openspec/changes/management-login-v1/specs/auth-shadow/spec.md`
+//! Requirement "Argon2id per-tier parameter selection".
+//!
+//! At first boot the kernel measures available RAM and picks a tier. The
+//! parameters are then embedded in each generated PHC string, so subsequent
+//! verification is self-describing — see [`smallaios_security::argon2id`].
+//!
+//! | Tier      | RAM                       | m_cost  | t_cost | p_cost |
+//! |-----------|---------------------------|---------|--------|--------|
+//! | `tiny`    | ≤ 256 MiB                 | 8 MiB   | 3      | 1      |
+//! | `default` | > 256 MiB and < 4 GiB     | 64 MiB  | 3      | 1      |
+//! | `strong`  | ≥ 4 GiB                   | 128 MiB | 4      | 2      |
+
+use smallaios_security::argon2id::Argon2idParams;
+
+/// Threshold separating the `tiny` and `default` tiers (≤ 256 MiB → tiny).
+pub const TINY_RAM_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Threshold separating the `default` and `strong` tiers (≥ 4 GiB → strong).
+pub const STRONG_RAM_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+
+/// Pick an Argon2id parameter set for the running target based on available
+/// RAM in bytes. Inputs at the boundaries fall in the lower tier:
+///
+/// - `available_ram_bytes <= 256 MiB`             → [`Argon2idParams::tiny`]
+/// - `256 MiB < available_ram_bytes < 4 GiB`      → [`Argon2idParams::default_tier`]
+/// - `available_ram_bytes >= 4 GiB`               → [`Argon2idParams::strong`]
+///
+/// The decision SHALL only be made when generating a *new* hash. When
+/// verifying an existing hash the parameters in the PHC string take
+/// precedence — this is enforced by [`smallaios_security::argon2id::argon2id_verify`].
+pub fn select_tier(available_ram_bytes: u64) -> Argon2idParams {
+    if available_ram_bytes <= TINY_RAM_BYTES {
+        Argon2idParams::tiny()
+    } else if available_ram_bytes < STRONG_RAM_BYTES {
+        Argon2idParams::default_tier()
+    } else {
+        Argon2idParams::strong()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tiny_for_under_256mib() {
+        assert_eq!(select_tier(0), Argon2idParams::tiny());
+        assert_eq!(select_tier(64 * 1024 * 1024), Argon2idParams::tiny());
+        assert_eq!(select_tier(256 * 1024 * 1024), Argon2idParams::tiny());
+    }
+
+    #[test]
+    fn default_for_between_256mib_and_4gib() {
+        assert_eq!(
+            select_tier(256 * 1024 * 1024 + 1),
+            Argon2idParams::default_tier()
+        );
+        assert_eq!(
+            select_tier(1024 * 1024 * 1024),
+            Argon2idParams::default_tier()
+        );
+        assert_eq!(
+            select_tier(4 * 1024 * 1024 * 1024 - 1),
+            Argon2idParams::default_tier()
+        );
+    }
+
+    #[test]
+    fn strong_for_4gib_and_up() {
+        assert_eq!(
+            select_tier(4 * 1024 * 1024 * 1024),
+            Argon2idParams::strong()
+        );
+        assert_eq!(
+            select_tier(16 * 1024 * 1024 * 1024),
+            Argon2idParams::strong()
+        );
+        assert_eq!(select_tier(u64::MAX), Argon2idParams::strong());
+    }
+
+    #[test]
+    fn jetson_orin_nx_16gib_picks_strong() {
+        // Spec scenario: "Jetson-class selects strong tier"
+        // Jetson Orin NX 16 GiB → strong (m=128 MiB, t=4, p=2).
+        let params = select_tier(16 * 1024 * 1024 * 1024);
+        assert_eq!(params.m_cost_kib, 128 * 1024);
+        assert_eq!(params.t_cost, 4);
+        assert_eq!(params.p_cost, 2);
+    }
+
+    #[test]
+    fn tiny_target_256mib_picks_tiny() {
+        // Spec scenario: "Tiny board selects tiny tier"
+        let params = select_tier(256 * 1024 * 1024);
+        assert_eq!(params.m_cost_kib, 8 * 1024);
+        assert_eq!(params.t_cost, 3);
+        assert_eq!(params.p_cost, 1);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of `management-login-v1`. Wires up the `auth/` Layer 1 crate's data model:

- `auth/src/role.rs` (146 LOC) — `Role` enum (`Root=0`, `Operator=1`, `Viewer=2`), reject-unknown ABI per spec.
- `auth/src/shadow.rs` (690 LOC) — colon-separated PHC + trailing fields, forward-compatible parsing of unknown trailing fields, RFC 4648 §6 base32 codec for TOTP secrets, `verify_file_permissions` mode-stricter-than-declared check.
- `auth/src/atomic_write.rs` (383 LOC) — `AtomicWriter` trait + `TestAtomicWriter` in-memory simulator with crash injection. `KernelAtomicWriter` is a stub returning `NotImplemented`; production wire-up to F2FS lands in `embedded-filesystem-v1` Phase 7.
- `auth/src/tier.rs` (105 LOC) — Argon2id tier auto-selection (`tiny` ≤256 MiB / `default` <4 GiB / `strong` ≥4 GiB).
- 41 new tests (role 7, tier 5, atomic_write 8, shadow 21) — all green.

## Deviations

- `username` is `alloc::String` (not `heapless::String<64>`) — matches Phase 1's no-`heapless` deviation; the crate already pulls in `alloc`.
- `KernelAtomicWriter` is intentionally a `NotImplemented` stub. Real F2FS-backed write path comes in `embedded-filesystem-v1` Phase 7.
- No new external crates — clean-room rule respected; `cargo vet check` is `Vetting Succeeded` with no new exemptions.

## Test plan

- [x] `cargo fmt --all -- --check` — clean.
- [x] `just clippy` (`-D warnings` workspace-wide) — clean.
- [x] `just test` — passes; `smallaios-auth --lib` 41/41 green.
- [x] `cargo vet check` — Vetting Succeeded.
- [x] `openspec validate management-login-v1 --strict` — clean.
- [x] `just build-kernel-arm` (default features) — succeeds.

CodeQL guardrails: standalone-line `// lgtm[rust/hard-coded-cryptographic-value]` comments preemptively applied to RFC 4648 base32 alphabet constants and synthetic test fixtures, matching the standalone-line form that's confirmed working in this repo (per the lessons from PR #150).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added role-based access control with three permission levels: Root, Operator, and Viewer
* Added comprehensive credential file parsing and serialization infrastructure
* Implemented atomic file writing mechanism for crash-safe critical data operations
* Added intelligent password hashing strength selection based on available system memory resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->