### PR TITLE
feat(fs): overlay merge logic + whiteout/opaque/reserved-suffix (embedded-overlay-v1 phase 1)

### DIFF
--- a/formal/kani/TODO.md
+++ b/formal/kani/TODO.md
@@ -1,0 +1,45 @@
+# Kani harness TODO
+
+This directory holds Kani-formatted proof sketches that the repository
+does not yet wire into CI. When Kani is added to the toolchain pin and
+a `cargo kani` task lands in `justfile`, the harnesses below should be
+promoted from sketches to verified properties.
+
+## Pending harnesses
+
+### `overlay_merge.rs` — overlay-v1 Phase 1
+
+**Property:** `lookup(upper, lower, path)` is a total function over
+the enumerated `(UpperState, LowerState)` space and satisfies
+upper-wins precedence per `embedded-overlay-v1` design Q14 /
+`fs-overlay-mount` Requirement "Upper-wins lookup precedence".
+
+**Proof obligation table:**
+
+| `upper_state` | `lower_state` | Expected `lookup` result    |
+|---------------|---------------|------------------------------|
+| `Whiteout`    | any           | `WhiteoutHidesLower`         |
+| `RegularFile` | any           | `Upper(RegularFile)`         |
+| `Directory`   | any           | `Upper(Directory)`           |
+| `Opaque`      | any           | `Upper(Opaque)`              |
+| `Absent`      | `Absent`      | `NotFound`                   |
+| `Absent`      | `RegularFile` | `Lower(RegularFile)`         |
+| `Absent`      | `Directory`   | `Lower(Directory)`           |
+
+**Today's coverage:** the
+`sweep_every_quadrant_of_upper_lower_state` and
+`sweep_with_whiteout_axis` integration tests in
+`fs/tests/overlay_phase1_conformance.rs` walk the same enumeration
+concretely. When the Kani harness ships, those tests stay (Kani is
+a complement to, not a replacement for, the conformance suite).
+
+## Wiring checklist (when Kani lands)
+
+1. Add `kani` to `rust-toolchain.toml` extra components, or pin it
+   in `.github/workflows/kani.yml` separately.
+2. Add a `kani` crate at `formal/kani/Cargo.toml` listing all
+   harnesses as `[[bin]]`s, with a `[features] kani` flag.
+3. Add `just kani` recipe wrapping `cargo kani --workspace` with
+   appropriate `--harness` filters.
+4. Wire `cargo kani --harness verify_overlay_merge_precedence` into
+   the formal-gate CI job.

--- a/formal/kani/overlay_merge.rs
+++ b/formal/kani/overlay_merge.rs
@@ -1,0 +1,127 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Kani harness for the overlay merge-lookup precedence invariant.
+//!
+//! Spec reference: `embedded-overlay-v1` design Q14 / `fs-overlay-mount`
+//! Requirement "Upper-wins lookup precedence".
+//!
+//! ## Proof obligation
+//!
+//! For every (upper_state, lower_state, name) triple where `upper_state`
+//! ∈ { Absent, RegularFile, Directory, Whiteout, Opaque } and
+//! `lower_state` ∈ { Absent, RegularFile, Directory }, the merge
+//! lookup function `lookup(upper, lower, name)` SHALL satisfy:
+//!
+//! ```text
+//!   upper_state == Whiteout    →  result == WhiteoutHidesLower
+//!   upper_state == RegularFile →  result == Upper(RegularFile)
+//!   upper_state == Directory   →  result == Upper(Directory)
+//!   upper_state == Opaque      →  result == Upper(Opaque)
+//!   upper_state == Absent      ∧ lower_state == Absent       →  result == NotFound
+//!   upper_state == Absent      ∧ lower_state == RegularFile  →  result == Lower(RegularFile)
+//!   upper_state == Absent      ∧ lower_state == Directory    →  result == Lower(Directory)
+//! ```
+//!
+//! No other state is reachable; the property is total over the
+//! enumerated input space.
+//!
+//! ## Status
+//!
+//! This harness is a **sketch**. The repository does not currently
+//! pin a Kani toolchain version (see `formal/kani/TODO.md`). When
+//! Kani lands as a CI tool, this harness should be moved to a `kani`
+//! crate, gated by `#[cfg(kani)]`, and run via `cargo kani --harness
+//! verify_overlay_merge_precedence`.
+//!
+//! Until then, the property is exercised by the
+//! `sweep_every_quadrant_of_upper_lower_state` and
+//! `sweep_with_whiteout_axis` integration tests in
+//! `fs/tests/overlay_phase1_conformance.rs`. Those tests cover the
+//! same enumerated state space concretely; Kani would replace the
+//! enumeration with `kani::any()` choices and prove the property
+//! across all reachable bit patterns.
+
+#![cfg(kani)]
+
+use smallaios_fs::overlay::{
+    lookup, LookupResult, MockLowerLayer, MockUpperLayer, UpperEntryKind,
+};
+
+#[derive(Clone, Copy, kani::Arbitrary)]
+enum UpperState {
+    Absent,
+    RegularFile,
+    Directory,
+    Whiteout,
+    Opaque,
+}
+
+#[derive(Clone, Copy, kani::Arbitrary)]
+enum LowerState {
+    Absent,
+    RegularFile,
+    Directory,
+}
+
+/// Build a `MockUpperLayer` with `name` in the requested state.
+fn build_upper(state: UpperState, name: &str) -> MockUpperLayer {
+    let mut u = MockUpperLayer::new();
+    match state {
+        UpperState::Absent => {}
+        UpperState::RegularFile => u.add_file(name, b"u"),
+        UpperState::Directory => u.add_dir(name),
+        UpperState::Whiteout => u.add_whiteout(name),
+        UpperState::Opaque => u.add_opaque(name),
+    }
+    u
+}
+
+/// Build a `MockLowerLayer` with `name` in the requested state.
+fn build_lower(state: LowerState, name: &str) -> MockLowerLayer {
+    let mut l = MockLowerLayer::new();
+    match state {
+        LowerState::Absent => {}
+        LowerState::RegularFile => l.add_file(name, b"l"),
+        LowerState::Directory => l.add_dir(name),
+    }
+    l
+}
+
+/// Property: lookup is a total function over the (upper, lower) state
+/// space and respects upper-wins precedence.
+#[kani::proof]
+fn verify_overlay_merge_precedence() {
+    let upper_state: UpperState = kani::any();
+    let lower_state: LowerState = kani::any();
+    let name = "p";
+
+    let u = build_upper(upper_state, name);
+    let l = build_lower(lower_state, name);
+    let r = lookup(&u, &l, name).expect("lookup is total");
+
+    match (upper_state, lower_state) {
+        (UpperState::Whiteout, _) => {
+            assert!(matches!(r, LookupResult::WhiteoutHidesLower));
+        }
+        (UpperState::RegularFile, _) => match r {
+            LookupResult::Upper(e) => assert_eq!(e.kind, UpperEntryKind::RegularFile),
+            _ => kani::cover!(false, "expected Upper(RegularFile)"),
+        },
+        (UpperState::Directory, _) => match r {
+            LookupResult::Upper(e) => assert_eq!(e.kind, UpperEntryKind::Directory),
+            _ => kani::cover!(false, "expected Upper(Directory)"),
+        },
+        (UpperState::Opaque, _) => match r {
+            LookupResult::Upper(e) => assert_eq!(e.kind, UpperEntryKind::Opaque),
+            _ => kani::cover!(false, "expected Upper(Opaque)"),
+        },
+        (UpperState::Absent, LowerState::Absent) => {
+            assert!(matches!(r, LookupResult::NotFound));
+        }
+        (UpperState::Absent, LowerState::RegularFile)
+        | (UpperState::Absent, LowerState::Directory) => {
+            assert!(matches!(r, LookupResult::Lower(_)));
+        }
+    }
+}

--- a/fs/src/lib.rs
+++ b/fs/src/lib.rs
@@ -98,7 +98,7 @@ pub mod cache {}
 ///
 /// Filled by `embedded-overlay-v1` Phases 1 → 6.
 #[cfg(feature = "fs-overlay-mounts")]
-pub mod overlay {}
+pub mod overlay;
 
 /// Raw-flash filesystem (littlefs v2.x) for MCU/FPGA targets.
 /// Includes `FlashDevice` trait, per-bus drivers (QSPI NOR, ONFI NAND),

--- a/fs/src/overlay/lookup.rs
+++ b/fs/src/overlay/lookup.rs
@@ -1,0 +1,242 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Upper-wins path lookup resolver.
+//!
+//! Implements the merge precedence rule from `fs-overlay-mount` spec
+//! "Upper-wins lookup precedence":
+//!
+//! > Path lookup under `/models/` SHALL consult the upper layer first.
+//! > If the upper has a regular file at the requested path, that file
+//! > SHALL be returned. If the upper has a whiteout marker
+//! > `<name>.whiteout` at the parent path, the lookup SHALL return
+//! > `-ENOENT`. Otherwise the lookup SHALL fall through to the lower
+//! > layer.
+//!
+//! Opaque-directory markers add a third precedence wrinkle: when the
+//! caller looks up something inside an opaque upper dir, the
+//! lower-side subtree is hidden — even if the upper has no entry for
+//! that specific path. See [`LookupResult::OpaqueHidesLowerSubtree`].
+
+use super::lower_layer::{LowerEntry, LowerError, LowerLayer};
+use super::upper_layer::{UpperEntry, UpperEntryKind, UpperError, UpperLayer};
+use super::OverlayError;
+
+/// One of five possible outcomes of a merge-aware path lookup.
+///
+/// Generic over the lower-entry type so the merge layer can be
+/// monomorphized against either [`super::MockLowerLayer`] or the
+/// future squashfs-backed lower without a `dyn` indirection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LookupResult<L> {
+    /// The upper has the entry; this is what the caller sees.
+    Upper(UpperEntry),
+    /// The upper has a `<name>.whiteout` for this path — the lower's
+    /// entry (if any) SHALL NOT be visible. POSIX-level surface:
+    /// `-ENOENT`.
+    WhiteoutHidesLower,
+    /// The lookup is for a path inside a directory that the upper
+    /// marks as opaque. The lower-side subtree at this path is hidden
+    /// and the upper has no entry for the specific path. POSIX-level
+    /// surface: `-ENOENT`.
+    OpaqueHidesLowerSubtree,
+    /// The upper has no entry, no whiteout, no opaque hide. The
+    /// lookup falls through to the lower's entry.
+    Lower(L),
+    /// Neither layer has the entry.
+    NotFound,
+}
+
+/// Look up `path` against the merged view.
+///
+/// `path` is slash-relative to the merge root (i.e. for `/models/foo.onnx`
+/// callers pass `"foo.onnx"`; for `/models/custom/x` they pass
+/// `"custom/x"`). An empty `path` resolves to the merge-root directory
+/// itself.
+///
+/// Returns [`OverlayError::Upper`] / [`OverlayError::Lower`] on backing-store
+/// failures. [`UpperError::NotFound`] from the upper is treated as
+/// "not in upper" (Ok(None)), not an error — this lets the merge
+/// keep working when only one side has the path.
+pub fn lookup<U: UpperLayer, L: LowerLayer>(
+    upper: &U,
+    lower: &L,
+    path: &str,
+) -> Result<LookupResult<LowerEntry>, OverlayError> {
+    // Step 1 — upper lookup at the exact path.
+    let upper_entry = upper.lookup(path)?;
+    if let Some(entry) = upper_entry {
+        return Ok(match entry.kind {
+            UpperEntryKind::Whiteout => LookupResult::WhiteoutHidesLower,
+            // RegularFile, Directory, Opaque all "win" — the caller
+            // sees the upper's entry directly. Opaque is a directory
+            // that hides the lower-side subtree but is itself a
+            // valid upper-side directory; the caller still sees it.
+            _ => LookupResult::Upper(entry),
+        });
+    }
+
+    // Step 2 — no exact upper hit. Check whether some ancestor
+    // directory of `path` is opaque. If yes, lower-side fall-through
+    // is suppressed.
+    if any_ancestor_opaque(upper, path)? {
+        return Ok(LookupResult::OpaqueHidesLowerSubtree);
+    }
+
+    // Step 3 — fall through to the lower layer.
+    match lower.lookup(path) {
+        Ok(Some(entry)) => Ok(LookupResult::Lower(entry)),
+        Ok(None) => Ok(LookupResult::NotFound),
+        Err(LowerError::NotFound) => Ok(LookupResult::NotFound),
+        Err(e) => Err(OverlayError::Lower(e)),
+    }
+}
+
+/// Walk every strict ancestor directory of `path` on the upper. Return
+/// `true` if any of them is opaque.
+///
+/// Pure ancestor walk — does NOT consult `path` itself. The caller
+/// already did that as Step 1 of [`lookup`].
+fn any_ancestor_opaque<U: UpperLayer>(upper: &U, path: &str) -> Result<bool, UpperError> {
+    let trimmed = path.trim_start_matches('/').trim_end_matches('/');
+    if trimmed.is_empty() {
+        return Ok(false);
+    }
+    let mut walked = alloc::string::String::new();
+    let parts: alloc::vec::Vec<&str> = trimmed.split('/').collect();
+    // Walk every prefix EXCEPT the full path.
+    let ancestor_count = parts.len().saturating_sub(1);
+    for part in parts.iter().take(ancestor_count) {
+        if !walked.is_empty() {
+            walked.push('/');
+        }
+        walked.push_str(part);
+        if let Some(entry) = upper.lookup(&walked)? {
+            if entry.kind == UpperEntryKind::Opaque {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::lower_layer::{LowerEntryKind, MockLowerLayer};
+    use super::super::upper_layer::MockUpperLayer;
+    use super::*;
+
+    #[test]
+    fn upper_file_shadows_lower_file() {
+        let mut u = MockUpperLayer::new();
+        u.add_file("a.onnx", b"upper");
+        let mut l = MockLowerLayer::new();
+        l.add_file("a.onnx", b"lower");
+        match lookup(&u, &l, "a.onnx").unwrap() {
+            LookupResult::Upper(e) => {
+                assert_eq!(e.name, "a.onnx");
+                assert_eq!(e.kind, UpperEntryKind::RegularFile);
+            }
+            other => panic!("expected Upper, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn lower_visible_when_upper_absent() {
+        let u = MockUpperLayer::new();
+        let mut l = MockLowerLayer::new();
+        l.add_file("a.onnx", b"lower");
+        match lookup(&u, &l, "a.onnx").unwrap() {
+            LookupResult::Lower(e) => {
+                assert_eq!(e.name, "a.onnx");
+                assert_eq!(e.kind, LowerEntryKind::RegularFile);
+            }
+            other => panic!("expected Lower, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn whiteout_hides_lower_returns_whiteoutresult() {
+        let mut u = MockUpperLayer::new();
+        u.add_whiteout("a.onnx");
+        let mut l = MockLowerLayer::new();
+        l.add_file("a.onnx", b"lower");
+        assert_eq!(
+            lookup(&u, &l, "a.onnx").unwrap(),
+            LookupResult::WhiteoutHidesLower
+        );
+    }
+
+    #[test]
+    fn opaque_dir_hides_lower_subtree() {
+        let mut u = MockUpperLayer::new();
+        u.add_opaque("custom");
+        let mut l = MockLowerLayer::new();
+        l.add_file("custom/leaf", b"lower");
+        // `custom/leaf`: upper has no entry, but `custom/` is opaque.
+        assert_eq!(
+            lookup(&u, &l, "custom/leaf").unwrap(),
+            LookupResult::OpaqueHidesLowerSubtree
+        );
+    }
+
+    #[test]
+    fn opaque_dir_itself_returns_upper() {
+        let mut u = MockUpperLayer::new();
+        u.add_opaque("custom");
+        let mut l = MockLowerLayer::new();
+        l.add_file("custom/leaf", b"lower");
+        // The opaque dir itself is an upper entry.
+        match lookup(&u, &l, "custom").unwrap() {
+            LookupResult::Upper(e) => {
+                assert_eq!(e.kind, UpperEntryKind::Opaque);
+            }
+            other => panic!("expected Upper(Opaque), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn not_found_when_neither_layer_has_entry() {
+        let u = MockUpperLayer::new();
+        let l = MockLowerLayer::new();
+        assert_eq!(lookup(&u, &l, "missing").unwrap(), LookupResult::NotFound);
+    }
+
+    #[test]
+    fn upper_directory_wins_over_lower_file() {
+        // Edge: upper has `foo` as a directory, lower has `foo` as a
+        // regular file. Upper-wins applies — caller sees the directory.
+        let mut u = MockUpperLayer::new();
+        u.add_dir("foo");
+        let mut l = MockLowerLayer::new();
+        l.add_file("foo", b"lower");
+        match lookup(&u, &l, "foo").unwrap() {
+            LookupResult::Upper(e) => assert_eq!(e.kind, UpperEntryKind::Directory),
+            other => panic!("expected Upper(Directory), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn nested_path_falls_through_when_upper_empty() {
+        let u = MockUpperLayer::new();
+        let mut l = MockLowerLayer::new();
+        l.add_file("a/b/c", b"lower");
+        match lookup(&u, &l, "a/b/c").unwrap() {
+            LookupResult::Lower(e) => assert_eq!(e.size, 5),
+            other => panic!("expected Lower, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn opaque_only_hides_at_or_below_marker() {
+        let mut u = MockUpperLayer::new();
+        u.add_opaque("custom");
+        let mut l = MockLowerLayer::new();
+        l.add_file("other.onnx", b"lower");
+        // `other.onnx` is not under `custom/` → lower visible.
+        match lookup(&u, &l, "other.onnx").unwrap() {
+            LookupResult::Lower(_) => {}
+            other => panic!("expected Lower, got {:?}", other),
+        }
+    }
+}

--- a/fs/src/overlay/lower_layer.rs
+++ b/fs/src/overlay/lower_layer.rs
@@ -1,0 +1,278 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `LowerLayer` trait — abstracts the read-only lower side of the overlay.
+//!
+//! At runtime the lower is the active squashfs A/B slot. Phase 1 keeps
+//! the merge logic decoupled from the squashfs reader by exposing a
+//! tiny trait, mirrored by [`MockLowerLayer`] for unit tests.
+//!
+//! The squashfs adapter lives in [`SquashfsLowerLayer`] (gated by
+//! `fs-on-disk-mounts`); when both feature flags are on, the merge
+//! layer can be wired to a real `Squashfs` reader. When only
+//! `fs-overlay-mounts` is on, the mock is the sole impl available
+//! to host-side tests.
+
+extern crate alloc;
+
+use alloc::collections::BTreeMap;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::fmt;
+
+/// Errors produced by the lower layer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LowerError {
+    /// Path does not exist in the lower layer.
+    NotFound,
+    /// Path resolved to something that isn't a directory.
+    NotADirectory,
+    /// Path resolved to a non-regular-file (Phase 1 doesn't read
+    /// symlinks through the merge view).
+    NotARegularFile,
+    /// Read offset exceeds file size.
+    OutOfRange,
+    /// I/O error on the backing store.
+    Io,
+}
+
+impl fmt::Display for LowerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFound => write!(f, "lower: not found"),
+            Self::NotADirectory => write!(f, "lower: not a directory"),
+            Self::NotARegularFile => write!(f, "lower: not a regular file"),
+            Self::OutOfRange => write!(f, "lower: read out of range"),
+            Self::Io => write!(f, "lower: I/O error"),
+        }
+    }
+}
+
+/// Kind of an entry surfaced by the lower layer.
+///
+/// Unlike the upper, the lower **never** surfaces whiteout or opaque
+/// markers — it's a plain read-only filesystem.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LowerEntryKind {
+    RegularFile,
+    Directory,
+    /// Symlink or other inode kind. The merge layer treats these the
+    /// same as `RegularFile` for listing purposes; readers go through
+    /// the real squashfs API which projects this anyway.
+    Other,
+}
+
+/// One entry surfaced by the lower layer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LowerEntry {
+    pub name: String,
+    pub kind: LowerEntryKind,
+    pub size: u64,
+    pub mode: u16,
+}
+
+/// Read-only lower-layer abstraction.
+///
+/// Paths are slash-relative to the lower-mount root, just like
+/// [`super::UpperLayer`].
+pub trait LowerLayer {
+    /// Resolve a path to an entry.
+    fn lookup(&self, path: &str) -> Result<Option<LowerEntry>, LowerError>;
+
+    /// Read up to `buf.len()` bytes from `path` starting at `offset`.
+    fn read_file(&self, path: &str, offset: u64, buf: &mut [u8]) -> Result<usize, LowerError>;
+
+    /// List entries in directory `path`.
+    fn iter_dir(&self, path: &str) -> Result<Vec<LowerEntry>, LowerError>;
+}
+
+// ─── MockLowerLayer ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum MockLowerEntry {
+    File(Vec<u8>),
+    Directory,
+}
+
+/// In-memory `LowerLayer` for unit tests.
+///
+/// Stores a flat `BTreeMap<String, MockLowerEntry>` keyed by full
+/// upper-relative path. Doesn't model squashfs's permission bits,
+/// inode numbers, etc. — Phase 1 only needs presence/absence and
+/// content for the merge tests.
+#[derive(Debug, Default, Clone)]
+pub struct MockLowerLayer {
+    entries: BTreeMap<String, MockLowerEntry>,
+}
+
+impl MockLowerLayer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_file(&mut self, path: &str, content: &[u8]) {
+        self.ensure_parents(path);
+        self.entries
+            .insert(normalize(path), MockLowerEntry::File(content.to_vec()));
+    }
+
+    pub fn add_dir(&mut self, path: &str) {
+        self.ensure_parents(path);
+        let key = normalize(path);
+        self.entries.entry(key).or_insert(MockLowerEntry::Directory);
+    }
+
+    fn ensure_parents(&mut self, path: &str) {
+        let n = normalize(path);
+        let mut walked = String::new();
+        for component in n.split('/').filter(|s| !s.is_empty()) {
+            if !walked.is_empty() {
+                walked.push('/');
+            }
+            let candidate = alloc::format!("{}{}", walked, component);
+            if candidate == n {
+                break;
+            }
+            self.entries
+                .entry(candidate.clone())
+                .or_insert(MockLowerEntry::Directory);
+            walked = candidate;
+        }
+    }
+}
+
+fn normalize(p: &str) -> String {
+    p.trim_start_matches('/').trim_end_matches('/').into()
+}
+
+impl LowerLayer for MockLowerLayer {
+    fn lookup(&self, path: &str) -> Result<Option<LowerEntry>, LowerError> {
+        let key = normalize(path);
+        if key.is_empty() {
+            return Ok(Some(LowerEntry {
+                name: String::new(),
+                kind: LowerEntryKind::Directory,
+                size: 0,
+                mode: 0o755,
+            }));
+        }
+        let bare = key.rsplit('/').next().unwrap_or("").to_string();
+        match self.entries.get(&key) {
+            Some(MockLowerEntry::File(bytes)) => Ok(Some(LowerEntry {
+                name: bare,
+                kind: LowerEntryKind::RegularFile,
+                size: bytes.len() as u64,
+                mode: 0o444,
+            })),
+            Some(MockLowerEntry::Directory) => Ok(Some(LowerEntry {
+                name: bare,
+                kind: LowerEntryKind::Directory,
+                size: 0,
+                mode: 0o555,
+            })),
+            None => Ok(None),
+        }
+    }
+
+    fn read_file(&self, path: &str, offset: u64, buf: &mut [u8]) -> Result<usize, LowerError> {
+        let key = normalize(path);
+        match self.entries.get(&key) {
+            Some(MockLowerEntry::File(bytes)) => {
+                let len = bytes.len() as u64;
+                if offset > len {
+                    return Err(LowerError::OutOfRange);
+                }
+                let start = offset as usize;
+                let avail = bytes.len() - start;
+                let n = core::cmp::min(buf.len(), avail);
+                buf[..n].copy_from_slice(&bytes[start..start + n]);
+                Ok(n)
+            }
+            Some(MockLowerEntry::Directory) => Err(LowerError::NotARegularFile),
+            None => Err(LowerError::NotFound),
+        }
+    }
+
+    fn iter_dir(&self, path: &str) -> Result<Vec<LowerEntry>, LowerError> {
+        let key = normalize(path);
+        if !key.is_empty() {
+            match self.entries.get(&key) {
+                Some(MockLowerEntry::Directory) => {}
+                Some(_) => return Err(LowerError::NotADirectory),
+                None => return Err(LowerError::NotFound),
+            }
+        }
+        let prefix = if key.is_empty() {
+            String::new()
+        } else {
+            alloc::format!("{}/", key)
+        };
+        let mut out = Vec::new();
+        for (k, v) in &self.entries {
+            if !k.starts_with(&prefix) {
+                continue;
+            }
+            let suffix = &k[prefix.len()..];
+            if suffix.is_empty() || suffix.contains('/') {
+                continue;
+            }
+            match v {
+                MockLowerEntry::File(bytes) => out.push(LowerEntry {
+                    name: suffix.into(),
+                    kind: LowerEntryKind::RegularFile,
+                    size: bytes.len() as u64,
+                    mode: 0o444,
+                }),
+                MockLowerEntry::Directory => out.push(LowerEntry {
+                    name: suffix.into(),
+                    kind: LowerEntryKind::Directory,
+                    size: 0,
+                    mode: 0o555,
+                }),
+            }
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mock_lower_lookup_file() {
+        let mut l = MockLowerLayer::new();
+        l.add_file("a", b"abc");
+        let e = l.lookup("a").unwrap().unwrap();
+        assert_eq!(e.name, "a");
+        assert_eq!(e.kind, LowerEntryKind::RegularFile);
+        assert_eq!(e.size, 3);
+    }
+
+    #[test]
+    fn mock_lower_lookup_absent_returns_none() {
+        let l = MockLowerLayer::new();
+        assert_eq!(l.lookup("a").unwrap(), None);
+    }
+
+    #[test]
+    fn mock_lower_iter_dir_root() {
+        let mut l = MockLowerLayer::new();
+        l.add_file("a", b"a");
+        l.add_file("b/c", b"c");
+        let entries = l.iter_dir("/").unwrap();
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"a"));
+        assert!(names.contains(&"b"));
+    }
+
+    #[test]
+    fn mock_lower_read_file() {
+        let mut l = MockLowerLayer::new();
+        l.add_file("a", b"hello");
+        let mut buf = [0u8; 5];
+        let n = l.read_file("a", 0, &mut buf).unwrap();
+        assert_eq!(n, 5);
+        assert_eq!(&buf, b"hello");
+    }
+}

--- a/fs/src/overlay/merge.rs
+++ b/fs/src/overlay/merge.rs
@@ -1,0 +1,303 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `readdir` merge logic.
+//!
+//! Returns the union of upper + lower entries minus:
+//!
+//! - Names whitelisted by an upper-layer whiteout.
+//! - Lower-side entries shadowed by an opaque-dir marker on the upper.
+//! - Names ending in any reserved suffix (`.whiteout`, `.opaque`,
+//!   `.sha3`, `.sig`) — those are overlay-internal markers.
+//!
+//! When the same name appears on both layers, the upper's entry wins.
+//! No duplicate names are ever returned.
+
+extern crate alloc;
+
+use alloc::collections::BTreeMap;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use super::lower_layer::{LowerEntryKind, LowerError, LowerLayer};
+use super::reserved::is_reserved_name;
+use super::upper_layer::{UpperEntryKind, UpperError, UpperLayer};
+use super::OverlayError;
+
+/// Kind of an entry yielded by the merged readdir.
+///
+/// Whiteouts and opaque markers are NEVER yielded — they're filtered
+/// out of the listing entirely. The merge surface is "what would the
+/// user see at this point in the namespace".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MergedEntryKind {
+    RegularFile,
+    Directory,
+    /// Symlink or other inode kind from the lower (squashfs may
+    /// surface these). The merge layer doesn't try to filter — it
+    /// yields whatever the lower had, with the same upper-wins
+    /// shadowing rules.
+    Other,
+}
+
+/// One entry in the merged readdir output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MergedEntry {
+    pub name: String,
+    pub kind: MergedEntryKind,
+    pub size: u64,
+    /// `true` if the entry came from the upper layer; `false` if from
+    /// the lower. Useful for diagnostics (operator-facing CLI may
+    /// surface this), not used by the kernel's POSIX path.
+    pub from_upper: bool,
+}
+
+/// Merge `readdir(dir)` across upper + lower.
+///
+/// `dir` is slash-relative to the merge root, like the lookup API.
+/// Empty `dir` lists the merge root.
+pub fn merge_readdir<U: UpperLayer, L: LowerLayer>(
+    upper: &U,
+    lower: &L,
+    dir: &str,
+) -> Result<Vec<MergedEntry>, OverlayError> {
+    // Step 1 — does the upper opaqueify this directory? If yes, only
+    // upper entries are visible.
+    let opaque = match upper.lookup(dir) {
+        Ok(Some(e)) => e.kind == UpperEntryKind::Opaque,
+        Ok(None) => false,
+        Err(e) => return Err(OverlayError::Upper(e)),
+    };
+
+    // Step 2 — collect upper entries (if any).
+    let upper_entries = match upper.iter_dir(dir) {
+        Ok(v) => v,
+        Err(UpperError::NotFound) | Err(UpperError::NotADirectory) => Vec::new(),
+        Err(e) => return Err(OverlayError::Upper(e)),
+    };
+
+    // Step 3 — collect lower entries (if any). Suppressed entirely
+    // when the upper marks the directory opaque.
+    let lower_entries = if opaque {
+        Vec::new()
+    } else {
+        match lower.iter_dir(dir) {
+            Ok(v) => v,
+            Err(LowerError::NotFound) | Err(LowerError::NotADirectory) => Vec::new(),
+            Err(e) => return Err(OverlayError::Lower(e)),
+        }
+    };
+
+    // Step 4 — first pass: gather whiteout names from the upper. These
+    // hide the lower's entries with the same bare name.
+    let mut whiteouts: alloc::collections::BTreeSet<String> = alloc::collections::BTreeSet::new();
+    for e in &upper_entries {
+        if e.kind == UpperEntryKind::Whiteout {
+            whiteouts.insert(e.name.clone());
+        }
+    }
+
+    // Step 5 — index upper non-marker entries by name (for shadowing).
+    let mut merged: BTreeMap<String, MergedEntry> = BTreeMap::new();
+    for e in upper_entries {
+        // Markers (Whiteout, Opaque) are NEVER user-facing.
+        if matches!(e.kind, UpperEntryKind::Whiteout | UpperEntryKind::Opaque) {
+            continue;
+        }
+        // Reserved-suffix safeguard: should be unreachable since the
+        // upper layer normally surfaces markers via Whiteout/Opaque
+        // kinds, but operator-supplied files could still appear with
+        // a reserved suffix if write enforcement is bypassed (Phase 2
+        // closes that gap; Phase 1 defends in depth here).
+        if is_reserved_name(&e.name) {
+            continue;
+        }
+        merged.insert(
+            e.name.clone(),
+            MergedEntry {
+                name: e.name,
+                kind: match e.kind {
+                    UpperEntryKind::RegularFile => MergedEntryKind::RegularFile,
+                    UpperEntryKind::Directory => MergedEntryKind::Directory,
+                    // Whiteout/Opaque already filtered above.
+                    UpperEntryKind::Whiteout | UpperEntryKind::Opaque => unreachable!(),
+                },
+                size: e.size,
+                from_upper: true,
+            },
+        );
+    }
+
+    // Step 6 — overlay lower entries: skip those shadowed by upper or
+    // by an active whiteout, and skip reserved-suffix names.
+    for e in lower_entries {
+        if whiteouts.contains(&e.name) {
+            continue;
+        }
+        if merged.contains_key(&e.name) {
+            // Upper wins — already present.
+            continue;
+        }
+        if is_reserved_name(&e.name) {
+            // Don't expose a lower-side `<...>.whiteout` or
+            // `<...>.sha3` even if the lower somehow has one.
+            continue;
+        }
+        merged.insert(
+            e.name.clone(),
+            MergedEntry {
+                name: e.name,
+                kind: match e.kind {
+                    LowerEntryKind::RegularFile => MergedEntryKind::RegularFile,
+                    LowerEntryKind::Directory => MergedEntryKind::Directory,
+                    LowerEntryKind::Other => MergedEntryKind::Other,
+                },
+                size: e.size,
+                from_upper: false,
+            },
+        );
+    }
+
+    // Stable, sorted output. Operator-facing readdir is small (tens to
+    // low hundreds of entries), so the BTreeMap → Vec collect is cheap
+    // and predictable.
+    Ok(merged.into_values().collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::lower_layer::MockLowerLayer;
+    use super::super::upper_layer::MockUpperLayer;
+    use super::*;
+
+    fn names(entries: &[MergedEntry]) -> Vec<&str> {
+        entries.iter().map(|e| e.name.as_str()).collect()
+    }
+
+    #[test]
+    fn merge_union_no_duplicates() {
+        let mut u = MockUpperLayer::new();
+        u.add_file("a", b"u");
+        u.add_file("b", b"u");
+        let mut l = MockLowerLayer::new();
+        l.add_file("a", b"l");
+        l.add_file("c", b"l");
+        let entries = merge_readdir(&u, &l, "/").unwrap();
+        let n = names(&entries);
+        // a, b, c — no duplicate of a.
+        assert_eq!(n, alloc::vec!["a", "b", "c"]);
+        // a came from upper.
+        let a = entries.iter().find(|e| e.name == "a").unwrap();
+        assert!(a.from_upper);
+        // c came from lower.
+        let c = entries.iter().find(|e| e.name == "c").unwrap();
+        assert!(!c.from_upper);
+    }
+
+    #[test]
+    fn merge_filters_reserved_suffixes_from_upper() {
+        let mut u = MockUpperLayer::new();
+        u.add_file("foo.onnx", b"x");
+        u.add_whiteout("bar");
+        u.add_opaque("baz");
+        let l = MockLowerLayer::new();
+        let entries = merge_readdir(&u, &l, "/").unwrap();
+        let n = names(&entries);
+        // Only foo.onnx is user-facing; `bar.whiteout` and `baz/.opaque`
+        // markers are filtered. `baz` itself (the opaque dir) is NOT
+        // listed because the merge code path skips upper entries
+        // marked Opaque (they're internal markers).
+        assert_eq!(n, alloc::vec!["foo.onnx"]);
+    }
+
+    #[test]
+    fn merge_filters_reserved_suffixes_from_lower() {
+        // Pathological: lower has a file with reserved suffix. Filter
+        // it out of the listing — defense in depth.
+        let u = MockUpperLayer::new();
+        let mut l = MockLowerLayer::new();
+        l.add_file("good.onnx", b"x");
+        l.add_file("bad.whiteout", b"x");
+        l.add_file("bad.sha3", b"x");
+        l.add_file("bad.sig", b"x");
+        let entries = merge_readdir(&u, &l, "/").unwrap();
+        let n = names(&entries);
+        assert_eq!(n, alloc::vec!["good.onnx"]);
+    }
+
+    #[test]
+    fn merge_whiteout_hides_lower_entry() {
+        let mut u = MockUpperLayer::new();
+        u.add_whiteout("a");
+        let mut l = MockLowerLayer::new();
+        l.add_file("a", b"x");
+        l.add_file("b", b"x");
+        let entries = merge_readdir(&u, &l, "/").unwrap();
+        let n = names(&entries);
+        assert_eq!(n, alloc::vec!["b"]);
+    }
+
+    #[test]
+    fn merge_opaque_dir_hides_entire_lower_subtree() {
+        let mut u = MockUpperLayer::new();
+        u.add_opaque("custom");
+        u.add_file("custom/upper-only", b"u");
+        let mut l = MockLowerLayer::new();
+        l.add_file("custom/lower-only", b"l");
+        l.add_file("custom/shared", b"l");
+        let entries = merge_readdir(&u, &l, "custom").unwrap();
+        let n = names(&entries);
+        // Only the upper entry is visible; lower-side entries are
+        // entirely suppressed.
+        assert_eq!(n, alloc::vec!["upper-only"]);
+    }
+
+    #[test]
+    fn merge_only_lower_when_upper_dir_missing() {
+        let u = MockUpperLayer::new();
+        let mut l = MockLowerLayer::new();
+        l.add_file("foo", b"x");
+        let entries = merge_readdir(&u, &l, "/").unwrap();
+        let n = names(&entries);
+        assert_eq!(n, alloc::vec!["foo"]);
+    }
+
+    #[test]
+    fn merge_empty_when_both_empty() {
+        let u = MockUpperLayer::new();
+        let l = MockLowerLayer::new();
+        let entries = merge_readdir(&u, &l, "/").unwrap();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn merge_yields_sorted_stable_output() {
+        let mut u = MockUpperLayer::new();
+        u.add_file("z", b"x");
+        u.add_file("m", b"x");
+        let mut l = MockLowerLayer::new();
+        l.add_file("a", b"x");
+        l.add_file("c", b"x");
+        let entries = merge_readdir(&u, &l, "/").unwrap();
+        let n = names(&entries);
+        assert_eq!(n, alloc::vec!["a", "c", "m", "z"]);
+    }
+
+    #[test]
+    fn merge_directory_entries_classified_correctly() {
+        let mut u = MockUpperLayer::new();
+        u.add_dir("upperdir");
+        u.add_file("upperfile", b"x");
+        let mut l = MockLowerLayer::new();
+        l.add_dir("lowerdir");
+        l.add_file("lowerfile", b"x");
+        let entries = merge_readdir(&u, &l, "/").unwrap();
+        for e in &entries {
+            match e.name.as_str() {
+                "upperdir" | "lowerdir" => assert_eq!(e.kind, MergedEntryKind::Directory),
+                "upperfile" | "lowerfile" => assert_eq!(e.kind, MergedEntryKind::RegularFile),
+                _ => {}
+            }
+        }
+    }
+}

--- a/fs/src/overlay/mod.rs
+++ b/fs/src/overlay/mod.rs
@@ -1,0 +1,179 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! OverlayFS-style merged `/models/` view.
+//!
+//! Phase 1 of `embedded-overlay-v1` ships **read-only merge logic**.
+//! The upper-layer write path, syscalls, and integrity verification
+//! land in later phases.
+//!
+//! ## Layering
+//!
+//! At runtime `/models/` is a 2-layer merge:
+//!
+//! - **lower** — the active squashfs A/B slot (read-only, supplied by
+//!   `embedded-filesystem-v1`'s [`squashfs::Squashfs`] reader).
+//! - **upper** — `/data/models-upper/` on F2FS (read-write, supplied
+//!   by `embedded-filesystem-v1` Phase 7 once the F2FS RW path lands).
+//!
+//! Phase 1 abstracts both layers behind traits ([`UpperLayer`] and
+//! [`LowerLayer`]) so the merge logic compiles and tests against
+//! synthetic in-memory fixtures while F2FS is still in flight.
+//!
+//! ## Merge semantics (read path)
+//!
+//! - **Upper-wins precedence.** A regular file in the upper shadows
+//!   the same name in the lower.
+//! - **Whiteout files.** A regular file `<name>.whiteout` in the upper
+//!   hides the lower's `<name>`. The whiteout file's contents are
+//!   never inspected — its mere presence is the marker.
+//! - **Opaque dirs.** A regular file `<dir>/.opaque` in an upper
+//!   directory hides the entire lower-side subtree at that path; only
+//!   upper entries under `<dir>/` are listed.
+//! - **Reserved suffixes.** Names ending in `.whiteout`, `.opaque`,
+//!   `.sha3`, `.sig` are filtered from `readdir` output (they're
+//!   internal markers) and rejected at the `model_add` boundary
+//!   (Phase 3).
+//!
+//! See `openspec/changes/embedded-overlay-v1/specs/fs-overlay-mount/spec.md`.
+//!
+//! ## Module map
+//!
+//! | Module           | Role                                                          |
+//! |------------------|---------------------------------------------------------------|
+//! | [`upper_layer`]  | `UpperLayer` trait + `MockUpperLayer` for tests               |
+//! | [`lower_layer`]  | `LowerLayer` trait + `MockLowerLayer` for tests               |
+//! | [`whiteout`]     | `<name>.whiteout` regular-file detection                      |
+//! | [`opaque`]       | `<dir>/.opaque` regular-file detection                        |
+//! | [`reserved`]     | Reserved-suffix list + name rejection                         |
+//! | [`lookup`]       | Upper-wins path lookup resolver                               |
+//! | [`merge`]        | `readdir` merger (upper ∪ lower − whiteouts − opaque)         |
+//!
+//! Filled by `embedded-overlay-v1` Phase 1.
+
+extern crate alloc;
+
+use alloc::string::String;
+use core::fmt;
+
+pub mod lookup;
+pub mod lower_layer;
+pub mod merge;
+pub mod opaque;
+pub mod reserved;
+pub mod upper_layer;
+pub mod whiteout;
+
+pub use lookup::{lookup, LookupResult};
+pub use lower_layer::{LowerEntry, LowerEntryKind, LowerError, LowerLayer, MockLowerLayer};
+pub use merge::{merge_readdir, MergedEntry, MergedEntryKind};
+pub use opaque::{is_opaque_dir, OPAQUE_MARKER_NAME};
+pub use reserved::{is_reserved_name, reject_if_reserved, RESERVED_SUFFIXES};
+pub use upper_layer::{MockUpperLayer, UpperEntry, UpperEntryKind, UpperError, UpperLayer};
+pub use whiteout::{is_whiteout, list_whiteouts_in, WHITEOUT_SUFFIX};
+
+/// Errors produced by the overlay merge layer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OverlayError {
+    /// Upper layer reported an error.
+    Upper(UpperError),
+    /// Lower layer reported an error.
+    Lower(LowerError),
+    /// Operator-supplied name conflicts with a reserved suffix
+    /// (`.whiteout`, `.opaque`, `.sha3`, `.sig`).
+    ReservedSuffix(String),
+    /// A path was supplied that does not start with `/`.
+    InvalidPath,
+    /// A write was attempted on the read-only Phase 1 overlay
+    /// (Phase 2 lifts this).
+    ReadOnly,
+}
+
+impl fmt::Display for OverlayError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Upper(e) => write!(f, "overlay: upper layer error: {:?}", e),
+            Self::Lower(e) => write!(f, "overlay: lower layer error: {:?}", e),
+            Self::ReservedSuffix(s) => {
+                write!(f, "overlay: name has reserved suffix: {}", s)
+            }
+            Self::InvalidPath => write!(f, "overlay: invalid path (must start with '/')"),
+            Self::ReadOnly => write!(f, "overlay: writes not yet supported (Phase 1 read-only)"),
+        }
+    }
+}
+
+impl From<UpperError> for OverlayError {
+    fn from(e: UpperError) -> Self {
+        Self::Upper(e)
+    }
+}
+
+impl From<LowerError> for OverlayError {
+    fn from(e: LowerError) -> Self {
+        Self::Lower(e)
+    }
+}
+
+/// Strip a leading `/` and any trailing `/` from a path. Used by the
+/// merge layer when normalizing operator-supplied paths into the
+/// lookup-key form the upper/lower layers expect.
+///
+/// Returns `None` if the path is empty or doesn't start with `/`.
+#[allow(dead_code)] // exercised by unit tests; reserved for the Phase 3 syscall layer
+pub(crate) fn normalize_path(path: &str) -> Option<&str> {
+    if !path.starts_with('/') {
+        return None;
+    }
+    let trimmed = path.trim_start_matches('/').trim_end_matches('/');
+    Some(trimmed)
+}
+
+/// Split a path into `(parent, name)` components. The parent is the
+/// portion before the last `/`; the name is everything after. The
+/// root path `""` returns `("", "")`.
+#[allow(dead_code)] // exercised by unit tests; reserved for the Phase 3 syscall layer
+pub(crate) fn split_parent_name(path: &str) -> (&str, &str) {
+    match path.rfind('/') {
+        Some(i) => (&path[..i], &path[i + 1..]),
+        None => ("", path),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_path_strips_leading_slash() {
+        assert_eq!(normalize_path("/foo"), Some("foo"));
+        assert_eq!(normalize_path("/foo/bar"), Some("foo/bar"));
+        assert_eq!(normalize_path("/"), Some(""));
+        assert_eq!(normalize_path("/foo/"), Some("foo"));
+    }
+
+    #[test]
+    fn normalize_path_rejects_relative() {
+        assert_eq!(normalize_path("foo"), None);
+        assert_eq!(normalize_path(""), None);
+    }
+
+    #[test]
+    fn split_parent_name_basic() {
+        assert_eq!(split_parent_name("foo"), ("", "foo"));
+        assert_eq!(split_parent_name("foo/bar"), ("foo", "bar"));
+        assert_eq!(split_parent_name("a/b/c"), ("a/b", "c"));
+        assert_eq!(split_parent_name(""), ("", ""));
+    }
+
+    #[test]
+    fn overlay_error_displays() {
+        use alloc::string::ToString;
+        let e = OverlayError::ReservedSuffix(".whiteout".into());
+        assert!(e.to_string().contains("reserved suffix"));
+        let e = OverlayError::InvalidPath;
+        assert!(e.to_string().contains("invalid path"));
+        let e = OverlayError::ReadOnly;
+        assert!(e.to_string().contains("read-only"));
+    }
+}

--- a/fs/src/overlay/opaque.rs
+++ b/fs/src/overlay/opaque.rs
@@ -1,0 +1,77 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Opaque-directory detection.
+//!
+//! An opaque-directory marker is a regular file named `.opaque` placed
+//! inside an upper-layer subdirectory. Its presence hides the entire
+//! lower-side subtree at that path; only upper entries are listed.
+//!
+//! Per `embedded-overlay-v1` spec scenario "Opaque dir hides whole
+//! subtree".
+
+use super::upper_layer::{UpperEntryKind, UpperLayer};
+
+/// The opaque-directory marker filename.
+pub const OPAQUE_MARKER_NAME: &str = ".opaque";
+
+/// Returns `true` if the upper layer's `dir` is opaque (i.e. an
+/// `.opaque` regular file lives inside it).
+///
+/// Implemented via `UpperLayer::lookup` of the directory itself: the
+/// upper-layer impl is responsible for surfacing
+/// [`UpperEntryKind::Opaque`] when the `.opaque` marker is present.
+/// The `MockUpperLayer` does this; the future F2FS upper will do the
+/// same.
+pub fn is_opaque_dir<U: UpperLayer>(upper: &U, dir: &str) -> bool {
+    matches!(
+        upper.lookup(dir),
+        Ok(Some(e)) if e.kind == UpperEntryKind::Opaque
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::upper_layer::MockUpperLayer;
+    use super::*;
+
+    #[test]
+    fn opaque_marker_name_value() {
+        assert_eq!(OPAQUE_MARKER_NAME, ".opaque");
+    }
+
+    #[test]
+    fn detects_opaque_directory() {
+        let mut u = MockUpperLayer::new();
+        u.add_opaque("custom");
+        assert!(is_opaque_dir(&u, "custom"));
+    }
+
+    #[test]
+    fn returns_false_for_normal_directory() {
+        let mut u = MockUpperLayer::new();
+        u.add_dir("custom");
+        assert!(!is_opaque_dir(&u, "custom"));
+    }
+
+    #[test]
+    fn returns_false_for_regular_file() {
+        let mut u = MockUpperLayer::new();
+        u.add_file("custom", b"data");
+        assert!(!is_opaque_dir(&u, "custom"));
+    }
+
+    #[test]
+    fn returns_false_for_missing_directory() {
+        let u = MockUpperLayer::new();
+        assert!(!is_opaque_dir(&u, "missing"));
+    }
+
+    #[test]
+    fn nested_opaque_directory() {
+        let mut u = MockUpperLayer::new();
+        u.add_opaque("models/custom");
+        assert!(is_opaque_dir(&u, "models/custom"));
+        assert!(!is_opaque_dir(&u, "models"));
+    }
+}

--- a/fs/src/overlay/reserved.rs
+++ b/fs/src/overlay/reserved.rs
@@ -1,0 +1,129 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Reserved-suffix list.
+//!
+//! Names ending in any of these suffixes are reserved for overlay-internal
+//! markers and SHALL NOT be operator-creatable. The merge layer filters
+//! them from `readdir` listings; the future `model_add` syscall (Phase 3)
+//! rejects them with `-EINVAL`.
+//!
+//! Per `embedded-overlay-v1` spec Q9 / `fs-overlay-mount` Requirement
+//! "Reserved-suffix names rejected".
+
+extern crate alloc;
+
+use alloc::string::ToString;
+
+use super::OverlayError;
+
+/// Suffixes reserved for overlay-internal sidecars and markers.
+///
+/// - `.whiteout` — file-based whiteout marker (per `fs-overlay-mount`).
+/// - `.opaque`   — opaque-directory marker.
+/// - `.sha3`     — SHA-3-256 fingerprint sidecar (Phase 5 integrity).
+/// - `.sig`      — ML-DSA-65 signature sidecar (Phase 5 integrity).
+pub const RESERVED_SUFFIXES: &[&str] = &[".whiteout", ".opaque", ".sha3", ".sig"];
+
+/// Returns `true` if `name` ends in any reserved suffix.
+///
+/// Matching is case-sensitive — operator-supplied names like
+/// `Foo.WHITEOUT` are NOT considered reserved (the operating system
+/// is case-sensitive throughout, and reserved markers are always
+/// emitted lowercase).
+pub fn is_reserved_name(name: &str) -> bool {
+    matched_reserved_suffix(name).is_some()
+}
+
+/// Returns the matched reserved suffix when one applies, else `None`.
+///
+/// Useful for emitting a clear error message naming the conflicting
+/// suffix (per the spec scenario "Reserved suffix on add").
+pub fn matched_reserved_suffix(name: &str) -> Option<&'static str> {
+    RESERVED_SUFFIXES
+        .iter()
+        .find(|&&suffix| name.ends_with(suffix))
+        .copied()
+}
+
+/// Reject `name` with [`OverlayError::ReservedSuffix`] if it ends in
+/// any reserved suffix. Used by `model_add` (Phase 3) and the merge
+/// layer's listing filter.
+pub fn reject_if_reserved(name: &str) -> Result<(), OverlayError> {
+    if let Some(suffix) = matched_reserved_suffix(name) {
+        Err(OverlayError::ReservedSuffix(suffix.to_string()))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reserved_suffix_list_is_complete() {
+        // Spec Q9 names exactly these four suffixes.
+        assert_eq!(RESERVED_SUFFIXES.len(), 4);
+        assert!(RESERVED_SUFFIXES.contains(&".whiteout"));
+        assert!(RESERVED_SUFFIXES.contains(&".opaque"));
+        assert!(RESERVED_SUFFIXES.contains(&".sha3"));
+        assert!(RESERVED_SUFFIXES.contains(&".sig"));
+    }
+
+    #[test]
+    fn is_reserved_name_matches_each_suffix() {
+        assert!(is_reserved_name("foo.whiteout"));
+        assert!(is_reserved_name("foo.opaque"));
+        assert!(is_reserved_name("foo.sha3"));
+        assert!(is_reserved_name("foo.sig"));
+        // The opaque-marker file itself is reserved.
+        assert!(is_reserved_name(".opaque"));
+    }
+
+    #[test]
+    fn is_reserved_name_rejects_non_reserved() {
+        assert!(!is_reserved_name("foo.onnx"));
+        assert!(!is_reserved_name("model.bin"));
+        assert!(!is_reserved_name("README"));
+        assert!(!is_reserved_name(""));
+    }
+
+    #[test]
+    fn is_reserved_name_is_case_sensitive() {
+        assert!(!is_reserved_name("foo.WHITEOUT"));
+        assert!(!is_reserved_name("foo.Sha3"));
+    }
+
+    #[test]
+    fn is_reserved_name_only_matches_real_suffix() {
+        // ".whiteout" inside the name (not at the end) is not a match.
+        assert!(!is_reserved_name("whiteout.foo"));
+        assert!(!is_reserved_name("foo.whiteout.tmp"));
+    }
+
+    #[test]
+    fn matched_reserved_suffix_returns_first_hit() {
+        assert_eq!(matched_reserved_suffix("foo.whiteout"), Some(".whiteout"));
+        assert_eq!(matched_reserved_suffix("foo.opaque"), Some(".opaque"));
+        assert_eq!(matched_reserved_suffix("foo.sha3"), Some(".sha3"));
+        assert_eq!(matched_reserved_suffix("foo.sig"), Some(".sig"));
+        assert_eq!(matched_reserved_suffix("foo.onnx"), None);
+    }
+
+    #[test]
+    fn reject_if_reserved_returns_error_with_suffix() {
+        let e = reject_if_reserved("foo.whiteout").unwrap_err();
+        if let OverlayError::ReservedSuffix(s) = e {
+            assert_eq!(s, ".whiteout");
+        } else {
+            panic!("expected ReservedSuffix error, got {:?}", e);
+        }
+    }
+
+    #[test]
+    fn reject_if_reserved_passes_normal_name() {
+        assert!(reject_if_reserved("model.onnx").is_ok());
+        assert!(reject_if_reserved("foo").is_ok());
+    }
+}

--- a/fs/src/overlay/upper_layer.rs
+++ b/fs/src/overlay/upper_layer.rs
@@ -1,0 +1,550 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `UpperLayer` trait — abstracts the read-write side of the overlay.
+//!
+//! Phase 1 ships:
+//!
+//! - [`UpperLayer`] trait (lookup / read / iter_dir).
+//! - [`UpperEntry`] / [`UpperEntryKind`] descriptors.
+//! - [`MockUpperLayer`] in-memory test fixture (used by Phase 1 tests
+//!   and any later phase wanting to exercise the merge in unit tests).
+//!
+//! `F2fsUpperLayer` is the production implementation that wires the
+//! trait to `embedded-filesystem-v1`'s F2FS RW path. Phase 2 of
+//! `embedded-overlay-v1` fills it in once F2FS RW lands.
+
+extern crate alloc;
+
+use alloc::collections::BTreeMap;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::fmt;
+
+/// Errors produced by the upper layer.
+///
+/// Mirrors the error vocabulary the future F2FS RW path will surface.
+/// Phase 1's [`MockUpperLayer`] returns a strict subset.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpperError {
+    /// Path does not exist in the upper layer.
+    NotFound,
+    /// Caller asked for a directory operation on a non-directory entry
+    /// (or vice versa).
+    NotADirectory,
+    /// Caller asked to read a file but the entry is not a regular file
+    /// (e.g. opaque marker, whiteout marker, or a directory).
+    NotARegularFile,
+    /// Read offset exceeds file size.
+    OutOfRange,
+    /// I/O error on the backing store (Phase 2 — F2FS error chain).
+    Io,
+}
+
+impl fmt::Display for UpperError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFound => write!(f, "upper: not found"),
+            Self::NotADirectory => write!(f, "upper: not a directory"),
+            Self::NotARegularFile => write!(f, "upper: not a regular file"),
+            Self::OutOfRange => write!(f, "upper: read out of range"),
+            Self::Io => write!(f, "upper: I/O error"),
+        }
+    }
+}
+
+/// Kind of an entry surfaced by the upper layer.
+///
+/// `Whiteout` and `Opaque` are reported by the upper layer rather than
+/// the raw filesystem — when the layer detects a `<name>.whiteout`
+/// regular file it surfaces a `Whiteout` entry under the bare name,
+/// and when a directory contains `.opaque` it surfaces `Opaque` for
+/// that directory.
+///
+/// The `MockUpperLayer` in this module follows the same convention so
+/// the merge code path is exercised identically in tests and at runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpperEntryKind {
+    /// Ordinary regular file.
+    RegularFile,
+    /// Ordinary directory.
+    Directory,
+    /// Whiteout marker (the upper has `<name>.whiteout`).
+    Whiteout,
+    /// Opaque-directory marker (the upper has `<dir>/.opaque`).
+    Opaque,
+}
+
+/// One entry surfaced by the upper layer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpperEntry {
+    /// File or directory name (final component, never a path).
+    pub name: String,
+    /// Kind of entry. See [`UpperEntryKind`].
+    pub kind: UpperEntryKind,
+    /// Size in bytes (0 for non-regular-file entries).
+    pub size: u64,
+    /// POSIX-style mode bits. Phase 1 doesn't enforce permissions; this
+    /// is plumbing for the Phase 5 integrity layer.
+    pub mode: u16,
+}
+
+/// Read-write upper-layer abstraction.
+///
+/// The merge layer ([`super::lookup`], [`super::merge`]) consumes only
+/// these methods. Any backing store (the test fixture, the production
+/// F2FS path) implements them and gets the merge logic for free.
+///
+/// All paths passed in are **slash-relative to the upper-layer root**,
+/// i.e. they do NOT start with `/` and do NOT include a `/data/models-upper/`
+/// prefix. The merge layer normalizes operator-facing paths before
+/// calling these methods.
+pub trait UpperLayer {
+    /// Resolve a path to an entry.
+    ///
+    /// Returns `Ok(Some(entry))` when present, `Ok(None)` when absent,
+    /// or `Err(...)` on I/O failure. **Whiteouts are surfaced as
+    /// `Some(UpperEntry { kind: Whiteout, .. })`** under the bare name
+    /// (i.e. `lookup("foo")` returns `Whiteout` if `foo.whiteout`
+    /// exists), so the merge layer doesn't need to do the suffix
+    /// dance itself.
+    fn lookup(&self, path: &str) -> Result<Option<UpperEntry>, UpperError>;
+
+    /// Read up to `buf.len()` bytes from `path` starting at `offset`.
+    ///
+    /// Returns the number of bytes actually read (≤ `buf.len()`). Reading
+    /// at exactly `file_size` returns `Ok(0)`. Reading past `file_size`
+    /// returns [`UpperError::OutOfRange`].
+    fn read_file(&self, path: &str, offset: u64, buf: &mut [u8]) -> Result<usize, UpperError>;
+
+    /// List entries in directory `path`.
+    ///
+    /// **Whiteout files are surfaced as `Whiteout` entries under the
+    /// bare name** (the `.whiteout` suffix is hidden by the layer
+    /// itself). Likewise an `.opaque` marker surfaces as a single
+    /// `Opaque` entry on the parent directory's listing. The merge
+    /// layer relies on this convention — see [`super::merge`].
+    fn iter_dir(&self, path: &str) -> Result<Vec<UpperEntry>, UpperError>;
+}
+
+// ─── MockUpperLayer ────────────────────────────────────────────────────────────
+
+/// Internal mock representation of one entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum MockEntry {
+    /// Regular file with raw content.
+    File(Vec<u8>),
+    /// Directory (entries enumerated by traversing the BTreeMap).
+    Directory,
+    /// Whiteout — internally stored as a regular file with the
+    /// `.whiteout` suffix. The Mock layer hides the suffix when
+    /// surfacing entries.
+    Whiteout(Vec<u8>),
+    /// Opaque marker — internally stored as a regular file named
+    /// `.opaque` inside a directory.
+    Opaque,
+}
+
+/// In-memory `UpperLayer` for unit tests.
+///
+/// Stores entries in a `BTreeMap<String, MockEntry>` keyed by full
+/// path (slash-relative to the upper root, no leading or trailing
+/// slashes). The test layer presents the SAME contract as the
+/// future F2FS-backed upper: whiteouts surface as `Whiteout` entries
+/// under the bare name, opaque markers surface as `Opaque` entries
+/// for the containing directory.
+///
+/// **Not** for production use; gated by `#[cfg(...)]` only via the
+/// surrounding cargo feature `fs-overlay-mounts`.
+#[derive(Debug, Default, Clone)]
+pub struct MockUpperLayer {
+    entries: BTreeMap<String, MockEntry>,
+}
+
+impl MockUpperLayer {
+    /// Construct an empty mock upper layer.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a regular file at the given upper-relative path with the
+    /// given content. Auto-creates parent directories.
+    pub fn add_file(&mut self, path: &str, content: &[u8]) {
+        self.ensure_parents(path);
+        self.entries
+            .insert(normalize(path), MockEntry::File(content.to_vec()));
+    }
+
+    /// Add an explicit directory entry. Most callers don't need this —
+    /// `add_file` auto-creates parents — but tests for empty
+    /// directories use it.
+    pub fn add_dir(&mut self, path: &str) {
+        self.ensure_parents(path);
+        let key = normalize(path);
+        self.entries.entry(key).or_insert(MockEntry::Directory);
+    }
+
+    /// Add a whiteout marker for `name` at the given parent.
+    ///
+    /// Internally creates a regular file at `parent/name.whiteout`.
+    /// Test code calls `add_whiteout("foo", "")` to put a whiteout
+    /// for `foo` at the upper-root, or `add_whiteout("custom/foo", "")`
+    /// to put a whiteout for `foo` inside `custom/`.
+    pub fn add_whiteout(&mut self, full_name: &str) {
+        self.ensure_parents(full_name);
+        let key = alloc::format!("{}.whiteout", normalize(full_name));
+        self.entries.insert(key, MockEntry::Whiteout(Vec::new()));
+    }
+
+    /// Add a non-empty whiteout marker (still hides the lower entry,
+    /// but stores arbitrary bytes per the spec scenario "Non-empty
+    /// whiteout still functional").
+    pub fn add_whiteout_with_content(&mut self, full_name: &str, content: &[u8]) {
+        self.ensure_parents(full_name);
+        let key = alloc::format!("{}.whiteout", normalize(full_name));
+        self.entries
+            .insert(key, MockEntry::Whiteout(content.to_vec()));
+    }
+
+    /// Add an opaque-directory marker on `dir`. Internally creates the
+    /// directory (if absent) and a regular file `<dir>/.opaque`.
+    pub fn add_opaque(&mut self, dir: &str) {
+        self.add_dir(dir);
+        let dir_key = normalize(dir);
+        let key = if dir_key.is_empty() {
+            ".opaque".into()
+        } else {
+            alloc::format!("{}/.opaque", dir_key)
+        };
+        self.entries.insert(key, MockEntry::Opaque);
+    }
+
+    fn ensure_parents(&mut self, path: &str) {
+        let n = normalize(path);
+        let mut walked = String::new();
+        for component in n.split('/').filter(|s| !s.is_empty()) {
+            // Don't auto-promote the leaf into a directory; only
+            // create entries for each non-leaf segment.
+            if !walked.is_empty() {
+                walked.push('/');
+            }
+            let candidate = alloc::format!("{}{}", walked, component);
+            // Skip the leaf — that's the entry being created.
+            if candidate == n {
+                break;
+            }
+            self.entries
+                .entry(candidate.clone())
+                .or_insert(MockEntry::Directory);
+            walked = candidate;
+        }
+    }
+}
+
+fn normalize(p: &str) -> String {
+    p.trim_start_matches('/').trim_end_matches('/').into()
+}
+
+impl UpperLayer for MockUpperLayer {
+    fn lookup(&self, path: &str) -> Result<Option<UpperEntry>, UpperError> {
+        let key = normalize(path);
+
+        // Empty key = upper root directory.
+        if key.is_empty() {
+            return Ok(Some(UpperEntry {
+                name: String::new(),
+                kind: UpperEntryKind::Directory,
+                size: 0,
+                mode: 0o755,
+            }));
+        }
+
+        let bare_name = key.rsplit('/').next().unwrap_or("").to_string();
+
+        // Case 1 — caller asks for `foo`: check `foo.whiteout` first,
+        // then `foo` itself.
+        let whiteout_key = alloc::format!("{}.whiteout", key);
+        if matches!(
+            self.entries.get(&whiteout_key),
+            Some(MockEntry::Whiteout(_))
+        ) {
+            return Ok(Some(UpperEntry {
+                name: bare_name.clone(),
+                kind: UpperEntryKind::Whiteout,
+                size: 0,
+                mode: 0o644,
+            }));
+        }
+
+        match self.entries.get(&key) {
+            Some(MockEntry::File(bytes)) => Ok(Some(UpperEntry {
+                name: bare_name,
+                kind: UpperEntryKind::RegularFile,
+                size: bytes.len() as u64,
+                mode: 0o644,
+            })),
+            Some(MockEntry::Directory) => {
+                // Surface `Opaque` if `<dir>/.opaque` exists.
+                let opaque_key = alloc::format!("{}/.opaque", key);
+                if self.entries.contains_key(&opaque_key) {
+                    Ok(Some(UpperEntry {
+                        name: bare_name,
+                        kind: UpperEntryKind::Opaque,
+                        size: 0,
+                        mode: 0o755,
+                    }))
+                } else {
+                    Ok(Some(UpperEntry {
+                        name: bare_name,
+                        kind: UpperEntryKind::Directory,
+                        size: 0,
+                        mode: 0o755,
+                    }))
+                }
+            }
+            Some(MockEntry::Whiteout(_)) => {
+                // The caller asked for the *literal* whiteout-suffixed
+                // name. Not exposed at the lookup layer.
+                Ok(None)
+            }
+            Some(MockEntry::Opaque) => {
+                // The caller asked for the literal `.opaque` filename.
+                // Not exposed.
+                Ok(None)
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn read_file(&self, path: &str, offset: u64, buf: &mut [u8]) -> Result<usize, UpperError> {
+        let key = normalize(path);
+        match self.entries.get(&key) {
+            Some(MockEntry::File(bytes)) => {
+                let len = bytes.len() as u64;
+                if offset > len {
+                    return Err(UpperError::OutOfRange);
+                }
+                let start = offset as usize;
+                let available = bytes.len() - start;
+                let n = core::cmp::min(buf.len(), available);
+                buf[..n].copy_from_slice(&bytes[start..start + n]);
+                Ok(n)
+            }
+            Some(MockEntry::Directory) | Some(MockEntry::Opaque) => {
+                Err(UpperError::NotARegularFile)
+            }
+            Some(MockEntry::Whiteout(_)) => Err(UpperError::NotARegularFile),
+            None => Err(UpperError::NotFound),
+        }
+    }
+
+    fn iter_dir(&self, path: &str) -> Result<Vec<UpperEntry>, UpperError> {
+        let key = normalize(path);
+
+        // The upper-root listing scans for direct children in the map.
+        // For non-root, verify the path resolves to a directory first.
+        if !key.is_empty() {
+            match self.entries.get(&key) {
+                Some(MockEntry::Directory) => {}
+                Some(_) => return Err(UpperError::NotADirectory),
+                None => return Err(UpperError::NotFound),
+            }
+        }
+
+        let prefix = if key.is_empty() {
+            String::new()
+        } else {
+            alloc::format!("{}/", key)
+        };
+
+        let mut out = Vec::new();
+        for (k, v) in &self.entries {
+            // Direct child only — `prefix` <= k <= no further `/`.
+            if !k.starts_with(&prefix) {
+                continue;
+            }
+            let suffix = &k[prefix.len()..];
+            if suffix.is_empty() || suffix.contains('/') {
+                continue;
+            }
+
+            // Hide the `.opaque` marker file from listings; the
+            // upper layer surfaces opaqueness via `Opaque` on the
+            // PARENT directory entry, not as a separate listing.
+            if suffix == ".opaque" {
+                continue;
+            }
+
+            // Whiteout file: surface under the bare name with kind
+            // Whiteout (suffix stripped).
+            if let Some(stripped) = suffix.strip_suffix(".whiteout") {
+                if let MockEntry::Whiteout(_) = v {
+                    out.push(UpperEntry {
+                        name: stripped.into(),
+                        kind: UpperEntryKind::Whiteout,
+                        size: 0,
+                        mode: 0o644,
+                    });
+                    continue;
+                }
+            }
+
+            match v {
+                MockEntry::File(bytes) => out.push(UpperEntry {
+                    name: suffix.into(),
+                    kind: UpperEntryKind::RegularFile,
+                    size: bytes.len() as u64,
+                    mode: 0o644,
+                }),
+                MockEntry::Directory => {
+                    let opaque_key = alloc::format!("{}/.opaque", k);
+                    let kind = if self.entries.contains_key(&opaque_key) {
+                        UpperEntryKind::Opaque
+                    } else {
+                        UpperEntryKind::Directory
+                    };
+                    out.push(UpperEntry {
+                        name: suffix.into(),
+                        kind,
+                        size: 0,
+                        mode: 0o755,
+                    });
+                }
+                // Whiteout files that for any reason didn't strip
+                // (e.g. the suffix didn't match): suppress.
+                MockEntry::Whiteout(_) => {}
+                MockEntry::Opaque => {}
+            }
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mock_upper_lookup_file() {
+        let mut u = MockUpperLayer::new();
+        u.add_file("foo.onnx", b"hello");
+        let e = u.lookup("foo.onnx").unwrap().unwrap();
+        assert_eq!(e.name, "foo.onnx");
+        assert_eq!(e.kind, UpperEntryKind::RegularFile);
+        assert_eq!(e.size, 5);
+    }
+
+    #[test]
+    fn mock_upper_lookup_absent() {
+        let u = MockUpperLayer::new();
+        assert_eq!(u.lookup("foo").unwrap(), None);
+    }
+
+    #[test]
+    fn mock_upper_lookup_whiteout_surfaces_under_bare_name() {
+        let mut u = MockUpperLayer::new();
+        u.add_whiteout("foo");
+        let e = u.lookup("foo").unwrap().unwrap();
+        assert_eq!(e.kind, UpperEntryKind::Whiteout);
+        assert_eq!(e.name, "foo");
+    }
+
+    #[test]
+    fn mock_upper_lookup_nonempty_whiteout_still_surfaces() {
+        let mut u = MockUpperLayer::new();
+        u.add_whiteout_with_content("foo", b"# comment");
+        let e = u.lookup("foo").unwrap().unwrap();
+        assert_eq!(e.kind, UpperEntryKind::Whiteout);
+    }
+
+    #[test]
+    fn mock_upper_lookup_opaque_dir_surfaces_as_opaque() {
+        let mut u = MockUpperLayer::new();
+        u.add_opaque("custom");
+        let e = u.lookup("custom").unwrap().unwrap();
+        assert_eq!(e.kind, UpperEntryKind::Opaque);
+    }
+
+    #[test]
+    fn mock_upper_read_file_bytes() {
+        let mut u = MockUpperLayer::new();
+        u.add_file("foo", b"abcdef");
+        let mut buf = [0u8; 4];
+        let n = u.read_file("foo", 0, &mut buf).unwrap();
+        assert_eq!(n, 4);
+        assert_eq!(&buf, b"abcd");
+        let mut buf2 = [0u8; 8];
+        let n = u.read_file("foo", 2, &mut buf2).unwrap();
+        assert_eq!(n, 4);
+        assert_eq!(&buf2[..4], b"cdef");
+    }
+
+    #[test]
+    fn mock_upper_read_file_at_eof_returns_zero() {
+        let mut u = MockUpperLayer::new();
+        u.add_file("foo", b"abc");
+        let mut buf = [0u8; 4];
+        let n = u.read_file("foo", 3, &mut buf).unwrap();
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn mock_upper_read_past_eof_errors() {
+        let mut u = MockUpperLayer::new();
+        u.add_file("foo", b"abc");
+        let mut buf = [0u8; 4];
+        assert_eq!(
+            u.read_file("foo", 100, &mut buf),
+            Err(UpperError::OutOfRange)
+        );
+    }
+
+    #[test]
+    fn mock_upper_iter_dir_root() {
+        let mut u = MockUpperLayer::new();
+        u.add_file("a", b"a");
+        u.add_file("b", b"b");
+        u.add_file("nested/c", b"c");
+        let entries = u.iter_dir("/").unwrap();
+        let names: alloc::vec::Vec<_> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"a"));
+        assert!(names.contains(&"b"));
+        assert!(names.contains(&"nested"));
+        // `nested/c` is NOT a direct child.
+        assert!(!names.contains(&"c"));
+    }
+
+    #[test]
+    fn mock_upper_iter_dir_hides_dot_opaque() {
+        let mut u = MockUpperLayer::new();
+        u.add_opaque("custom");
+        u.add_file("custom/foo", b"x");
+        let entries = u.iter_dir("custom").unwrap();
+        let names: alloc::vec::Vec<_> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"foo"));
+        assert!(!names.contains(&".opaque"));
+    }
+
+    #[test]
+    fn mock_upper_iter_dir_surfaces_whiteout_under_bare_name() {
+        let mut u = MockUpperLayer::new();
+        u.add_whiteout("foo");
+        let entries = u.iter_dir("/").unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "foo");
+        assert_eq!(entries[0].kind, UpperEntryKind::Whiteout);
+    }
+
+    #[test]
+    fn mock_upper_iter_dir_not_found() {
+        let u = MockUpperLayer::new();
+        assert_eq!(u.iter_dir("missing"), Err(UpperError::NotFound));
+    }
+
+    #[test]
+    fn mock_upper_iter_dir_not_a_directory() {
+        let mut u = MockUpperLayer::new();
+        u.add_file("foo", b"x");
+        assert_eq!(u.iter_dir("foo"), Err(UpperError::NotADirectory));
+    }
+}

--- a/fs/src/overlay/whiteout.rs
+++ b/fs/src/overlay/whiteout.rs
@@ -1,0 +1,123 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Whiteout-marker detection.
+//!
+//! A whiteout is a regular file named `<name>.whiteout` placed at the
+//! parent path in the upper layer. Its mere presence hides the lower
+//! layer's `<name>` entry; the file's contents (zero bytes or
+//! arbitrary comment text) are never inspected.
+//!
+//! Per `embedded-overlay-v1` spec scenario "Empty whiteout file enough
+//! to hide" + "Non-empty whiteout still functional".
+
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use super::upper_layer::{UpperEntryKind, UpperError, UpperLayer};
+
+/// The reserved suffix for whiteout markers.
+pub const WHITEOUT_SUFFIX: &str = ".whiteout";
+
+/// Returns `true` if the upper layer has an active whiteout for
+/// `name` at `parent`.
+///
+/// The check is "does `parent/name` resolve to an `Whiteout` entry on
+/// the upper layer?". The `MockUpperLayer` (and the future F2FS
+/// upper) surface whiteouts under the bare name with kind
+/// [`UpperEntryKind::Whiteout`], so the merge layer doesn't need to
+/// dance with the suffix itself.
+pub fn is_whiteout<U: UpperLayer>(upper: &U, parent: &str, name: &str) -> bool {
+    let path = if parent.is_empty() {
+        alloc::string::ToString::to_string(name)
+    } else {
+        alloc::format!("{}/{}", parent.trim_end_matches('/'), name)
+    };
+    matches!(
+        upper.lookup(&path),
+        Ok(Some(e)) if e.kind == UpperEntryKind::Whiteout
+    )
+}
+
+/// List all active whiteouts in `parent` (the bare names of entries
+/// that the upper hides via a `<name>.whiteout` marker).
+///
+/// Returns an empty Vec if `parent` doesn't exist on the upper.
+pub fn list_whiteouts_in<U: UpperLayer>(upper: &U, parent: &str) -> Vec<String> {
+    match upper.iter_dir(parent) {
+        Ok(entries) => entries
+            .into_iter()
+            .filter(|e| e.kind == UpperEntryKind::Whiteout)
+            .map(|e| e.name)
+            .collect(),
+        Err(UpperError::NotFound) | Err(UpperError::NotADirectory) => Vec::new(),
+        Err(_) => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::upper_layer::MockUpperLayer;
+    use super::*;
+
+    #[test]
+    fn whiteout_suffix_value() {
+        assert_eq!(WHITEOUT_SUFFIX, ".whiteout");
+    }
+
+    #[test]
+    fn is_whiteout_detects_marker() {
+        let mut u = MockUpperLayer::new();
+        u.add_whiteout("foo");
+        assert!(is_whiteout(&u, "", "foo"));
+    }
+
+    #[test]
+    fn is_whiteout_false_when_absent() {
+        let u = MockUpperLayer::new();
+        assert!(!is_whiteout(&u, "", "foo"));
+    }
+
+    #[test]
+    fn is_whiteout_false_for_regular_file_with_same_name() {
+        let mut u = MockUpperLayer::new();
+        u.add_file("foo", b"bar");
+        assert!(!is_whiteout(&u, "", "foo"));
+    }
+
+    #[test]
+    fn is_whiteout_works_for_nested_path() {
+        let mut u = MockUpperLayer::new();
+        u.add_whiteout("custom/foo");
+        assert!(is_whiteout(&u, "custom", "foo"));
+        assert!(!is_whiteout(&u, "", "foo"));
+    }
+
+    #[test]
+    fn is_whiteout_nonempty_marker_still_hides() {
+        let mut u = MockUpperLayer::new();
+        u.add_whiteout_with_content("foo", b"# operator note");
+        assert!(is_whiteout(&u, "", "foo"));
+    }
+
+    #[test]
+    fn list_whiteouts_in_root() {
+        use alloc::string::ToString;
+        let mut u = MockUpperLayer::new();
+        u.add_whiteout("a");
+        u.add_whiteout("b");
+        u.add_file("c", b"x");
+        let mut wh = list_whiteouts_in(&u, "/");
+        wh.sort();
+        assert_eq!(wh, alloc::vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn list_whiteouts_in_nonexistent_dir_is_empty() {
+        let u = MockUpperLayer::new();
+        let wh = list_whiteouts_in(&u, "/missing");
+        assert!(wh.is_empty());
+    }
+}

--- a/fs/tests/overlay_phase1_conformance.rs
+++ b/fs/tests/overlay_phase1_conformance.rs
@@ -1,0 +1,773 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration conformance tests for `embedded-overlay-v1` Phase 1.
+//!
+//! These tests assert the **read-only merge logic** end-to-end against
+//! synthetic in-memory `MockUpperLayer` + `MockLowerLayer` fixtures.
+//! Every requirement-level scenario from
+//! `openspec/changes/embedded-overlay-v1/specs/fs-overlay-mount/spec.md`
+//! has at least one direct test here; the broader test suite covers
+//! corner cases and reserved-suffix filtering.
+//!
+//! Phase 1 does NOT exercise:
+//!
+//! - F2FS RW backing store (Phase 2 of the change).
+//! - The `model_add` / `model_remove` syscalls (Phase 3).
+//! - SHA-3-256 fingerprint sidecar verification (Phase 5).
+//! - Capacity-cap enforcement or audit emission (Phase 6).
+
+#![cfg(feature = "fs-overlay-mounts")]
+
+extern crate alloc;
+use alloc::string::ToString;
+
+use smallaios_fs::overlay::{
+    is_opaque_dir, is_reserved_name, is_whiteout, list_whiteouts_in, lookup, merge_readdir,
+    reject_if_reserved, LookupResult, LowerEntry, LowerLayer, MergedEntryKind, MockLowerLayer,
+    MockUpperLayer, OverlayError, UpperEntryKind, UpperLayer, RESERVED_SUFFIXES,
+};
+
+// ─── Spec scenario tests ───────────────────────────────────────────────────────
+
+/// `fs-overlay-mount` Requirement: Upper-wins lookup precedence
+/// Scenario: Upper file shadows lower file
+#[test]
+fn spec_upper_file_shadows_lower_file() {
+    let mut u = MockUpperLayer::new();
+    u.add_file("llama-3.onnx", b"upper-content");
+    let mut l = MockLowerLayer::new();
+    l.add_file("llama-3.onnx", b"lower-content");
+
+    let result = lookup(&u, &l, "llama-3.onnx").unwrap();
+    match result {
+        LookupResult::Upper(e) => {
+            assert_eq!(e.name, "llama-3.onnx");
+            assert_eq!(e.size, 13);
+            // And reading bytes returns the upper content.
+            let mut buf = [0u8; 13];
+            let n = u.read_file("llama-3.onnx", 0, &mut buf).unwrap();
+            assert_eq!(&buf[..n], b"upper-content");
+        }
+        other => panic!("expected Upper, got {:?}", other),
+    }
+}
+
+/// Scenario: Lower visible when upper absent
+#[test]
+fn spec_lower_visible_when_upper_absent() {
+    let u = MockUpperLayer::new();
+    let mut l = MockLowerLayer::new();
+    l.add_file("whisper.onnx", b"lower-bytes");
+
+    let result = lookup(&u, &l, "whisper.onnx").unwrap();
+    match result {
+        LookupResult::Lower(e) => {
+            assert_eq!(e.name, "whisper.onnx");
+            let mut buf = [0u8; 11];
+            let n = l.read_file("whisper.onnx", 0, &mut buf).unwrap();
+            assert_eq!(&buf[..n], b"lower-bytes");
+        }
+        other => panic!("expected Lower, got {:?}", other),
+    }
+}
+
+/// Scenario: Whiteout hides lower
+#[test]
+fn spec_whiteout_hides_lower_returns_whiteoutresult() {
+    let mut u = MockUpperLayer::new();
+    u.add_whiteout("llama-3.onnx");
+    let mut l = MockLowerLayer::new();
+    l.add_file("llama-3.onnx", b"lower-content");
+
+    assert_eq!(
+        lookup(&u, &l, "llama-3.onnx").unwrap(),
+        LookupResult::WhiteoutHidesLower
+    );
+}
+
+/// Scenario: Whiteout hides lower — readdir does NOT list the name
+#[test]
+fn spec_whiteout_filters_lower_from_readdir() {
+    let mut u = MockUpperLayer::new();
+    u.add_whiteout("llama-3.onnx");
+    let mut l = MockLowerLayer::new();
+    l.add_file("llama-3.onnx", b"lower");
+    l.add_file("whisper.onnx", b"keep-me");
+
+    let entries = merge_readdir(&u, &l, "/").unwrap();
+    let names: alloc::vec::Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    assert!(!names.contains(&"llama-3.onnx"));
+    assert!(names.contains(&"whisper.onnx"));
+}
+
+/// Scenario: Opaque dir hides whole subtree
+#[test]
+fn spec_opaque_dir_hides_whole_subtree() {
+    let mut u = MockUpperLayer::new();
+    u.add_opaque("custom");
+    u.add_file("custom/upper.onnx", b"u");
+    let mut l = MockLowerLayer::new();
+    l.add_file("custom/lower-a.onnx", b"l");
+    l.add_file("custom/lower-b.onnx", b"l");
+
+    let entries = merge_readdir(&u, &l, "custom").unwrap();
+    let names: alloc::vec::Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    // Only the upper-side entry under custom/ is visible.
+    assert_eq!(names, alloc::vec!["upper.onnx"]);
+    assert!(!names.contains(&"lower-a.onnx"));
+    assert!(!names.contains(&"lower-b.onnx"));
+}
+
+/// Scenario: Empty whiteout file enough to hide
+#[test]
+fn spec_empty_whiteout_hides() {
+    let mut u = MockUpperLayer::new();
+    // Default add_whiteout creates an empty marker.
+    u.add_whiteout("foo.onnx");
+    let mut l = MockLowerLayer::new();
+    l.add_file("foo.onnx", b"lower");
+
+    assert!(is_whiteout(&u, "", "foo.onnx"));
+    match lookup(&u, &l, "foo.onnx").unwrap() {
+        LookupResult::WhiteoutHidesLower => {}
+        other => panic!("expected WhiteoutHidesLower, got {:?}", other),
+    }
+}
+
+/// Scenario: Non-empty whiteout still functional
+#[test]
+fn spec_nonempty_whiteout_still_hides() {
+    let mut u = MockUpperLayer::new();
+    u.add_whiteout_with_content("foo.onnx", b"# Operator: removed by Bob 2026-04-01");
+    let mut l = MockLowerLayer::new();
+    l.add_file("foo.onnx", b"lower");
+
+    assert!(is_whiteout(&u, "", "foo.onnx"));
+    match lookup(&u, &l, "foo.onnx").unwrap() {
+        LookupResult::WhiteoutHidesLower => {}
+        other => panic!("expected WhiteoutHidesLower, got {:?}", other),
+    }
+}
+
+/// Scenario: Reserved suffix on add (the merge layer's reject_if_reserved
+/// is the building block; the syscall path lands in Phase 3).
+#[test]
+fn spec_reserved_suffix_on_add_rejected() {
+    for suffix in RESERVED_SUFFIXES {
+        let candidate = alloc::format!("foo{}", suffix);
+        let result = reject_if_reserved(&candidate);
+        match result {
+            Err(OverlayError::ReservedSuffix(s)) => {
+                assert_eq!(&s, suffix, "suffix mismatch for {}", suffix);
+            }
+            other => panic!("expected ReservedSuffix({}), got {:?}", suffix, other),
+        }
+    }
+}
+
+// ─── Comprehensive merge behaviour ─────────────────────────────────────────────
+
+#[test]
+fn merge_root_union_upper_wins() {
+    let mut u = MockUpperLayer::new();
+    u.add_file("a", b"upper-a");
+    u.add_file("shared", b"upper-shared");
+    let mut l = MockLowerLayer::new();
+    l.add_file("b", b"lower-b");
+    l.add_file("shared", b"lower-shared");
+
+    let entries = merge_readdir(&u, &l, "/").unwrap();
+    let names: alloc::vec::Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    assert_eq!(names, alloc::vec!["a", "b", "shared"]);
+
+    let shared = entries.iter().find(|e| e.name == "shared").unwrap();
+    assert!(shared.from_upper, "upper-wins on merged readdir");
+    assert_eq!(shared.size, 12); // upper-shared = 12 bytes
+}
+
+#[test]
+fn merge_no_duplicate_names() {
+    let mut u = MockUpperLayer::new();
+    u.add_file("dup", b"u");
+    let mut l = MockLowerLayer::new();
+    l.add_file("dup", b"l");
+    let entries = merge_readdir(&u, &l, "/").unwrap();
+    let count = entries.iter().filter(|e| e.name == "dup").count();
+    assert_eq!(count, 1);
+}
+
+#[test]
+fn merge_yields_directories_correctly() {
+    let mut u = MockUpperLayer::new();
+    u.add_dir("upper-dir");
+    let mut l = MockLowerLayer::new();
+    l.add_dir("lower-dir");
+    let entries = merge_readdir(&u, &l, "/").unwrap();
+    for e in &entries {
+        if e.name.ends_with("-dir") {
+            assert_eq!(e.kind, MergedEntryKind::Directory);
+        }
+    }
+}
+
+#[test]
+fn merge_reserved_suffix_files_filtered_from_listing() {
+    // Defense-in-depth: even if a `<name>.whiteout` somehow got into
+    // the lower layer (shouldn't happen — squashfs is operator-built —
+    // but any squashfs the kernel ever sees), the merge layer hides it.
+    let u = MockUpperLayer::new();
+    let mut l = MockLowerLayer::new();
+    l.add_file("good.onnx", b"x");
+    for suffix in RESERVED_SUFFIXES {
+        let name = alloc::format!("evil{}", suffix);
+        l.add_file(&name, b"x");
+    }
+    let entries = merge_readdir(&u, &l, "/").unwrap();
+    let names: alloc::vec::Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    assert_eq!(names, alloc::vec!["good.onnx"]);
+}
+
+#[test]
+fn merge_marks_provenance() {
+    let mut u = MockUpperLayer::new();
+    u.add_file("only-upper", b"u");
+    u.add_file("shared", b"u");
+    let mut l = MockLowerLayer::new();
+    l.add_file("only-lower", b"l");
+    l.add_file("shared", b"l");
+
+    let entries = merge_readdir(&u, &l, "/").unwrap();
+    for e in &entries {
+        match e.name.as_str() {
+            "only-upper" | "shared" => assert!(e.from_upper),
+            "only-lower" => assert!(!e.from_upper),
+            _ => panic!("unexpected entry {}", e.name),
+        }
+    }
+}
+
+#[test]
+fn merge_handles_deep_nested_paths() {
+    let u = MockUpperLayer::new();
+    let mut l = MockLowerLayer::new();
+    l.add_file("a/b/c/d/e/f/leaf", b"deep");
+    let entries = merge_readdir(&u, &l, "a/b/c/d/e/f").unwrap();
+    let names: alloc::vec::Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    assert_eq!(names, alloc::vec!["leaf"]);
+}
+
+#[test]
+fn merge_dir_only_in_upper() {
+    let mut u = MockUpperLayer::new();
+    u.add_file("upper-only/file", b"u");
+    let l = MockLowerLayer::new();
+    let entries = merge_readdir(&u, &l, "upper-only").unwrap();
+    let names: alloc::vec::Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    assert_eq!(names, alloc::vec!["file"]);
+}
+
+#[test]
+fn merge_dir_only_in_lower() {
+    let u = MockUpperLayer::new();
+    let mut l = MockLowerLayer::new();
+    l.add_file("lower-only/file", b"l");
+    let entries = merge_readdir(&u, &l, "lower-only").unwrap();
+    let names: alloc::vec::Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    assert_eq!(names, alloc::vec!["file"]);
+}
+
+#[test]
+fn merge_completely_empty_returns_empty_vec() {
+    let u = MockUpperLayer::new();
+    let l = MockLowerLayer::new();
+    let entries = merge_readdir(&u, &l, "/").unwrap();
+    assert!(entries.is_empty());
+}
+
+#[test]
+fn merge_skipping_lower_when_upper_dir_is_opaque() {
+    let mut u = MockUpperLayer::new();
+    u.add_opaque("models");
+    u.add_file("models/foo", b"u");
+    let mut l = MockLowerLayer::new();
+    l.add_file("models/bar", b"l");
+    let entries = merge_readdir(&u, &l, "models").unwrap();
+    let names: alloc::vec::Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    assert_eq!(names, alloc::vec!["foo"]);
+    assert!(!names.contains(&"bar"));
+}
+
+#[test]
+fn merge_multiple_whiteouts_in_one_dir() {
+    let mut u = MockUpperLayer::new();
+    u.add_whiteout("a");
+    u.add_whiteout("b");
+    u.add_whiteout("c");
+    u.add_file("d", b"upper-d");
+    let mut l = MockLowerLayer::new();
+    l.add_file("a", b"l");
+    l.add_file("b", b"l");
+    l.add_file("c", b"l");
+    l.add_file("e", b"l");
+
+    let entries = merge_readdir(&u, &l, "/").unwrap();
+    let names: alloc::vec::Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    assert_eq!(names, alloc::vec!["d", "e"]);
+}
+
+// ─── Lookup precedence corner cases ────────────────────────────────────────────
+
+#[test]
+fn lookup_neither_layer_has_path() {
+    let u = MockUpperLayer::new();
+    let l = MockLowerLayer::new();
+    assert_eq!(lookup(&u, &l, "missing").unwrap(), LookupResult::NotFound);
+}
+
+#[test]
+fn lookup_root_returns_upper_root() {
+    // Looking up the empty path yields the upper-root directory.
+    let u = MockUpperLayer::new();
+    let l = MockLowerLayer::new();
+    match lookup(&u, &l, "").unwrap() {
+        LookupResult::Upper(e) => assert_eq!(e.kind, UpperEntryKind::Directory),
+        other => panic!("expected Upper(Directory), got {:?}", other),
+    }
+}
+
+#[test]
+fn lookup_upper_directory_wins_over_lower_file() {
+    let mut u = MockUpperLayer::new();
+    u.add_dir("collision");
+    let mut l = MockLowerLayer::new();
+    l.add_file("collision", b"lower");
+    match lookup(&u, &l, "collision").unwrap() {
+        LookupResult::Upper(e) => assert_eq!(e.kind, UpperEntryKind::Directory),
+        other => panic!("expected Upper(Directory), got {:?}", other),
+    }
+}
+
+#[test]
+fn lookup_upper_file_wins_over_lower_directory() {
+    let mut u = MockUpperLayer::new();
+    u.add_file("collision", b"upper");
+    let mut l = MockLowerLayer::new();
+    l.add_dir("collision");
+    match lookup(&u, &l, "collision").unwrap() {
+        LookupResult::Upper(e) => assert_eq!(e.kind, UpperEntryKind::RegularFile),
+        other => panic!("expected Upper(RegularFile), got {:?}", other),
+    }
+}
+
+#[test]
+fn lookup_inside_opaque_dir_with_no_upper_entry_returns_opaque() {
+    let mut u = MockUpperLayer::new();
+    u.add_opaque("custom");
+    let mut l = MockLowerLayer::new();
+    l.add_file("custom/leaf", b"lower");
+    assert_eq!(
+        lookup(&u, &l, "custom/leaf").unwrap(),
+        LookupResult::OpaqueHidesLowerSubtree
+    );
+}
+
+#[test]
+fn lookup_inside_opaque_dir_with_upper_entry_returns_upper() {
+    let mut u = MockUpperLayer::new();
+    u.add_opaque("custom");
+    u.add_file("custom/leaf", b"upper");
+    let mut l = MockLowerLayer::new();
+    l.add_file("custom/leaf", b"lower");
+    match lookup(&u, &l, "custom/leaf").unwrap() {
+        LookupResult::Upper(e) => assert_eq!(e.size, 5),
+        other => panic!("expected Upper, got {:?}", other),
+    }
+}
+
+#[test]
+fn lookup_outside_opaque_dir_unaffected() {
+    let mut u = MockUpperLayer::new();
+    u.add_opaque("custom");
+    let mut l = MockLowerLayer::new();
+    l.add_file("other.onnx", b"lower");
+    match lookup(&u, &l, "other.onnx").unwrap() {
+        LookupResult::Lower(_) => {}
+        other => panic!("expected Lower, got {:?}", other),
+    }
+}
+
+#[test]
+fn lookup_whiteout_only_in_specific_dir() {
+    let mut u = MockUpperLayer::new();
+    u.add_whiteout("a/foo");
+    let mut l = MockLowerLayer::new();
+    l.add_file("a/foo", b"lower");
+    l.add_file("b/foo", b"lower");
+    // a/foo whiteout-hidden.
+    assert_eq!(
+        lookup(&u, &l, "a/foo").unwrap(),
+        LookupResult::WhiteoutHidesLower
+    );
+    // b/foo not affected by the whiteout in a/.
+    match lookup(&u, &l, "b/foo").unwrap() {
+        LookupResult::Lower(_) => {}
+        other => panic!("expected Lower for b/foo, got {:?}", other),
+    }
+}
+
+#[test]
+fn lookup_path_under_models_routes_through_merge_layer() {
+    // Phase 1's merge layer doesn't itself enforce a `/models/`
+    // prefix — the kernel VFS hands paths that have already been
+    // stripped of the prefix. This test pins that contract: the
+    // merge layer treats paths slash-relative to the merge root.
+    let mut u = MockUpperLayer::new();
+    u.add_file("foo", b"u");
+    let l = MockLowerLayer::new();
+    match lookup(&u, &l, "foo").unwrap() {
+        LookupResult::Upper(_) => {}
+        _ => panic!("path under merge root resolved to Upper"),
+    }
+}
+
+#[test]
+fn lookup_path_outside_merge_returns_notfound_in_layered_world() {
+    // When the upper has nothing for a path and the lower has nothing
+    // for that path, the layered world says NotFound — the kernel's
+    // VFS surfaces -ENOENT.
+    let u = MockUpperLayer::new();
+    let l = MockLowerLayer::new();
+    assert_eq!(
+        lookup(&u, &l, "definitely/not/here").unwrap(),
+        LookupResult::NotFound
+    );
+}
+
+// ─── Whiteout helpers ──────────────────────────────────────────────────────────
+
+#[test]
+fn is_whiteout_at_root() {
+    let mut u = MockUpperLayer::new();
+    u.add_whiteout("foo");
+    assert!(is_whiteout(&u, "", "foo"));
+}
+
+#[test]
+fn is_whiteout_in_nested_dir() {
+    let mut u = MockUpperLayer::new();
+    u.add_whiteout("a/b/c");
+    assert!(is_whiteout(&u, "a/b", "c"));
+    assert!(!is_whiteout(&u, "a", "c"));
+}
+
+#[test]
+fn is_whiteout_returns_false_for_real_file() {
+    let mut u = MockUpperLayer::new();
+    u.add_file("foo", b"x");
+    assert!(!is_whiteout(&u, "", "foo"));
+}
+
+#[test]
+fn list_whiteouts_in_empty_layer() {
+    let u = MockUpperLayer::new();
+    let wh = list_whiteouts_in(&u, "/");
+    assert!(wh.is_empty());
+}
+
+#[test]
+fn list_whiteouts_in_dir_with_files_and_whiteouts() {
+    let mut u = MockUpperLayer::new();
+    u.add_whiteout("hidden-1");
+    u.add_whiteout("hidden-2");
+    u.add_file("real-file", b"x");
+    let mut wh = list_whiteouts_in(&u, "/");
+    wh.sort();
+    assert_eq!(wh.len(), 2);
+    assert!(wh.contains(&"hidden-1".to_string()));
+    assert!(wh.contains(&"hidden-2".to_string()));
+}
+
+// ─── Opaque-dir helpers ────────────────────────────────────────────────────────
+
+#[test]
+fn is_opaque_dir_at_subdir() {
+    let mut u = MockUpperLayer::new();
+    u.add_opaque("custom");
+    assert!(is_opaque_dir(&u, "custom"));
+}
+
+#[test]
+fn is_opaque_dir_returns_false_for_normal_dir() {
+    let mut u = MockUpperLayer::new();
+    u.add_dir("custom");
+    assert!(!is_opaque_dir(&u, "custom"));
+}
+
+#[test]
+fn is_opaque_dir_returns_false_for_file() {
+    let mut u = MockUpperLayer::new();
+    u.add_file("custom", b"data");
+    assert!(!is_opaque_dir(&u, "custom"));
+}
+
+// ─── Reserved-suffix conformance ───────────────────────────────────────────────
+
+#[test]
+fn reserved_suffix_constant_matches_spec() {
+    // Spec Q9: exactly four suffixes.
+    assert_eq!(RESERVED_SUFFIXES.len(), 4);
+    assert!(RESERVED_SUFFIXES.contains(&".whiteout"));
+    assert!(RESERVED_SUFFIXES.contains(&".opaque"));
+    assert!(RESERVED_SUFFIXES.contains(&".sha3"));
+    assert!(RESERVED_SUFFIXES.contains(&".sig"));
+}
+
+#[test]
+fn reserved_suffix_rejection_for_each() {
+    let ok_names = [
+        "model.onnx",
+        "model",
+        ".hidden",
+        ".whiteoutish", // doesn't end in `.whiteout`
+        "x.WHITEOUT",   // case-sensitive
+    ];
+    for n in &ok_names {
+        assert!(reject_if_reserved(n).is_ok(), "expected ok: {}", n);
+    }
+    let bad_names = ["foo.whiteout", "foo.opaque", "foo.sha3", "foo.sig"];
+    for n in &bad_names {
+        assert!(reject_if_reserved(n).is_err(), "expected reject: {}", n);
+    }
+}
+
+#[test]
+fn reserved_name_predicate() {
+    assert!(is_reserved_name("foo.whiteout"));
+    assert!(is_reserved_name("foo.opaque"));
+    assert!(is_reserved_name("foo.sha3"));
+    assert!(is_reserved_name("foo.sig"));
+    assert!(!is_reserved_name("foo.onnx"));
+}
+
+#[test]
+fn reserved_suffix_with_double_extension() {
+    // `foo.bin.sig` ends in `.sig` → reserved.
+    assert!(is_reserved_name("foo.bin.sig"));
+    assert!(reject_if_reserved("foo.bin.sig").is_err());
+}
+
+// ─── Listing-layer reserved-suffix filtering ───────────────────────────────────
+
+#[test]
+fn listing_filters_lower_side_sha3_and_sig() {
+    let u = MockUpperLayer::new();
+    let mut l = MockLowerLayer::new();
+    l.add_file("model.onnx", b"x");
+    l.add_file("model.onnx.sha3", b"x");
+    l.add_file("model.onnx.sig", b"x");
+    let entries = merge_readdir(&u, &l, "/").unwrap();
+    let names: alloc::vec::Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    assert_eq!(names, alloc::vec!["model.onnx"]);
+}
+
+#[test]
+fn listing_filters_upper_side_internal_markers() {
+    let mut u = MockUpperLayer::new();
+    u.add_file("real-model.onnx", b"x");
+    u.add_whiteout("hidden");
+    u.add_opaque("opaque-dir");
+    let l = MockLowerLayer::new();
+    let entries = merge_readdir(&u, &l, "/").unwrap();
+    let names: alloc::vec::Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    assert_eq!(names, alloc::vec!["real-model.onnx"]);
+}
+
+// ─── Mock fixture round-trips ──────────────────────────────────────────────────
+
+#[test]
+fn mock_upper_round_trip_file_contents() {
+    let mut u = MockUpperLayer::new();
+    u.add_file("a/b/c.bin", b"\x00\x01\x02\x03\x04");
+    let mut buf = [0u8; 5];
+    let n = u.read_file("a/b/c.bin", 0, &mut buf).unwrap();
+    assert_eq!(n, 5);
+    assert_eq!(&buf, b"\x00\x01\x02\x03\x04");
+}
+
+#[test]
+fn mock_upper_offset_read() {
+    let mut u = MockUpperLayer::new();
+    u.add_file("file", b"0123456789");
+    let mut buf = [0u8; 4];
+    let n = u.read_file("file", 4, &mut buf).unwrap();
+    assert_eq!(n, 4);
+    assert_eq!(&buf, b"4567");
+}
+
+#[test]
+fn mock_upper_partial_read() {
+    let mut u = MockUpperLayer::new();
+    u.add_file("file", b"abc");
+    let mut buf = [0u8; 100];
+    let n = u.read_file("file", 0, &mut buf).unwrap();
+    assert_eq!(n, 3);
+}
+
+#[test]
+fn mock_lower_round_trip_file_contents() {
+    let mut l = MockLowerLayer::new();
+    l.add_file("foo", b"hello world");
+    let mut buf = [0u8; 11];
+    let n = l.read_file("foo", 0, &mut buf).unwrap();
+    assert_eq!(n, 11);
+    assert_eq!(&buf, b"hello world");
+}
+
+// ─── Property-style sweeps ─────────────────────────────────────────────────────
+
+#[test]
+fn sweep_every_quadrant_of_upper_lower_state() {
+    // Quadrants: { upper-has, upper-absent } × { lower-has, lower-absent }
+    // × { upper-whiteout, no-whiteout } × { upper-opaque-parent, not }
+    //
+    // Here we sweep the four core quadrants without the marker
+    // axes — those are tested separately. This is the matrix of
+    // upper_present × lower_present with no markers:
+    //
+    //   upper=Y, lower=Y → Upper wins
+    //   upper=Y, lower=N → Upper wins
+    //   upper=N, lower=Y → Lower fall-through
+    //   upper=N, lower=N → NotFound
+    type Predicate = fn(LookupResult<LowerEntry>) -> bool;
+    let cases: &[(bool, bool, Predicate)] = &[
+        (true, true, |r| matches!(r, LookupResult::Upper(_))),
+        (true, false, |r| matches!(r, LookupResult::Upper(_))),
+        (false, true, |r| matches!(r, LookupResult::Lower(_))),
+        (false, false, |r| matches!(r, LookupResult::NotFound)),
+    ];
+
+    for &(upper_has, lower_has, predicate) in cases {
+        let mut u = MockUpperLayer::new();
+        let mut l = MockLowerLayer::new();
+        if upper_has {
+            u.add_file("path", b"u");
+        }
+        if lower_has {
+            l.add_file("path", b"l");
+        }
+        let r = lookup(&u, &l, "path").unwrap();
+        assert!(
+            predicate(r.clone()),
+            "quadrant (upper={}, lower={}) gave {:?}",
+            upper_has,
+            lower_has,
+            r
+        );
+    }
+}
+
+#[test]
+fn sweep_with_whiteout_axis() {
+    // Whiteout always wins regardless of lower state.
+    for lower_has in [false, true] {
+        let mut u = MockUpperLayer::new();
+        u.add_whiteout("path");
+        let mut l = MockLowerLayer::new();
+        if lower_has {
+            l.add_file("path", b"l");
+        }
+        assert_eq!(
+            lookup(&u, &l, "path").unwrap(),
+            LookupResult::WhiteoutHidesLower,
+            "whiteout should win even when lower_has={}",
+            lower_has
+        );
+    }
+}
+
+#[test]
+fn sweep_with_opaque_axis_path_inside_opaque_dir() {
+    for lower_has in [false, true] {
+        let mut u = MockUpperLayer::new();
+        u.add_opaque("dir");
+        let mut l = MockLowerLayer::new();
+        if lower_has {
+            l.add_file("dir/leaf", b"l");
+        }
+        assert_eq!(
+            lookup(&u, &l, "dir/leaf").unwrap(),
+            LookupResult::OpaqueHidesLowerSubtree,
+            "opaque should hide lower regardless of lower_has={}",
+            lower_has
+        );
+    }
+}
+
+#[test]
+fn sweep_merge_readdir_listing_completeness() {
+    // For a fixed scenario we assert the listing is a precisely
+    // computable function of the inputs.
+    let mut u = MockUpperLayer::new();
+    u.add_file("u-only", b"u");
+    u.add_file("shared", b"u");
+    u.add_whiteout("hidden");
+    let mut l = MockLowerLayer::new();
+    l.add_file("l-only", b"l");
+    l.add_file("shared", b"l");
+    l.add_file("hidden", b"l");
+
+    let entries = merge_readdir(&u, &l, "/").unwrap();
+    let names: alloc::vec::Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    // Expected: u-only, shared (upper), l-only — but NOT hidden.
+    assert_eq!(names, alloc::vec!["l-only", "shared", "u-only"]);
+}
+
+// ─── Sanity: many entries, deep paths ──────────────────────────────────────────
+
+#[test]
+fn merge_handles_many_entries() {
+    let mut u = MockUpperLayer::new();
+    let mut l = MockLowerLayer::new();
+    for i in 0..50 {
+        u.add_file(&alloc::format!("u{:02}", i), b"u");
+        l.add_file(&alloc::format!("l{:02}", i), b"l");
+    }
+    let entries = merge_readdir(&u, &l, "/").unwrap();
+    assert_eq!(entries.len(), 100);
+}
+
+#[test]
+fn merge_root_listing_is_sorted() {
+    let mut u = MockUpperLayer::new();
+    u.add_file("zoo", b"u");
+    u.add_file("alpha", b"u");
+    let mut l = MockLowerLayer::new();
+    l.add_file("middle", b"l");
+    let entries = merge_readdir(&u, &l, "/").unwrap();
+    let names: alloc::vec::Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    assert_eq!(names, alloc::vec!["alpha", "middle", "zoo"]);
+}
+
+#[test]
+fn lookup_into_empty_overlay_returns_notfound() {
+    let u = MockUpperLayer::new();
+    let l = MockLowerLayer::new();
+    let result = lookup(&u, &l, "anything").unwrap();
+    assert_eq!(result, LookupResult::NotFound);
+}
+
+#[test]
+fn merge_yields_independent_clones_no_shared_state() {
+    // After collecting once, the upper and lower fixtures should be
+    // unchanged. (Smoke test on the by-value collection path.)
+    let mut u = MockUpperLayer::new();
+    u.add_file("a", b"u");
+    let mut l = MockLowerLayer::new();
+    l.add_file("b", b"l");
+
+    let _ = merge_readdir(&u, &l, "/").unwrap();
+    let _ = merge_readdir(&u, &l, "/").unwrap();
+    let entries = merge_readdir(&u, &l, "/").unwrap();
+    assert_eq!(entries.len(), 2);
+}


### PR DESCRIPTION
## Summary

Phase 1 of `embedded-overlay-v1`. Read-only merge logic for the future two-layer view at `/models/`. Behind `fs-overlay-mounts` cargo feature (default off).

- 8 production modules under `fs/src/overlay/` (~1,880 LOC):
  - `upper_layer.rs` — `UpperLayer` trait + `MockUpperLayer` (550 LOC)
  - `lower_layer.rs` — `LowerLayer` trait + `MockLowerLayer` (278 LOC)
  - `lookup.rs` — upper-wins resolver returning `LookupResult::{Upper, WhiteoutHidesLower, OpaqueHidesLowerSubtree, Lower, NotFound}` (242 LOC)
  - `merge.rs` — `merge_readdir`: union of upper + lower minus whiteouts/opaque + reserved suffixes (303 LOC)
  - `whiteout.rs` — `<name>.whiteout` file detection (123 LOC)
  - `opaque.rs` — `<dir>/.opaque` marker (77 LOC)
  - `reserved.rs` — reject `.whiteout`/`.opaque`/`.sha3`/`.sig` suffixes (129 LOC)
  - `mod.rs` — module root + `OverlayError` + path helpers (179 LOC)
- 116 new tests (61 unit + 55 conformance) — all passing.
- `formal/kani/overlay_merge.rs` (127 LOC) — Kani harness sketch for the merge precedence invariant + `formal/kani/TODO.md` proof obligation table.

## Implementation notes

- The `UpperLayer` contract surfaces whiteouts as `UpperEntryKind::Whiteout` and opaque markers as `UpperEntryKind::Opaque` on the parent directory — keeps the merge code path completely free of suffix-string fiddling. The future `F2fsUpperLayer` will follow the same convention.
- `merge_readdir` defends in depth by filtering reserved-suffix names from BOTH upper and lower listings.
- `lookup`'s `OpaqueHidesLowerSubtree` walks every strict ancestor of the requested path so opaque hiding propagates correctly into deeper subtrees.

## Deviations (called out)

- Added `LowerLayer` trait + `MockLowerLayer` (the spec mentioned "tiny trait... implemented by both Squashfs (when feature on) and a `MockLowerLayer`"). Phase 1 delivers the trait + mock; the squashfs adapter waits for Phase 3 (when the merge view is wired into POSIX VFS).
- Kani harness is a sketch only — no Kani toolchain pinned in repo. Documented in `formal/kani/TODO.md`. The integration `sweep_*` tests cover the same enumeration concretely.
- `F2fsUpperLayer` production impl intentionally not added — F2FS RW path is `embedded-filesystem-v1` Phase 7 work.
- `OverlayError::ReadOnly` exists as plumbing for Phase 2 but is not yet returned from anywhere in Phase 1 (no write path exists yet to fail).

## Test plan

- [x] `cargo fmt -p smallaios-fs -- --check` clean.
- [x] `cargo clippy -p smallaios-fs --features fs-overlay-mounts --tests -- -D warnings` clean.
- [x] `cargo clippy -p smallaios-fs --tests -- -D warnings` (no overlay feature) clean.
- [x] `cargo test -p smallaios-fs --features fs-overlay-mounts --lib --tests` — 116 passed.
- [x] `cargo test -p smallaios-fs --no-default-features` clean.
- [x] `cargo vet check` Vetting Succeeded (no new deps).
- [x] `openspec validate embedded-overlay-v1 --strict` clean.
- [x] AArch64 kernel build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)