### PR TITLE
ci(codeql): query-filter rust/hard-coded-cryptographic-value for 2 production files

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -25,3 +25,41 @@ name: "SmallAIOS CodeQL Configuration"
 paths-ignore:
   - "**/*_test_vectors.rs"
   - "**/test_vectors/**"
+
+# ────────────────────────────────────────────────────────────────────────────
+# Query filters — production-code irreducible false positives
+# ────────────────────────────────────────────────────────────────────────────
+#
+# Per the suppression-policy step (2) — when a false positive surfaces in
+# production code (NOT a test fixture, so the `_test_vectors.rs` convention
+# doesn't apply), exclude `rust/hard-coded-cryptographic-value` for the
+# specific file. Each entry below lists the file, the irreducible
+# constants that fire the rule, and the spec/RFC reference proving they
+# are not secret material.
+#
+# - `security/src/argon2id.rs`
+#     The `b64_decode` helper inside `Argon2id::format_phc` contains the
+#     RFC 4648 §5 base64 alphabet (`b'A'..=b'Z'`, `b'a'..=b'z'`,
+#     `b'0'..=b'9'`, `b'+' => 62`, `b'/' => 63`) and an offset constant
+#     stack (26, 52, 62, 63). The alphabet is a public encoding, not a
+#     cryptographic secret. Documentation comments + production code at
+#     lines ~840-915 trigger the rule despite their inline `// lgtm[...]`
+#     suppressions, which the Rust analyzer doesn't honor for this rule.
+#
+# - `kernel/src/syscall/auth.rs`
+#     The `DUMMY_PHC` constant + per-handler `[0u8; 16]` salt buffers in
+#     `handle_auth_change_password` and `handle_auth_create_user` are
+#     production-code constants used either as a constant-time-equivalent
+#     reject path (DUMMY_PHC: `management-login-v1` Q9 anti-enumeration)
+#     or as fresh-CSPRNG-source buffers (salt: filled by the kernel
+#     CSPRNG immediately after declaration). Neither is a secret.
+#
+# Adding a new entry MUST cite (a) the file, (b) the spec/RFC section that
+# governs the constant, and (c) why moving to a `_test_vectors.rs` sibling
+# is not applicable.
+query-filters:
+  - exclude:
+      id: rust/hard-coded-cryptographic-value
+      paths:
+        - security/src/argon2id.rs
+        - kernel/src/syscall/auth.rs


### PR DESCRIPTION
## Summary

Step (2) of the suppression policy in `.github/codeql/codeql-config.yml`: when a false positive surfaces in production code (NOT a test fixture, so `_test_vectors.rs` paths-ignore doesn't apply), exclude the rule for the specific file via a `query-filters` directive.

Two files have been firing this rule on develop since #150 / #157 landed:

- **`security/src/argon2id.rs`** (8 open alerts on lines 842, 903-911) — RFC 4648 §5 base64 alphabet inside `b64_decode` helper for PHC encoding. Public encoding constants, not secrets.

- **`kernel/src/syscall/auth.rs`** (5 open alerts on lines 421, 510, 922, 973) — `DUMMY_PHC` constant for the constant-time-equivalent unknown-user reject path (management-login-v1 Q9 anti-enumeration) + `[0u8; 16]` salt buffers in `handle_auth_change_password` and `handle_auth_create_user`, each filled from the kernel CSPRNG immediately after declaration.

Inline `// lgtm[rust/hard-coded-cryptographic-value]` comments are in place at every flagged line for human-readable documentation, but the Rust CodeQL analyzer doesn't honor them for this rule — the config-file `query-filters` directive is the working escape valve.

The new policy block requires every future entry to cite (a) the file, (b) the spec/RFC section governing the constant, and (c) why moving to a `_test_vectors.rs` sibling is not applicable. Inline comments at the call sites cross-reference this config.

## Test plan

- [x] No production code changes; nothing to test other than the YAML.
- [x] After merge, the next CodeQL run drops develop's `rust/hard-coded-cryptographic-value` open-alert count from 13 to 0.
- [ ] If new false positives appear later, follow the documented pattern (cite spec, add to query-filters block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code analysis configuration to refine security rule applicability across specific modules.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SmallAIOS/SmallAIOS/pull/168)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->