### PR TITLE
feat(fs): GPT partition table + protective MBR + v1 layout (embedded-filesystem-v1 phase 2)

### DIFF
--- a/fs/src/gpt/layout.rs
+++ b/fs/src/gpt/layout.rs
@@ -1,0 +1,272 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! v1 SmallAIOS GPT layout enforcement.
+//!
+//! Per the `fs-partition-table` spec, a SmallAIOS-formatted disk has
+//! exactly five partitions in a fixed order:
+//!
+//! | Idx | Type GUID                              | Size      | Purpose                            |
+//! |----:|----------------------------------------|-----------|------------------------------------|
+//! |   1 | `C12A7328-F81F-11D2-BA4B-00A0C93EC93B` | 256 MiB   | UEFI ESP                           |
+//! |   2 | `A3F7C2E0-FACE-4FFF-AAAA-000000000001` | 4 GiB     | squashfs `/models/` slot A         |
+//! |   3 | `A3F7C2E0-FACE-4FFF-AAAA-000000000002` | 4 GiB     | squashfs `/models/` slot B         |
+//! |   4 | `8DA63339-0007-60C0-C436-083AC8230908` | remainder | F2FS `/data/`                      |
+//! |   5 | `A3F7C2E0-FACE-4FFF-BBBB-000000000000` | 8 MiB     | A/B boot config                    |
+//!
+//! [`parse_layout`] enforces both the count and the type-GUID-by-slot
+//! ordering and rejects with [`GptError::LayoutMismatch`] on any
+//! deviation.
+
+use super::{GptError, Guid, PartitionEntry};
+
+/// EFI System Partition type GUID (UEFI 2.10 §5.3.3 / canonical).
+//
+// lgtm[rust/hard-coded-cryptographic-value] — UEFI ESP type GUID per UEFI 2.10, public constant
+pub const ESP_TYPE_GUID: Guid = Guid([
+    0x28, 0x73, 0x2A, 0xC1, 0x1F, 0xF8, 0xD2, 0x11, 0xBA, 0x4B, 0x00, 0xA0, 0xC9, 0x3E, 0xC9, 0x3B,
+]);
+
+/// SmallAIOS squashfs slot A type GUID (mixed-endian on disk).
+///
+/// Canonical text: `A3F7C2E0-FACE-4FFF-AAAA-000000000001`.
+//
+// lgtm[rust/hard-coded-cryptographic-value] — SmallAIOS-registered type GUID, public constant per docs/architecture.md
+pub const SQUASHFS_SLOT_A_TYPE_GUID: Guid = Guid([
+    0xE0, 0xC2, 0xF7, 0xA3, 0xCE, 0xFA, 0xFF, 0x4F, 0xAA, 0xAA, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+]);
+
+/// SmallAIOS squashfs slot B type GUID (mixed-endian on disk).
+///
+/// Canonical text: `A3F7C2E0-FACE-4FFF-AAAA-000000000002`.
+//
+// lgtm[rust/hard-coded-cryptographic-value] — SmallAIOS-registered type GUID, public constant per docs/architecture.md
+pub const SQUASHFS_SLOT_B_TYPE_GUID: Guid = Guid([
+    0xE0, 0xC2, 0xF7, 0xA3, 0xCE, 0xFA, 0xFF, 0x4F, 0xAA, 0xAA, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+]);
+
+/// Linux F2FS partition type GUID (canonical text:
+/// `8DA63339-0007-60C0-C436-083AC8230908`).
+//
+// lgtm[rust/hard-coded-cryptographic-value] — Linux F2FS type GUID per util-linux registry, public constant
+pub const F2FS_TYPE_GUID: Guid = Guid([
+    0x39, 0x33, 0xA6, 0x8D, 0x07, 0x00, 0xC0, 0x60, 0xC4, 0x36, 0x08, 0x3A, 0xC8, 0x23, 0x09, 0x08,
+]);
+
+/// SmallAIOS A/B boot config type GUID (mixed-endian on disk).
+///
+/// Canonical text: `A3F7C2E0-FACE-4FFF-BBBB-000000000000`.
+//
+// lgtm[rust/hard-coded-cryptographic-value] — SmallAIOS-registered type GUID, public constant per docs/architecture.md
+pub const BOOT_CONFIG_TYPE_GUID: Guid = Guid([
+    0xE0, 0xC2, 0xF7, 0xA3, 0xCE, 0xFA, 0xFF, 0x4F, 0xBB, 0xBB, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+]);
+
+/// Parsed v1 SmallAIOS layout.
+///
+/// Each field is a clone of the corresponding [`PartitionEntry`] from
+/// the GPT parse; consumers may inspect `starting_lba` / `ending_lba`
+/// to set up squashfs / F2FS / boot-config readers.
+#[derive(Debug, Clone)]
+pub struct SmallaiosLayout {
+    /// Partition #1 — UEFI ESP.
+    pub esp: PartitionEntry,
+    /// Partition #2 — squashfs `/models/` slot A.
+    pub squashfs_a: PartitionEntry,
+    /// Partition #3 — squashfs `/models/` slot B.
+    pub squashfs_b: PartitionEntry,
+    /// Partition #4 — F2FS `/data/`.
+    pub data_f2fs: PartitionEntry,
+    /// Partition #5 — A/B boot config.
+    pub boot_config: PartitionEntry,
+}
+
+/// Validate that `entries` matches the v1 SmallAIOS layout in count,
+/// order, and type GUIDs.
+///
+/// # Errors
+///
+/// - [`GptError::LayoutMismatch`] — count != 5, ordering wrong, OR
+///   any slot's type GUID doesn't match the v1 expectation.
+pub fn parse_layout(entries: &[PartitionEntry]) -> Result<SmallaiosLayout, GptError> {
+    if entries.len() != 5 {
+        return Err(GptError::LayoutMismatch);
+    }
+    let expected = [
+        (&entries[0].type_guid, &ESP_TYPE_GUID),
+        (&entries[1].type_guid, &SQUASHFS_SLOT_A_TYPE_GUID),
+        (&entries[2].type_guid, &SQUASHFS_SLOT_B_TYPE_GUID),
+        (&entries[3].type_guid, &F2FS_TYPE_GUID),
+        (&entries[4].type_guid, &BOOT_CONFIG_TYPE_GUID),
+    ];
+    for (got, want) in expected {
+        if got != want {
+            return Err(GptError::LayoutMismatch);
+        }
+    }
+    Ok(SmallaiosLayout {
+        esp: entries[0].clone(),
+        squashfs_a: entries[1].clone(),
+        squashfs_b: entries[2].clone(),
+        data_f2fs: entries[3].clone(),
+        boot_config: entries[4].clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gpt::PartitionName;
+
+    fn entry(type_guid: Guid) -> PartitionEntry {
+        PartitionEntry {
+            type_guid,
+            unique_guid: Guid::from_str_canonical("11111111-2222-3333-4444-555555555555").unwrap(),
+            starting_lba: 100,
+            ending_lba: 200,
+            attributes: 0,
+            name: PartitionName::empty(),
+        }
+    }
+
+    #[test]
+    fn esp_guid_matches_canonical_text() {
+        let canonical = Guid::from_str_canonical("C12A7328-F81F-11D2-BA4B-00A0C93EC93B").unwrap();
+        assert_eq!(canonical, ESP_TYPE_GUID);
+    }
+
+    #[test]
+    fn squashfs_slot_a_guid_matches_canonical_text() {
+        let canonical = Guid::from_str_canonical("A3F7C2E0-FACE-4FFF-AAAA-000000000001").unwrap();
+        assert_eq!(canonical, SQUASHFS_SLOT_A_TYPE_GUID);
+    }
+
+    #[test]
+    fn squashfs_slot_b_guid_matches_canonical_text() {
+        let canonical = Guid::from_str_canonical("A3F7C2E0-FACE-4FFF-AAAA-000000000002").unwrap();
+        assert_eq!(canonical, SQUASHFS_SLOT_B_TYPE_GUID);
+    }
+
+    #[test]
+    fn f2fs_guid_matches_canonical_text() {
+        let canonical = Guid::from_str_canonical("8DA63339-0007-60C0-C436-083AC8230908").unwrap();
+        assert_eq!(canonical, F2FS_TYPE_GUID);
+    }
+
+    #[test]
+    fn boot_config_guid_matches_canonical_text() {
+        let canonical = Guid::from_str_canonical("A3F7C2E0-FACE-4FFF-BBBB-000000000000").unwrap();
+        assert_eq!(canonical, BOOT_CONFIG_TYPE_GUID);
+    }
+
+    #[test]
+    fn correct_layout_parses() {
+        let entries = alloc::vec![
+            entry(ESP_TYPE_GUID),
+            entry(SQUASHFS_SLOT_A_TYPE_GUID),
+            entry(SQUASHFS_SLOT_B_TYPE_GUID),
+            entry(F2FS_TYPE_GUID),
+            entry(BOOT_CONFIG_TYPE_GUID),
+        ];
+        let layout = parse_layout(&entries).unwrap();
+        assert_eq!(layout.esp.type_guid, ESP_TYPE_GUID);
+        assert_eq!(layout.squashfs_a.type_guid, SQUASHFS_SLOT_A_TYPE_GUID);
+        assert_eq!(layout.squashfs_b.type_guid, SQUASHFS_SLOT_B_TYPE_GUID);
+        assert_eq!(layout.data_f2fs.type_guid, F2FS_TYPE_GUID);
+        assert_eq!(layout.boot_config.type_guid, BOOT_CONFIG_TYPE_GUID);
+    }
+
+    #[test]
+    fn fewer_than_five_entries_rejected() {
+        let entries = alloc::vec![
+            entry(ESP_TYPE_GUID),
+            entry(SQUASHFS_SLOT_A_TYPE_GUID),
+            entry(SQUASHFS_SLOT_B_TYPE_GUID),
+            entry(F2FS_TYPE_GUID),
+        ];
+        assert!(matches!(
+            parse_layout(&entries),
+            Err(GptError::LayoutMismatch)
+        ));
+    }
+
+    #[test]
+    fn more_than_five_entries_rejected() {
+        let entries = alloc::vec![
+            entry(ESP_TYPE_GUID),
+            entry(SQUASHFS_SLOT_A_TYPE_GUID),
+            entry(SQUASHFS_SLOT_B_TYPE_GUID),
+            entry(F2FS_TYPE_GUID),
+            entry(BOOT_CONFIG_TYPE_GUID),
+            entry(ESP_TYPE_GUID),
+        ];
+        assert!(matches!(
+            parse_layout(&entries),
+            Err(GptError::LayoutMismatch)
+        ));
+    }
+
+    #[test]
+    fn wrong_order_rejected() {
+        // Slot A and B swapped.
+        let entries = alloc::vec![
+            entry(ESP_TYPE_GUID),
+            entry(SQUASHFS_SLOT_B_TYPE_GUID),
+            entry(SQUASHFS_SLOT_A_TYPE_GUID),
+            entry(F2FS_TYPE_GUID),
+            entry(BOOT_CONFIG_TYPE_GUID),
+        ];
+        assert!(matches!(
+            parse_layout(&entries),
+            Err(GptError::LayoutMismatch)
+        ));
+    }
+
+    #[test]
+    fn missing_f2fs_rejected() {
+        let entries = alloc::vec![
+            entry(ESP_TYPE_GUID),
+            entry(SQUASHFS_SLOT_A_TYPE_GUID),
+            entry(SQUASHFS_SLOT_B_TYPE_GUID),
+            entry(BOOT_CONFIG_TYPE_GUID), // wrong: should be F2FS
+            entry(BOOT_CONFIG_TYPE_GUID),
+        ];
+        assert!(matches!(
+            parse_layout(&entries),
+            Err(GptError::LayoutMismatch)
+        ));
+    }
+
+    #[test]
+    fn missing_boot_config_rejected() {
+        // Five entries but #5 has wrong type.
+        let foreign = Guid::from_str_canonical("DEADBEEF-1234-5678-9ABC-DEF012345678").unwrap();
+        let entries = alloc::vec![
+            entry(ESP_TYPE_GUID),
+            entry(SQUASHFS_SLOT_A_TYPE_GUID),
+            entry(SQUASHFS_SLOT_B_TYPE_GUID),
+            entry(F2FS_TYPE_GUID),
+            entry(foreign),
+        ];
+        assert!(matches!(
+            parse_layout(&entries),
+            Err(GptError::LayoutMismatch)
+        ));
+    }
+
+    #[test]
+    fn foreign_guid_in_squashfs_slot_rejected() {
+        let foreign = Guid::from_str_canonical("11112222-3333-4444-5555-666666666666").unwrap();
+        let entries = alloc::vec![
+            entry(ESP_TYPE_GUID),
+            entry(foreign), // wrong type for squashfs slot A
+            entry(SQUASHFS_SLOT_B_TYPE_GUID),
+            entry(F2FS_TYPE_GUID),
+            entry(BOOT_CONFIG_TYPE_GUID),
+        ];
+        assert!(matches!(
+            parse_layout(&entries),
+            Err(GptError::LayoutMismatch)
+        ));
+    }
+}

--- a/fs/src/gpt/mod.rs
+++ b/fs/src/gpt/mod.rs
@@ -1,0 +1,1000 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! GUID Partition Table (GPT) parser, protective-MBR writer, and v1
+//! SmallAIOS layout enforcement.
+//!
+//! Implements the read path of UEFI Specification 2.10 §5.3:
+//!
+//! - Read the protective MBR at LBA 0 (only used to reject MBR-only
+//!   disks; GPT itself does not depend on its contents).
+//! - Read the primary GPT header at LBA 1 and validate signature,
+//!   revision, header CRC32, and partition-array bounds.
+//! - Read the partition entry array (typically LBA 2..=33) and
+//!   validate its CRC32 against the header.
+//! - On primary failure, fall through to the secondary GPT at the
+//!   tail of the device (header at the last LBA, entry array at
+//!   `header.partition_entry_lba`) and accept it if its CRCs pass,
+//!   logging a one-time warning.
+//! - On both-corrupt return [`GptError::BothHeadersCorrupt`].
+//!
+//! The write path is intentionally narrow — only the protective MBR
+//! ([`protective_mbr::write_protective_mbr`]) is needed by the
+//! fresh-format flow. GPT writes are out of scope for v1; SmallAIOS
+//! disks are partitioned externally by `sgdisk`/`parted` and only
+//! re-read by the kernel.
+//!
+//! GUIDs are stored on disk in mixed-endian per RFC 4122 §4.1.2:
+//! the first three fields (`time_low`, `time_mid`, `time_hi_and_version`)
+//! are little-endian, the remaining 8 bytes are big-endian.
+//! [`Guid`] preserves the canonical text representation but stores
+//! bytes in the on-disk byte order so equality comparison and CRC
+//! reconstruction round-trip exactly.
+//!
+//! Owned by `embedded-filesystem-v1` Phase 2.
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use core::fmt;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use crate::block::{BlockDevice, BlockError};
+
+pub mod layout;
+pub mod protective_mbr;
+
+pub use layout::{parse_layout, SmallaiosLayout};
+pub use protective_mbr::write_protective_mbr;
+
+/// "EFI PART" signature at the start of every GPT header.
+///
+// lgtm[rust/hard-coded-cryptographic-value] — UEFI 2.10 §5.3 fixed signature, public constant
+pub const GPT_SIGNATURE: [u8; 8] = *b"EFI PART";
+
+/// GPT header revision constant for v1.0 (UEFI 2.10 §5.3.2).
+pub const GPT_REVISION_1_0: u32 = 0x0001_0000;
+
+/// GPT header size in bytes per UEFI 2.10 §5.3.2.
+pub const GPT_HEADER_SIZE: u32 = 92;
+
+/// Maximum total size of the partition entry array, in bytes
+/// (UEFI 2.10 §5.3.2: `num_partition_entries * partition_entry_size <= 16384`).
+pub const PARTITION_ARRAY_MAX_BYTES: usize = 16_384;
+
+/// On-disk partition entry size (UEFI 2.10 §5.3.3 — usually 128).
+pub const PARTITION_ENTRY_SIZE: u32 = 128;
+
+/// Maximum length, in bytes, of a partition name on disk: 36 UTF-16LE
+/// code units.
+pub const PARTITION_NAME_BYTES: usize = 72;
+
+/// Maximum number of UTF-16LE code units in a partition name (per
+/// UEFI 2.10 §5.3.3).
+pub const PARTITION_NAME_CODE_UNITS: usize = 36;
+
+/// MBR signature `0x55AA` at offset 510 of LBA 0.
+///
+// lgtm[rust/hard-coded-cryptographic-value] — IBM-PC MBR magic (legacy public constant)
+pub const MBR_SIGNATURE_LE: [u8; 2] = [0x55, 0xAA];
+
+/// MBR partition type byte `0xEE` reserved for "GPT protective".
+pub const MBR_TYPE_GPT_PROTECTIVE: u8 = 0xEE;
+
+/// Errors surfaced by the GPT parser and protective-MBR writer.
+///
+/// Carries [`BlockError`] for transport-level failures so the caller
+/// can distinguish a media error from a parser error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GptError {
+    /// Primary header CRC failed; secondary was accepted instead.
+    /// Surfaced only as a logged warning, never returned from
+    /// [`parse_gpt`] when the secondary is valid.
+    PrimaryHeaderCorrupt,
+    /// Secondary header CRC failed; primary was used. Surfaced only
+    /// as a logged warning.
+    SecondaryHeaderCorrupt,
+    /// Both primary and secondary GPT headers failed CRC validation.
+    /// The disk is unrecoverable from SmallAIOS' perspective; manual
+    /// intervention required.
+    BothHeadersCorrupt,
+    /// Header CRC32 mismatch on a header being read directly (e.g.,
+    /// a single-header parse path).
+    HeaderCrcMismatch,
+    /// Partition entry array CRC32 mismatch.
+    PartitionArrayCrcMismatch,
+    /// Header `revision` is not [`GPT_REVISION_1_0`].
+    UnsupportedRevision,
+    /// `num_partition_entries * partition_entry_size > 16384`, OR
+    /// `partition_entry_size` is not a power of two ≥ 128, OR
+    /// `num_partition_entries == 0`.
+    EntryCountOutOfRange,
+    /// Disk has an MBR signature at LBA 0 but no GPT header at LBA 1.
+    /// MBR-only disks are rejected per spec Q1 / `fs-partition-table`.
+    MbrOnlyDiskRejected,
+    /// Encountered a partition with a type GUID outside the registered
+    /// SmallAIOS prefix or the EFI/Linux GUIDs the v1 layout expects.
+    /// Used by [`layout::parse_layout`].
+    UnknownPartitionType,
+    /// The five-partition v1 layout did not match: wrong count, wrong
+    /// order, or a type GUID is wrong for that slot.
+    LayoutMismatch,
+    /// Underlying block-device error.
+    BlockError(BlockError),
+}
+
+impl From<BlockError> for GptError {
+    fn from(e: BlockError) -> Self {
+        Self::BlockError(e)
+    }
+}
+
+impl fmt::Display for GptError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::PrimaryHeaderCorrupt => f.write_str("primary GPT header CRC failed"),
+            Self::SecondaryHeaderCorrupt => f.write_str("secondary GPT header CRC failed"),
+            Self::BothHeadersCorrupt => f.write_str("both GPT headers corrupt; recovery required"),
+            Self::HeaderCrcMismatch => f.write_str("GPT header CRC32 mismatch"),
+            Self::PartitionArrayCrcMismatch => f.write_str("GPT partition array CRC32 mismatch"),
+            Self::UnsupportedRevision => f.write_str("unsupported GPT revision"),
+            Self::EntryCountOutOfRange => f.write_str("GPT entry count out of range"),
+            Self::MbrOnlyDiskRejected => f.write_str("GPT required, MBR-only disk rejected"),
+            Self::UnknownPartitionType => f.write_str("unknown partition type GUID"),
+            Self::LayoutMismatch => f.write_str("v1 GPT layout mismatch"),
+            Self::BlockError(e) => write!(f, "block error: {e}"),
+        }
+    }
+}
+
+/// 16-byte mixed-endian GUID (RFC 4122 §4.1.2).
+///
+/// Stored as the on-disk byte order so equality comparison and round-
+/// trip reads are byte-identical. Use [`Self::from_str_canonical`] to
+/// parse the textual form `XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX` and
+/// [`Self::to_string_canonical`] to render it back.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Guid(pub [u8; 16]);
+
+impl Guid {
+    /// Construct from the 16 raw on-disk bytes.
+    pub const fn from_bytes(bytes: [u8; 16]) -> Self {
+        Self(bytes)
+    }
+
+    /// Return the 16 raw on-disk bytes.
+    pub const fn as_bytes(&self) -> &[u8; 16] {
+        &self.0
+    }
+
+    /// All-zero GUID, used by the unused-entry test (UEFI 2.10 §5.3.3).
+    pub const fn nil() -> Self {
+        Self([0u8; 16])
+    }
+
+    /// True iff every byte is zero.
+    pub fn is_nil(&self) -> bool {
+        self.0 == [0u8; 16]
+    }
+
+    /// Parse from canonical text form `XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX`.
+    ///
+    /// Per RFC 4122 §4.1.2, the first three fields (`time_low`,
+    /// `time_mid`, `time_hi`) are little-endian on disk, the remaining
+    /// 8 bytes are big-endian. So the canonical text `01020304-0506-0708-090A-0B0C0D0E0F10`
+    /// becomes the byte sequence `[04 03 02 01, 06 05, 08 07, 09 0A, 0B 0C 0D 0E 0F 10]`.
+    ///
+    /// Returns `None` if the input is malformed.
+    pub fn from_str_canonical(s: &str) -> Option<Self> {
+        let b = s.as_bytes();
+        if b.len() != 36 {
+            return None;
+        }
+        // Position of the four hyphens.
+        for &i in &[8usize, 13, 18, 23] {
+            if b[i] != b'-' {
+                return None;
+            }
+        }
+        // Hex segments (counts of hex chars between hyphens).
+        // 8-4-4-4-12 = 32 hex chars total.
+        let mut nibbles = [0u8; 32];
+        let mut idx = 0;
+        for (i, &c) in b.iter().enumerate() {
+            if i == 8 || i == 13 || i == 18 || i == 23 {
+                continue;
+            }
+            let n = match c {
+                b'0'..=b'9' => c - b'0',
+                b'a'..=b'f' => c - b'a' + 10,
+                b'A'..=b'F' => c - b'A' + 10,
+                _ => return None,
+            };
+            if idx >= 32 {
+                return None;
+            }
+            nibbles[idx] = n;
+            idx += 1;
+        }
+        if idx != 32 {
+            return None;
+        }
+        // Pack 32 nibbles → 16 bytes (big-endian as written in the text).
+        let mut be = [0u8; 16];
+        for i in 0..16 {
+            be[i] = (nibbles[2 * i] << 4) | nibbles[2 * i + 1];
+        }
+        // Apply mixed-endian: reverse the first 4-byte field, then the
+        // 2-byte field at offset 4, then the 2-byte field at offset 6.
+        // The last 8 bytes (offsets 8..16) are stored as-written.
+        let mut out = [0u8; 16];
+        out[0] = be[3];
+        out[1] = be[2];
+        out[2] = be[1];
+        out[3] = be[0];
+        out[4] = be[5];
+        out[5] = be[4];
+        out[6] = be[7];
+        out[7] = be[6];
+        out[8..16].copy_from_slice(&be[8..16]);
+        Some(Self(out))
+    }
+
+    /// Render in canonical text form.
+    pub fn to_string_canonical(&self) -> alloc::string::String {
+        use alloc::string::String;
+        let bytes = &self.0;
+        // Reverse the mixed-endian back to the canonical text byte order.
+        let be = [
+            bytes[3], bytes[2], bytes[1], bytes[0], bytes[5], bytes[4], bytes[7], bytes[6],
+            bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15],
+        ];
+        let mut s = String::with_capacity(36);
+        const HEX: &[u8; 16] = b"0123456789ABCDEF";
+        let push = |s: &mut String, byte: u8| {
+            s.push(HEX[(byte >> 4) as usize] as char);
+            s.push(HEX[(byte & 0xF) as usize] as char);
+        };
+        for &byte in &be[0..4] {
+            push(&mut s, byte);
+        }
+        s.push('-');
+        push(&mut s, be[4]);
+        push(&mut s, be[5]);
+        s.push('-');
+        push(&mut s, be[6]);
+        push(&mut s, be[7]);
+        s.push('-');
+        push(&mut s, be[8]);
+        push(&mut s, be[9]);
+        s.push('-');
+        for &byte in &be[10..16] {
+            push(&mut s, byte);
+        }
+        s
+    }
+}
+
+impl fmt::Debug for Guid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Guid")
+            .field(&self.to_string_canonical())
+            .finish()
+    }
+}
+
+impl fmt::Display for Guid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_string_canonical())
+    }
+}
+
+/// Fixed-capacity UTF-8 partition name (up to 72 UTF-8 bytes, decoded
+/// from up to 36 UTF-16LE code units per UEFI 2.10 §5.3.3).
+///
+/// Implemented inline rather than via `heapless` so the `fs` crate
+/// adds no new external dependencies (clean-room rule).
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct PartitionName {
+    bytes: [u8; PARTITION_NAME_BYTES],
+    len: u8,
+}
+
+impl PartitionName {
+    /// Empty name.
+    pub const fn empty() -> Self {
+        Self {
+            bytes: [0u8; PARTITION_NAME_BYTES],
+            len: 0,
+        }
+    }
+
+    /// Construct from a `&str`, returning `None` if it doesn't fit
+    /// in [`PARTITION_NAME_BYTES`].
+    pub fn try_from_str(s: &str) -> Option<Self> {
+        let b = s.as_bytes();
+        if b.len() > PARTITION_NAME_BYTES {
+            return None;
+        }
+        let mut out = [0u8; PARTITION_NAME_BYTES];
+        out[..b.len()].copy_from_slice(b);
+        Some(Self {
+            bytes: out,
+            len: b.len() as u8,
+        })
+    }
+
+    /// Number of UTF-8 bytes in the name.
+    pub const fn len(&self) -> usize {
+        self.len as usize
+    }
+
+    /// True if the name is empty.
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Borrow as `&str`.
+    pub fn as_str(&self) -> &str {
+        // SAFETY: `bytes[..len]` is constructed only via UTF-8 validating
+        // paths (`from_str`, `from_utf16le_bytes`).
+        // `forbid(unsafe_code)` is set crate-wide; use the safe checked
+        // conversion instead. The cost is one re-validation per access
+        // which is fine for parser-output.
+        core::str::from_utf8(&self.bytes[..self.len as usize]).unwrap_or("")
+    }
+
+    /// Decode 72 bytes of UTF-16LE (36 code units, NUL-terminated)
+    /// into UTF-8 with replacement characters for invalid surrogate
+    /// halves. Per UEFI 2.10 §5.3.3 the on-disk encoding is little-
+    /// endian.
+    pub fn from_utf16le_bytes(bytes: &[u8; PARTITION_NAME_BYTES]) -> Self {
+        // Decode UTF-16LE up to first NUL.
+        let mut units: [u16; PARTITION_NAME_CODE_UNITS] = [0; PARTITION_NAME_CODE_UNITS];
+        for i in 0..PARTITION_NAME_CODE_UNITS {
+            let lo = bytes[2 * i] as u16;
+            let hi = bytes[2 * i + 1] as u16;
+            units[i] = lo | (hi << 8);
+        }
+        // Find effective length (truncate at NUL).
+        let mut nul_at = PARTITION_NAME_CODE_UNITS;
+        for (i, &u) in units.iter().enumerate() {
+            if u == 0 {
+                nul_at = i;
+                break;
+            }
+        }
+        // Decode UTF-16 → UTF-8 with replacement on lone surrogates.
+        let mut out = [0u8; PARTITION_NAME_BYTES];
+        let mut out_len = 0usize;
+
+        let mut i = 0usize;
+        while i < nul_at {
+            let u = units[i];
+            let cp: u32 = if (0xD800..=0xDBFF).contains(&u) {
+                // High surrogate; need a low surrogate next.
+                if i + 1 < nul_at {
+                    let v = units[i + 1];
+                    if (0xDC00..=0xDFFF).contains(&v) {
+                        i += 1;
+                        0x10000 + (((u as u32) - 0xD800) << 10) + ((v as u32) - 0xDC00)
+                    } else {
+                        // Lone high surrogate — replace.
+                        0xFFFD
+                    }
+                } else {
+                    0xFFFD
+                }
+            } else if (0xDC00..=0xDFFF).contains(&u) {
+                // Lone low surrogate.
+                0xFFFD
+            } else {
+                u as u32
+            };
+            // Encode cp as UTF-8 into `out`.
+            let needed = if cp < 0x80 {
+                1
+            } else if cp < 0x800 {
+                2
+            } else if cp < 0x10000 {
+                3
+            } else {
+                4
+            };
+            if out_len + needed > PARTITION_NAME_BYTES {
+                // Truncate — should never happen for 36 BMP code units
+                // since 36 * 3 = 108 but max we accept is 72 bytes.
+                // For 4-byte UTF-8 coming from surrogate pairs we
+                // could exceed 72 bytes only if many CPs >= U+10000.
+                // We stop here to preserve the buffer length invariant.
+                break;
+            }
+            match needed {
+                1 => out[out_len] = cp as u8,
+                2 => {
+                    out[out_len] = 0xC0 | ((cp >> 6) as u8);
+                    out[out_len + 1] = 0x80 | ((cp & 0x3F) as u8);
+                }
+                3 => {
+                    out[out_len] = 0xE0 | ((cp >> 12) as u8);
+                    out[out_len + 1] = 0x80 | (((cp >> 6) & 0x3F) as u8);
+                    out[out_len + 2] = 0x80 | ((cp & 0x3F) as u8);
+                }
+                4 => {
+                    out[out_len] = 0xF0 | ((cp >> 18) as u8);
+                    out[out_len + 1] = 0x80 | (((cp >> 12) & 0x3F) as u8);
+                    out[out_len + 2] = 0x80 | (((cp >> 6) & 0x3F) as u8);
+                    out[out_len + 3] = 0x80 | ((cp & 0x3F) as u8);
+                }
+                _ => unreachable!(),
+            }
+            out_len += needed;
+            i += 1;
+        }
+        Self {
+            bytes: out,
+            len: out_len as u8,
+        }
+    }
+}
+
+impl fmt::Debug for PartitionName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("PartitionName")
+            .field(&self.as_str())
+            .finish()
+    }
+}
+
+impl fmt::Display for PartitionName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// GPT header (UEFI 2.10 §5.3.2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GptHeader {
+    pub signature: [u8; 8],
+    pub revision: u32,
+    pub header_size: u32,
+    pub header_crc32: u32,
+    pub current_lba: u64,
+    pub backup_lba: u64,
+    pub first_usable_lba: u64,
+    pub last_usable_lba: u64,
+    pub disk_guid: Guid,
+    pub partition_entry_lba: u64,
+    pub num_partition_entries: u32,
+    pub partition_entry_size: u32,
+    pub partition_array_crc32: u32,
+}
+
+impl GptHeader {
+    /// Parse a header out of the first 92 bytes of a block.
+    ///
+    /// Performs structural validation (signature, revision, size) but
+    /// does NOT verify the header CRC; that is done by [`parse_gpt`]
+    /// against the surrounding block.
+    pub fn parse(block: &[u8]) -> Result<Self, GptError> {
+        if block.len() < GPT_HEADER_SIZE as usize {
+            return Err(GptError::HeaderCrcMismatch);
+        }
+        let mut signature = [0u8; 8];
+        signature.copy_from_slice(&block[0..8]);
+        if signature != GPT_SIGNATURE {
+            // Not a GPT header — caller decides whether to fall through
+            // to the secondary or reject as MBR-only.
+            return Err(GptError::HeaderCrcMismatch);
+        }
+        let revision = u32_le(&block[8..12]);
+        if revision != GPT_REVISION_1_0 {
+            return Err(GptError::UnsupportedRevision);
+        }
+        let header_size = u32_le(&block[12..16]);
+        if header_size < GPT_HEADER_SIZE || header_size as usize > block.len() {
+            return Err(GptError::HeaderCrcMismatch);
+        }
+        let header_crc32 = u32_le(&block[16..20]);
+        // bytes [20..24] reserved (must be 0 per spec but parsers
+        // accept any value).
+        let current_lba = u64_le(&block[24..32]);
+        let backup_lba = u64_le(&block[32..40]);
+        let first_usable_lba = u64_le(&block[40..48]);
+        let last_usable_lba = u64_le(&block[48..56]);
+        let mut disk_guid_bytes = [0u8; 16];
+        disk_guid_bytes.copy_from_slice(&block[56..72]);
+        let disk_guid = Guid::from_bytes(disk_guid_bytes);
+        let partition_entry_lba = u64_le(&block[72..80]);
+        let num_partition_entries = u32_le(&block[80..84]);
+        let partition_entry_size = u32_le(&block[84..88]);
+        let partition_array_crc32 = u32_le(&block[88..92]);
+
+        // Bounds check on entry array size.
+        let entries_total = (num_partition_entries as u64)
+            .checked_mul(partition_entry_size as u64)
+            .ok_or(GptError::EntryCountOutOfRange)?;
+        if entries_total == 0 || entries_total > PARTITION_ARRAY_MAX_BYTES as u64 {
+            return Err(GptError::EntryCountOutOfRange);
+        }
+        // Per UEFI 2.10 §5.3.3, partition_entry_size must be a power
+        // of two >= 128.
+        if partition_entry_size < 128 || !partition_entry_size.is_power_of_two() {
+            return Err(GptError::EntryCountOutOfRange);
+        }
+
+        Ok(Self {
+            signature,
+            revision,
+            header_size,
+            header_crc32,
+            current_lba,
+            backup_lba,
+            first_usable_lba,
+            last_usable_lba,
+            disk_guid,
+            partition_entry_lba,
+            num_partition_entries,
+            partition_entry_size,
+            partition_array_crc32,
+        })
+    }
+
+    /// Compute the header CRC32 over the canonical 92-byte window with
+    /// the `header_crc32` field zero'd. Bytes outside the first
+    /// `header_size` are excluded per UEFI 2.10 §5.3.2.
+    pub fn compute_header_crc(block: &[u8], header_size: u32) -> u32 {
+        let len = (header_size as usize).min(block.len());
+        let mut buf = alloc::vec![0u8; len];
+        buf.copy_from_slice(&block[..len]);
+        // Zero-out the header_crc32 field (offset 16..20).
+        for byte in buf.iter_mut().take(20).skip(16) {
+            *byte = 0;
+        }
+        crc32(&buf)
+    }
+}
+
+/// Parsed partition entry (UEFI 2.10 §5.3.3).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PartitionEntry {
+    pub type_guid: Guid,
+    pub unique_guid: Guid,
+    pub starting_lba: u64,
+    pub ending_lba: u64,
+    pub attributes: u64,
+    pub name: PartitionName,
+}
+
+impl PartitionEntry {
+    /// Parse a single 128-byte partition entry. Trailing bytes (if
+    /// `partition_entry_size > 128`) are ignored per UEFI 2.10 §5.3.3.
+    pub fn parse(entry: &[u8]) -> Result<Self, GptError> {
+        if entry.len() < 128 {
+            return Err(GptError::EntryCountOutOfRange);
+        }
+        let mut type_guid_bytes = [0u8; 16];
+        type_guid_bytes.copy_from_slice(&entry[0..16]);
+        let mut unique_guid_bytes = [0u8; 16];
+        unique_guid_bytes.copy_from_slice(&entry[16..32]);
+        let starting_lba = u64_le(&entry[32..40]);
+        let ending_lba = u64_le(&entry[40..48]);
+        let attributes = u64_le(&entry[48..56]);
+        let mut name_bytes = [0u8; PARTITION_NAME_BYTES];
+        name_bytes.copy_from_slice(&entry[56..56 + PARTITION_NAME_BYTES]);
+        Ok(Self {
+            type_guid: Guid::from_bytes(type_guid_bytes),
+            unique_guid: Guid::from_bytes(unique_guid_bytes),
+            starting_lba,
+            ending_lba,
+            attributes,
+            name: PartitionName::from_utf16le_bytes(&name_bytes),
+        })
+    }
+
+    /// True iff this entry is unused (type GUID is the all-zero GUID
+    /// per UEFI 2.10 §5.3.3).
+    pub fn is_unused(&self) -> bool {
+        self.type_guid.is_nil()
+    }
+}
+
+/// Top-level GPT parse entry point.
+///
+/// Reads the protective MBR at LBA 0, the primary GPT header at LBA 1,
+/// and the partition entry array. Validates header signature, revision,
+/// header CRC32, partition array CRC32, and entry count bounds.
+///
+/// On primary corruption, falls through to the secondary GPT at the
+/// disk's last LBA and uses it if its CRC passes (logging a one-time
+/// warning). Returns [`GptError::BothHeadersCorrupt`] if both fail.
+///
+/// Hybrid-MBR layouts (some macOS dual-boot disks where the MBR
+/// describes one GPT-protective entry plus other entries) are honored
+/// as plain GPT — i.e., a non-protective MBR signature does not
+/// invalidate a GPT that is otherwise well-formed.
+pub fn parse_gpt(device: &dyn BlockDevice) -> Result<Vec<PartitionEntry>, GptError> {
+    let bs = device.block_size_bytes() as usize;
+    let block_count = device.block_count();
+    if block_count < 4 {
+        // Need at least LBA0 (MBR) + LBA1 (primary header) + 1 entry
+        // block + secondary header. A 3-block disk is unsupportable.
+        return Err(GptError::EntryCountOutOfRange);
+    }
+
+    // Step 1: read LBA 0, classify whether this looks like an MBR-only
+    // disk or a (hybrid-)protective MBR + GPT.
+    let mut lba0 = alloc::vec![0u8; bs];
+    device.read_block(0, &mut lba0)?;
+    // We do NOT reject hybrid-MBR layouts here. We only fail later if
+    // BOTH GPT headers are corrupt AND LBA1 also lacks the GPT signature.
+    let mbr_signature_present =
+        bs >= 512 && lba0[510] == MBR_SIGNATURE_LE[0] && lba0[511] == MBR_SIGNATURE_LE[1];
+
+    // Step 2: try primary GPT (LBA 1).
+    let primary = read_and_validate_gpt(device, 1, false);
+
+    // Step 3: try secondary GPT (last LBA).
+    let secondary_lba = block_count - 1;
+    let secondary = read_and_validate_gpt(device, secondary_lba, true);
+
+    // Decide which to use.
+    match (primary, secondary) {
+        (Ok((header, entries)), _) => {
+            // Sanity: header.current_lba should be 1.
+            let _ = header;
+            Ok(entries)
+        }
+        (Err(GptError::HeaderCrcMismatch), Err(GptError::HeaderCrcMismatch))
+        | (Err(GptError::PartitionArrayCrcMismatch), Err(GptError::HeaderCrcMismatch))
+        | (Err(GptError::HeaderCrcMismatch), Err(GptError::PartitionArrayCrcMismatch))
+        | (Err(GptError::PartitionArrayCrcMismatch), Err(GptError::PartitionArrayCrcMismatch)) => {
+            // Both corrupt — but if LBA0 had a valid MBR signature and
+            // no GPT signature, classify as "MBR-only" instead.
+            if mbr_signature_present && !lba0_looks_like_protective_mbr(&lba0) {
+                Err(GptError::MbrOnlyDiskRejected)
+            } else {
+                Err(GptError::BothHeadersCorrupt)
+            }
+        }
+        (Err(GptError::HeaderCrcMismatch), Ok((_, entries))) => {
+            // Primary corrupt → fall through to secondary.
+            warn_primary_fallthrough();
+            Ok(entries)
+        }
+        (Err(GptError::PartitionArrayCrcMismatch), Ok((_, entries))) => {
+            warn_primary_fallthrough();
+            Ok(entries)
+        }
+        (Err(e), _) => Err(e),
+    }
+}
+
+/// One-time warning latch for "primary GPT corrupt, using secondary".
+static PRIMARY_FALLTHROUGH_WARNED: AtomicBool = AtomicBool::new(false);
+
+fn warn_primary_fallthrough() {
+    // Only warn on first occurrence per kernel boot. The current crate
+    // has no logging infrastructure (the kernel log is in `kernel/`); we
+    // record the state here so the boot-time mounter can read it via
+    // [`primary_fallthrough_was_warned`] and emit the actual log line.
+    PRIMARY_FALLTHROUGH_WARNED.store(true, Ordering::SeqCst);
+}
+
+/// Test introspection: whether [`parse_gpt`] has fallen through to the
+/// secondary GPT at any point during this process's lifetime.
+pub fn primary_fallthrough_was_warned() -> bool {
+    PRIMARY_FALLTHROUGH_WARNED.load(Ordering::SeqCst)
+}
+
+/// Reset the one-time warn latch — only used by tests.
+#[cfg(any(test, feature = "fs-on-disk-mounts"))]
+pub fn reset_primary_fallthrough_latch() {
+    PRIMARY_FALLTHROUGH_WARNED.store(false, Ordering::SeqCst);
+}
+
+/// Heuristic to detect a "pure" protective MBR (single partition entry
+/// of type 0xEE covering most of the disk). If this returns false but
+/// the MBR signature is present, the disk is classified as MBR-only.
+fn lba0_looks_like_protective_mbr(lba0: &[u8]) -> bool {
+    // The first MBR partition entry starts at offset 446. Each entry
+    // is 16 bytes; the type byte is at offset +4.
+    if lba0.len() < 512 {
+        return false;
+    }
+    for slot in 0..4 {
+        let off = 446 + slot * 16;
+        if lba0[off + 4] == MBR_TYPE_GPT_PROTECTIVE {
+            return true;
+        }
+    }
+    false
+}
+
+/// Read and validate a GPT header at `header_lba` plus its partition
+/// array. Returns the parsed header and the live (non-unused) entries.
+///
+/// `is_secondary` toggles whether `current_lba` is expected to equal
+/// the device's last LBA (true) or LBA 1 (false).
+fn read_and_validate_gpt(
+    device: &dyn BlockDevice,
+    header_lba: u64,
+    is_secondary: bool,
+) -> Result<(GptHeader, Vec<PartitionEntry>), GptError> {
+    let bs = device.block_size_bytes() as usize;
+    let mut header_block = alloc::vec![0u8; bs];
+    device.read_block(header_lba, &mut header_block)?;
+
+    let header = GptHeader::parse(&header_block)?;
+
+    // Verify CRC32 over the first `header_size` bytes with the CRC
+    // field zero'd.
+    let computed = GptHeader::compute_header_crc(&header_block, header.header_size);
+    if computed != header.header_crc32 {
+        return Err(GptError::HeaderCrcMismatch);
+    }
+
+    // Sanity-check current_lba.
+    if !is_secondary && header.current_lba != header_lba {
+        return Err(GptError::HeaderCrcMismatch);
+    }
+
+    // Read the partition array.
+    let total_bytes =
+        (header.num_partition_entries as usize) * (header.partition_entry_size as usize);
+    if total_bytes > PARTITION_ARRAY_MAX_BYTES {
+        return Err(GptError::EntryCountOutOfRange);
+    }
+    // Round up to a multiple of `bs`.
+    let blocks = total_bytes.div_ceil(bs);
+    let mut array_buf = alloc::vec![0u8; blocks * bs];
+    for i in 0..blocks {
+        let block_lba = header
+            .partition_entry_lba
+            .checked_add(i as u64)
+            .ok_or(GptError::EntryCountOutOfRange)?;
+        let off = i * bs;
+        device.read_block(block_lba, &mut array_buf[off..off + bs])?;
+    }
+
+    // Validate partition array CRC32 over exactly `total_bytes`.
+    let array_crc = crc32(&array_buf[..total_bytes]);
+    if array_crc != header.partition_array_crc32 {
+        return Err(GptError::PartitionArrayCrcMismatch);
+    }
+
+    // Decode entries, skipping unused.
+    let mut out = Vec::new();
+    for i in 0..header.num_partition_entries as usize {
+        let off = i * header.partition_entry_size as usize;
+        let entry = PartitionEntry::parse(&array_buf[off..off + 128])?;
+        if !entry.is_unused() {
+            out.push(entry);
+        }
+    }
+
+    Ok((header, out))
+}
+
+// ─── byte parsing helpers ────────────────────────────────────────────────────
+
+#[inline]
+fn u32_le(b: &[u8]) -> u32 {
+    u32::from_le_bytes([b[0], b[1], b[2], b[3]])
+}
+
+#[inline]
+fn u64_le(b: &[u8]) -> u64 {
+    u64::from_le_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]])
+}
+
+// ─── CRC32 (IEEE 802.3 polynomial 0xEDB88320) ───────────────────────────────
+
+/// CRC-32/ISO-HDLC, the polynomial used by GPT and UEFI.
+///
+/// Computed bit-reversed; same algorithm as `zlib`'s `crc32()` and
+/// `crc32fast`'s default mode. Implemented inline so the `fs` crate
+/// adds no new dependencies (clean-room rule).
+pub fn crc32(data: &[u8]) -> u32 {
+    let mut crc: u32 = 0xFFFF_FFFF;
+    for &b in data {
+        crc ^= b as u32;
+        for _ in 0..8 {
+            let mask = (crc & 1).wrapping_neg();
+            crc = (crc >> 1) ^ (0xEDB8_8320 & mask);
+        }
+    }
+    !crc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn crc32_known_vectors() {
+        // From ITU-T V.42 / IEEE 802.3 reference vectors.
+        assert_eq!(crc32(b""), 0x0000_0000);
+        assert_eq!(crc32(b"a"), 0xE8B7_BE43);
+        assert_eq!(crc32(b"123456789"), 0xCBF4_3926);
+    }
+
+    #[test]
+    fn guid_parse_and_render_roundtrip() {
+        let s = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B";
+        let g = Guid::from_str_canonical(s).unwrap();
+        // Mixed-endian on disk: time_low is little-endian.
+        assert_eq!(g.0[0], 0x28);
+        assert_eq!(g.0[1], 0x73);
+        assert_eq!(g.0[2], 0x2A);
+        assert_eq!(g.0[3], 0xC1);
+        // time_mid little-endian.
+        assert_eq!(g.0[4], 0x1F);
+        assert_eq!(g.0[5], 0xF8);
+        // time_hi little-endian.
+        assert_eq!(g.0[6], 0xD2);
+        assert_eq!(g.0[7], 0x11);
+        // Last 8 bytes big-endian (as written).
+        assert_eq!(g.0[8], 0xBA);
+        assert_eq!(g.0[9], 0x4B);
+        assert_eq!(&g.0[10..16], &[0x00, 0xA0, 0xC9, 0x3E, 0xC9, 0x3B]);
+        // Round-trip the textual form.
+        assert_eq!(g.to_string_canonical(), s);
+    }
+
+    #[test]
+    fn guid_from_str_rejects_malformed() {
+        assert!(Guid::from_str_canonical("").is_none());
+        assert!(Guid::from_str_canonical("not-a-guid").is_none());
+        // Wrong length.
+        assert!(Guid::from_str_canonical("C12A7328-F81F-11D2-BA4B-00A0C93EC93").is_none());
+        // Bad hex.
+        assert!(Guid::from_str_canonical("C12A732G-F81F-11D2-BA4B-00A0C93EC93B").is_none());
+        // Wrong hyphen positions.
+        assert!(Guid::from_str_canonical("C12A73-28F81F-11D2-BA4B-00A0C93EC93B").is_none());
+    }
+
+    #[test]
+    fn guid_lowercase_accepted() {
+        let upper = Guid::from_str_canonical("C12A7328-F81F-11D2-BA4B-00A0C93EC93B").unwrap();
+        let lower = Guid::from_str_canonical("c12a7328-f81f-11d2-ba4b-00a0c93ec93b").unwrap();
+        assert_eq!(upper, lower);
+    }
+
+    #[test]
+    fn guid_nil_works() {
+        let g = Guid::nil();
+        assert!(g.is_nil());
+        assert_eq!(
+            g.to_string_canonical(),
+            "00000000-0000-0000-0000-000000000000"
+        );
+    }
+
+    #[test]
+    fn partition_name_ascii_decodes() {
+        // "ESP" in UTF-16LE: 'E','S','P','\0'… padded.
+        let mut bytes = [0u8; PARTITION_NAME_BYTES];
+        bytes[0] = b'E';
+        bytes[2] = b'S';
+        bytes[4] = b'P';
+        let name = PartitionName::from_utf16le_bytes(&bytes);
+        assert_eq!(name.as_str(), "ESP");
+    }
+
+    #[test]
+    fn partition_name_truncates_at_nul() {
+        let mut bytes = [0u8; PARTITION_NAME_BYTES];
+        bytes[0] = b'A';
+        // bytes[2..4] = 0 → NUL terminator.
+        bytes[4] = b'B';
+        let name = PartitionName::from_utf16le_bytes(&bytes);
+        assert_eq!(name.as_str(), "A");
+    }
+
+    #[test]
+    fn partition_name_handles_lone_high_surrogate() {
+        let mut bytes = [0u8; PARTITION_NAME_BYTES];
+        // High surrogate 0xD800 followed by a non-surrogate.
+        bytes[0] = 0x00;
+        bytes[1] = 0xD8;
+        bytes[2] = b'X';
+        bytes[3] = 0;
+        let name = PartitionName::from_utf16le_bytes(&bytes);
+        // Expect U+FFFD then 'X'.
+        assert!(name.as_str().starts_with('\u{FFFD}'));
+        assert!(name.as_str().ends_with('X'));
+    }
+
+    #[test]
+    fn partition_name_handles_supplementary_plane() {
+        // U+1F4A9 PILE OF POO = surrogate pair (0xD83D, 0xDCA9).
+        let mut bytes = [0u8; PARTITION_NAME_BYTES];
+        bytes[0] = 0x3D;
+        bytes[1] = 0xD8;
+        bytes[2] = 0xA9;
+        bytes[3] = 0xDC;
+        let name = PartitionName::from_utf16le_bytes(&bytes);
+        assert_eq!(name.as_str(), "\u{1F4A9}");
+    }
+
+    #[test]
+    fn header_parse_rejects_bad_signature() {
+        let block = [0u8; 92];
+        assert!(matches!(
+            GptHeader::parse(&block),
+            Err(GptError::HeaderCrcMismatch)
+        ));
+    }
+
+    #[test]
+    fn header_parse_rejects_bad_revision() {
+        let mut block = [0u8; 92];
+        block[..8].copy_from_slice(&GPT_SIGNATURE);
+        block[8..12].copy_from_slice(&0xDEAD_BEEFu32.to_le_bytes());
+        block[12..16].copy_from_slice(&92u32.to_le_bytes());
+        assert!(matches!(
+            GptHeader::parse(&block),
+            Err(GptError::UnsupportedRevision)
+        ));
+    }
+
+    #[test]
+    fn header_parse_rejects_zero_entry_count() {
+        let mut block = [0u8; 92];
+        block[..8].copy_from_slice(&GPT_SIGNATURE);
+        block[8..12].copy_from_slice(&GPT_REVISION_1_0.to_le_bytes());
+        block[12..16].copy_from_slice(&92u32.to_le_bytes());
+        // num_partition_entries=0 (offset 80..84)
+        block[80..84].copy_from_slice(&0u32.to_le_bytes());
+        block[84..88].copy_from_slice(&128u32.to_le_bytes());
+        assert!(matches!(
+            GptHeader::parse(&block),
+            Err(GptError::EntryCountOutOfRange)
+        ));
+    }
+
+    #[test]
+    fn header_parse_rejects_oversized_entry_count() {
+        let mut block = [0u8; 92];
+        block[..8].copy_from_slice(&GPT_SIGNATURE);
+        block[8..12].copy_from_slice(&GPT_REVISION_1_0.to_le_bytes());
+        block[12..16].copy_from_slice(&92u32.to_le_bytes());
+        // 200 entries * 128 bytes = 25600 > 16384.
+        block[80..84].copy_from_slice(&200u32.to_le_bytes());
+        block[84..88].copy_from_slice(&128u32.to_le_bytes());
+        assert!(matches!(
+            GptHeader::parse(&block),
+            Err(GptError::EntryCountOutOfRange)
+        ));
+    }
+
+    #[test]
+    fn header_parse_rejects_non_pow2_entry_size() {
+        let mut block = [0u8; 92];
+        block[..8].copy_from_slice(&GPT_SIGNATURE);
+        block[8..12].copy_from_slice(&GPT_REVISION_1_0.to_le_bytes());
+        block[12..16].copy_from_slice(&92u32.to_le_bytes());
+        block[80..84].copy_from_slice(&128u32.to_le_bytes());
+        // 192 is not a power of two.
+        block[84..88].copy_from_slice(&192u32.to_le_bytes());
+        assert!(matches!(
+            GptHeader::parse(&block),
+            Err(GptError::EntryCountOutOfRange)
+        ));
+    }
+
+    #[test]
+    fn gpt_error_block_error_conversion() {
+        let e: GptError = BlockError::Timeout.into();
+        assert!(matches!(e, GptError::BlockError(BlockError::Timeout)));
+    }
+
+    #[test]
+    fn gpt_error_display_includes_kind() {
+        use core::fmt::Write;
+        let mut s = alloc::string::String::new();
+        write!(s, "{}", GptError::BothHeadersCorrupt).unwrap();
+        assert!(s.contains("both"));
+    }
+}

--- a/fs/src/gpt/protective_mbr.rs
+++ b/fs/src/gpt/protective_mbr.rs
@@ -1,0 +1,174 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Protective MBR writer.
+//!
+//! Per UEFI 2.10 §5.2.3, a GPT-formatted disk SHALL contain a
+//! protective MBR at LBA 0. The protective MBR has:
+//!
+//! - Boot code: zero-filled (446 bytes, offset 0..446).
+//! - Partition table: 4 entries × 16 bytes = 64 bytes (offset 446..510).
+//!   The first entry is type `0xEE` (GPT protective) covering the whole
+//!   disk; the other three are zero.
+//! - Boot signature: `0x55AA` little-endian at offset 510..512.
+//!
+//! The single 0xEE entry's `starting_lba` is 1 and its `size_in_lba`
+//! is `device.block_count() - 1`, capped at `0xFFFFFFFF` for disks
+//! larger than 2 TiB.
+//!
+//! This is the only GPT-related write operation v1 SmallAIOS performs;
+//! GPT itself is partitioned externally. Once the kernel can read GPT
+//! it can also lay down the protective MBR for greenfield systems.
+
+extern crate alloc;
+
+use crate::block::BlockDevice;
+
+use super::{GptError, MBR_SIGNATURE_LE, MBR_TYPE_GPT_PROTECTIVE};
+
+/// Write a protective MBR to LBA 0.
+///
+/// Per the GPT spec the entry uses CHS values of `0x000200` for start
+/// (cylinder 0, head 0, sector 2) and `0xFFFFFF` for end (max), so
+/// pre-EFI boot loaders that walk the MBR table see one large
+/// protective partition.
+pub fn write_protective_mbr(device: &mut dyn BlockDevice) -> Result<(), GptError> {
+    let bs = device.block_size_bytes() as usize;
+    if bs < 512 {
+        // GPT spec requires LBA 0 to be at least 512 bytes; the
+        // SmallAIOS sector adapter never emits a sub-512-byte device.
+        return Err(GptError::EntryCountOutOfRange);
+    }
+
+    let mut block = alloc::vec![0u8; bs];
+
+    // Boot code (offset 0..446) is zeroed by the vec! macro.
+
+    // Partition table starts at offset 446. Build the single 0xEE
+    // entry covering LBA 1 .. block_count() - 1.
+    let pt = &mut block[446..446 + 64];
+    write_protective_entry(pt, device.block_count());
+
+    // Boot signature 0x55AA at offset 510..512 (little-endian).
+    block[510] = MBR_SIGNATURE_LE[0];
+    block[511] = MBR_SIGNATURE_LE[1];
+
+    device.write_block(0, &block)?;
+    device.flush()?;
+    Ok(())
+}
+
+/// Build a single MBR partition entry of type `0xEE` covering LBAs
+/// 1 .. `block_count - 1` into the first 16 bytes of `pt`. The other
+/// three entries (offsets 16..32, 32..48, 48..64) are left untouched.
+fn write_protective_entry(pt: &mut [u8], block_count: u64) {
+    debug_assert!(pt.len() >= 16);
+    // Boot indicator: 0x00 (non-bootable).
+    pt[0] = 0x00;
+    // Starting CHS: cylinder=0, head=0, sector=2 → bytes [0x00, 0x02, 0x00].
+    pt[1] = 0x00;
+    pt[2] = 0x02;
+    pt[3] = 0x00;
+    // Partition type: 0xEE (GPT protective).
+    pt[4] = MBR_TYPE_GPT_PROTECTIVE;
+    // Ending CHS: 0xFFFFFF (max — protective marker).
+    pt[5] = 0xFF;
+    pt[6] = 0xFF;
+    pt[7] = 0xFF;
+    // Starting LBA = 1 (LE u32).
+    pt[8..12].copy_from_slice(&1u32.to_le_bytes());
+    // Size in LBAs = block_count - 1, capped at 0xFFFFFFFF for >2 TiB
+    // disks per UEFI 2.10 §5.2.3.
+    let size = block_count.saturating_sub(1);
+    let size_u32 = if size > 0xFFFF_FFFF {
+        0xFFFF_FFFFu32
+    } else {
+        size as u32
+    };
+    pt[12..16].copy_from_slice(&size_u32.to_le_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block::mock::MockBlockDevice;
+
+    #[test]
+    fn writes_signature_and_type_byte() {
+        let mut dev = MockBlockDevice::new(512, 64);
+        write_protective_mbr(&mut dev).unwrap();
+        let lba0 = dev.snapshot(0, 512);
+        assert_eq!(lba0[510], 0x55);
+        assert_eq!(lba0[511], 0xAA);
+        // Type byte at offset 446 + 4 = 450.
+        assert_eq!(lba0[450], 0xEE);
+        // Starting LBA = 1.
+        assert_eq!(&lba0[454..458], &1u32.to_le_bytes());
+        // Size = block_count - 1 = 63.
+        assert_eq!(&lba0[458..462], &63u32.to_le_bytes());
+    }
+
+    #[test]
+    fn boot_code_zero_filled() {
+        let mut dev = MockBlockDevice::new(512, 64);
+        // Pre-pollute LBA 0 with non-zero bytes.
+        dev.preload(0, &alloc::vec![0xAB; 512]);
+        write_protective_mbr(&mut dev).unwrap();
+        let lba0 = dev.snapshot(0, 512);
+        assert!(lba0[0..446].iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn other_three_entries_zero() {
+        let mut dev = MockBlockDevice::new(512, 64);
+        dev.preload(0, &alloc::vec![0xAB; 512]);
+        write_protective_mbr(&mut dev).unwrap();
+        let lba0 = dev.snapshot(0, 512);
+        assert!(lba0[462..510].iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn flushes_after_write() {
+        let mut dev = MockBlockDevice::new(512, 64);
+        assert_eq!(dev.flush_count(), 0);
+        write_protective_mbr(&mut dev).unwrap();
+        assert_eq!(dev.flush_count(), 1);
+    }
+
+    #[test]
+    fn caps_size_at_u32_max_for_large_disks() {
+        let mut pt = [0u8; 64];
+        // 8 TiB at 512 B/sector = 16e9 LBAs > u32::MAX.
+        write_protective_entry(&mut pt, 16_000_000_000);
+        assert_eq!(pt[4], 0xEE);
+        assert_eq!(&pt[12..16], &0xFFFF_FFFFu32.to_le_bytes());
+    }
+
+    #[test]
+    fn handles_4k_native_devices() {
+        let mut dev = MockBlockDevice::new(4096, 16);
+        write_protective_mbr(&mut dev).unwrap();
+        let lba0 = dev.snapshot(0, 4096);
+        // Signature still at offset 510..512.
+        assert_eq!(lba0[510], 0x55);
+        assert_eq!(lba0[511], 0xAA);
+        // Type byte at offset 450.
+        assert_eq!(lba0[450], 0xEE);
+        // Size = 16 - 1 = 15.
+        assert_eq!(&lba0[458..462], &15u32.to_le_bytes());
+        // Bytes from offset 512 onward should remain zero (4K block,
+        // protective MBR fills the first 512 bytes only).
+        assert!(lba0[512..].iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn block_error_propagated() {
+        let mut dev = MockBlockDevice::new(512, 64);
+        dev.set_permanent_failure(crate::block::BlockError::MediaError);
+        let res = write_protective_mbr(&mut dev);
+        assert!(matches!(
+            res,
+            Err(GptError::BlockError(crate::block::BlockError::MediaError))
+        ));
+    }
+}

--- a/fs/src/lib.rs
+++ b/fs/src/lib.rs
@@ -55,7 +55,7 @@ pub mod block;
 ///
 /// Filled by `embedded-filesystem-v1` Phase 2.
 #[cfg(feature = "fs-on-disk-mounts")]
-pub mod gpt {}
+pub mod gpt;
 
 /// Squashfs 4.0 read-only reader with zstd/xz/gzip/lz4 decoders and
 /// the appended SmallAIOS manifest-footer verifier.

--- a/fs/tests/common/mod.rs
+++ b/fs/tests/common/mod.rs
@@ -1,0 +1,480 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Synthetic GPT disk-image fixture helpers shared across the
+//! integration test files. Lives at `tests/common/mod.rs` so each
+//! test binary can `mod common;` it.
+
+#![cfg(feature = "fs-on-disk-mounts")]
+#![allow(dead_code)] // Each test binary uses a different subset.
+
+use smallaios_fs::block::mock::MockBlockDevice;
+use smallaios_fs::block::BlockDevice;
+use smallaios_fs::gpt::{
+    crc32, layout::*, write_protective_mbr, Guid, GPT_REVISION_1_0, GPT_SIGNATURE,
+};
+
+/// Default fixture disk size in 512 B sectors (1 MiB).
+pub const DEFAULT_SECTORS: u64 = 2048;
+
+/// Build a fully-valid v1 SmallAIOS GPT on a freshly-zeroed mock device.
+pub fn build_valid_v1_disk(sectors: u64) -> MockBlockDevice {
+    build_valid_v1_disk_with_block_size(sectors, 512)
+}
+
+/// Build a fully-valid v1 SmallAIOS GPT at the given LBA size.
+///
+/// Supports 512-byte and 4096-byte sectors.
+pub fn build_valid_v1_disk_with_block_size(sectors: u64, block_size: u32) -> MockBlockDevice {
+    assert!(sectors > 100);
+    assert!(block_size == 512 || block_size == 4096);
+
+    let bs = block_size as usize;
+    let mut dev = MockBlockDevice::new(block_size, sectors);
+
+    // Protective MBR.
+    write_protective_mbr(&mut dev).unwrap();
+
+    let num_entries: u32 = 128;
+    let entry_size: u32 = 128;
+    let array_bytes = (num_entries * entry_size) as usize; // 16384
+
+    // Number of LBAs the entry array occupies.
+    let array_blocks = array_bytes.div_ceil(bs);
+
+    // 1 (MBR) + 1 (primary header) + array_blocks (primary array)
+    let usable_first: u64 = 2 + array_blocks as u64;
+    let usable_last: u64 = sectors - 2 - array_blocks as u64;
+
+    let chunk = (usable_last - usable_first + 1) / 5;
+    assert!(chunk >= 1, "test disk too small");
+
+    let starts = [
+        usable_first,
+        usable_first + chunk,
+        usable_first + 2 * chunk,
+        usable_first + 3 * chunk,
+        usable_first + 4 * chunk,
+    ];
+    let ends = [
+        starts[1] - 1,
+        starts[2] - 1,
+        starts[3] - 1,
+        starts[4] - 1,
+        usable_last,
+    ];
+    let types = [
+        ESP_TYPE_GUID,
+        SQUASHFS_SLOT_A_TYPE_GUID,
+        SQUASHFS_SLOT_B_TYPE_GUID,
+        F2FS_TYPE_GUID,
+        BOOT_CONFIG_TYPE_GUID,
+    ];
+
+    let mut array = vec![0u8; array_bytes];
+    for (i, ((ty, &start), &end)) in types.iter().zip(starts.iter()).zip(ends.iter()).enumerate() {
+        let off = i * entry_size as usize;
+        write_partition_entry(
+            &mut array[off..off + entry_size as usize],
+            ty,
+            start,
+            end,
+            i as u32,
+        );
+    }
+    let array_crc = crc32(&array);
+    let disk_guid = Guid::from_str_canonical("DEADBEEF-FACE-CAFE-1234-567890ABCDEF").unwrap();
+
+    let primary_header = build_header(
+        sectors,
+        1,
+        sectors - 1,
+        usable_first,
+        usable_last,
+        &disk_guid,
+        2,
+        num_entries,
+        entry_size,
+        array_crc,
+    );
+    let primary_block = pad_block(&primary_header, bs);
+    dev.preload(1, &primary_block);
+
+    let mut padded_array = vec![0u8; array_blocks * bs];
+    padded_array[..array_bytes].copy_from_slice(&array);
+    dev.preload(2, &padded_array);
+
+    // Secondary at tail.
+    let secondary_array_lba = sectors - 1 - array_blocks as u64;
+    let secondary_header = build_header(
+        sectors,
+        sectors - 1,
+        1,
+        usable_first,
+        usable_last,
+        &disk_guid,
+        secondary_array_lba,
+        num_entries,
+        entry_size,
+        array_crc,
+    );
+    let secondary_block = pad_block(&secondary_header, bs);
+    dev.preload(sectors - 1, &secondary_block);
+    dev.preload(secondary_array_lba, &padded_array);
+
+    dev
+}
+
+/// Build a 92-byte GPT header with a correct CRC32.
+#[allow(clippy::too_many_arguments)]
+pub fn build_header(
+    _sectors: u64,
+    current_lba: u64,
+    backup_lba: u64,
+    first_usable_lba: u64,
+    last_usable_lba: u64,
+    disk_guid: &Guid,
+    partition_entry_lba: u64,
+    num_partition_entries: u32,
+    partition_entry_size: u32,
+    partition_array_crc32: u32,
+) -> [u8; 92] {
+    let mut header = [0u8; 92];
+    header[0..8].copy_from_slice(&GPT_SIGNATURE);
+    header[8..12].copy_from_slice(&GPT_REVISION_1_0.to_le_bytes());
+    header[12..16].copy_from_slice(&92u32.to_le_bytes());
+    header[16..20].copy_from_slice(&0u32.to_le_bytes());
+    header[24..32].copy_from_slice(&current_lba.to_le_bytes());
+    header[32..40].copy_from_slice(&backup_lba.to_le_bytes());
+    header[40..48].copy_from_slice(&first_usable_lba.to_le_bytes());
+    header[48..56].copy_from_slice(&last_usable_lba.to_le_bytes());
+    header[56..72].copy_from_slice(disk_guid.as_bytes());
+    header[72..80].copy_from_slice(&partition_entry_lba.to_le_bytes());
+    header[80..84].copy_from_slice(&num_partition_entries.to_le_bytes());
+    header[84..88].copy_from_slice(&partition_entry_size.to_le_bytes());
+    header[88..92].copy_from_slice(&partition_array_crc32.to_le_bytes());
+    let crc = crc32(&header);
+    header[16..20].copy_from_slice(&crc.to_le_bytes());
+    header
+}
+
+/// Build one 128-byte partition entry.
+pub fn write_partition_entry(
+    buf: &mut [u8],
+    type_guid: &Guid,
+    starting_lba: u64,
+    ending_lba: u64,
+    name_index: u32,
+) {
+    assert!(buf.len() >= 128);
+    buf[0..16].copy_from_slice(type_guid.as_bytes());
+    let mut unique = [0u8; 16];
+    unique[0..4].copy_from_slice(&name_index.to_le_bytes());
+    unique[4..8].copy_from_slice(&0xFEEDFACEu32.to_le_bytes());
+    unique[8..16].copy_from_slice(&0xCAFE_BABE_DEAD_BEEFu64.to_le_bytes());
+    buf[16..32].copy_from_slice(&unique);
+    buf[32..40].copy_from_slice(&starting_lba.to_le_bytes());
+    buf[40..48].copy_from_slice(&ending_lba.to_le_bytes());
+    buf[48..56].copy_from_slice(&0u64.to_le_bytes());
+    let label = match name_index {
+        0 => "ESP",
+        1 => "Models A",
+        2 => "Models B",
+        3 => "Data",
+        4 => "Boot",
+        _ => "Unknown",
+    };
+    let mut off = 56;
+    for c in label.chars() {
+        let mut units = [0u16; 2];
+        let n = c.encode_utf16(&mut units).len();
+        for &u in &units[..n] {
+            buf[off] = (u & 0xFF) as u8;
+            buf[off + 1] = (u >> 8) as u8;
+            off += 2;
+            if off >= 56 + 72 {
+                break;
+            }
+        }
+    }
+}
+
+/// Pad `data` to a block-sized buffer.
+pub fn pad_block(data: &[u8], block_size: usize) -> Vec<u8> {
+    let mut out = vec![0u8; block_size];
+    out[..data.len()].copy_from_slice(data);
+    out
+}
+
+// ─── Corruption helpers ─────────────────────────────────────────────────────
+
+/// Flip bytes in the primary header so its CRC fails.
+pub fn corrupt_primary_header(dev: &mut MockBlockDevice) {
+    let mut block = vec![0u8; dev.block_size_bytes() as usize];
+    dev.read_block(1, &mut block).unwrap();
+    block[20] ^= 0xFF;
+    block[24] ^= 0xFF;
+    dev.write_block(1, &block).unwrap();
+}
+
+/// Flip bytes in the secondary header so its CRC fails.
+pub fn corrupt_secondary_header(dev: &mut MockBlockDevice) {
+    let secondary_lba = dev.block_count() - 1;
+    let mut block = vec![0u8; dev.block_size_bytes() as usize];
+    dev.read_block(secondary_lba, &mut block).unwrap();
+    block[20] ^= 0xFF;
+    block[24] ^= 0xFF;
+    dev.write_block(secondary_lba, &block).unwrap();
+}
+
+/// Flip a byte in the primary partition array.
+pub fn corrupt_primary_array(dev: &mut MockBlockDevice) {
+    let mut block = vec![0u8; dev.block_size_bytes() as usize];
+    dev.read_block(2, &mut block).unwrap();
+    block[100] ^= 0xFF;
+    dev.write_block(2, &block).unwrap();
+}
+
+/// Zero out the GPT signature at LBA 1 entirely.
+pub fn obliterate_primary_header(dev: &mut MockBlockDevice) {
+    let block = vec![0u8; dev.block_size_bytes() as usize];
+    dev.write_block(1, &block).unwrap();
+}
+
+/// Zero out the secondary header at the disk tail.
+pub fn obliterate_secondary_header(dev: &mut MockBlockDevice) {
+    let secondary_lba = dev.block_count() - 1;
+    let block = vec![0u8; dev.block_size_bytes() as usize];
+    dev.write_block(secondary_lba, &block).unwrap();
+}
+
+/// Build an MBR-only disk: a 0x55AA signature at LBA 0 with no
+/// protective entry of type 0xEE, and zeroed LBA 1..end (no GPT).
+pub fn build_mbr_only_disk(sectors: u64) -> MockBlockDevice {
+    let mut dev = MockBlockDevice::new(512, sectors);
+    let mut block = vec![0u8; 512];
+    // First MBR partition entry: type 0x83 (Linux), not 0xEE.
+    let pt_off = 446;
+    block[pt_off + 4] = 0x83;
+    // Boot signature 0x55AA.
+    block[510] = 0x55;
+    block[511] = 0xAA;
+    dev.write_block(0, &block).unwrap();
+    // LBA 1..end stays zero — no GPT.
+    dev
+}
+
+/// Build an MBR-only disk where the type is 0xEE (looks protective) but
+/// no GPT exists. This is malformed; the parser should reject as
+/// "both corrupt" since the secondary GPT is also absent.
+pub fn build_protective_mbr_only_disk(sectors: u64) -> MockBlockDevice {
+    let mut dev = MockBlockDevice::new(512, sectors);
+    write_protective_mbr(&mut dev).unwrap();
+    // Don't write any GPT structures.
+    dev
+}
+
+/// Build a hybrid-MBR disk: protective MBR PLUS the GPT, with one
+/// extra non-0xEE entry in the MBR slot 2. This emulates macOS dual-
+/// boot. Per Q-spec, the parser should still honor the GPT.
+pub fn build_hybrid_mbr_disk(sectors: u64) -> MockBlockDevice {
+    let mut dev = build_valid_v1_disk(sectors);
+    // Read LBA 0, add a "fake" entry in MBR slot 1 (offset 446 + 16 = 462).
+    let mut block = vec![0u8; 512];
+    dev.read_block(0, &mut block).unwrap();
+    block[462 + 4] = 0x07; // NTFS, just for show
+    block[462 + 8..462 + 12].copy_from_slice(&100u32.to_le_bytes()); // start LBA
+    block[462 + 12..462 + 16].copy_from_slice(&50u32.to_le_bytes()); // size
+    dev.write_block(0, &block).unwrap();
+    dev
+}
+
+/// Build a disk where partition #4 is not F2FS.
+pub fn build_disk_missing_f2fs(sectors: u64) -> MockBlockDevice {
+    build_disk_with_swapped_type(sectors, 3, BOOT_CONFIG_TYPE_GUID)
+}
+
+/// Build a disk where partition #5 has the wrong type.
+pub fn build_disk_missing_boot_config(sectors: u64) -> MockBlockDevice {
+    build_disk_with_swapped_type(sectors, 4, F2FS_TYPE_GUID)
+}
+
+/// Build a disk where partition #2 has a foreign type GUID but the
+/// partition name is "SmallAIOS Models A" (the spec scenario).
+pub fn build_disk_foreign_type_with_smallaios_name(sectors: u64) -> MockBlockDevice {
+    let foreign = Guid::from_str_canonical("11112222-3333-4444-5555-666666666666").unwrap();
+    build_disk_with_swapped_type(sectors, 1, foreign)
+}
+
+/// Generic helper: rebuild the partition array with the given index's
+/// type GUID replaced and rewrite the primary + secondary headers.
+fn build_disk_with_swapped_type(
+    sectors: u64,
+    swap_index: usize,
+    new_type: Guid,
+) -> MockBlockDevice {
+    let bs = 512usize;
+    let mut dev = MockBlockDevice::new(bs as u32, sectors);
+    write_protective_mbr(&mut dev).unwrap();
+
+    let num_entries: u32 = 128;
+    let entry_size: u32 = 128;
+    let array_bytes = (num_entries * entry_size) as usize;
+    let array_blocks = array_bytes.div_ceil(bs);
+
+    let usable_first: u64 = 2 + array_blocks as u64;
+    let usable_last: u64 = sectors - 2 - array_blocks as u64;
+    let chunk = (usable_last - usable_first + 1) / 5;
+
+    let starts = [
+        usable_first,
+        usable_first + chunk,
+        usable_first + 2 * chunk,
+        usable_first + 3 * chunk,
+        usable_first + 4 * chunk,
+    ];
+    let ends = [
+        starts[1] - 1,
+        starts[2] - 1,
+        starts[3] - 1,
+        starts[4] - 1,
+        usable_last,
+    ];
+    let mut types = [
+        ESP_TYPE_GUID,
+        SQUASHFS_SLOT_A_TYPE_GUID,
+        SQUASHFS_SLOT_B_TYPE_GUID,
+        F2FS_TYPE_GUID,
+        BOOT_CONFIG_TYPE_GUID,
+    ];
+    types[swap_index] = new_type;
+
+    let mut array = vec![0u8; array_bytes];
+    for (i, ((ty, &start), &end)) in types.iter().zip(starts.iter()).zip(ends.iter()).enumerate() {
+        let off = i * entry_size as usize;
+        write_partition_entry(
+            &mut array[off..off + entry_size as usize],
+            ty,
+            start,
+            end,
+            i as u32,
+        );
+    }
+    let array_crc = crc32(&array);
+    let disk_guid = Guid::from_str_canonical("DEADBEEF-FACE-CAFE-1234-567890ABCDEF").unwrap();
+
+    let primary_header = build_header(
+        sectors,
+        1,
+        sectors - 1,
+        usable_first,
+        usable_last,
+        &disk_guid,
+        2,
+        num_entries,
+        entry_size,
+        array_crc,
+    );
+    dev.preload(1, &pad_block(&primary_header, bs));
+
+    let mut padded_array = vec![0u8; array_blocks * bs];
+    padded_array[..array_bytes].copy_from_slice(&array);
+    dev.preload(2, &padded_array);
+
+    let secondary_array_lba = sectors - 1 - array_blocks as u64;
+    let secondary_header = build_header(
+        sectors,
+        sectors - 1,
+        1,
+        usable_first,
+        usable_last,
+        &disk_guid,
+        secondary_array_lba,
+        num_entries,
+        entry_size,
+        array_crc,
+    );
+    dev.preload(sectors - 1, &pad_block(&secondary_header, bs));
+    dev.preload(secondary_array_lba, &padded_array);
+
+    dev
+}
+
+/// Build a disk with too few partitions (e.g., only 4).
+pub fn build_disk_with_n_partitions(sectors: u64, n: usize) -> MockBlockDevice {
+    let bs = 512usize;
+    let mut dev = MockBlockDevice::new(bs as u32, sectors);
+    write_protective_mbr(&mut dev).unwrap();
+
+    let num_entries: u32 = 128;
+    let entry_size: u32 = 128;
+    let array_bytes = (num_entries * entry_size) as usize;
+    let array_blocks = array_bytes.div_ceil(bs);
+
+    let usable_first: u64 = 2 + array_blocks as u64;
+    let usable_last: u64 = sectors - 2 - array_blocks as u64;
+    let chunk = (usable_last - usable_first + 1) / 5;
+
+    let mut array = vec![0u8; array_bytes];
+    let types = [
+        ESP_TYPE_GUID,
+        SQUASHFS_SLOT_A_TYPE_GUID,
+        SQUASHFS_SLOT_B_TYPE_GUID,
+        F2FS_TYPE_GUID,
+        BOOT_CONFIG_TYPE_GUID,
+    ];
+    for (i, ty) in types.iter().enumerate().take(n.min(5)) {
+        let off = i * entry_size as usize;
+        let start = usable_first + i as u64 * chunk;
+        let end = if i + 1 < 5 {
+            start + chunk - 1
+        } else {
+            usable_last
+        };
+        write_partition_entry(
+            &mut array[off..off + entry_size as usize],
+            ty,
+            start,
+            end,
+            i as u32,
+        );
+    }
+    let array_crc = crc32(&array);
+    let disk_guid = Guid::from_str_canonical("DEADBEEF-FACE-CAFE-1234-567890ABCDEF").unwrap();
+
+    let primary_header = build_header(
+        sectors,
+        1,
+        sectors - 1,
+        usable_first,
+        usable_last,
+        &disk_guid,
+        2,
+        num_entries,
+        entry_size,
+        array_crc,
+    );
+    dev.preload(1, &pad_block(&primary_header, bs));
+
+    let mut padded_array = vec![0u8; array_blocks * bs];
+    padded_array[..array_bytes].copy_from_slice(&array);
+    dev.preload(2, &padded_array);
+
+    let secondary_array_lba = sectors - 1 - array_blocks as u64;
+    let secondary_header = build_header(
+        sectors,
+        sectors - 1,
+        1,
+        usable_first,
+        usable_last,
+        &disk_guid,
+        secondary_array_lba,
+        num_entries,
+        entry_size,
+        array_crc,
+    );
+    dev.preload(sectors - 1, &pad_block(&secondary_header, bs));
+    dev.preload(secondary_array_lba, &padded_array);
+
+    dev
+}

--- a/fs/tests/gpt_conformance.rs
+++ b/fs/tests/gpt_conformance.rs
@@ -1,0 +1,415 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! GPT parser conformance suite.
+//!
+//! Implements every observable scenario from
+//! `openspec/changes/embedded-filesystem-v1/specs/fs-partition-table/spec.md`
+//! plus boundary cases on top of that. Fixtures are generated in
+//! memory (no binary blobs in the repo) by `tests/common/mod.rs`.
+
+#![cfg(feature = "fs-on-disk-mounts")]
+
+mod common;
+
+use smallaios_fs::block::mock::MockBlockDevice;
+use smallaios_fs::block::{BlockDevice, BlockError};
+use smallaios_fs::gpt::{
+    crc32, layout::*, parse_gpt, parse_layout, write_protective_mbr, GptError, Guid,
+    PartitionEntry, PartitionName, GPT_REVISION_1_0, GPT_SIGNATURE, MBR_SIGNATURE_LE,
+    MBR_TYPE_GPT_PROTECTIVE, PARTITION_ARRAY_MAX_BYTES, PARTITION_ENTRY_SIZE,
+};
+
+use common::*;
+
+// ─── 1. Valid GPT parses successfully ───────────────────────────────────────
+
+#[test]
+fn scenario_valid_gpt_parses_successfully() {
+    let dev = build_valid_v1_disk(DEFAULT_SECTORS);
+    let entries = parse_gpt(&dev).expect("valid GPT must parse");
+    assert_eq!(entries.len(), 5, "v1 layout has exactly 5 partitions");
+}
+
+#[test]
+fn valid_gpt_returns_type_guids_and_lba_ranges() {
+    let dev = build_valid_v1_disk(DEFAULT_SECTORS);
+    let entries = parse_gpt(&dev).unwrap();
+    for e in &entries {
+        assert!(
+            !e.type_guid.is_nil(),
+            "live entries have non-zero type GUID"
+        );
+        assert!(e.starting_lba > 0);
+        assert!(e.ending_lba >= e.starting_lba);
+    }
+}
+
+#[test]
+fn valid_gpt_decodes_partition_names_utf8() {
+    let dev = build_valid_v1_disk(DEFAULT_SECTORS);
+    let entries = parse_gpt(&dev).unwrap();
+    assert_eq!(entries[0].name.as_str(), "ESP");
+    assert_eq!(entries[1].name.as_str(), "Models A");
+    assert_eq!(entries[2].name.as_str(), "Models B");
+    assert_eq!(entries[3].name.as_str(), "Data");
+    assert_eq!(entries[4].name.as_str(), "Boot");
+}
+
+#[test]
+fn valid_gpt_unique_guids_distinct() {
+    let dev = build_valid_v1_disk(DEFAULT_SECTORS);
+    let entries = parse_gpt(&dev).unwrap();
+    let mut seen = vec![];
+    for e in &entries {
+        assert!(
+            !seen.contains(&e.unique_guid),
+            "unique_guid collision among entries"
+        );
+        seen.push(e.unique_guid);
+    }
+}
+
+// ─── 2. Corrupt primary GPT falls through to secondary ───────────────────────
+
+#[test]
+fn scenario_primary_corrupt_falls_through_to_secondary() {
+    let mut dev = build_valid_v1_disk(DEFAULT_SECTORS);
+    corrupt_primary_header(&mut dev);
+    let entries = parse_gpt(&dev).unwrap();
+    assert_eq!(entries.len(), 5);
+}
+
+#[test]
+fn primary_array_corrupt_falls_through_to_secondary() {
+    let mut dev = build_valid_v1_disk(DEFAULT_SECTORS);
+    corrupt_primary_array(&mut dev);
+    let entries = parse_gpt(&dev).unwrap();
+    assert_eq!(entries.len(), 5);
+}
+
+#[test]
+fn obliterating_primary_falls_through_to_secondary() {
+    let mut dev = build_valid_v1_disk(DEFAULT_SECTORS);
+    obliterate_primary_header(&mut dev);
+    let entries = parse_gpt(&dev).unwrap();
+    assert_eq!(entries.len(), 5);
+}
+
+#[test]
+fn primary_corrupt_secondary_valid_warning_latch_set() {
+    use smallaios_fs::gpt::{primary_fallthrough_was_warned, reset_primary_fallthrough_latch};
+    reset_primary_fallthrough_latch();
+    let mut dev = build_valid_v1_disk(DEFAULT_SECTORS);
+    corrupt_primary_header(&mut dev);
+    let _ = parse_gpt(&dev).unwrap();
+    assert!(
+        primary_fallthrough_was_warned(),
+        "fallthrough latch must be set so kernel logs warning once"
+    );
+}
+
+// ─── 3. Both primary and secondary corrupt rejected ─────────────────────────
+
+#[test]
+fn scenario_both_corrupt_rejected() {
+    let mut dev = build_valid_v1_disk(DEFAULT_SECTORS);
+    corrupt_primary_header(&mut dev);
+    corrupt_secondary_header(&mut dev);
+    assert!(matches!(parse_gpt(&dev), Err(GptError::BothHeadersCorrupt)));
+}
+
+#[test]
+fn obliterating_both_headers_rejected() {
+    let mut dev = build_valid_v1_disk(DEFAULT_SECTORS);
+    obliterate_primary_header(&mut dev);
+    obliterate_secondary_header(&mut dev);
+    let res = parse_gpt(&dev);
+    // Both headers obliterated → looks like protective MBR with no GPT.
+    // Per parser policy we report BothHeadersCorrupt (a protective MBR
+    // is NOT classified as MBR-only).
+    assert!(matches!(res, Err(GptError::BothHeadersCorrupt)));
+}
+
+// ─── 4. MBR-only disk rejected ──────────────────────────────────────────────
+
+#[test]
+fn scenario_mbr_only_disk_rejected() {
+    let dev = build_mbr_only_disk(DEFAULT_SECTORS);
+    let res = parse_gpt(&dev);
+    assert!(matches!(res, Err(GptError::MbrOnlyDiskRejected)));
+}
+
+#[test]
+fn protective_mbr_without_gpt_rejected_as_both_corrupt() {
+    // A disk with only a protective MBR but no GPT is malformed.
+    // Since MBR has type 0xEE, we don't classify as MBR-only; we report
+    // BothHeadersCorrupt (LBA 1 lacks an "EFI PART" signature).
+    let dev = build_protective_mbr_only_disk(DEFAULT_SECTORS);
+    let res = parse_gpt(&dev);
+    assert!(matches!(res, Err(GptError::BothHeadersCorrupt)));
+}
+
+// ─── 5. Protective MBR present after format ─────────────────────────────────
+
+#[test]
+fn scenario_protective_mbr_present_after_format() {
+    let mut dev = MockBlockDevice::new(512, 1024);
+    write_protective_mbr(&mut dev).unwrap();
+    let lba0 = dev.snapshot(0, 512);
+    // Type 0xEE.
+    assert_eq!(lba0[450], MBR_TYPE_GPT_PROTECTIVE);
+    // 0x55AA signature.
+    assert_eq!(lba0[510], MBR_SIGNATURE_LE[0]);
+    assert_eq!(lba0[511], MBR_SIGNATURE_LE[1]);
+}
+
+#[test]
+fn protective_mbr_covers_entire_disk() {
+    let mut dev = MockBlockDevice::new(512, 1024);
+    write_protective_mbr(&mut dev).unwrap();
+    let lba0 = dev.snapshot(0, 512);
+    // Starting LBA = 1.
+    assert_eq!(&lba0[454..458], &1u32.to_le_bytes());
+    // Size = 1023 (block_count - 1).
+    assert_eq!(&lba0[458..462], &1023u32.to_le_bytes());
+}
+
+// ─── 6. Correct layout mounts ───────────────────────────────────────────────
+
+#[test]
+fn scenario_correct_layout_parses() {
+    let dev = build_valid_v1_disk(DEFAULT_SECTORS);
+    let entries = parse_gpt(&dev).unwrap();
+    let layout = parse_layout(&entries).expect("v1 layout valid");
+    // Each slot has the right type GUID.
+    assert_eq!(layout.esp.type_guid, ESP_TYPE_GUID);
+    assert_eq!(layout.squashfs_a.type_guid, SQUASHFS_SLOT_A_TYPE_GUID);
+    assert_eq!(layout.squashfs_b.type_guid, SQUASHFS_SLOT_B_TYPE_GUID);
+    assert_eq!(layout.data_f2fs.type_guid, F2FS_TYPE_GUID);
+    assert_eq!(layout.boot_config.type_guid, BOOT_CONFIG_TYPE_GUID);
+}
+
+// ─── 7. Missing F2FS partition rejected ─────────────────────────────────────
+
+#[test]
+fn scenario_missing_f2fs_partition_rejected() {
+    let dev = build_disk_missing_f2fs(DEFAULT_SECTORS);
+    let entries = parse_gpt(&dev).unwrap();
+    assert!(matches!(
+        parse_layout(&entries),
+        Err(GptError::LayoutMismatch)
+    ));
+}
+
+// ─── 8. Missing boot config partition rejected ──────────────────────────────
+
+#[test]
+fn scenario_missing_boot_config_partition_rejected() {
+    let dev = build_disk_missing_boot_config(DEFAULT_SECTORS);
+    let entries = parse_gpt(&dev).unwrap();
+    assert!(matches!(
+        parse_layout(&entries),
+        Err(GptError::LayoutMismatch)
+    ));
+}
+
+#[test]
+fn fewer_than_5_partitions_rejected() {
+    let dev = build_disk_with_n_partitions(DEFAULT_SECTORS, 4);
+    let entries = parse_gpt(&dev).unwrap();
+    assert_eq!(entries.len(), 4);
+    assert!(matches!(
+        parse_layout(&entries),
+        Err(GptError::LayoutMismatch)
+    ));
+}
+
+#[test]
+fn three_partitions_rejected() {
+    let dev = build_disk_with_n_partitions(DEFAULT_SECTORS, 3);
+    let entries = parse_gpt(&dev).unwrap();
+    assert!(matches!(
+        parse_layout(&entries),
+        Err(GptError::LayoutMismatch)
+    ));
+}
+
+// ─── 9. SmallAIOS GUIDs round-trip with canonical text ──────────────────────
+
+#[test]
+fn esp_type_guid_has_canonical_text() {
+    let canonical = Guid::from_str_canonical("C12A7328-F81F-11D2-BA4B-00A0C93EC93B").unwrap();
+    assert_eq!(canonical, ESP_TYPE_GUID);
+    assert_eq!(
+        ESP_TYPE_GUID.to_string_canonical(),
+        "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
+    );
+}
+
+#[test]
+fn squashfs_slot_a_type_guid_has_canonical_text() {
+    let canonical = Guid::from_str_canonical("A3F7C2E0-FACE-4FFF-AAAA-000000000001").unwrap();
+    assert_eq!(canonical, SQUASHFS_SLOT_A_TYPE_GUID);
+}
+
+#[test]
+fn squashfs_slot_b_type_guid_has_canonical_text() {
+    let canonical = Guid::from_str_canonical("A3F7C2E0-FACE-4FFF-AAAA-000000000002").unwrap();
+    assert_eq!(canonical, SQUASHFS_SLOT_B_TYPE_GUID);
+}
+
+#[test]
+fn f2fs_type_guid_has_canonical_text() {
+    let canonical = Guid::from_str_canonical("8DA63339-0007-60C0-C436-083AC8230908").unwrap();
+    assert_eq!(canonical, F2FS_TYPE_GUID);
+}
+
+#[test]
+fn boot_config_type_guid_has_canonical_text() {
+    let canonical = Guid::from_str_canonical("A3F7C2E0-FACE-4FFF-BBBB-000000000000").unwrap();
+    assert_eq!(canonical, BOOT_CONFIG_TYPE_GUID);
+}
+
+// ─── 10. Foreign GUID with same name rejected ───────────────────────────────
+
+#[test]
+fn scenario_foreign_guid_with_smallaios_name_rejected() {
+    // Build a disk where the slot-A position has a non-SmallAIOS type
+    // GUID (so the type-by-slot check in parse_layout fails). The
+    // partition name in the fixture is "Models A" — a foreign-typed
+    // partition labelled with the SmallAIOS naming convention is
+    // exactly what the spec says to reject.
+    let dev = build_disk_foreign_type_with_smallaios_name(DEFAULT_SECTORS);
+    let entries = parse_gpt(&dev).unwrap();
+    // The name still says "Models A" …
+    assert_eq!(entries[1].name.as_str(), "Models A");
+    // … but the type GUID is foreign, so layout enforcement rejects.
+    assert!(matches!(
+        parse_layout(&entries),
+        Err(GptError::LayoutMismatch)
+    ));
+}
+
+// ─── 11. Header-level structural validation ─────────────────────────────────
+
+#[test]
+fn corrupting_revision_field_rejects() {
+    let mut dev = build_valid_v1_disk(DEFAULT_SECTORS);
+    let mut block = vec![0u8; 512];
+    dev.read_block(1, &mut block).unwrap();
+    // Corrupt revision field to 0x00020000.
+    block[8..12].copy_from_slice(&0x0002_0000u32.to_le_bytes());
+    // Also recompute CRC otherwise we'll fail there first; but the
+    // spec wants us to detect the *unsupported revision* path. We
+    // recompute the header CRC after setting the bad revision to
+    // exercise the right branch.
+    let header_size = u32::from_le_bytes([block[12], block[13], block[14], block[15]]) as usize;
+    block[16..20].copy_from_slice(&0u32.to_le_bytes());
+    let crc = crc32(&block[..header_size]);
+    block[16..20].copy_from_slice(&crc.to_le_bytes());
+    dev.write_block(1, &block).unwrap();
+    // Same on secondary so we don't fall through to a valid copy.
+    let secondary_lba = dev.block_count() - 1;
+    let mut sb = vec![0u8; 512];
+    dev.read_block(secondary_lba, &mut sb).unwrap();
+    sb[8..12].copy_from_slice(&0x0002_0000u32.to_le_bytes());
+    sb[16..20].copy_from_slice(&0u32.to_le_bytes());
+    let crc2 = crc32(&sb[..header_size]);
+    sb[16..20].copy_from_slice(&crc2.to_le_bytes());
+    dev.write_block(secondary_lba, &sb).unwrap();
+
+    let res = parse_gpt(&dev);
+    assert!(matches!(res, Err(GptError::UnsupportedRevision)));
+}
+
+// ─── 12. Block-error propagation ────────────────────────────────────────────
+
+#[test]
+fn block_error_during_parse_propagates() {
+    let dev = MockBlockDevice::new(512, 2048);
+    dev.set_permanent_failure(BlockError::MediaError);
+    let res = parse_gpt(&dev);
+    assert!(matches!(
+        res,
+        Err(GptError::BlockError(BlockError::MediaError))
+    ));
+}
+
+#[test]
+fn write_protective_mbr_propagates_block_error() {
+    let mut dev = MockBlockDevice::new(512, 2048);
+    dev.set_permanent_failure(BlockError::Timeout);
+    let res = write_protective_mbr(&mut dev);
+    assert!(matches!(
+        res,
+        Err(GptError::BlockError(BlockError::Timeout))
+    ));
+}
+
+// ─── 13. Hybrid MBR is honored ──────────────────────────────────────────────
+
+#[test]
+fn hybrid_mbr_is_honored_as_plain_gpt() {
+    // A hybrid MBR has 0xEE plus other entries. We accept it as plain GPT.
+    let dev = build_hybrid_mbr_disk(DEFAULT_SECTORS);
+    let entries = parse_gpt(&dev).unwrap();
+    assert_eq!(entries.len(), 5);
+}
+
+// ─── 14. Layout enforcement order strict ────────────────────────────────────
+
+#[test]
+fn layout_rejects_swapped_slot_a_and_b() {
+    let dev = build_valid_v1_disk(DEFAULT_SECTORS);
+    let entries = parse_gpt(&dev).unwrap();
+    // Swap entries 1 and 2 (slot A and slot B).
+    let mut shuffled = entries.clone();
+    shuffled.swap(1, 2);
+    assert!(matches!(
+        parse_layout(&shuffled),
+        Err(GptError::LayoutMismatch)
+    ));
+}
+
+#[test]
+fn layout_rejects_empty_slice() {
+    let entries: Vec<PartitionEntry> = vec![];
+    assert!(matches!(
+        parse_layout(&entries),
+        Err(GptError::LayoutMismatch)
+    ));
+}
+
+// ─── 15. PartitionName edge cases ───────────────────────────────────────────
+
+#[test]
+fn partition_name_empty_decodes_to_empty_string() {
+    let bytes = [0u8; 72];
+    let name = PartitionName::from_utf16le_bytes(&bytes);
+    assert_eq!(name.as_str(), "");
+    assert!(name.is_empty());
+}
+
+// ─── 16. Constants are sane ─────────────────────────────────────────────────
+
+#[test]
+fn constants_have_expected_values() {
+    assert_eq!(GPT_SIGNATURE, *b"EFI PART");
+    assert_eq!(GPT_REVISION_1_0, 0x0001_0000);
+    assert_eq!(PARTITION_ENTRY_SIZE, 128);
+    assert_eq!(PARTITION_ARRAY_MAX_BYTES, 16384);
+    assert_eq!(MBR_SIGNATURE_LE, [0x55, 0xAA]);
+    assert_eq!(MBR_TYPE_GPT_PROTECTIVE, 0xEE);
+}
+
+// ─── 17. CRC32 known-vector regression ──────────────────────────────────────
+
+#[test]
+fn crc32_known_vectors_regression() {
+    assert_eq!(crc32(b""), 0x0000_0000);
+    assert_eq!(crc32(b"a"), 0xE8B7_BE43);
+    assert_eq!(crc32(b"123456789"), 0xCBF4_3926);
+    // Standard 32-byte zero block.
+    assert_eq!(crc32(&[0u8; 32]), 0x190A_55AD);
+}

--- a/fs/tests/gpt_synthetic.rs
+++ b/fs/tests/gpt_synthetic.rs
@@ -1,0 +1,65 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Smoke tests for the synthetic-disk fixtures in `tests/common/mod.rs`.
+//!
+//! Larger-scope spec scenarios live in [`gpt_conformance.rs`].
+
+#![cfg(feature = "fs-on-disk-mounts")]
+
+mod common;
+
+use smallaios_fs::block::BlockDevice;
+use smallaios_fs::gpt::{layout::*, parse_gpt, parse_layout, GptError};
+
+#[test]
+fn synthetic_valid_disk_parses() {
+    let dev = common::build_valid_v1_disk(common::DEFAULT_SECTORS);
+    let entries = parse_gpt(&dev).expect("valid disk should parse");
+    assert_eq!(entries.len(), 5);
+}
+
+#[test]
+fn synthetic_valid_disk_layout_matches_v1() {
+    let dev = common::build_valid_v1_disk(common::DEFAULT_SECTORS);
+    let entries = parse_gpt(&dev).unwrap();
+    let layout = parse_layout(&entries).unwrap();
+    assert_eq!(layout.esp.type_guid, ESP_TYPE_GUID);
+    assert_eq!(layout.squashfs_a.type_guid, SQUASHFS_SLOT_A_TYPE_GUID);
+    assert_eq!(layout.squashfs_b.type_guid, SQUASHFS_SLOT_B_TYPE_GUID);
+    assert_eq!(layout.data_f2fs.type_guid, F2FS_TYPE_GUID);
+    assert_eq!(layout.boot_config.type_guid, BOOT_CONFIG_TYPE_GUID);
+}
+
+#[test]
+fn synthetic_disk_block_count_correct() {
+    let dev = common::build_valid_v1_disk(common::DEFAULT_SECTORS);
+    assert_eq!(dev.block_count(), common::DEFAULT_SECTORS);
+    assert_eq!(dev.block_size_bytes(), 512);
+}
+
+#[test]
+fn synthetic_disk_parses_at_4k_block_size() {
+    let dev = common::build_valid_v1_disk_with_block_size(256, 4096);
+    let entries = parse_gpt(&dev).unwrap();
+    assert_eq!(entries.len(), 5);
+    let layout = parse_layout(&entries).unwrap();
+    assert_eq!(layout.boot_config.type_guid, BOOT_CONFIG_TYPE_GUID);
+}
+
+#[test]
+fn corrupting_primary_header_makes_secondary_take_over() {
+    let mut dev = common::build_valid_v1_disk(common::DEFAULT_SECTORS);
+    common::corrupt_primary_header(&mut dev);
+    let entries = parse_gpt(&dev).unwrap();
+    assert_eq!(entries.len(), 5);
+}
+
+#[test]
+fn corrupting_both_headers_rejects() {
+    let mut dev = common::build_valid_v1_disk(common::DEFAULT_SECTORS);
+    common::corrupt_primary_header(&mut dev);
+    common::corrupt_secondary_header(&mut dev);
+    let res = parse_gpt(&dev);
+    assert!(matches!(res, Err(GptError::BothHeadersCorrupt)));
+}

--- a/openspec/changes/embedded-filesystem-v1/tasks.md
+++ b/openspec/changes/embedded-filesystem-v1/tasks.md
@@ -13,11 +13,11 @@
 
 ## 2. Phase 2 — GPT partition table
 
-- [ ] 2.1 `fs/src/gpt.rs` — clean-room GPT parser per UEFI 2.10 §5.3
-- [ ] 2.2 Primary + secondary header validation, fallback on primary corrupt
-- [ ] 2.3 Protective MBR writer (for fresh-format path)
-- [ ] 2.4 v1 partition layout enforcement (5-partition table, type GUID checks)
-- [ ] 2.5 SmallAIOS-specific type GUID allocation, documented in `docs/architecture.md`
+- [x] 2.1 `fs/src/gpt.rs` — clean-room GPT parser per UEFI 2.10 §5.3
+- [x] 2.2 Primary + secondary header validation, fallback on primary corrupt
+- [x] 2.3 Protective MBR writer (for fresh-format path)
+- [x] 2.4 v1 partition layout enforcement (5-partition table, type GUID checks)
+- [x] 2.5 SmallAIOS-specific type GUID allocation, documented in `docs/architecture.md`
 - [ ] 2.6 GPT parser fuzz harness
 - [ ] 2.7 Kani harness for parser bounds (no out-of-buffer reads on adversarial input)
 - [ ] 2.8 Tests against `parted`/`gdisk`-produced disks


### PR DESCRIPTION
## Summary

Phase 2 of `embedded-filesystem-v1`. Adds GPT partition table parsing.

- `fs/src/gpt/mod.rs` (~1,000 LOC) — GPT parser per UEFI 2.10 §5.3, mixed-endian GUID handling per RFC 4122 §4.1.2, primary + secondary header CRC validation with fallback. Hand-rolled CRC-32/ISO-HDLC (~12 LOC, validated against three IEEE 802.3 vectors). `PartitionName` is a fixed-capacity 72-byte struct with UTF-16LE → UTF-8 decode + surrogate-pair handling + U+FFFD replacement.
- `fs/src/gpt/layout.rs` (272 LOC) — v1 SmallAIOS 5-partition layout enforcement. Type GUID constants: ESP, squashfs slot A/B, F2FS data, A/B boot config (matching the Wave 0 prefix scheme in `docs/architecture.md`).
- `fs/src/gpt/protective_mbr.rs` (174 LOC) — single 0xEE entry covering the disk, capped at u32::MAX.
- `fs/tests/gpt_conformance.rs` + `gpt_synthetic.rs` + `tests/common/mod.rs` (~960 LOC) — **34 conformance tests** covering every spec scenario (valid GPT, primary-corrupt fallthrough, both-corrupt rejected, MBR-only rejected, hybrid-MBR honored as plain GPT, missing slots, foreign GUIDs, etc.) plus 6 synthetic fixture smoke tests. **162 fs tests total** with `--features fs-on-disk-mounts`.

## Deviations

- No `heapless` dep — hand-rolled `PartitionName` instead. Matches Phase 1's choice.
- Hand-rolled CRC-32 instead of pulling in `crc32fast`. Validated against IEEE 802.3 vectors.
- Tasks 2.6 (fuzz harness), 2.7 (Kani harness), 2.8 (parted/gdisk fixtures) deliberately deferred to a follow-up Phase 2.x — these are cross-cutting verification work that fits Checkpoint A's `CA.5` gating slot, not Phase 2's parser landing.

## Test plan

- [x] `cargo fmt --all -- --check` — clean.
- [x] `just clippy` (`-D warnings`) — clean.
- [x] `cargo test -p smallaios-fs --features fs-on-disk-mounts --lib --tests` — 162 passed.
- [x] `cargo vet check` — Vetting Succeeded.
- [x] `openspec validate embedded-filesystem-v1 --strict` — clean.
- [x] `just build-kernel-arm` — succeeds.
- [x] Bare-metal `cargo build --release --target aarch64-unknown-none -p smallaios-fs --features fs-on-disk-mounts` — succeeds.

CodeQL guardrails: standalone-line `// lgtm[rust/hard-coded-cryptographic-value]` on all fixed byte/GUID constants (`GPT_SIGNATURE`, `MBR_SIGNATURE_LE`, the five partition type GUIDs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)