### PR TITLE
chore(codeql): extract argon2id + auth-syscall test vectors to *_test_vectors.rs

### DIFF
--- a/kernel/src/syscall/auth.rs
+++ b/kernel/src/syscall/auth.rs
@@ -653,7 +653,12 @@ pub fn sys_auth_totp_setup(args: &SyscallArgs) -> SyscallResult {
 // ─── Integration tests ──────────────────────────────────────────────────────
 
 #[cfg(test)]
+#[path = "auth_test_vectors.rs"]
+mod test_vectors;
+
+#[cfg(test)]
 mod tests {
+    use super::test_vectors::*;
     use super::*;
     use crate::auth::shadow_provider::{MockShadowProvider, ShadowProviderEntry};
     use crate::auth::sweeper::{CapturingAuditSink, IdlePolicy};
@@ -665,8 +670,6 @@ mod tests {
     /// resulting Argon2id PHC is reproducible across runs. NOT a CSPRNG
     /// — only used to keep auth tests independent of the kernel's
     /// global CSPRNG seed state.
-    //
-    // lgtm[rust/hard-coded-cryptographic-value] — synthetic deterministic test salt source, not a real CSPRNG
     fn deterministic_salt(out: &mut [u8]) -> Result<(), ()> {
         use core::sync::atomic::{AtomicU8, Ordering};
         static COUNTER: AtomicU8 = AtomicU8::new(0);
@@ -681,10 +684,8 @@ mod tests {
     // PHC strings here are *not* shipped credentials — they are
     // generated per-test from a fixed plaintext through Argon2id.
     fn make_phc(password: &[u8]) -> alloc::string::String {
-        // 16-byte salt of zeros — fixture only.
-        //
-        // lgtm[rust/hard-coded-cryptographic-value] — synthetic test fixture, not a real credential
-        let salt = [0u8; 16];
+        // 16-byte zero salt — see `auth_test_vectors.rs::ZERO_SALT_16`.
+        let salt = ZERO_SALT_16;
         let params = Argon2idParams::tiny();
         let tag = argon2id_hash(password, &salt, params);
         argon2id_format_phc(&salt, &tag, params)
@@ -692,7 +693,6 @@ mod tests {
 
     fn seed_user(provider: &MockShadowProvider, name: &str, role: Role, password: &[u8]) -> u32 {
         provider.seed(ShadowProviderEntry {
-            // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
             stable_user_id: 0,
             username: name.to_string(),
             phc: make_phc(password),
@@ -723,16 +723,14 @@ mod tests {
     fn login_success_returns_session_id() {
         crate::auth::clear_current_session();
         let provider = MockShadowProvider::new();
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-        seed_user(&provider, "alice", Role::Operator, b"correct-horse");
+        seed_user(&provider, "alice", Role::Operator, PASSWORD_CORRECT_HORSE);
 
         let mut table = SessionTable::new();
         let sweeper = Sweeper::with_policy(IdlePolicy::defaults());
         let mut audit = CapturingAuditSink::new();
         let mut ctx = make_ctx(&mut table, &provider, &sweeper, &mut audit, 1_700_000_000);
 
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-        let r = handle_auth_login(&mut ctx, b"alice", b"correct-horse", &[]);
+        let r = handle_auth_login(&mut ctx, b"alice", PASSWORD_CORRECT_HORSE, &[]);
         assert!(r >= 0, "login returned {r}");
         let id = SessionId::from_raw(r as u32);
         assert!(!id.is_none());
@@ -740,20 +738,17 @@ mod tests {
     }
 
     #[test]
-    // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
     fn login_wrong_password_returns_eacces() {
         crate::auth::clear_current_session();
         let provider = MockShadowProvider::new();
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-        seed_user(&provider, "alice", Role::Operator, b"correct-horse");
+        seed_user(&provider, "alice", Role::Operator, PASSWORD_CORRECT_HORSE);
 
         let mut table = SessionTable::new();
         let sweeper = Sweeper::new();
         let mut audit = CapturingAuditSink::new();
         let mut ctx = make_ctx(&mut table, &provider, &sweeper, &mut audit, 0);
 
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-        let r = handle_auth_login(&mut ctx, b"alice", b"wrong-password", &[]);
+        let r = handle_auth_login(&mut ctx, b"alice", PASSWORD_WRONG, &[]);
         assert_eq!(r, ERRNO_EACCES);
         assert!(crate::auth::current_session().is_none());
     }
@@ -761,7 +756,6 @@ mod tests {
     #[test]
     fn login_unknown_user_returns_eacces_after_dummy_verify() {
         // Spec: "Constant-time-equivalent reject on user-not-found"
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
         crate::auth::clear_current_session();
         let provider = MockShadowProvider::new();
         let mut table = SessionTable::new();
@@ -769,8 +763,7 @@ mod tests {
         let mut audit = CapturingAuditSink::new();
         let mut ctx = make_ctx(&mut table, &provider, &sweeper, &mut audit, 0);
 
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-        let r = handle_auth_login(&mut ctx, b"ghost", b"any-password", &[]);
+        let r = handle_auth_login(&mut ctx, b"ghost", PASSWORD_ANY_FOR_LOGIN, &[]);
         assert_eq!(r, ERRNO_EACCES);
     }
 
@@ -778,12 +771,10 @@ mod tests {
     fn login_locked_out_user_returns_eagain() {
         crate::auth::clear_current_session();
         let provider = MockShadowProvider::new();
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
         provider.seed(ShadowProviderEntry {
             stable_user_id: 0,
             username: "alice".to_string(),
-            // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-            phc: make_phc(b"correct-horse"),
+            phc: make_phc(PASSWORD_CORRECT_HORSE),
             role: Role::Viewer,
             flags: 0,
             lockout_until_unix: 1_700_000_500,
@@ -791,12 +782,10 @@ mod tests {
 
         let mut table = SessionTable::new();
         let sweeper = Sweeper::new();
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
         let mut audit = CapturingAuditSink::new();
         let mut ctx = make_ctx(&mut table, &provider, &sweeper, &mut audit, 1_700_000_000);
 
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-        let r = handle_auth_login(&mut ctx, b"alice", b"correct-horse", &[]);
+        let r = handle_auth_login(&mut ctx, b"alice", PASSWORD_CORRECT_HORSE, &[]);
         assert_eq!(r, ERRNO_EAGAIN);
     }
 
@@ -804,16 +793,14 @@ mod tests {
     fn login_factor2_nonempty_returns_einval_phase3() {
         crate::auth::clear_current_session();
         let provider = MockShadowProvider::new();
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
-        seed_user(&provider, "alice", Role::Viewer, b"correct-horse");
+        seed_user(&provider, "alice", Role::Viewer, PASSWORD_CORRECT_HORSE);
 
         let mut table = SessionTable::new();
         let sweeper = Sweeper::new();
         let mut audit = CapturingAuditSink::new();
         let mut ctx = make_ctx(&mut table, &provider, &sweeper, &mut audit, 0);
 
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-        let r = handle_auth_login(&mut ctx, b"alice", b"correct-horse", b"123456");
+        let r = handle_auth_login(&mut ctx, b"alice", PASSWORD_CORRECT_HORSE, PHASE3_FACTOR2);
         assert_eq!(r, ERRNO_EINVAL);
     }
 
@@ -821,22 +808,19 @@ mod tests {
     fn login_table_full_returns_enospc() {
         crate::auth::clear_current_session();
         let provider = MockShadowProvider::new();
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
-        seed_user(&provider, "alice", Role::Viewer, b"pw");
+        seed_user(&provider, "alice", Role::Viewer, PASSWORD_PW);
 
         let mut table = SessionTable::new();
         // Fill to capacity with synthetic sessions.
         for i in 0..crate::auth::SESSION_TABLE_CAP {
-            let s = Session::new(i as u32, b"filler", Role::Viewer, 0, false).unwrap();
+            let s = Session::new(i as u32, FILLER_USERNAME, Role::Viewer, 0, false).unwrap();
             table.acquire(s).unwrap();
         }
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
         let sweeper = Sweeper::new();
         let mut audit = CapturingAuditSink::new();
         let mut ctx = make_ctx(&mut table, &provider, &sweeper, &mut audit, 0);
 
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-        let r = handle_auth_login(&mut ctx, b"alice", b"pw", &[]);
+        let r = handle_auth_login(&mut ctx, b"alice", PASSWORD_PW, &[]);
         assert_eq!(r, ERRNO_ENOSPC);
     }
 
@@ -844,16 +828,14 @@ mod tests {
     fn logout_clears_current_session() {
         crate::auth::clear_current_session();
         let provider = MockShadowProvider::new();
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
-        seed_user(&provider, "alice", Role::Operator, b"pw");
+        seed_user(&provider, "alice", Role::Operator, PASSWORD_PW);
 
         let mut table = SessionTable::new();
         let sweeper = Sweeper::new();
         let mut audit = CapturingAuditSink::new();
         let mut ctx = make_ctx(&mut table, &provider, &sweeper, &mut audit, 0);
 
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-        handle_auth_login(&mut ctx, b"alice", b"pw", &[]);
+        handle_auth_login(&mut ctx, b"alice", PASSWORD_PW, &[]);
         assert!(!crate::auth::current_session().is_none());
 
         let r = handle_auth_logout(&mut ctx);
@@ -861,7 +843,6 @@ mod tests {
         assert!(crate::auth::current_session().is_none());
     }
 
-    // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
     #[test]
     fn logout_without_session_returns_eacces() {
         crate::auth::clear_current_session();
@@ -882,8 +863,7 @@ mod tests {
         provider.seed(ShadowProviderEntry {
             stable_user_id: 0,
             username: "alice".to_string(),
-            // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-            phc: make_phc(b"old-pw"),
+            phc: make_phc(PASSWORD_OLD_PW),
             role: Role::Operator,
             flags: FLAG_MUST_CHANGE_PASSWORD,
             lockout_until_unix: 0,
@@ -891,23 +871,19 @@ mod tests {
 
         let mut table = SessionTable::new();
         let sweeper = Sweeper::new();
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
         let mut audit = CapturingAuditSink::new();
         let mut ctx = make_ctx(&mut table, &provider, &sweeper, &mut audit, 0);
 
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-        handle_auth_login(&mut ctx, b"alice", b"old-pw", &[]);
-        let r = handle_auth_change_password(&mut ctx, b"old-pw", b"new-pw-much-longer", &[]);
+        handle_auth_login(&mut ctx, b"alice", PASSWORD_OLD_PW, &[]);
+        let r = handle_auth_change_password(&mut ctx, PASSWORD_OLD_PW, PASSWORD_NEW_PW_LONG, &[]);
         assert_eq!(r, 0);
 
         // Verify mock has been updated.
         let after = provider.current_phc("alice").unwrap();
         assert!(after.starts_with("$argon2id$"));
         // Round-trip new password verifies.
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
         let ok =
-            // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
-            smallaios_security::argon2id::argon2id_verify(b"new-pw-much-longer", &after).unwrap();
+            smallaios_security::argon2id::argon2id_verify(PASSWORD_NEW_PW_LONG, &after).unwrap();
         assert!(ok);
         // `must_change_password` flag cleared.
         let flags = provider.current_flags("alice").unwrap();
@@ -915,42 +891,34 @@ mod tests {
     }
 
     #[test]
-    // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
     fn change_password_wrong_old_returns_eacces() {
         crate::auth::clear_current_session();
         let provider = MockShadowProvider::new();
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-        seed_user(&provider, "alice", Role::Viewer, b"correct-old");
+        seed_user(&provider, "alice", Role::Viewer, PASSWORD_CORRECT_OLD);
 
         let mut table = SessionTable::new();
         let sweeper = Sweeper::new();
         let mut audit = CapturingAuditSink::new();
         let mut ctx = make_ctx(&mut table, &provider, &sweeper, &mut audit, 0);
 
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-        handle_auth_login(&mut ctx, b"alice", b"correct-old", &[]);
-        let r = handle_auth_change_password(&mut ctx, b"wrong-old", b"new-pw", &[]);
+        handle_auth_login(&mut ctx, b"alice", PASSWORD_CORRECT_OLD, &[]);
+        let r = handle_auth_change_password(&mut ctx, PASSWORD_WRONG_OLD, PASSWORD_NEW_PW, &[]);
         assert_eq!(r, ERRNO_EACCES);
     }
 
     #[test]
     fn change_password_cross_rotate_requires_root() {
         crate::auth::clear_current_session();
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
         let provider = MockShadowProvider::new();
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
-        seed_user(&provider, "operator-1", Role::Operator, b"op-pw");
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-        seed_user(&provider, "viewer-1", Role::Viewer, b"viewer-pw");
+        seed_user(&provider, "operator-1", Role::Operator, PASSWORD_OP_PW);
+        seed_user(&provider, "viewer-1", Role::Viewer, PASSWORD_VIEWER_PW);
 
         let mut table = SessionTable::new();
         let sweeper = Sweeper::new();
         let mut audit = CapturingAuditSink::new();
         let mut ctx = make_ctx(&mut table, &provider, &sweeper, &mut audit, 0);
 
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
-        handle_auth_login(&mut ctx, b"operator-1", b"op-pw", &[]);
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
+        handle_auth_login(&mut ctx, b"operator-1", PASSWORD_OP_PW, &[]);
         let r = handle_auth_change_password(&mut ctx, b"any", b"new-pw-strong", b"viewer-1");
         assert_eq!(r, ERRNO_EACCES);
     }
@@ -958,56 +926,50 @@ mod tests {
     #[test]
     fn change_password_cross_rotate_force_logout_other_sessions() {
         crate::auth::clear_current_session();
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
         let provider = MockShadowProvider::new();
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
-        seed_user(&provider, "root-1", Role::Root, b"root-pw");
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-        let target_uid = seed_user(&provider, "victim", Role::Viewer, b"old-pw");
+        seed_user(&provider, "root-1", Role::Root, PASSWORD_ROOT_PW);
+        let target_uid = seed_user(&provider, "victim", Role::Viewer, PASSWORD_OLD_PW);
 
         let mut table = SessionTable::new();
         let sweeper = Sweeper::new();
         let mut audit = CapturingAuditSink::new();
 
         // First, log victim in via two sessions.
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
-        let s1 = Session::new(target_uid, b"victim", Role::Viewer, 0, false).unwrap();
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
-        let s2 = Session::new(target_uid, b"victim", Role::Viewer, 0, false).unwrap();
+        let s1 = Session::new(target_uid, VICTIM_USERNAME, Role::Viewer, 0, false).unwrap();
+        let s2 = Session::new(target_uid, VICTIM_USERNAME, Role::Viewer, 0, false).unwrap();
         let id1 = table.acquire(s1).unwrap();
         let id2 = table.acquire(s2).unwrap();
         assert_eq!(table.live_count(), 2);
 
         // Now log root in (separate from victim's sessions).
         let mut ctx = make_ctx(&mut table, &provider, &sweeper, &mut audit, 0);
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-        handle_auth_login(&mut ctx, b"root-1", b"root-pw", &[]);
+        handle_auth_login(&mut ctx, b"root-1", PASSWORD_ROOT_PW, &[]);
 
         // Cross-rotate victim's password — both victim sessions must be killed.
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-        let r = handle_auth_change_password(&mut ctx, b"unused", b"new-pw-much-longer", b"victim");
+        let r = handle_auth_change_password(
+            &mut ctx,
+            PASSWORD_UNUSED,
+            PASSWORD_NEW_PW_LONG,
+            VICTIM_USERNAME,
+        );
         assert_eq!(r, 0);
 
         assert!(table.lookup(id1).is_err());
         assert!(table.lookup(id2).is_err());
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
     }
 
     #[test]
-    // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
     fn create_user_root_only() {
         crate::auth::clear_current_session();
         let provider = MockShadowProvider::new();
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-        seed_user(&provider, "operator-1", Role::Operator, b"pw");
+        seed_user(&provider, "operator-1", Role::Operator, PASSWORD_PW);
 
         let mut table = SessionTable::new();
         let sweeper = Sweeper::new();
         let mut audit = CapturingAuditSink::new();
         let mut ctx = make_ctx(&mut table, &provider, &sweeper, &mut audit, 0);
 
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-        handle_auth_login(&mut ctx, b"operator-1", b"pw", &[]);
+        handle_auth_login(&mut ctx, b"operator-1", PASSWORD_PW, &[]);
         let r = handle_auth_create_user(&mut ctx, b"new-user", Role::Operator.as_u8(), b"new-pw");
         assert_eq!(r, ERRNO_EACCES);
     }
@@ -1015,91 +977,80 @@ mod tests {
     #[test]
     fn create_user_with_root_succeeds_and_sets_must_change_flag() {
         crate::auth::clear_current_session();
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
         let provider = MockShadowProvider::new();
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
-        seed_user(&provider, "root-1", Role::Root, b"root-pw");
+        seed_user(&provider, "root-1", Role::Root, PASSWORD_ROOT_PW);
 
         let mut table = SessionTable::new();
         let sweeper = Sweeper::new();
         let mut audit = CapturingAuditSink::new();
         let mut ctx = make_ctx(&mut table, &provider, &sweeper, &mut audit, 0);
 
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-        handle_auth_login(&mut ctx, b"root-1", b"root-pw", &[]);
-        let r = handle_auth_create_user(&mut ctx, b"new-op", Role::Operator.as_u8(), b"initial-pw");
+        handle_auth_login(&mut ctx, b"root-1", PASSWORD_ROOT_PW, &[]);
+        let r = handle_auth_create_user(
+            &mut ctx,
+            b"new-op",
+            Role::Operator.as_u8(),
+            PASSWORD_INITIAL_PW,
+        );
         assert_eq!(r, 0);
 
         let flags = provider.current_flags("new-op").unwrap();
         assert_eq!(flags & FLAG_MUST_CHANGE_PASSWORD, FLAG_MUST_CHANGE_PASSWORD);
     }
 
-    // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
     #[test]
-    // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
     fn create_user_invalid_role_returns_einval() {
         crate::auth::clear_current_session();
         let provider = MockShadowProvider::new();
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-        seed_user(&provider, "root-1", Role::Root, b"root-pw");
+        seed_user(&provider, "root-1", Role::Root, PASSWORD_ROOT_PW);
 
         let mut table = SessionTable::new();
         let sweeper = Sweeper::new();
         let mut audit = CapturingAuditSink::new();
         let mut ctx = make_ctx(&mut table, &provider, &sweeper, &mut audit, 0);
 
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-        handle_auth_login(&mut ctx, b"root-1", b"root-pw", &[]);
-        let r = handle_auth_create_user(&mut ctx, b"x", 7, b"pw");
+        handle_auth_login(&mut ctx, b"root-1", PASSWORD_ROOT_PW, &[]);
+        let r = handle_auth_create_user(&mut ctx, b"x", 7, PASSWORD_PW);
         assert_eq!(r, ERRNO_EINVAL);
     }
 
     #[test]
     fn create_user_duplicate_returns_eexist() {
         crate::auth::clear_current_session();
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
         let provider = MockShadowProvider::new();
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
-        seed_user(&provider, "root-1", Role::Root, b"root-pw");
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-        seed_user(&provider, "dup", Role::Viewer, b"x-pw");
+        seed_user(&provider, "root-1", Role::Root, PASSWORD_ROOT_PW);
+        seed_user(&provider, "dup", Role::Viewer, PASSWORD_X_PW);
 
         let mut table = SessionTable::new();
         let sweeper = Sweeper::new();
         let mut audit = CapturingAuditSink::new();
         let mut ctx = make_ctx(&mut table, &provider, &sweeper, &mut audit, 0);
 
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
-        handle_auth_login(&mut ctx, b"root-1", b"root-pw", &[]);
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
-        let r = handle_auth_create_user(&mut ctx, b"dup", Role::Operator.as_u8(), b"pw");
+        handle_auth_login(&mut ctx, b"root-1", PASSWORD_ROOT_PW, &[]);
+        let r = handle_auth_create_user(&mut ctx, b"dup", Role::Operator.as_u8(), PASSWORD_PW);
         assert_eq!(r, ERRNO_EEXIST);
     }
 
     #[test]
     fn whoami_writes_struct() {
         crate::auth::clear_current_session();
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
         let provider = MockShadowProvider::new();
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
-        seed_user(&provider, "alice", Role::Operator, b"pw");
+        seed_user(&provider, "alice", Role::Operator, PASSWORD_PW);
 
         let mut table = SessionTable::new();
         let sweeper = Sweeper::new();
         let mut audit = CapturingAuditSink::new();
         let mut ctx = make_ctx(&mut table, &provider, &sweeper, &mut audit, 1_700_000_100);
 
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-        handle_auth_login(&mut ctx, b"alice", b"pw", &[]);
+        handle_auth_login(&mut ctx, b"alice", PASSWORD_PW, &[]);
 
         let mut out = WhoamiOut {
             role: 0xFF,
-            _pad: [0; 3],
+            _pad: WHOAMI_PAD_3,
             user_id: 0,
             login_unix_time: 0,
             idle_seconds: 0,
-            // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
-            _pad2: [0; 4],
+            _pad2: WHOAMI_PAD_4,
         };
 
         // Now bump now_unix to simulate a 50-second-old session.
@@ -1122,11 +1073,11 @@ mod tests {
 
         let mut out = WhoamiOut {
             role: 0,
-            _pad: [0; 3],
+            _pad: WHOAMI_PAD_3,
             user_id: 0,
             login_unix_time: 0,
             idle_seconds: 0,
-            _pad2: [0; 4],
+            _pad2: WHOAMI_PAD_4,
         };
         let r = unsafe { handle_auth_whoami(&mut ctx, &mut out as *mut _) };
         assert_eq!(r, ERRNO_EACCES);
@@ -1136,24 +1087,20 @@ mod tests {
     fn whoami_null_pointer_returns_efault() {
         crate::auth::clear_current_session();
         let provider = MockShadowProvider::new();
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-        seed_user(&provider, "alice", Role::Viewer, b"pw");
+        seed_user(&provider, "alice", Role::Viewer, PASSWORD_PW);
         let mut table = SessionTable::new();
         let sweeper = Sweeper::new();
         let mut audit = CapturingAuditSink::new();
         let mut ctx = make_ctx(&mut table, &provider, &sweeper, &mut audit, 0);
 
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / spec-mandated constant
-        handle_auth_login(&mut ctx, b"alice", b"pw", &[]);
+        handle_auth_login(&mut ctx, b"alice", PASSWORD_PW, &[]);
         let r = unsafe { handle_auth_whoami(&mut ctx, core::ptr::null_mut()) };
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
         assert_eq!(r, ERRNO_EFAULT);
     }
 
     #[test]
     fn totp_setup_returns_enosys_in_phase3() {
         crate::auth::clear_current_session();
-        // lgtm[rust/hard-coded-cryptographic-value] - test fixture / no-op constant; CodeQL false-positive
         let provider = MockShadowProvider::new();
         let mut table = SessionTable::new();
         let sweeper = Sweeper::new();

--- a/kernel/src/syscall/auth_test_vectors.rs
+++ b/kernel/src/syscall/auth_test_vectors.rs
@@ -1,0 +1,96 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Deterministic byte-array fixtures for the auth-syscall handler unit
+//! tests in `auth.rs`.
+//!
+//! These constants are extracted from inline `#[cfg(test)]` literals in
+//! `auth.rs` so GitHub CodeQL's `rust/hard-coded-cryptographic-value`
+//! heuristic does not re-fire on every scan. They are NOT loaded by any
+//! production code path; the module is gated behind `#[cfg(test)]`.
+//!
+//! The corresponding `paths-ignore` entry lives in
+//! `.github/codeql/codeql-config.yml` (`**/*_test_vectors.rs`). See
+//! `openspec/changes/codeql-quality-cleanup-v1/specs/codeql-suppression-policy/spec.md`
+//! for the full policy, and `net/src/quic/protection_test_vectors.rs`
+//! for the canonical pattern.
+//!
+//! All passwords here are synthetic test fixtures driven through Argon2id
+//! at the `tiny` tier — they are NOT shipped credentials.
+
+#![cfg(test)]
+
+// ── Salt fixtures ──────────────────────────────────────────────────────────
+
+/// Sixteen-byte zero salt for [`super::tests::make_phc`]. The PHC strings
+/// produced by hashing test passwords against this salt are never used as
+/// real credentials.
+pub(super) const ZERO_SALT_16: [u8; 16] = [0u8; 16];
+
+/// Three-byte zero padding for `WhoamiOut::_pad`.
+pub(super) const WHOAMI_PAD_3: [u8; 3] = [0; 3];
+
+/// Four-byte zero padding for `WhoamiOut::_pad2`.
+pub(super) const WHOAMI_PAD_4: [u8; 4] = [0; 4];
+
+// ── Test passwords ─────────────────────────────────────────────────────────
+//
+// All entries are synthetic ASCII patterns used to exercise login,
+// change-password, create-user, and whoami code paths. None are real
+// secrets.
+
+/// Canonical "happy-path" password used by most login tests.
+pub(super) const PASSWORD_CORRECT_HORSE: &[u8] = b"correct-horse";
+
+/// Negative-case password — must not match `PASSWORD_CORRECT_HORSE`.
+pub(super) const PASSWORD_WRONG: &[u8] = b"wrong-password";
+
+/// Generic short password used in capacity / EAGAIN / negative tests.
+pub(super) const PASSWORD_PW: &[u8] = b"pw";
+
+/// Old password for self-rotate flow.
+pub(super) const PASSWORD_OLD_PW: &[u8] = b"old-pw";
+
+/// New password for self-rotate flow (≥ minimum length).
+pub(super) const PASSWORD_NEW_PW_LONG: &[u8] = b"new-pw-much-longer";
+
+/// Old password for cross-rotate flow.
+pub(super) const PASSWORD_CORRECT_OLD: &[u8] = b"correct-old";
+
+/// Wrong-old password for cross-rotate negative flow.
+pub(super) const PASSWORD_WRONG_OLD: &[u8] = b"wrong-old";
+
+/// Truncated new password for negative flow.
+pub(super) const PASSWORD_NEW_PW: &[u8] = b"new-pw";
+
+/// Operator-tier login password.
+pub(super) const PASSWORD_OP_PW: &[u8] = b"op-pw";
+
+/// Viewer-tier login password.
+pub(super) const PASSWORD_VIEWER_PW: &[u8] = b"viewer-pw";
+
+/// Root-tier login password.
+pub(super) const PASSWORD_ROOT_PW: &[u8] = b"root-pw";
+
+/// Stand-in for a meaningless old-password input on a cross-rotate.
+pub(super) const PASSWORD_UNUSED: &[u8] = b"unused";
+
+/// Generic per-user password for duplicate-create test fixtures.
+pub(super) const PASSWORD_X_PW: &[u8] = b"x-pw";
+
+/// Initial password for `create_user` flow.
+pub(super) const PASSWORD_INITIAL_PW: &[u8] = b"initial-pw";
+
+/// Wrong-password input for `auth_login`.
+pub(super) const PASSWORD_ANY_FOR_LOGIN: &[u8] = b"any-password";
+
+// ── Username fixtures (test-only, bound to passwords above) ────────────────
+
+/// Filler bytes used to occupy session-table slots.
+pub(super) const FILLER_USERNAME: &[u8] = b"filler";
+
+/// Username for a victim of a cross-rotate force-logout test.
+pub(super) const VICTIM_USERNAME: &[u8] = b"victim";
+
+/// Phase-3 placeholder factor-2 input — must be rejected with EINVAL.
+pub(super) const PHASE3_FACTOR2: &[u8] = b"123456";

--- a/security/src/argon2id.rs
+++ b/security/src/argon2id.rs
@@ -948,7 +948,12 @@ fn b64_decode(s: &str) -> Result<Vec<u8>, Error> {
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
+#[path = "argon2id_test_vectors.rs"]
+mod test_vectors;
+
+#[cfg(test)]
 mod tests {
+    use super::test_vectors::*;
     use super::*;
 
     /// RFC 9106 §5.3 Argon2id reference test vector.
@@ -964,38 +969,31 @@ mod tests {
     ///   d0 1e f0 45 2d 75 b6 5e  b5 25 20 e9 6b 01 e6 59
     #[test]
     fn rfc9106_section5_3_argon2id_kat() {
-        // RFC 9106 §5.3 reference vector — deterministic test fixtures, not production secrets.
-        // lgtm[rust/hard-coded-cryptographic-value] — RFC 9106 §5.3 test vector
-        let password = [0x01u8; 32];
-        // lgtm[rust/hard-coded-cryptographic-value] — RFC 9106 §5.3 test vector
-        let salt = [0x02u8; 16];
-        // lgtm[rust/hard-coded-cryptographic-value] — RFC 9106 §5.3 test vector
-        let secret = [0x03u8; 8];
-        // lgtm[rust/hard-coded-cryptographic-value] — RFC 9106 §5.3 test vector
-        let ad = [0x04u8; 12];
+        // RFC 9106 §5.3 reference vector — see `argon2id_test_vectors.rs`.
         let params = Argon2idParams {
             m_cost_kib: 32,
             t_cost: 3,
             p_cost: 4,
         };
-        let expected: [u8; 32] = [
-            0x0D, 0x64, 0x0D, 0xF5, 0x8D, 0x78, 0x76, 0x6C, 0x08, 0xC0, 0x37, 0xA3, 0x4A, 0x8B,
-            0x53, 0xC9, 0xD0, 0x1E, 0xF0, 0x45, 0x2D, 0x75, 0xB6, 0x5E, 0xB5, 0x25, 0x20, 0xE9,
-            0x6B, 0x01, 0xE6, 0x59,
-        ];
-        let tag = argon2id_hash_full(&password, &salt, &secret, &ad, params, 32).unwrap();
-        assert_eq!(tag.as_slice(), &expected[..]);
+        let tag = argon2id_hash_full(
+            &RFC9106_PASSWORD,
+            &RFC9106_SALT,
+            &RFC9106_SECRET,
+            &RFC9106_AD,
+            params,
+            32,
+        )
+        .unwrap();
+        assert_eq!(tag.as_slice(), &RFC9106_EXPECTED_TAG[..]);
     }
 
     /// PHC round-trip: hash a password, format, parse, verify.
     #[test]
     fn phc_round_trip() {
-        // Test-only fixtures, not production secrets.
+        // Test-only fixtures — see `argon2id_test_vectors.rs`.
         // Use the absolute-minimum tier to keep tests fast.
-        // lgtm[rust/hard-coded-cryptographic-value] — test fixture
-        let password = b"correct horse battery staple";
-        // lgtm[rust/hard-coded-cryptographic-value] — test fixture
-        let salt = b"saltsalt12345678";
+        let password = PHC_ROUND_TRIP_PASSWORD;
+        let salt = PHC_ROUND_TRIP_SALT;
         let params = Argon2idParams {
             m_cost_kib: 8,
             t_cost: 1,
@@ -1011,8 +1009,7 @@ mod tests {
         assert!(argon2id_verify(password, &phc).unwrap());
 
         // Different password fails.
-        // lgtm[rust/hard-coded-cryptographic-value] — negative-case test fixture
-        assert!(!argon2id_verify(b"wrong password", &phc).unwrap());
+        assert!(!argon2id_verify(PHC_ROUND_TRIP_WRONG_PASSWORD, &phc).unwrap());
     }
 
     /// Tier constructors return valid parameters.
@@ -1032,8 +1029,15 @@ mod tests {
             t_cost: 1,
             p_cost: 1,
         };
-        // lgtm[rust/hard-coded-cryptographic-value] — short-salt negative-case test fixture
-        let r = argon2id_hash_full(b"pw", b"short", &[], &[], params, 32);
+        // Negative-case fixture — see `argon2id_test_vectors.rs`.
+        let r = argon2id_hash_full(
+            SHORT_SALT_PASSWORD,
+            SHORT_SALT_INVALID,
+            &[],
+            &[],
+            params,
+            32,
+        );
         assert!(matches!(r, Err(Error::InvalidSalt)));
     }
 
@@ -1044,12 +1048,9 @@ mod tests {
         use argon2::{Algorithm, Argon2, Params, Version};
 
         for &(m, t, p) in &[(8u32, 1u32, 1u32), (16, 2, 1), (32, 3, 2)] {
-            // Oracle-comparison test fixtures, not production secrets.
-            // lgtm[rust/hard-coded-cryptographic-value] — test fixture
-            let password = b"oracle-test-password";
-            // 17 bytes ≥ 8.
-            // lgtm[rust/hard-coded-cryptographic-value] — test fixture
-            let salt = b"oracle-test-saltX";
+            // Oracle-comparison fixtures — see `argon2id_test_vectors.rs`.
+            let password = ORACLE_PASSWORD;
+            let salt = ORACLE_SALT; // 17 bytes ≥ 8.
             let params = Argon2idParams {
                 m_cost_kib: m,
                 t_cost: t,
@@ -1074,11 +1075,9 @@ mod tests {
         use argon2::password_hash::{PasswordHash, PasswordVerifier};
         use argon2::Argon2;
 
-        // PHC interop test fixtures, not production secrets.
-        // lgtm[rust/hard-coded-cryptographic-value] — test fixture
-        let password = b"interop-test";
-        // lgtm[rust/hard-coded-cryptographic-value] — test fixture
-        let salt = b"interop-saltAAAAAAAA";
+        // PHC interop fixtures — see `argon2id_test_vectors.rs`.
+        let password = INTEROP_PASSWORD;
+        let salt = INTEROP_SALT;
         let params = Argon2idParams {
             m_cost_kib: 16,
             t_cost: 2,
@@ -1098,11 +1097,9 @@ mod tests {
     /// must all complete without panicking and produce 32-byte tags.
     #[test]
     fn parameter_sweep() {
-        // Parameter-sweep test fixtures, not production secrets.
-        // lgtm[rust/hard-coded-cryptographic-value] — test fixture
-        let password = b"sweep";
-        // lgtm[rust/hard-coded-cryptographic-value] — test fixture
-        let salt = b"sweepsalt0000000";
+        // Parameter-sweep fixtures — see `argon2id_test_vectors.rs`.
+        let password = SWEEP_PASSWORD;
+        let salt = SWEEP_SALT;
         for &m in &[8u32, 16, 32] {
             for &t in &[1u32, 2] {
                 for &p in &[1u32, 2] {

--- a/security/src/argon2id_test_vectors.rs
+++ b/security/src/argon2id_test_vectors.rs
@@ -1,0 +1,94 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Deterministic byte-array fixtures for `argon2id` unit tests.
+//!
+//! These constants are extracted from inline `#[cfg(test)]` literals in
+//! `argon2id.rs` so GitHub CodeQL's `rust/hard-coded-cryptographic-value`
+//! heuristic does not re-fire on every scan. They are NOT loaded by any
+//! production code path; the module is gated behind `#[cfg(test)]`.
+//!
+//! The corresponding `paths-ignore` entry lives in
+//! `.github/codeql/codeql-config.yml` (`**/*_test_vectors.rs`). See
+//! `openspec/changes/codeql-quality-cleanup-v1/specs/codeql-suppression-policy/spec.md`
+//! for the full policy, and `net/src/quic/protection_test_vectors.rs`
+//! for the canonical pattern.
+//!
+//! References:
+//! - RFC 9106 §5.3 — Argon2id reference test vector
+
+#![cfg(test)]
+
+// ── RFC 9106 §5.3 reference vector ─────────────────────────────────────────
+//
+// Parameters: t=3, m=32 KiB, p=4, version=0x13, type=Argon2id, tag length=32.
+// The expected tag below is the ground truth from RFC 9106 §5.3.
+
+/// RFC 9106 §5.3 password input — 32 bytes of `0x01`.
+pub(super) const RFC9106_PASSWORD: [u8; 32] = [0x01u8; 32];
+
+/// RFC 9106 §5.3 salt input — 16 bytes of `0x02`.
+pub(super) const RFC9106_SALT: [u8; 16] = [0x02u8; 16];
+
+/// RFC 9106 §5.3 secret (key) input — 8 bytes of `0x03`.
+pub(super) const RFC9106_SECRET: [u8; 8] = [0x03u8; 8];
+
+/// RFC 9106 §5.3 associated-data input — 12 bytes of `0x04`.
+pub(super) const RFC9106_AD: [u8; 12] = [0x04u8; 12];
+
+/// RFC 9106 §5.3 expected 32-byte Argon2id tag:
+///
+/// ```text
+/// 0d 64 0d f5 8d 78 76 6c  08 c0 37 a3 4a 8b 53 c9
+/// d0 1e f0 45 2d 75 b6 5e  b5 25 20 e9 6b 01 e6 59
+/// ```
+pub(super) const RFC9106_EXPECTED_TAG: [u8; 32] = [
+    0x0D, 0x64, 0x0D, 0xF5, 0x8D, 0x78, 0x76, 0x6C, 0x08, 0xC0, 0x37, 0xA3, 0x4A, 0x8B, 0x53, 0xC9,
+    0xD0, 0x1E, 0xF0, 0x45, 0x2D, 0x75, 0xB6, 0x5E, 0xB5, 0x25, 0x20, 0xE9, 0x6B, 0x01, 0xE6, 0x59,
+];
+
+// ── PHC round-trip fixtures ────────────────────────────────────────────────
+
+/// Plaintext password used by `phc_round_trip` to drive a hash → format →
+/// parse → verify cycle. Not a credential.
+pub(super) const PHC_ROUND_TRIP_PASSWORD: &[u8] = b"correct horse battery staple";
+
+/// Salt used by `phc_round_trip`. Sixteen-byte ASCII pattern.
+pub(super) const PHC_ROUND_TRIP_SALT: &[u8] = b"saltsalt12345678";
+
+/// Negative-case password for `phc_round_trip` — verify must reject this
+/// against a PHC produced from `PHC_ROUND_TRIP_PASSWORD`.
+pub(super) const PHC_ROUND_TRIP_WRONG_PASSWORD: &[u8] = b"wrong password";
+
+// ── Short-salt rejection fixture ───────────────────────────────────────────
+
+/// Plaintext password for `short_salt_rejected`.
+pub(super) const SHORT_SALT_PASSWORD: &[u8] = b"pw";
+
+/// Salt that is shorter than 8 bytes and must be rejected.
+pub(super) const SHORT_SALT_INVALID: &[u8] = b"short";
+
+// ── Oracle-comparison fixtures ─────────────────────────────────────────────
+
+/// Plaintext password used by `argon2_oracle_matches` to cross-check
+/// against the upstream `argon2` crate.
+pub(super) const ORACLE_PASSWORD: &[u8] = b"oracle-test-password";
+
+/// 17-byte salt (≥ 8) for `argon2_oracle_matches`.
+pub(super) const ORACLE_SALT: &[u8] = b"oracle-test-saltX";
+
+// ── PHC interoperability fixtures ──────────────────────────────────────────
+
+/// Plaintext password used by `phc_interoperates_with_oracle`.
+pub(super) const INTEROP_PASSWORD: &[u8] = b"interop-test";
+
+/// 20-byte salt for `phc_interoperates_with_oracle`.
+pub(super) const INTEROP_SALT: &[u8] = b"interop-saltAAAAAAAA";
+
+// ── Parameter-sweep fixtures ───────────────────────────────────────────────
+
+/// Plaintext password used by `parameter_sweep`.
+pub(super) const SWEEP_PASSWORD: &[u8] = b"sweep";
+
+/// 16-byte salt for `parameter_sweep`.
+pub(super) const SWEEP_SALT: &[u8] = b"sweepsalt0000000";


### PR DESCRIPTION
## Summary

Following the canonical pattern from `net/src/quic/protection_test_vectors.rs` (introduced by #131), extracts CodeQL false-positive test fixtures from two production files into sibling `*_test_vectors.rs` modules. The codeql-config's `paths-ignore: ["**/*_test_vectors.rs", "**/test_vectors/**"]` excludes those files from analysis entirely, so the 73 open `rust/hard-coded-cryptographic-value` alerts in these two files drop to ≤5 each (production-code lgtm-suppressed only).

## Files added

- `security/src/argon2id_test_vectors.rs` (94 LOC) — 10 constants: RFC 9106 §5.3 inputs (`RFC9106_PASSWORD/SALT/SECRET/AD/EXPECTED_TAG`), PHC round-trip fixtures, short-salt negative case, oracle, interop, sweep.
- `kernel/src/syscall/auth_test_vectors.rs` (96 LOC) — 15 constants: salt/padding (`ZERO_SALT_16`, `WHOAMI_PAD_3/4`), test passwords (`PASSWORD_CORRECT_HORSE`, `PASSWORD_WRONG`, etc.), usernames/factor2.

Both follow the canonical pattern: `#![cfg(test)]`-gated, `pub(super) const` items pulled into the parent's test module via `#[path = "..."] mod test_vectors; use super::test_vectors::*;`.

## What stays in production files

Real production-code constants are untouched:
- `argon2id.rs` — RFC 4648 base64 alphabet inside `b64_decode` (5 lines, lgtm-suppressed)
- `auth.rs` — `DUMMY_PHC` for constant-time-equivalent reject (line 70), salt buffers in `handle_auth_change_password`/`handle_auth_create_user` (lines 420/509)

These keep their existing standalone-line `// lgtm[rust/hard-coded-cryptographic-value]` comments. A follow-on phase will address them via the codeql-config's `query-filters` if the standalone-line lgtm comments still don't take effect post-config.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `just clippy` `-D warnings` clean.
- [x] `cargo test -p smallaios-security --lib` — **882/882** pass.
- [x] `cargo test -p smallaios-kernel --lib` — **579/579** pass (21/21 in `syscall::auth::tests`).
- [x] `just test` workspace clean.
- [x] `cargo vet check` Vetting Succeeded (no new exemptions).
- [x] `openspec validate codeql-quality-cleanup-v1 --strict` clean.
- [x] `openspec validate management-login-v1 --strict` clean.
- [x] Both new filenames match `**/*_test_vectors.rs` glob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Consolidated authentication and Argon2id test vectors into dedicated modules for improved maintainability and reduced duplication across test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->