### PR TITLE
feat(fs): mount machinery + LRU cache + write-coalescing + integrity (embedded-filesystem-v1 phase 6)

### DIFF
--- a/fs/src/cache.rs
+++ b/fs/src/cache.rs
@@ -1,0 +1,657 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-mount LRU block cache and write-coalescing buffer.
+//!
+//! Per the `fs-block-device` Q10 design answer, every on-disk mount
+//! gets its own LRU block cache with a configurable budget:
+//!
+//! - `/models/` (squashfs) — default 16 MiB.
+//! - `/data/` (F2FS) — default 4 MiB.
+//!
+//! The cache is keyed by `(lba, partition_id)` from the caller's point
+//! of view; this module only stores the `lba` since each [`LruCache`]
+//! instance is owned by exactly one mount. Eviction policy is simple
+//! LRU (least-recently-used) — adequate for both the read-heavy
+//! squashfs path and the small-working-set F2FS metadata path.
+//!
+//! In addition the F2FS audit-log writer needs a 256 KiB
+//! write-coalescing buffer that batches short appends before flushing
+//! to the underlying [`crate::block::BlockDevice`]. The buffer is a
+//! ring rather than a tree because its access pattern is strictly
+//! sequential (audit log entries are written in order) and it is
+//! periodically drained via [`WriteCoalescer::take_pending`].
+//!
+//! Both structures are `#![no_std]`-friendly: storage uses
+//! `alloc::vec::Vec` and `alloc::collections::BTreeMap` so no `std`
+//! hash dependency leaks into bare-metal builds.
+//!
+//! Owned by `embedded-filesystem-v1` Phase 6.
+
+extern crate alloc;
+
+use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
+
+use crate::config_defaults::{
+    FS_CACHE_DATA_BYTES, FS_CACHE_DATA_FLOOR_BYTES, FS_CACHE_MODELS_BYTES,
+    FS_CACHE_MODELS_FLOOR_BYTES, FS_WRITE_COALESCE_BYTES,
+};
+
+// ─── Cache budget validator ──────────────────────────────────────────────────
+
+/// Errors returned by the cache-budget validator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheBudgetError {
+    /// Models cache budget is below [`FS_CACHE_MODELS_FLOOR_BYTES`].
+    ModelsBelowFloor { requested: u64, floor: u64 },
+    /// Data cache budget is below [`FS_CACHE_DATA_FLOOR_BYTES`].
+    DataBelowFloor { requested: u64, floor: u64 },
+    /// Block size is zero (would cause divide-by-zero in `evict`).
+    ZeroBlockSize,
+}
+
+/// Validate a `(models, data)` cache-budget pair against the documented
+/// floors. The validator is called by both the `mgmt` config loader and
+/// the [`LruCache::new`] constructor so a misconfigured policy.toml is
+/// rejected early, before any I/O happens.
+pub fn validate_cache_budgets(models_bytes: u64, data_bytes: u64) -> Result<(), CacheBudgetError> {
+    if models_bytes < FS_CACHE_MODELS_FLOOR_BYTES {
+        return Err(CacheBudgetError::ModelsBelowFloor {
+            requested: models_bytes,
+            floor: FS_CACHE_MODELS_FLOOR_BYTES,
+        });
+    }
+    if data_bytes < FS_CACHE_DATA_FLOOR_BYTES {
+        return Err(CacheBudgetError::DataBelowFloor {
+            requested: data_bytes,
+            floor: FS_CACHE_DATA_FLOOR_BYTES,
+        });
+    }
+    Ok(())
+}
+
+// ─── LRU block cache ─────────────────────────────────────────────────────────
+
+/// One cached block stored alongside an `epoch` counter that ranks
+/// recency. Higher `epoch` is more recent.
+#[derive(Debug, Clone)]
+struct CacheEntry {
+    bytes: Vec<u8>,
+    epoch: u64,
+}
+
+/// Per-mount LRU block cache.
+///
+/// Keys are 64-bit LBAs (relative to the mount partition); values are
+/// fixed-size block buffers. Eviction is LRU — the entry with the
+/// lowest `epoch` is dropped first when the budget is exceeded.
+///
+/// The cache is single-threaded; callers that need cross-thread access
+/// MUST wrap it in their own synchronization. The kernel mount table
+/// always accesses each cache from the matching mount thread, so this
+/// is a non-issue for the v1 boot path.
+#[derive(Debug)]
+pub struct LruCache {
+    /// LBA → (bytes, epoch) map. Storing in a `BTreeMap` keeps the
+    /// crate `#![no_std]`-clean (no `hashbrown`/`std::collections`
+    /// indirection) and is fast enough at the cache sizes we care
+    /// about (≤ ~5 K entries at 16 MiB / 4 KiB blocks).
+    entries: BTreeMap<u64, CacheEntry>,
+    budget_bytes: u64,
+    block_size_bytes: u32,
+    /// Monotonic counter incremented on every access; used to break LRU
+    /// ties.
+    next_epoch: u64,
+    /// Cache hits since construction (test introspection).
+    hits: u64,
+    /// Cache misses since construction (test introspection).
+    misses: u64,
+    /// Evictions since construction (test introspection).
+    evictions: u64,
+}
+
+impl LruCache {
+    /// Construct a cache with the given budget (in bytes) and block
+    /// size. Budget must be at least `block_size_bytes`; smaller
+    /// budgets are not rejected here (the validator runs upstream)
+    /// but they will result in eviction-on-every-put which the cache
+    /// gracefully handles.
+    pub fn new(budget_bytes: u64, block_size_bytes: u32) -> Self {
+        Self {
+            entries: BTreeMap::new(),
+            budget_bytes,
+            block_size_bytes,
+            next_epoch: 0,
+            hits: 0,
+            misses: 0,
+            evictions: 0,
+        }
+    }
+
+    /// Returns the configured budget in bytes.
+    pub fn budget_bytes(&self) -> u64 {
+        self.budget_bytes
+    }
+
+    /// Returns the configured block size in bytes.
+    pub fn block_size_bytes(&self) -> u32 {
+        self.block_size_bytes
+    }
+
+    /// Number of currently cached blocks.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// `true` iff the cache holds zero entries.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Bytes currently resident in the cache (`len * block_size`).
+    pub fn used_bytes(&self) -> u64 {
+        (self.entries.len() as u64).saturating_mul(self.block_size_bytes as u64)
+    }
+
+    /// Cache-hit count (test introspection).
+    pub fn hit_count(&self) -> u64 {
+        self.hits
+    }
+
+    /// Cache-miss count (test introspection).
+    pub fn miss_count(&self) -> u64 {
+        self.misses
+    }
+
+    /// Eviction count (test introspection).
+    pub fn eviction_count(&self) -> u64 {
+        self.evictions
+    }
+
+    /// Probe the cache for `lba`. On hit the entry is reuse-promoted
+    /// (its epoch advanced) so it survives the next eviction round.
+    pub fn get(&mut self, lba: u64) -> Option<&[u8]> {
+        let new_epoch = self.next_epoch.wrapping_add(1);
+        let hit = match self.entries.get_mut(&lba) {
+            Some(e) => {
+                e.epoch = new_epoch;
+                true
+            }
+            None => false,
+        };
+        if hit {
+            self.next_epoch = new_epoch;
+            self.hits += 1;
+            // Re-borrow to satisfy the borrow checker after the
+            // mutable borrow above.
+            return self.entries.get(&lba).map(|e| e.bytes.as_slice());
+        }
+        self.misses += 1;
+        None
+    }
+
+    /// Read-only probe — does NOT advance the LRU epoch. Useful in
+    /// tests to inspect cache state without disturbing eviction order.
+    pub fn peek(&self, lba: u64) -> Option<&[u8]> {
+        self.entries.get(&lba).map(|e| e.bytes.as_slice())
+    }
+
+    /// Insert `data` at `lba`. If the new entry would push the cache
+    /// over budget, the least-recently-used entries are evicted until
+    /// enough room is freed.
+    pub fn put(&mut self, lba: u64, data: &[u8]) {
+        // Reject odd-sized inserts in debug builds to make bugs loud.
+        debug_assert_eq!(
+            data.len(),
+            self.block_size_bytes as usize,
+            "LruCache::put expects block-sized buffers"
+        );
+        let new_epoch = self.next_epoch.wrapping_add(1);
+        self.next_epoch = new_epoch;
+        self.entries.insert(
+            lba,
+            CacheEntry {
+                bytes: data.to_vec(),
+                epoch: new_epoch,
+            },
+        );
+        self.evict_to_budget();
+    }
+
+    /// Drop entries until the cache is within budget.
+    ///
+    /// Implementation note: `BTreeMap` does not give us O(1) LRU
+    /// eviction, but we only reach this path on `put` and the inputs
+    /// are bounded by the per-mount budget. The naive scan is
+    /// O(n log n) in the size of the cache (sort by epoch); for the
+    /// v1 budgets (≤ 5 K entries) this is fast enough that the
+    /// simpler code beats a separate doubly-linked-list ledger.
+    pub fn evict_to_budget(&mut self) {
+        let block_size_u64 = self.block_size_bytes as u64;
+        if block_size_u64 == 0 {
+            // Defensive: avoid divide-by-zero if a misconfigured cache
+            // slips past the validator. The cache becomes a no-op.
+            self.entries.clear();
+            return;
+        }
+        // How many entries fit?
+        let max_entries = (self.budget_bytes / block_size_u64) as usize;
+        if self.entries.len() <= max_entries {
+            return;
+        }
+        // Build a (epoch, lba) list and pick the smallest epochs to
+        // drop. Use stable iteration so the test counter is exact.
+        let mut snapshot: Vec<(u64, u64)> = self
+            .entries
+            .iter()
+            .map(|(lba, e)| (e.epoch, *lba))
+            .collect();
+        snapshot.sort_unstable_by_key(|(epoch, _lba)| *epoch);
+        let to_drop = self.entries.len() - max_entries;
+        for (_epoch, lba) in snapshot.into_iter().take(to_drop) {
+            if self.entries.remove(&lba).is_some() {
+                self.evictions += 1;
+            }
+        }
+    }
+
+    /// Clear the cache; reset hit/miss/eviction counters.
+    pub fn clear(&mut self) {
+        self.entries.clear();
+        self.hits = 0;
+        self.misses = 0;
+        self.evictions = 0;
+        self.next_epoch = 0;
+    }
+}
+
+/// Build a cache pre-sized for the `/models/` mount.
+pub fn models_cache(block_size_bytes: u32) -> LruCache {
+    LruCache::new(FS_CACHE_MODELS_BYTES, block_size_bytes)
+}
+
+/// Build a cache pre-sized for the `/data/` mount.
+pub fn data_cache(block_size_bytes: u32) -> LruCache {
+    LruCache::new(FS_CACHE_DATA_BYTES, block_size_bytes)
+}
+
+// ─── Write-coalescing buffer ─────────────────────────────────────────────────
+
+/// Per-mount write-coalescing buffer.
+///
+/// The audit-log writer on `/data/` issues short appends (one
+/// JSON-Lines record per security event); calling
+/// `BlockDevice::write_block` per record would push 4 KiB of metadata
+/// per write, which is wasteful at SD-card class storage. The
+/// coalescer batches up to [`FS_WRITE_COALESCE_BYTES`] of pending bytes
+/// in RAM and exposes [`take_pending`] for the higher-level F2FS
+/// commit path to flush them in one shot.
+///
+/// The buffer is intentionally simple: it is NOT a circular ring;
+/// it is a linear `Vec` reset on `take_pending`. Spill semantics:
+/// `append` returns `false` (caller must flush first) when the new
+/// bytes would exceed `capacity_bytes`.
+#[derive(Debug)]
+pub struct WriteCoalescer {
+    pending: Vec<u8>,
+    capacity_bytes: usize,
+    flushes: u64,
+    appended_records: u64,
+}
+
+impl WriteCoalescer {
+    /// Construct a coalescer with the requested capacity (in bytes).
+    pub fn new(capacity_bytes: u64) -> Self {
+        Self {
+            pending: Vec::new(),
+            capacity_bytes: capacity_bytes as usize,
+            flushes: 0,
+            appended_records: 0,
+        }
+    }
+
+    /// Default 256 KiB coalescer.
+    pub fn default_size() -> Self {
+        Self::new(FS_WRITE_COALESCE_BYTES)
+    }
+
+    /// Maximum bytes the coalescer can hold before requiring a flush.
+    pub fn capacity_bytes(&self) -> usize {
+        self.capacity_bytes
+    }
+
+    /// Bytes currently pending.
+    pub fn pending_bytes(&self) -> usize {
+        self.pending.len()
+    }
+
+    /// `true` iff the buffer holds zero pending bytes.
+    pub fn is_empty(&self) -> bool {
+        self.pending.is_empty()
+    }
+
+    /// Number of times [`take_pending`] has drained the buffer.
+    pub fn flush_count(&self) -> u64 {
+        self.flushes
+    }
+
+    /// Number of [`append`] calls that successfully landed bytes.
+    pub fn appended_records(&self) -> u64 {
+        self.appended_records
+    }
+
+    /// Append `bytes` to the pending buffer.
+    ///
+    /// Returns `false` (and does NOT mutate the buffer) when the new
+    /// bytes would exceed [`capacity_bytes`]. The caller MUST drain
+    /// the buffer with [`take_pending`] and flush to the underlying
+    /// device before retrying.
+    pub fn append(&mut self, bytes: &[u8]) -> bool {
+        if self.pending.len().saturating_add(bytes.len()) > self.capacity_bytes {
+            return false;
+        }
+        self.pending.extend_from_slice(bytes);
+        self.appended_records += 1;
+        true
+    }
+
+    /// Drain the pending buffer, returning the bytes to the caller.
+    /// Resets internal state so subsequent [`append`] calls start
+    /// from zero.
+    pub fn take_pending(&mut self) -> Vec<u8> {
+        if self.pending.is_empty() {
+            return Vec::new();
+        }
+        self.flushes += 1;
+        core::mem::take(&mut self.pending)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ─── Validator tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn defaults_pass_validator() {
+        validate_cache_budgets(FS_CACHE_MODELS_BYTES, FS_CACHE_DATA_BYTES).unwrap();
+    }
+
+    #[test]
+    fn models_below_floor_rejected() {
+        let too_small = FS_CACHE_MODELS_FLOOR_BYTES - 1;
+        match validate_cache_budgets(too_small, FS_CACHE_DATA_BYTES) {
+            Err(CacheBudgetError::ModelsBelowFloor { requested, floor }) => {
+                assert_eq!(requested, too_small);
+                assert_eq!(floor, FS_CACHE_MODELS_FLOOR_BYTES);
+            }
+            other => panic!("expected ModelsBelowFloor, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn data_below_floor_rejected() {
+        let too_small = FS_CACHE_DATA_FLOOR_BYTES - 1;
+        match validate_cache_budgets(FS_CACHE_MODELS_BYTES, too_small) {
+            Err(CacheBudgetError::DataBelowFloor { requested, floor }) => {
+                assert_eq!(requested, too_small);
+                assert_eq!(floor, FS_CACHE_DATA_FLOOR_BYTES);
+            }
+            other => panic!("expected DataBelowFloor, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn floor_value_is_exactly_acceptable() {
+        // Exactly the floor passes (the floor is inclusive).
+        validate_cache_budgets(FS_CACHE_MODELS_FLOOR_BYTES, FS_CACHE_DATA_FLOOR_BYTES).unwrap();
+    }
+
+    #[test]
+    fn validator_rejects_zero_models() {
+        assert!(validate_cache_budgets(0, FS_CACHE_DATA_BYTES).is_err());
+    }
+
+    #[test]
+    fn validator_rejects_zero_data() {
+        assert!(validate_cache_budgets(FS_CACHE_MODELS_BYTES, 0).is_err());
+    }
+
+    // ─── LruCache tests ─────────────────────────────────────────────────────
+
+    fn make_block(byte: u8) -> Vec<u8> {
+        alloc::vec![byte; 4096]
+    }
+
+    #[test]
+    fn empty_cache_has_no_entries() {
+        let c = LruCache::new(16 * 1024 * 1024, 4096);
+        assert!(c.is_empty());
+        assert_eq!(c.len(), 0);
+        assert_eq!(c.used_bytes(), 0);
+    }
+
+    #[test]
+    fn put_then_get_returns_data() {
+        let mut c = LruCache::new(16 * 1024 * 1024, 4096);
+        let block = make_block(0x42);
+        c.put(7, &block);
+        let got = c.get(7).expect("hit");
+        assert_eq!(got.len(), 4096);
+        assert_eq!(got[0], 0x42);
+        assert_eq!(c.hit_count(), 1);
+        assert_eq!(c.miss_count(), 0);
+    }
+
+    #[test]
+    fn miss_increments_miss_counter() {
+        let mut c = LruCache::new(16 * 1024 * 1024, 4096);
+        assert!(c.get(99).is_none());
+        assert_eq!(c.miss_count(), 1);
+        assert_eq!(c.hit_count(), 0);
+    }
+
+    #[test]
+    fn put_overwrite_replaces_data() {
+        let mut c = LruCache::new(16 * 1024 * 1024, 4096);
+        c.put(1, &make_block(0xAA));
+        c.put(1, &make_block(0xBB));
+        let got = c.get(1).unwrap();
+        assert_eq!(got[0], 0xBB);
+    }
+
+    #[test]
+    fn cache_evicts_when_over_budget() {
+        // 8 KiB budget at 4 KiB blocks → exactly 2 entries fit.
+        let mut c = LruCache::new(8 * 1024, 4096);
+        c.put(1, &make_block(1));
+        c.put(2, &make_block(2));
+        assert_eq!(c.len(), 2);
+        c.put(3, &make_block(3));
+        assert_eq!(c.len(), 2);
+        assert_eq!(c.eviction_count(), 1);
+        // Block 1 (oldest) should be gone.
+        assert!(c.peek(1).is_none());
+        assert!(c.peek(2).is_some());
+        assert!(c.peek(3).is_some());
+    }
+
+    #[test]
+    fn lru_promotes_recently_accessed() {
+        let mut c = LruCache::new(8 * 1024, 4096);
+        c.put(1, &make_block(1));
+        c.put(2, &make_block(2));
+        // Access block 1 — it should now be more recent than block 2.
+        assert!(c.get(1).is_some());
+        // Inserting block 3 should evict block 2, not block 1.
+        c.put(3, &make_block(3));
+        assert!(c.peek(1).is_some(), "block 1 should still be cached");
+        assert!(c.peek(2).is_none(), "block 2 should have been evicted");
+        assert!(c.peek(3).is_some());
+    }
+
+    #[test]
+    fn peek_does_not_change_lru_order() {
+        let mut c = LruCache::new(8 * 1024, 4096);
+        c.put(1, &make_block(1));
+        c.put(2, &make_block(2));
+        // Peek block 1 — should NOT promote it.
+        assert!(c.peek(1).is_some());
+        c.put(3, &make_block(3));
+        // Block 1 was the oldest and was peeked (not get'd) so it
+        // should be the eviction victim.
+        assert!(c.peek(1).is_none());
+        assert!(c.peek(2).is_some());
+        assert!(c.peek(3).is_some());
+    }
+
+    #[test]
+    fn evict_to_budget_idempotent_when_under() {
+        let mut c = LruCache::new(16 * 1024, 4096);
+        c.put(1, &make_block(1));
+        c.evict_to_budget();
+        c.evict_to_budget();
+        assert_eq!(c.len(), 1);
+        assert_eq!(c.eviction_count(), 0);
+    }
+
+    #[test]
+    fn evict_to_budget_after_lowering_budget_drops_excess() {
+        // Standard 16 MiB cache with two entries, then a very tight
+        // synthetic budget — the next put triggers eviction.
+        let mut c = LruCache::new(16 * 1024, 4096); // 4 entries fit
+        c.put(1, &make_block(1));
+        c.put(2, &make_block(2));
+        c.put(3, &make_block(3));
+        c.put(4, &make_block(4));
+        assert_eq!(c.len(), 4);
+        // Adding a 5th forces eviction of one entry.
+        c.put(5, &make_block(5));
+        assert_eq!(c.len(), 4);
+        assert_eq!(c.eviction_count(), 1);
+    }
+
+    #[test]
+    fn clear_resets_state() {
+        let mut c = LruCache::new(16 * 1024 * 1024, 4096);
+        c.put(1, &make_block(1));
+        let _ = c.get(1);
+        let _ = c.get(99);
+        assert!(c.hit_count() > 0);
+        assert!(c.miss_count() > 0);
+        c.clear();
+        assert!(c.is_empty());
+        assert_eq!(c.hit_count(), 0);
+        assert_eq!(c.miss_count(), 0);
+        assert_eq!(c.eviction_count(), 0);
+    }
+
+    #[test]
+    fn models_cache_uses_default_budget() {
+        let c = models_cache(4096);
+        assert_eq!(c.budget_bytes(), FS_CACHE_MODELS_BYTES);
+        assert_eq!(c.block_size_bytes(), 4096);
+    }
+
+    #[test]
+    fn data_cache_uses_default_budget() {
+        let c = data_cache(4096);
+        assert_eq!(c.budget_bytes(), FS_CACHE_DATA_BYTES);
+    }
+
+    #[test]
+    fn many_puts_respect_budget() {
+        // 16 KiB budget at 4 KiB blocks → 4 entries cap.
+        let mut c = LruCache::new(16 * 1024, 4096);
+        for i in 0..20 {
+            c.put(i, &make_block(i as u8));
+        }
+        assert_eq!(c.len(), 4);
+        assert!(c.eviction_count() >= 16);
+        // Last 4 should be there.
+        assert!(c.peek(16).is_some());
+        assert!(c.peek(17).is_some());
+        assert!(c.peek(18).is_some());
+        assert!(c.peek(19).is_some());
+    }
+
+    // ─── WriteCoalescer tests ───────────────────────────────────────────────
+
+    #[test]
+    fn coalescer_default_holds_256kib() {
+        let c = WriteCoalescer::default_size();
+        assert_eq!(c.capacity_bytes(), FS_WRITE_COALESCE_BYTES as usize);
+        assert!(c.is_empty());
+    }
+
+    #[test]
+    fn append_accumulates_bytes() {
+        let mut c = WriteCoalescer::new(1024);
+        assert!(c.append(b"hello "));
+        assert!(c.append(b"world"));
+        assert_eq!(c.pending_bytes(), 11);
+        assert_eq!(c.appended_records(), 2);
+    }
+
+    #[test]
+    fn append_rejects_overflow_without_dropping_data() {
+        let mut c = WriteCoalescer::new(8);
+        assert!(c.append(b"abcd"));
+        // Next append would exceed capacity → reject.
+        assert!(!c.append(b"efghi"));
+        // Pending bytes are unchanged from the rejected append.
+        assert_eq!(c.pending_bytes(), 4);
+        // A drain frees room for the rejected append.
+        let drained = c.take_pending();
+        assert_eq!(drained, b"abcd");
+        assert!(c.append(b"efghi"));
+        assert_eq!(c.pending_bytes(), 5);
+    }
+
+    #[test]
+    fn take_pending_resets_buffer_and_increments_flush_count() {
+        let mut c = WriteCoalescer::new(64);
+        c.append(b"first ").unwrap();
+        c.append(b"second").unwrap();
+        let drained = c.take_pending();
+        assert_eq!(drained, b"first second");
+        assert!(c.is_empty());
+        assert_eq!(c.flush_count(), 1);
+    }
+
+    #[test]
+    fn take_pending_on_empty_does_not_increment_flush() {
+        let mut c = WriteCoalescer::new(64);
+        let drained = c.take_pending();
+        assert!(drained.is_empty());
+        assert_eq!(c.flush_count(), 0);
+    }
+
+    #[test]
+    fn coalescer_batches_many_short_writes_into_one_flush() {
+        // Simulates the audit-log writer: 100 short records (~64 B
+        // each) coalesced into a single take_pending().
+        let mut c = WriteCoalescer::new(256 * 1024);
+        let mut record = [0u8; 64];
+        for i in 0..100 {
+            record.fill(i as u8);
+            assert!(c.append(&record));
+        }
+        assert_eq!(c.appended_records(), 100);
+        let drained = c.take_pending();
+        assert_eq!(drained.len(), 100 * 64);
+        assert_eq!(c.flush_count(), 1);
+    }
+
+    // Helper: enable the `_ = c.append(...).unwrap();` pattern above.
+    trait AppendAssert {
+        fn unwrap(self);
+    }
+    impl AppendAssert for bool {
+        fn unwrap(self) {
+            assert!(self, "append unexpectedly returned false");
+        }
+    }
+}

--- a/fs/src/config_defaults.rs
+++ b/fs/src/config_defaults.rs
@@ -1,0 +1,111 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Default values for the `fs.*` config-field surface.
+//!
+//! These constants are the single source of truth for the
+//! `fs.cache.*`, `fs.block.*`, and `fs.boot.*` field defaults declared
+//! by the `mgmt-config-layout` spec. The `mgmt` crate's Phase 5 config
+//! loader pulls these values directly so the runtime defaults and the
+//! spec stay in lock-step. Operators can override them via
+//! `policy.toml`; the validator in `mgmt` rejects values that fall
+//! below the floors documented in the `embedded-filesystem-v1` change.
+//!
+//! Owned by `embedded-filesystem-v1` Phase 6.
+
+// ─── Block-cache budgets ─────────────────────────────────────────────────────
+
+/// Default LRU block-cache budget for the `/models/` (squashfs) mount,
+/// in bytes. 16 MiB matches the Q10 answer in the
+/// `fs-block-device` design clarifications.
+pub const FS_CACHE_MODELS_BYTES: u64 = 16 * 1024 * 1024;
+
+/// Default LRU block-cache budget for the `/data/` (F2FS) mount, in
+/// bytes. 4 MiB is sized for short-lived metadata working sets.
+pub const FS_CACHE_DATA_BYTES: u64 = 4 * 1024 * 1024;
+
+/// Floor for `fs.cache.models_bytes`. Configurations below this floor
+/// are rejected by the `mgmt` validator. Keeps the cache large enough
+/// to hold the squashfs root + a working set of metadata blocks.
+pub const FS_CACHE_MODELS_FLOOR_BYTES: u64 = 4 * 1024 * 1024;
+
+/// Floor for `fs.cache.data_bytes`. One MiB holds the `/data/auth/`
+/// shadow file plus a small audit-log working set.
+pub const FS_CACHE_DATA_FLOOR_BYTES: u64 = 1024 * 1024;
+
+/// Default size of the per-mount write-coalescing buffer used by the
+/// `/data/` audit-log writer to batch short metadata appends, in bytes.
+pub const FS_WRITE_COALESCE_BYTES: u64 = 256 * 1024;
+
+// ─── Block-device timeouts and retry policy ──────────────────────────────────
+
+/// Default per-read timeout (milliseconds).
+pub const FS_BLOCK_READ_TIMEOUT_MS: u64 = 250;
+
+/// Default per-write timeout (milliseconds). Larger than reads because
+/// flush-completion paths on eMMC can stall briefly.
+pub const FS_BLOCK_WRITE_TIMEOUT_MS: u64 = 1000;
+
+/// Default number of retries for a transient block-device error before
+/// giving up and surfacing the failure.
+pub const FS_BLOCK_RETRY_COUNT: u32 = 3;
+
+/// Default backoff (milliseconds) inserted between retries.
+pub const FS_BLOCK_RETRY_BACKOFF_MS: u64 = 500;
+
+// ─── Boot watchdog ───────────────────────────────────────────────────────────
+
+/// Default boot watchdog window, in seconds. If `boot_success` is not
+/// asserted within this window the bootloader rolls back to the
+/// previously-known-good slot.
+pub const FS_BOOT_WATCHDOG_SECONDS: u32 = 60;
+
+#[cfg(test)]
+mod tests {
+    // These tests are intentional compile-time documentation assertions
+    // on `const` values — they read like runtime tests but verify
+    // constant invariants. clippy's `assertions_on_constants` and
+    // `bool_assert_comparison` lints object; opted out for the module.
+    #![allow(clippy::assertions_on_constants)]
+    #![allow(clippy::bool_assert_comparison)]
+
+    use super::*;
+
+    #[test]
+    fn cache_defaults_above_floor() {
+        assert!(FS_CACHE_MODELS_BYTES >= FS_CACHE_MODELS_FLOOR_BYTES);
+        assert!(FS_CACHE_DATA_BYTES >= FS_CACHE_DATA_FLOOR_BYTES);
+    }
+
+    #[test]
+    fn write_coalesce_buffer_at_least_one_block() {
+        // Must hold at least one 4 KiB block; 256 KiB easily clears
+        // that bar but the assertion documents intent.
+        assert!(FS_WRITE_COALESCE_BYTES >= 4096);
+    }
+
+    #[test]
+    fn timeouts_are_non_zero() {
+        assert!(FS_BLOCK_READ_TIMEOUT_MS > 0);
+        assert!(FS_BLOCK_WRITE_TIMEOUT_MS > 0);
+    }
+
+    #[test]
+    fn retry_policy_is_finite() {
+        assert!(FS_BLOCK_RETRY_COUNT > 0);
+        assert!(FS_BLOCK_RETRY_BACKOFF_MS > 0);
+    }
+
+    #[test]
+    fn boot_watchdog_window_is_positive() {
+        assert!(FS_BOOT_WATCHDOG_SECONDS > 0);
+    }
+
+    #[test]
+    fn write_timeout_at_least_read_timeout() {
+        // Documented invariant: write paths can stall longer than reads
+        // (eMMC flush completion), so the default write timeout must be
+        // at least the read timeout.
+        assert!(FS_BLOCK_WRITE_TIMEOUT_MS >= FS_BLOCK_READ_TIMEOUT_MS);
+    }
+}

--- a/fs/src/integrity.rs
+++ b/fs/src/integrity.rs
@@ -1,0 +1,234 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Fail-closed read-path policy for the filesystem stack.
+//!
+//! Per the `fs-integrity` spec, the kernel SHALL keep the system
+//! reachable when both squashfs slots fail signature verification:
+//!
+//! - `/models/` is left unmounted; any `model_load` syscall returns
+//!   `-EROFS` with a `system not in service` message.
+//! - `/data/`, login, audit, and console SHALL keep working so an
+//!   operator can investigate and stage a recovery image.
+//!
+//! This module owns the [`InferenceLockout`] guard that captures the
+//! "both slots invalid" state. The guard is consulted by the
+//! `model_load` overlay path (added in Phase 3 of the overlay change)
+//! and by the management API; it is a pure-functional state machine
+//! with no I/O side effects of its own.
+//!
+//! Owned by `embedded-filesystem-v1` Phase 6.
+
+extern crate alloc;
+
+/// One-line operator-facing message printed on the console and
+/// returned from `model_load` when [`InferenceLockout::is_locked`].
+pub const SYSTEM_NOT_IN_SERVICE_MSG: &str =
+    "system not in service: both squashfs slots invalid; stage a recovery image";
+
+/// The reason a [`InferenceLockout`] guard was raised.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LockoutReason {
+    /// Both A and B squashfs slots failed signature verification at
+    /// mount time. Inference is hard-disabled until a valid slot is
+    /// restored; `auth`, audit, and `/data/` paths continue to work.
+    BothSlotsInvalid,
+    /// A per-read SHA-3-256 mismatch was observed after mount; the
+    /// in-memory squashfs has been quarantined for the rest of this
+    /// boot to prevent serving any byte from a corrupt block.
+    BlockHashMismatch,
+}
+
+impl LockoutReason {
+    /// Stable, lowercase ASCII tag used in the audit ring.
+    pub const fn audit_tag(&self) -> &'static str {
+        match self {
+            Self::BothSlotsInvalid => "both_slots_invalid",
+            Self::BlockHashMismatch => "block_hash_mismatch",
+        }
+    }
+}
+
+/// Inference-lockout guard.
+///
+/// The `MountTable` owns one of these. While `is_locked()` is true,
+/// any caller to `model_load` SHALL receive `-EROFS` and the lockout
+/// reason SHALL be stamped into the audit log. Login, audit, and
+/// `/data/` continue to work unchanged.
+///
+/// The guard is intentionally append-only: there is no public unlock
+/// path, so the only way to clear it is to reboot after staging a
+/// recovery image. Tests reach for [`InferenceLockout::reset`] to
+/// fabricate a clean state between scenarios; that helper is gated
+/// behind `cfg(test)` so production code cannot accidentally clear
+/// the lockout.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct InferenceLockout {
+    locked: bool,
+    reason: Option<LockoutReason>,
+    /// Number of `model_load` calls rejected by this guard. Reset by
+    /// [`take_rejected_count`] for audit-record batching.
+    rejected_count: u32,
+}
+
+impl InferenceLockout {
+    /// Construct a permissive guard (inference allowed). Used by the
+    /// happy-path mount where at least one squashfs slot verifies.
+    pub const fn permissive() -> Self {
+        Self {
+            locked: false,
+            reason: None,
+            rejected_count: 0,
+        }
+    }
+
+    /// Construct a guard that locks out inference with the given
+    /// reason. The caller is responsible for emitting the audit
+    /// record at the time of construction; the guard merely tracks
+    /// the state.
+    pub const fn locked(reason: LockoutReason) -> Self {
+        Self {
+            locked: true,
+            reason: Some(reason),
+            rejected_count: 0,
+        }
+    }
+
+    /// `true` iff inference is hard-disabled.
+    pub const fn is_locked(&self) -> bool {
+        self.locked
+    }
+
+    /// Reason the guard was raised (if any).
+    pub const fn reason(&self) -> Option<LockoutReason> {
+        self.reason
+    }
+
+    /// Operator-facing message returned to user code from
+    /// `model_load` when locked. Returns `None` while the guard is
+    /// permissive.
+    pub const fn user_message(&self) -> Option<&'static str> {
+        if self.locked {
+            Some(SYSTEM_NOT_IN_SERVICE_MSG)
+        } else {
+            None
+        }
+    }
+
+    /// Tally one `model_load` rejection. Returns the new total.
+    /// Production code calls this from the `model_load` syscall
+    /// epilogue when the guard rejects the call.
+    pub fn record_rejection(&mut self) -> u32 {
+        self.rejected_count = self.rejected_count.saturating_add(1);
+        self.rejected_count
+    }
+
+    /// How many `model_load` calls have been rejected since the last
+    /// [`take_rejected_count`].
+    pub const fn rejected_count(&self) -> u32 {
+        self.rejected_count
+    }
+
+    /// Drain the rejection counter (used by the audit-batcher).
+    pub fn take_rejected_count(&mut self) -> u32 {
+        let n = self.rejected_count;
+        self.rejected_count = 0;
+        n
+    }
+
+    /// Test-only reset (clears the guard back to permissive state).
+    #[cfg(test)]
+    pub fn reset(&mut self) {
+        self.locked = false;
+        self.reason = None;
+        self.rejected_count = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn permissive_default_does_not_lock() {
+        let g = InferenceLockout::permissive();
+        assert!(!g.is_locked());
+        assert!(g.reason().is_none());
+        assert!(g.user_message().is_none());
+    }
+
+    #[test]
+    fn locked_guard_carries_reason_and_message() {
+        let g = InferenceLockout::locked(LockoutReason::BothSlotsInvalid);
+        assert!(g.is_locked());
+        assert_eq!(g.reason(), Some(LockoutReason::BothSlotsInvalid));
+        assert_eq!(g.user_message(), Some(SYSTEM_NOT_IN_SERVICE_MSG));
+    }
+
+    #[test]
+    fn audit_tag_matches_spec() {
+        assert_eq!(
+            LockoutReason::BothSlotsInvalid.audit_tag(),
+            "both_slots_invalid"
+        );
+        assert_eq!(
+            LockoutReason::BlockHashMismatch.audit_tag(),
+            "block_hash_mismatch"
+        );
+    }
+
+    #[test]
+    fn rejection_counter_increments() {
+        let mut g = InferenceLockout::locked(LockoutReason::BothSlotsInvalid);
+        assert_eq!(g.record_rejection(), 1);
+        assert_eq!(g.record_rejection(), 2);
+        assert_eq!(g.rejected_count(), 2);
+    }
+
+    #[test]
+    fn rejection_counter_drains() {
+        let mut g = InferenceLockout::locked(LockoutReason::BothSlotsInvalid);
+        let _ = g.record_rejection();
+        let _ = g.record_rejection();
+        let _ = g.record_rejection();
+        assert_eq!(g.take_rejected_count(), 3);
+        assert_eq!(g.rejected_count(), 0);
+    }
+
+    #[test]
+    fn rejection_counter_saturates() {
+        let mut g = InferenceLockout::locked(LockoutReason::BothSlotsInvalid);
+        // Advance to near saturation by manipulating the counter via
+        // the public API a few times; we don't actually run u32::MAX
+        // iterations — the saturating_add semantics are clear from
+        // the implementation. Just spot-check that the API does not
+        // panic at high counts.
+        for _ in 0..1000 {
+            let _ = g.record_rejection();
+        }
+        assert_eq!(g.rejected_count(), 1000);
+    }
+
+    #[test]
+    fn block_hash_mismatch_locks_too() {
+        let g = InferenceLockout::locked(LockoutReason::BlockHashMismatch);
+        assert!(g.is_locked());
+        assert_eq!(g.reason(), Some(LockoutReason::BlockHashMismatch));
+    }
+
+    #[test]
+    fn test_only_reset_clears_state() {
+        let mut g = InferenceLockout::locked(LockoutReason::BothSlotsInvalid);
+        let _ = g.record_rejection();
+        g.reset();
+        assert!(!g.is_locked());
+        assert_eq!(g.rejected_count(), 0);
+    }
+
+    #[test]
+    fn message_string_is_user_friendly() {
+        // Operator-facing message contains a clear next-step hint.
+        assert!(SYSTEM_NOT_IN_SERVICE_MSG.contains("recovery"));
+        assert!(SYSTEM_NOT_IN_SERVICE_MSG.contains("not in service"));
+    }
+}

--- a/fs/src/lib.rs
+++ b/fs/src/lib.rs
@@ -91,7 +91,25 @@ pub mod delta;
 ///
 /// Filled by `embedded-filesystem-v1` Phase 6.
 #[cfg(feature = "fs-on-disk-mounts")]
-pub mod cache {}
+pub mod cache;
+
+/// Boot-time mount sequence: GPT → A/B boot config → squashfs A/B
+/// fallback → F2FS `/data/`. Owned by `embedded-filesystem-v1`
+/// Phase 6.
+#[cfg(feature = "fs-on-disk-mounts")]
+pub mod mount;
+
+/// Inference-lockout guard + fail-closed read-path policy. Captured
+/// when both squashfs slots fail signature verification at mount
+/// time. Owned by `embedded-filesystem-v1` Phase 6.
+#[cfg(feature = "fs-on-disk-mounts")]
+pub mod integrity;
+
+/// Default values for the `fs.*` policy.toml field surface
+/// (cache budgets, block-device timeouts, boot watchdog window).
+/// Owned by `embedded-filesystem-v1` Phase 6.
+#[cfg(feature = "fs-on-disk-mounts")]
+pub mod config_defaults;
 
 /// OverlayFS-style merged `/models/` view (upper = F2FS, lower =
 /// squashfs A/B slot), file-based whiteouts, capacity-cap, optional

--- a/fs/src/mount.rs
+++ b/fs/src/mount.rs
@@ -1,0 +1,720 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Boot-time mount sequence for SmallAIOS on-disk filesystems.
+//!
+//! [`mount_all`] orchestrates the steps documented in the
+//! `embedded-filesystem-v1` change Phase 6:
+//!
+//! 1. Parse the GPT and validate the v1 SmallAIOS layout
+//!    (5 partitions, fixed type GUIDs, fixed order). Layout
+//!    mismatches are surfaced as [`MountError::GptLayoutMismatch`].
+//! 2. Read the A/B boot config record from partition #5; pick the
+//!    active squashfs slot (per the highest-valid-generation rule).
+//! 3. Mount the squashfs partition for the active slot at `/models/`.
+//!    On signature/manifest failure fall through to the OTHER slot.
+//!    If both slots fail, raise the [`InferenceLockout`] guard, log
+//!    `both_slots_invalid` to the audit ring, and continue boot — per
+//!    `fs-integrity` the system MUST stay reachable so login, audit,
+//!    and `/data/` can serve a recovery image.
+//! 4. Mount the F2FS `/data/` partition. If unformatted AND physical
+//!    presence is asserted → format (deferred — see note below). If
+//!    unformatted AND no presence → return
+//!    [`MountError::DataUnformatted`].
+//! 5. Hand back the populated mount-table descriptor to the kernel.
+//!
+//! The kernel boot sequencer plugs the concrete `Squashfs<D>` and
+//! `F2fs<'_, D>` runtime handles into the VFS slots after this
+//! function returns; the mount table itself records only the markers
+//! that path resolution needs (which mount the kernel SHOULD route
+//! a given path to). Mirrors how the existing `/flash/` mount works.
+//!
+//! ## F2FS auto-format
+//!
+//! F2FS write-path support lands in Phase 7; the v1 read-only F2FS
+//! reader cannot format an unformatted partition by itself. This
+//! module therefore signals the caller via
+//! [`MountAllOutcome::data_needs_format`] when the F2FS partition
+//! does not have a valid superblock. The kernel boot path is
+//! responsible for shelling out to the future
+//! `smallaios-fs::f2fs::format` helper once it lands; until then the
+//! signal MUST be accompanied by a recovery image that ships a
+//! pre-formatted `/data/` partition.
+//!
+//! Owned by `embedded-filesystem-v1` Phase 6.
+
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::fmt;
+
+use crate::block::BlockDevice;
+use crate::boot_config::{
+    read_active, ActiveSquashfsSlot, BootConfigError, BootConfigRecord, SlotPosition,
+};
+use crate::f2fs::{F2fs, F2fsError};
+use crate::gpt::layout::{parse_layout, SmallaiosLayout};
+use crate::gpt::{parse_gpt, GptError};
+use crate::integrity::{InferenceLockout, LockoutReason};
+use crate::squashfs::{Squashfs, SquashfsError};
+
+/// Trait the mount sequencer uses to ask "is the operator physically
+/// present for high-trust operations like auto-formatting `/data/`?".
+///
+/// Mirrors [`smallaios_auth::presence::PhysicalPresenceProvider`] but
+/// stays inside the `fs` crate so we don't have to add `auth` to the
+/// `fs` dep graph. The kernel boot path constructs an adapter that
+/// forwards to the auth registry. An empty / never-asserting provider
+/// causes [`mount_all`] to refuse the auto-format; this is the
+/// fail-closed default.
+pub trait PhysicalPresenceProvider {
+    /// `true` iff the operator is physically present.
+    fn asserted(&self) -> bool;
+}
+
+/// Adapter that always reports "not present". Used in tests where
+/// presence does not matter and as the fail-closed default.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoPresence;
+
+impl PhysicalPresenceProvider for NoPresence {
+    fn asserted(&self) -> bool {
+        false
+    }
+}
+
+/// Adapter that always reports "present". Tests that exercise the
+/// auto-format branch flip a [`StaticPresence`] in.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct StaticPresence(pub bool);
+
+impl PhysicalPresenceProvider for StaticPresence {
+    fn asserted(&self) -> bool {
+        self.0
+    }
+}
+
+/// Errors surfaced by [`mount_all`].
+///
+/// Note that "both squashfs slots invalid" is NOT in this enum — per
+/// `fs-integrity` the kernel MUST keep booting in that case; the
+/// state is captured in [`MountAllOutcome::lockout`] instead.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MountError {
+    /// GPT parse / validation failed at the disk level (bad header
+    /// CRCs, layout mismatch, etc.).
+    GptError(String),
+    /// The disk's GPT does NOT match the v1 SmallAIOS layout.
+    GptLayoutMismatch,
+    /// Both A/B boot-config records failed validation; nothing to
+    /// boot from.
+    BothBootRecordsInvalid,
+    /// Boot-config decode produced an error other than "both invalid"
+    /// (corrupt magic, etc.). The kernel SHALL halt with a recovery
+    /// hint.
+    BootConfigError(String),
+    /// `/data/` partition exists but does not contain a valid F2FS
+    /// superblock AND physical presence was NOT asserted, so the
+    /// kernel CANNOT auto-format. Operator must boot with presence
+    /// asserted (e.g. via `auth.skip-firstboot`) to recover.
+    DataUnformatted,
+    /// `/data/` partition contains a parseable F2FS superblock but
+    /// some other non-recoverable error (corrupt checkpoint, etc.).
+    DataMountFailed(String),
+    /// Both squashfs slots are invalid. Kept around in case the
+    /// caller wants the strict-mode behavior; `mount_all` itself
+    /// reports lockout in [`MountAllOutcome`] rather than returning
+    /// this error so boot proceeds. Test code uses this variant.
+    BothSlotsInvalid,
+}
+
+impl fmt::Display for MountError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::GptError(msg) => write!(f, "GPT error: {msg}"),
+            Self::GptLayoutMismatch => f.write_str("GPT layout does not match v1 SmallAIOS spec"),
+            Self::BothBootRecordsInvalid => f.write_str("both A/B boot-config records invalid"),
+            Self::BootConfigError(msg) => write!(f, "boot-config error: {msg}"),
+            Self::DataUnformatted => {
+                f.write_str("/data/ partition unformatted; physical presence required")
+            }
+            Self::DataMountFailed(msg) => write!(f, "/data/ mount failed: {msg}"),
+            Self::BothSlotsInvalid => f.write_str("both squashfs slots failed verification"),
+        }
+    }
+}
+
+impl From<GptError> for MountError {
+    fn from(e: GptError) -> Self {
+        match e {
+            GptError::LayoutMismatch => Self::GptLayoutMismatch,
+            other => {
+                use alloc::format;
+                Self::GptError(format!("{other:?}"))
+            }
+        }
+    }
+}
+
+impl From<BootConfigError> for MountError {
+    fn from(e: BootConfigError) -> Self {
+        match e {
+            BootConfigError::BothSlotsInvalid => Self::BothBootRecordsInvalid,
+            other => {
+                use alloc::format;
+                Self::BootConfigError(format!("{other:?}"))
+            }
+        }
+    }
+}
+
+/// Status of one squashfs slot after [`mount_all`] tried to mount it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SlotStatus {
+    /// Slot mounted and verified successfully.
+    Ok,
+    /// Slot mount failed with the given error (signature mismatch,
+    /// bad magic, corrupted manifest, etc.).
+    Failed(SquashfsError),
+    /// Slot was not attempted (e.g. fallback chain reached `Ok` on
+    /// the active slot first).
+    NotAttempted,
+}
+
+impl SlotStatus {
+    /// `true` iff this slot mounted successfully.
+    pub fn is_ok(&self) -> bool {
+        matches!(self, Self::Ok)
+    }
+}
+
+/// What [`mount_all`] tells the kernel boot sequencer.
+///
+/// Carries the parsed GPT layout, the active boot record, the
+/// per-slot mount outcomes, and the [`InferenceLockout`] guard. The
+/// kernel uses this to plug the concrete runtime handles into the
+/// VFS, then calls [`smallaios_posix::vfs::MountTable::mount_squashfs`]
+/// + [`mount_f2fs`] to flip the path-resolution markers.
+#[derive(Debug, Clone)]
+pub struct MountAllOutcome {
+    /// Parsed v1 SmallAIOS layout. The kernel reads partition LBAs /
+    /// sizes from here for runtime-handle wiring.
+    pub layout: SmallaiosLayout,
+    /// The active boot-config record selected by the highest-valid-
+    /// generation rule.
+    pub active_boot_record: BootConfigRecord,
+    /// Which physical slot of the boot-config partition the active
+    /// record was read from.
+    pub active_slot_position: SlotPosition,
+    /// Slot A mount status.
+    pub slot_a: SlotStatus,
+    /// Slot B mount status.
+    pub slot_b: SlotStatus,
+    /// Which squashfs slot ended up serving `/models/`. `None` if both
+    /// failed verification.
+    pub active_squashfs_slot: Option<ActiveSquashfsSlot>,
+    /// Inference-lockout guard. If `is_locked()`, both squashfs slots
+    /// failed verification and `model_load` SHALL return `-EROFS`.
+    pub lockout: InferenceLockout,
+    /// `/data/` mount status — `true` if F2FS mounted cleanly.
+    pub data_mounted: bool,
+    /// `true` iff `/data/` lacked a valid F2FS superblock and the
+    /// kernel SHALL run the (future) `f2fs::format` helper before
+    /// proceeding. Always `false` if presence was not asserted (in
+    /// that case `mount_all` returns `DataUnformatted` instead).
+    pub data_needs_format: bool,
+}
+
+impl MountAllOutcome {
+    /// `true` iff `/models/` ended up mounted.
+    pub fn models_mounted(&self) -> bool {
+        self.active_squashfs_slot.is_some()
+    }
+
+    /// Whether boot SHOULD proceed. Always true unless this struct
+    /// was hand-crafted by tests with an inconsistent state.
+    pub fn boot_proceeds(&self) -> bool {
+        // Per spec, EVERY case where this struct is returned the
+        // boot should proceed — failures land in `MountError`. The
+        // method exists for clarity at the kernel call site.
+        true
+    }
+}
+
+/// Run the boot-time mount sequence.
+///
+/// See module docs for the step-by-step description. On success
+/// returns a populated [`MountAllOutcome`] the kernel uses to wire
+/// VFS handles + the inference-lockout guard. On hard failure
+/// (unparseable GPT, wrong layout, both boot records invalid,
+/// unformatted `/data/` without presence) returns [`MountError`].
+pub fn mount_all<D: BlockDevice, P: PhysicalPresenceProvider + ?Sized>(
+    device: &mut D,
+    presence: &P,
+    public_key: &[u8],
+) -> Result<MountAllOutcome, MountError> {
+    // ─── Step 1: GPT parse + layout validation ──────────────────────────────
+    let entries = parse_gpt(device as &dyn BlockDevice).map_err(MountError::from)?;
+    let layout = parse_layout(&entries).map_err(MountError::from)?;
+
+    // ─── Step 2: A/B boot config ───────────────────────────────────────────
+    let bs = device.block_size_bytes() as u64;
+    if bs == 0 {
+        return Err(MountError::BootConfigError(String::from("zero block size")));
+    }
+    let boot_partition_lba = layout.boot_config.starting_lba;
+    let (active_boot_record, active_slot_position) =
+        read_active(&*device, boot_partition_lba).map_err(MountError::from)?;
+
+    // ─── Step 3: squashfs A/B slot mount ───────────────────────────────────
+    let (slot_a, slot_b, active_squashfs_slot) =
+        mount_squashfs_with_fallback(device, &layout, active_boot_record.active_slot, public_key);
+
+    let lockout = if active_squashfs_slot.is_none() {
+        crate::squashfs::audit_stub(LockoutReason::BothSlotsInvalid.audit_tag(), "");
+        InferenceLockout::locked(LockoutReason::BothSlotsInvalid)
+    } else {
+        InferenceLockout::permissive()
+    };
+
+    // ─── Step 4: F2FS /data/ mount ─────────────────────────────────────────
+    let data_partition_lba = layout.data_f2fs.starting_lba;
+    let data_partition_size_lbas = layout
+        .data_f2fs
+        .ending_lba
+        .saturating_sub(layout.data_f2fs.starting_lba)
+        .saturating_add(1);
+
+    let (data_mounted, data_needs_format) = mount_f2fs_or_signal_format(
+        device,
+        presence,
+        data_partition_lba,
+        data_partition_size_lbas,
+    )?;
+
+    Ok(MountAllOutcome {
+        layout,
+        active_boot_record,
+        active_slot_position,
+        slot_a,
+        slot_b,
+        active_squashfs_slot,
+        lockout,
+        data_mounted,
+        data_needs_format,
+    })
+}
+
+/// Try to mount the squashfs slot indicated by `preferred`. On any
+/// verification error fall through to the other slot. Returns
+/// `(slot_a_status, slot_b_status, active_slot_logical)`.
+fn mount_squashfs_with_fallback<D: BlockDevice>(
+    device: &D,
+    layout: &SmallaiosLayout,
+    preferred: ActiveSquashfsSlot,
+    public_key: &[u8],
+) -> (SlotStatus, SlotStatus, Option<ActiveSquashfsSlot>) {
+    // Probe `preferred` first, then the other slot.
+    let other = preferred.flip();
+    let preferred_result = try_mount_one_slot(device, layout, preferred, public_key);
+    if preferred_result.is_ok() {
+        // Preferred mounted; we don't even probe the other slot
+        // (matches the spec's "If signature/manifest fails, try
+        // the OTHER slot").
+        let (a, b) = match preferred {
+            ActiveSquashfsSlot::A => (SlotStatus::Ok, SlotStatus::NotAttempted),
+            ActiveSquashfsSlot::B => (SlotStatus::NotAttempted, SlotStatus::Ok),
+        };
+        return (a, b, Some(preferred));
+    }
+    let other_result = try_mount_one_slot(device, layout, other, public_key);
+
+    let preferred_status = match preferred_result {
+        Ok(()) => SlotStatus::Ok,
+        Err(e) => SlotStatus::Failed(e),
+    };
+    let other_status = match other_result {
+        Ok(()) => SlotStatus::Ok,
+        Err(e) => SlotStatus::Failed(e),
+    };
+
+    let (slot_a, slot_b) = match preferred {
+        ActiveSquashfsSlot::A => (preferred_status.clone(), other_status.clone()),
+        ActiveSquashfsSlot::B => (other_status.clone(), preferred_status.clone()),
+    };
+
+    let active = if other_status.is_ok() {
+        Some(other)
+    } else if preferred_status.is_ok() {
+        Some(preferred)
+    } else {
+        None
+    };
+
+    (slot_a, slot_b, active)
+}
+
+fn try_mount_one_slot<D: BlockDevice>(
+    device: &D,
+    layout: &SmallaiosLayout,
+    slot: ActiveSquashfsSlot,
+    public_key: &[u8],
+) -> Result<(), SquashfsError> {
+    let part = match slot {
+        ActiveSquashfsSlot::A => &layout.squashfs_a,
+        ActiveSquashfsSlot::B => &layout.squashfs_b,
+    };
+    let lba = part.starting_lba;
+    let size_lbas = part.ending_lba.saturating_sub(lba).saturating_add(1);
+    // `Squashfs::mount` runs the manifest/signature check internally
+    // and verifies every block against the manifest hash array. We
+    // discard the in-memory handle here — the kernel constructs a
+    // fresh one to retain after `mount_all` succeeds.
+    Squashfs::<D>::mount(device, lba, size_lbas, public_key).map(|_| ())
+}
+
+/// Mount F2FS at `/data/`. Returns `(mounted, needs_format)`:
+/// - `(true, false)` — clean mount, runtime handle ready.
+/// - `(false, true)` — unformatted; presence was asserted, kernel
+///   SHOULD format and retry.
+/// - `Err(DataUnformatted)` — unformatted AND no presence.
+/// - `Err(DataMountFailed)` — superblock parses but other error.
+fn mount_f2fs_or_signal_format<D: BlockDevice, P: PhysicalPresenceProvider + ?Sized>(
+    device: &D,
+    presence: &P,
+    partition_lba: u64,
+    size_lbas: u64,
+) -> Result<(bool, bool), MountError> {
+    match F2fs::<D>::mount(device, partition_lba, size_lbas) {
+        Ok(_) => Ok((true, false)),
+        Err(F2fsError::BadMagic) | Err(F2fsError::SuperblockCrcMismatch) => {
+            // Treat both "no recognizable superblock magic" and
+            // "both superblock CRCs failed" as "needs format" if
+            // presence is asserted — operator chose to wipe.
+            if presence.asserted() {
+                Ok((false, true))
+            } else {
+                Err(MountError::DataUnformatted)
+            }
+        }
+        Err(other) => {
+            use alloc::format;
+            Err(MountError::DataMountFailed(format!("{other}")))
+        }
+    }
+}
+
+/// Snapshot of all the mount-table-relevant facts the kernel needs
+/// from a [`MountAllOutcome`]. Used by tests + the future
+/// `posix::vfs::MountTable::apply_outcome` adapter to flip the path
+/// resolution markers in one shot.
+#[derive(Debug, Clone)]
+pub struct MountTableMarkers {
+    /// Active squashfs slot for `/models/`. `None` means lockout.
+    pub models_slot: Option<ActiveSquashfsSlot>,
+    /// `true` iff the F2FS `/data/` mount is live.
+    pub data_active: bool,
+    /// `true` iff the kernel must run the format helper before the
+    /// `/data/` mount can proceed.
+    pub data_needs_format: bool,
+    /// Inference-lockout guard.
+    pub lockout: InferenceLockout,
+    /// LBA + size of the squashfs partition that ended up active
+    /// (so the kernel can construct the runtime handle).
+    pub models_partition: Option<(u64, u64)>,
+    /// LBA + size of the F2FS `/data/` partition.
+    pub data_partition: Option<(u64, u64)>,
+}
+
+impl MountAllOutcome {
+    /// Project the outcome into the markers the VFS mount-table
+    /// needs.
+    pub fn markers(&self) -> MountTableMarkers {
+        let models_partition = self.active_squashfs_slot.map(|slot| {
+            let part = match slot {
+                ActiveSquashfsSlot::A => &self.layout.squashfs_a,
+                ActiveSquashfsSlot::B => &self.layout.squashfs_b,
+            };
+            let lba = part.starting_lba;
+            let size_lbas = part.ending_lba.saturating_sub(lba).saturating_add(1);
+            (lba, size_lbas)
+        });
+        let data_partition = if self.data_mounted || self.data_needs_format {
+            let part = &self.layout.data_f2fs;
+            let lba = part.starting_lba;
+            let size_lbas = part.ending_lba.saturating_sub(lba).saturating_add(1);
+            Some((lba, size_lbas))
+        } else {
+            None
+        };
+        MountTableMarkers {
+            models_slot: self.active_squashfs_slot,
+            data_active: self.data_mounted,
+            data_needs_format: self.data_needs_format,
+            lockout: self.lockout,
+            models_partition,
+            data_partition,
+        }
+    }
+
+    /// List of audit events the kernel SHOULD append after `mount_all`
+    /// returns. Each event is paired with a short detail string.
+    pub fn pending_audit_events(&self) -> Vec<(&'static str, String)> {
+        use alloc::format;
+        let mut events = Vec::new();
+        if let SlotStatus::Failed(e) = &self.slot_a {
+            events.push(("squashfs_slot_a_failed", format!("{e}")));
+        }
+        if let SlotStatus::Failed(e) = &self.slot_b {
+            events.push(("squashfs_slot_b_failed", format!("{e}")));
+        }
+        if self.lockout.is_locked() {
+            events.push((
+                self.lockout
+                    .reason()
+                    .map(|r| r.audit_tag())
+                    .unwrap_or("inference_locked"),
+                String::from("model_load disabled"),
+            ));
+        }
+        if self.data_needs_format {
+            events.push((
+                "data_format_required",
+                String::from("F2FS superblock missing; presence asserted"),
+            ));
+        }
+        events
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ─── Tiny stub helpers ─────────────────────────────────────────────────
+
+    /// In-memory disk that can be pre-wired with arbitrary 4 KiB blocks.
+    /// Used here for unit tests that target the lifting of mount errors
+    /// without paying the cost of building a full GPT layout. The
+    /// integration tests in `fs/tests/mount_conformance.rs` build a real
+    /// disk with valid GPT + boot_config + squashfs slots.
+    use crate::block::mock::MockBlockDevice;
+
+    #[test]
+    fn no_presence_returns_false() {
+        let p = NoPresence;
+        assert!(!p.asserted());
+    }
+
+    #[test]
+    fn static_presence_round_trips() {
+        let p = StaticPresence(true);
+        assert!(p.asserted());
+        let p2 = StaticPresence(false);
+        assert!(!p2.asserted());
+    }
+
+    #[test]
+    fn mount_error_display_renders() {
+        // Sanity check that every Display branch produces non-empty
+        // output. The kernel surfaces these to the console.
+        let cases: &[MountError] = &[
+            MountError::GptError(String::from("ouch")),
+            MountError::GptLayoutMismatch,
+            MountError::BothBootRecordsInvalid,
+            MountError::BootConfigError(String::from("ouch")),
+            MountError::DataUnformatted,
+            MountError::DataMountFailed(String::from("ouch")),
+            MountError::BothSlotsInvalid,
+        ];
+        for e in cases {
+            let s = alloc::format!("{e}");
+            assert!(!s.is_empty(), "empty Display for {:?}", e);
+        }
+    }
+
+    #[test]
+    fn mount_error_from_gpt_layout_mismatch() {
+        let e: MountError = GptError::LayoutMismatch.into();
+        assert_eq!(e, MountError::GptLayoutMismatch);
+    }
+
+    #[test]
+    fn mount_error_from_boot_both_invalid() {
+        let e: MountError = BootConfigError::BothSlotsInvalid.into();
+        assert_eq!(e, MountError::BothBootRecordsInvalid);
+    }
+
+    #[test]
+    fn mount_error_from_boot_other() {
+        let e: MountError = BootConfigError::BadMagic.into();
+        match e {
+            MountError::BootConfigError(_) => {}
+            other => panic!("expected BootConfigError, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn slot_status_helpers() {
+        assert!(SlotStatus::Ok.is_ok());
+        assert!(!SlotStatus::Failed(SquashfsError::BadMagic).is_ok());
+        assert!(!SlotStatus::NotAttempted.is_ok());
+    }
+
+    #[test]
+    fn mount_all_blank_disk_returns_gpt_error() {
+        // A blank 4 GiB device has no GPT — `parse_gpt` returns an
+        // error that `mount_all` lifts to `MountError::GptError(_)`.
+        let mut device = MockBlockDevice::new(4096, 1024);
+        let err = mount_all(&mut device, &NoPresence, &[0u8; 32]).unwrap_err();
+        // Could be GptError or GptLayoutMismatch depending on which
+        // sub-step trips first; just ensure some error came back.
+        assert!(matches!(
+            err,
+            MountError::GptError(_) | MountError::GptLayoutMismatch
+        ));
+    }
+
+    #[test]
+    fn outcome_markers_for_locked_inference() {
+        // Synthesize an outcome by hand to test marker extraction on
+        // the both-slots-bad path.
+        let layout = SmallaiosLayout {
+            esp: dummy_entry(0, 100),
+            squashfs_a: dummy_entry(101, 200),
+            squashfs_b: dummy_entry(201, 300),
+            data_f2fs: dummy_entry(301, 400),
+            boot_config: dummy_entry(401, 402),
+        };
+        let outcome = MountAllOutcome {
+            layout,
+            active_boot_record: BootConfigRecord::new(ActiveSquashfsSlot::A, 1),
+            active_slot_position: SlotPosition::SlotX,
+            slot_a: SlotStatus::Failed(SquashfsError::ManifestSignatureInvalid),
+            slot_b: SlotStatus::Failed(SquashfsError::ManifestSignatureInvalid),
+            active_squashfs_slot: None,
+            lockout: InferenceLockout::locked(LockoutReason::BothSlotsInvalid),
+            data_mounted: true,
+            data_needs_format: false,
+        };
+        let m = outcome.markers();
+        assert!(m.lockout.is_locked());
+        assert!(m.models_slot.is_none());
+        assert!(m.models_partition.is_none());
+        assert!(m.data_active);
+        assert!(m.data_partition.is_some());
+    }
+
+    #[test]
+    fn outcome_markers_for_happy_path() {
+        let layout = SmallaiosLayout {
+            esp: dummy_entry(0, 100),
+            squashfs_a: dummy_entry(101, 200),
+            squashfs_b: dummy_entry(201, 300),
+            data_f2fs: dummy_entry(301, 400),
+            boot_config: dummy_entry(401, 402),
+        };
+        let outcome = MountAllOutcome {
+            layout,
+            active_boot_record: BootConfigRecord::new(ActiveSquashfsSlot::B, 1),
+            active_slot_position: SlotPosition::SlotY,
+            slot_a: SlotStatus::NotAttempted,
+            slot_b: SlotStatus::Ok,
+            active_squashfs_slot: Some(ActiveSquashfsSlot::B),
+            lockout: InferenceLockout::permissive(),
+            data_mounted: true,
+            data_needs_format: false,
+        };
+        let m = outcome.markers();
+        assert!(!m.lockout.is_locked());
+        assert_eq!(m.models_slot, Some(ActiveSquashfsSlot::B));
+        assert_eq!(m.models_partition, Some((201, 100)));
+        assert!(m.data_active);
+        assert_eq!(m.data_partition, Some((301, 100)));
+    }
+
+    #[test]
+    fn pending_audit_events_lists_failures() {
+        let layout = SmallaiosLayout {
+            esp: dummy_entry(0, 100),
+            squashfs_a: dummy_entry(101, 200),
+            squashfs_b: dummy_entry(201, 300),
+            data_f2fs: dummy_entry(301, 400),
+            boot_config: dummy_entry(401, 402),
+        };
+        let outcome = MountAllOutcome {
+            layout,
+            active_boot_record: BootConfigRecord::new(ActiveSquashfsSlot::A, 1),
+            active_slot_position: SlotPosition::SlotX,
+            slot_a: SlotStatus::Failed(SquashfsError::ManifestSignatureInvalid),
+            slot_b: SlotStatus::Failed(SquashfsError::ManifestSignatureInvalid),
+            active_squashfs_slot: None,
+            lockout: InferenceLockout::locked(LockoutReason::BothSlotsInvalid),
+            data_mounted: true,
+            data_needs_format: false,
+        };
+        let events = outcome.pending_audit_events();
+        assert!(events.iter().any(|(t, _)| *t == "squashfs_slot_a_failed"));
+        assert!(events.iter().any(|(t, _)| *t == "squashfs_slot_b_failed"));
+        assert!(events.iter().any(|(t, _)| *t == "both_slots_invalid"));
+    }
+
+    #[test]
+    fn pending_audit_events_for_format_needed() {
+        let layout = SmallaiosLayout {
+            esp: dummy_entry(0, 100),
+            squashfs_a: dummy_entry(101, 200),
+            squashfs_b: dummy_entry(201, 300),
+            data_f2fs: dummy_entry(301, 400),
+            boot_config: dummy_entry(401, 402),
+        };
+        let outcome = MountAllOutcome {
+            layout,
+            active_boot_record: BootConfigRecord::new(ActiveSquashfsSlot::A, 1),
+            active_slot_position: SlotPosition::SlotX,
+            slot_a: SlotStatus::Ok,
+            slot_b: SlotStatus::NotAttempted,
+            active_squashfs_slot: Some(ActiveSquashfsSlot::A),
+            lockout: InferenceLockout::permissive(),
+            data_mounted: false,
+            data_needs_format: true,
+        };
+        let events = outcome.pending_audit_events();
+        assert!(events.iter().any(|(t, _)| *t == "data_format_required"));
+    }
+
+    #[test]
+    fn happy_outcome_pending_audit_events_empty() {
+        let layout = SmallaiosLayout {
+            esp: dummy_entry(0, 100),
+            squashfs_a: dummy_entry(101, 200),
+            squashfs_b: dummy_entry(201, 300),
+            data_f2fs: dummy_entry(301, 400),
+            boot_config: dummy_entry(401, 402),
+        };
+        let outcome = MountAllOutcome {
+            layout,
+            active_boot_record: BootConfigRecord::new(ActiveSquashfsSlot::A, 1),
+            active_slot_position: SlotPosition::SlotX,
+            slot_a: SlotStatus::Ok,
+            slot_b: SlotStatus::NotAttempted,
+            active_squashfs_slot: Some(ActiveSquashfsSlot::A),
+            lockout: InferenceLockout::permissive(),
+            data_mounted: true,
+            data_needs_format: false,
+        };
+        assert!(outcome.pending_audit_events().is_empty());
+    }
+
+    fn dummy_entry(start: u64, end: u64) -> crate::gpt::PartitionEntry {
+        crate::gpt::PartitionEntry {
+            type_guid: crate::gpt::Guid::nil(),
+            unique_guid: crate::gpt::Guid::nil(),
+            starting_lba: start,
+            ending_lba: end,
+            attributes: 0,
+            name: crate::gpt::PartitionName::empty(),
+        }
+    }
+}

--- a/posix/Cargo.toml
+++ b/posix/Cargo.toml
@@ -18,6 +18,12 @@ fs-flash = ["dep:smallaios-fs", "smallaios-fs/fs-flash"]
 # `smallaios-fs` so the mount conformance tests in `posix` and `fs`
 # can exercise `/flash/` without real hardware.
 fs-flash-mock = ["dep:smallaios-fs", "smallaios-fs/fs-flash-mock"]
+# `fs-on-disk-mounts`: opt-in `/models/` (squashfs) and `/data/` (F2FS)
+# mounts. Mirrors the same-named feature on `smallaios-fs` and pulls
+# in the GPT, A/B boot config, and integrity layers. Default off so
+# bare-metal targets that don't have block-device storage stay
+# byte-identical with the in-memory VFS path.
+fs-on-disk-mounts = ["dep:smallaios-fs", "smallaios-fs/fs-on-disk-mounts"]
 
 [dependencies]
 smallaios-kernel = { path = "../kernel" }

--- a/posix/src/vfs.rs
+++ b/posix/src/vfs.rs
@@ -433,9 +433,12 @@ pub fn build_default_vfs() -> VfsTree {
 /// renames/etc. under the mount path to the littlefs runtime in
 /// `smallaios-fs`.
 ///
-/// Phase 3 of `embedded-flash-fs-v1` lands the wiring; future on-disk
-/// mounts (squashfs `/models/`, F2FS `/data/`) plug in by adding new
-/// variants here.
+/// Phase 3 of `embedded-flash-fs-v1` landed `LittleFs`. Phase 6 of
+/// `embedded-filesystem-v1` adds `Squashfs` (read-only `/models/`) and
+/// `F2fs` (read/write `/data/`); both are marker variants for the
+/// same reason as `LittleFs` — the concrete runtime handle has a
+/// `'a D` borrow against the underlying [`smallaios_fs::block::BlockDevice`]
+/// owned by the kernel boot sequencer.
 ///
 /// The `InMemory` variant is intentionally the dominant code path (it
 /// holds the existing static tree); boxing it would force every
@@ -454,6 +457,16 @@ pub enum MountedFs {
     /// `LittleFs<'_, D>` handle through (the kernel currently owns it).
     #[cfg(feature = "fs-flash")]
     LittleFs(FlashMount),
+    /// Squashfs-backed read-only `/models/` mount. The marker records
+    /// the active A/B slot + the device LBA range; the kernel keeps
+    /// the [`smallaios_fs::squashfs::Squashfs`] runtime handle.
+    #[cfg(feature = "fs-on-disk-mounts")]
+    Squashfs(SquashfsMount),
+    /// F2FS-backed read/write `/data/` mount. The marker records the
+    /// device LBA range; the kernel keeps the
+    /// [`smallaios_fs::f2fs::F2fs`] runtime handle.
+    #[cfg(feature = "fs-on-disk-mounts")]
+    F2fs(F2fsMount),
 }
 
 /// Marker handle for a `/flash/` mount point.
@@ -474,6 +487,44 @@ pub struct FlashMount {
     /// to this mount slot. v1 toggles this from
     /// [`MountTable::mount_flash`]; future revisions will store the
     /// runtime handle directly.
+    pub bound: bool,
+}
+
+/// Marker handle for the `/models/` squashfs mount.
+///
+/// Phase 6 records only the active A/B slot identifier and partition
+/// LBA / size; the [`smallaios_fs::squashfs::Squashfs`] runtime handle
+/// is owned by the kernel boot sequencer. The marker is what tells
+/// path resolution to send opens under `/models/` to that handle.
+#[cfg(feature = "fs-on-disk-mounts")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SquashfsMount {
+    /// Mount-point absolute path (always `/models` in v1).
+    pub path: &'static str,
+    /// Active squashfs A/B slot byte (0 = A, 1 = B). Mirrors
+    /// `smallaios_fs::boot_config::ActiveSquashfsSlot::as_u8`.
+    pub active_slot: u8,
+    /// Partition starting LBA on the underlying block device.
+    pub partition_lba: u64,
+    /// Partition length in device LBAs.
+    pub size_lbas: u64,
+    /// `true` once the kernel has wired a [`smallaios_fs::squashfs::Squashfs`]
+    /// runtime instance to this slot.
+    pub bound: bool,
+}
+
+/// Marker handle for the `/data/` F2FS mount.
+#[cfg(feature = "fs-on-disk-mounts")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct F2fsMount {
+    /// Mount-point absolute path (always `/data` in v1).
+    pub path: &'static str,
+    /// Partition starting LBA on the underlying block device.
+    pub partition_lba: u64,
+    /// Partition length in device LBAs.
+    pub size_lbas: u64,
+    /// `true` once the kernel has wired a [`smallaios_fs::f2fs::F2fs`]
+    /// runtime instance to this slot.
     pub bound: bool,
 }
 
@@ -542,6 +593,16 @@ pub struct MountTable {
     in_memory: VfsTree,
     #[cfg(feature = "fs-flash")]
     flash: Option<FlashMount>,
+    #[cfg(feature = "fs-on-disk-mounts")]
+    squashfs: Option<SquashfsMount>,
+    #[cfg(feature = "fs-on-disk-mounts")]
+    f2fs: Option<F2fsMount>,
+    /// `true` iff both squashfs A/B slots failed signature verification
+    /// at mount-time. While this flag is set the syscall layer SHALL
+    /// reject `model_load` with `-EROFS` per `fs-integrity`. Login,
+    /// audit, and `/data/` continue to work unchanged.
+    #[cfg(feature = "fs-on-disk-mounts")]
+    models_disabled: bool,
 }
 
 impl Default for MountTable {
@@ -552,12 +613,18 @@ impl Default for MountTable {
 
 impl MountTable {
     /// Build a mount table with the default in-memory tree and no
-    /// `/flash/` slot.
+    /// on-disk slots bound.
     pub fn new() -> Self {
         Self {
             in_memory: build_default_vfs(),
             #[cfg(feature = "fs-flash")]
             flash: None,
+            #[cfg(feature = "fs-on-disk-mounts")]
+            squashfs: None,
+            #[cfg(feature = "fs-on-disk-mounts")]
+            f2fs: None,
+            #[cfg(feature = "fs-on-disk-mounts")]
+            models_disabled: false,
         }
     }
 


### PR DESCRIPTION
## Summary

Phase 6 of `embedded-filesystem-v1`. Wires squashfs (Phase 3) + F2FS RO (Phase 5) + A/B boot config (Phase 4) into the kernel boot sequence and `posix::vfs`.

- `fs/src/mount.rs` (724 LOC) — `mount_all()` orchestrator: GPT parse + layout validate, A/B slot pick, squashfs mount with fallback-to-other-slot on signature/manifest fail, F2FS mount with format-on-physical-presence path, both-slots-bad halt path.
- `fs/src/cache.rs` (657 LOC) — per-mount LRU block cache (16 MiB models, 4 MiB data defaults; configurable via `mgmt/policy.toml fs.cache.*`); 256 KiB write-coalescing buffer for `/data/` writes.
- `fs/src/integrity.rs` (234 LOC) — fail-closed read path for both-slots-bad; `models_disabled` flag returned via `MountTable`.
- `fs/src/config_defaults.rs` (104 LOC) — declares const default values that mgmt phase 5's `Config` struct references.
- `posix/src/vfs.rs` — extends `MountedFs` enum with `Squashfs(SquashfsMount)` and `F2fs(F2fsMount)` variants alongside existing `InMemory(VfsTree)` and `LittleFs(FlashMount)`. Routes `/models/`, `/data/`, `/flash/`, `/dev/`, `/proc/` correctly. `is_auth_protected_path("/data/auth/...")` guard from Phase 3 fires BEFORE F2fs lookup.

319 tests pass with `--features fs-on-disk-mounts`; 341 with full feature set (zstd+xz+gzip+lz4).

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy -p smallaios-fs --features fs-on-disk-mounts --all-targets -- -D warnings` clean.
- [x] `cargo test -p smallaios-fs --features fs-on-disk-mounts --lib` — 319/319.
- [x] `cargo test -p smallaios-fs --features fs-on-disk-mounts,fs-test-helpers,fs-squashfs-{zstd,xz,gzip,lz4} --lib` — 341/341.
- [x] `cargo vet check` Vetting Succeeded.
- [x] `openspec validate embedded-filesystem-v1 --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)