### PR TITLE
feat(mgmt): TOML loader + universal-exposure CI walker (management-login-v1 phase 6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,6 +775,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,6 +936,7 @@ dependencies = [
  "smallaios-auth",
  "smallaios-kernel",
  "smallaios-security",
+ "toml",
 ]
 
 [[package]]
@@ -1032,6 +1042,40 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -1222,6 +1266,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1308,6 +1361,10 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
+
+[[package]]
+name = "xtask"
+version = "0.2.1"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "mgmt",
     "fs",
     "tools/coverage-probe",
+    "xtask",
 ]
 
 [workspace.package]

--- a/Justfile
+++ b/Justfile
@@ -351,6 +351,7 @@ test:
         -p smallaios-auth \
         -p smallaios-mgmt \
         -p smallaios-fs \
+        -p xtask \
         -p smallaios-peripheral --features smallaios-peripheral/uart
 
 # Run Metal GPU tests (macOS only)
@@ -375,6 +376,7 @@ clippy:
         -p smallaios-auth \
         -p smallaios-mgmt \
         -p smallaios-fs \
+        -p xtask \
         -p smallaios-peripheral --features smallaios-peripheral/uart \
         -- -D warnings
 

--- a/mgmt/Cargo.toml
+++ b/mgmt/Cargo.toml
@@ -14,6 +14,13 @@ smallaios-auth = { path = "../auth" }
 smallaios-security = { path = "../security" }
 smallaios-kernel = { path = "../kernel" }
 
+[dev-dependencies]
+# Dev-only "oracle" used by mgmt/tests/toml_oracle.rs to cross-check
+# our clean-room TOML parser against the upstream `toml` crate. Only
+# pulled in for `cargo test` — production builds (kernel + container)
+# do NOT depend on this crate.
+toml = { version = "0.8", default-features = false, features = ["parse"] }
+
 [features]
 default = []
 # Build-time wiring per `management-login-v1` design:

--- a/mgmt/src/lib.rs
+++ b/mgmt/src/lib.rs
@@ -52,9 +52,15 @@ pub mod validate;
 /// notifications. Subscribers pull on their own schedule.
 pub mod notify;
 
+/// Clean-room `#![no_std]` TOML 1.0 (subset) parser and serialiser
+/// used by [`loader_toml`]. The clean-room rule precludes the
+/// upstream `toml` crate at runtime; the dev-only `toml` oracle in
+/// `mgmt/tests/` validates round-trips against this implementation.
+pub mod toml;
+
 /// TOML loader/saver — a `ConfigSurface` impl over `/data/*.toml`.
-/// Filled by `management-login-v1` Phase 6.
-pub mod loader_toml {}
+/// First real surface implementing [`ConfigSurface`].
+pub mod loader_toml;
 
 /// Zenoh admin/telemetry — a `ConfigSurface` impl over the existing
 /// PQC-backed Zenoh transport at `smallaios/admin/**` and

--- a/mgmt/src/loader_toml/loader_test_vectors.rs
+++ b/mgmt/src/loader_toml/loader_test_vectors.rs
@@ -1,0 +1,134 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Test vectors (sample TOML strings) for [`crate::loader_toml`].
+//!
+//! Lives in a `*_test_vectors.rs` sibling so codeql-config's
+//! `paths-ignore` rule excludes it from analysis — large literal
+//! constants here would otherwise trip CodeQL's "magic number"
+//! heuristics.
+
+#![cfg(test)]
+
+/// `system.toml` rendered from [`crate::config::Config::v1_defaults`].
+///
+/// The exact byte-for-byte form depends on the BTreeMap iteration
+/// order in the serialiser, so the loader's
+/// `round_trip_via_seeded_default_files` test re-renders rather than
+/// relying on this constant. This vector is for human-eyeball
+/// inspection of "what does a default `system.toml` look like".
+pub const SYSTEM_TOML_DEFAULT: &[u8] = b"\
+[flash]
+prefer_flash_for_models = true
+readback_verify = true
+
+[fs]
+block_read_timeout_ms = 5000
+block_retry_count = 3
+boot_watchdog_seconds = 60
+cache_data_bytes = 67108864
+cache_models_bytes = 67108864
+
+[idle]
+operator_minutes = 60
+root_minutes = 15
+viewer_minutes = 60
+
+[password]
+dictionary_check = true
+max_length = 128
+min_length = 12
+require_classes = [\"lower\", \"upper\", \"digit\"]
+";
+
+/// `mgmt/policy.toml` rendered from
+/// [`crate::config::Config::v1_defaults`]. See
+/// [`SYSTEM_TOML_DEFAULT`] for caveats on byte-exactness.
+pub const MGMT_POLICY_TOML_DEFAULT: &[u8] = b"\
+[audit]
+keep_archives = 8
+max_total_disk_bytes = 268435456
+rotate_age_hours = 24
+rotate_size_bytes = 16777216
+signed_checkpoints = true
+
+[metrics]
+adaptive_cpu_high_pct = 80
+adaptive_cpu_low_pct = 20
+cpu_interval_ms = 1000
+inference_interval_ms = 500
+memory_interval_ms = 5000
+network_interval_ms = 1000
+
+[mgmt]
+token_two_tier = true
+zenoh_per_identity_max = 4
+zenoh_total_max = 32
+
+[overlay]
+allow_operator_unhide = true
+require_signed = true
+upper_max_bytes = 268435456
+";
+
+/// Hand-crafted "minimal valid" `system.toml` that exercises every
+/// scalar variant — used in lex/parse round-trip tests.
+pub const MIXED_SCALARS_TOML: &[u8] = b"\
+[idle]
+root_minutes = 15
+operator_minutes = 60
+viewer_minutes = 60
+
+[password]
+min_length = 12
+max_length = 128
+dictionary_check = false
+require_classes = [\"lower\", \"upper\"]
+";
+
+/// Vector with a deliberate unknown key to exercise
+/// [`crate::loader_toml::LoaderError::UnknownField`].
+pub const UNKNOWN_KEY_TOML: &[u8] = b"\
+[idle]
+root_minutes = 15
+unknown_key = 1
+";
+
+/// Vector with deliberately wrong type to exercise
+/// [`crate::loader_toml::LoaderError::TypeMismatch`].
+pub const TYPE_MISMATCH_TOML: &[u8] = b"\
+[idle]
+root_minutes = \"not-a-number\"
+";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixture_constants_are_non_empty() {
+        assert!(!SYSTEM_TOML_DEFAULT.is_empty());
+        assert!(!MGMT_POLICY_TOML_DEFAULT.is_empty());
+        assert!(!MIXED_SCALARS_TOML.is_empty());
+        assert!(!UNKNOWN_KEY_TOML.is_empty());
+        assert!(!TYPE_MISMATCH_TOML.is_empty());
+    }
+
+    #[test]
+    fn system_default_parses_through_clean_room_parser() {
+        let s = core::str::from_utf8(SYSTEM_TOML_DEFAULT).unwrap();
+        let _ = crate::toml::parse(s).expect("default system.toml parses cleanly");
+    }
+
+    #[test]
+    fn policy_default_parses_through_clean_room_parser() {
+        let s = core::str::from_utf8(MGMT_POLICY_TOML_DEFAULT).unwrap();
+        let _ = crate::toml::parse(s).expect("default policy.toml parses cleanly");
+    }
+
+    #[test]
+    fn mixed_scalars_parses() {
+        let s = core::str::from_utf8(MIXED_SCALARS_TOML).unwrap();
+        let _ = crate::toml::parse(s).unwrap();
+    }
+}

--- a/mgmt/src/loader_toml/mod.rs
+++ b/mgmt/src/loader_toml/mod.rs
@@ -1,0 +1,1660 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! TOML loader/saver — first real [`crate::ConfigSurface`] impl.
+//!
+//! Spec:
+//! - `openspec/changes/management-login-v1/specs/mgmt-config-surface-trait/spec.md`
+//!   ("TOML surface implements ConfigSurface" scenario).
+//! - `openspec/changes/management-login-v1/specs/mgmt-config-layout/spec.md`
+//!   (`/data/` directory layout, per-file permission declaration,
+//!   stricter-than-declared rule).
+//! - `openspec/changes/management-login-v1/specs/mgmt-config-model/spec.md`
+//!   ("Apply lifecycle" — parse, validate, stage, fsync, rename,
+//!    notify, audit).
+//!
+//! ## Apply lifecycle
+//!
+//! On a [`TomlLoader::write`]:
+//!
+//! 1. **Parse** the proposed [`Value`] into the typed schema.
+//! 2. **Validate** per-field and cross-field via
+//!    [`crate::validate`]. Failure leaves on-disk and in-memory
+//!    state untouched.
+//! 3. **Stage** the rewritten file at `<file>.tmp` via the configured
+//!    [`AtomicWriter`]. The writer itself fsyncs and renames.
+//! 4. **Update** the in-memory [`Config`] iff the field has
+//!    `ReloadKind::Live`. Boot-deferred fields are accumulated in
+//!    [`TomlLoader::pending_reboot`] for the operator to see.
+//! 5. **Notify** subscribers via the broadcast channel.
+//!
+//! ## First-boot generation
+//!
+//! When [`TomlLoader::load`] finds a file missing it generates a
+//! skeleton with [`Config::v1_defaults`]-derived contents iff the
+//! caller passes [`FirstBootPolicy::Generate`] (this is the case the
+//! kernel sets on a freshly-formatted F2FS partition). With
+//! [`FirstBootPolicy::Strict`] a missing file is a fatal error —
+//! "config disappeared between boots" is a corruption signal that
+//! deserves operator attention.
+//!
+//! ## File-mode-stricter-than-declared rule
+//!
+//! Per `mgmt-config-layout`, every file has a declared mode (e.g.,
+//! `0640` for `mgmt/policy.toml`). The loader refuses to read a file
+//! whose mode is laxer than declared (e.g., `0644` shadow rejected).
+//! Stricter-than-declared modes are accepted.
+
+use alloc::collections::BTreeMap;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::cell::RefCell;
+use core::fmt;
+
+use crate::config::registry::{self, FieldType};
+use crate::config::Config;
+use crate::notify::{BroadcastTx, NotifyEvent, Subscriber};
+use crate::surface::{
+    AuditIdentity, ConfigPath, ConfigSurface, Error as SurfaceError, PasswordClassSet, ReloadKind,
+    SurfaceKind, Value,
+};
+use crate::toml::{parse as toml_parse, serialize as toml_serialize, TomlTable, TomlValue};
+use crate::validate;
+
+use smallaios_auth::atomic_write::{AtomicWriteError, AtomicWriter};
+
+#[cfg(test)]
+mod loader_test_vectors;
+
+/// Behaviour when a per-subsystem file is missing on [`TomlLoader::load`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FirstBootPolicy {
+    /// First boot after a fresh F2FS format — generate skeleton files
+    /// from [`Config::v1_defaults`].
+    Generate,
+    /// Strict — a missing file is a fatal error.
+    Strict,
+}
+
+/// Loader-level error. Distinct from [`SurfaceError`] because the
+/// loader sees a few categories the trait doesn't (config layout
+/// corruption, mode mismatch, generation failure). Implements
+/// `From<LoaderError>` -> [`SurfaceError`] so the trait surface can
+/// report it cleanly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LoaderError {
+    /// A declared file is missing and [`FirstBootPolicy::Strict`] is
+    /// in effect.
+    Missing {
+        /// Absolute path that was expected.
+        path: String,
+    },
+    /// On-disk mode is laxer than the declared mode for `path`.
+    ModeViolation {
+        /// File whose mode was rejected.
+        path: String,
+        /// Declared mode (octal, e.g. `0o640`).
+        declared: u16,
+        /// Observed mode (octal).
+        actual: u16,
+    },
+    /// TOML parse / serialise error.
+    Toml(crate::toml::Error),
+    /// Per-field or cross-field validation rejected the on-disk
+    /// content.
+    Validation(&'static str),
+    /// Backing I/O failure. Carries the static reason from
+    /// [`AtomicWriteError`] or the backend metadata source.
+    Io(&'static str),
+    /// File contains a TOML key whose dotted path does not match any
+    /// known [`Config`] field. Strict by spec — unknown keys are a
+    /// drift signal.
+    UnknownField(String),
+    /// File contains a TOML scalar whose runtime variant does not
+    /// match the registry's typed [`FieldType`]. Lossy file edits
+    /// (e.g., a `bool` typed as a string) trigger this.
+    TypeMismatch {
+        /// Dotted path that mismatched.
+        path: String,
+        /// Expected variant tag.
+        expected: &'static str,
+        /// Actual variant tag.
+        got: &'static str,
+    },
+}
+
+impl fmt::Display for LoaderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Missing { path } => write!(f, "loader_toml: missing required file: {path}"),
+            Self::ModeViolation {
+                path,
+                declared,
+                actual,
+            } => write!(
+                f,
+                "loader_toml: mode violation on {path}: declared 0o{declared:o}, actual 0o{actual:o}"
+            ),
+            Self::Toml(e) => write!(f, "loader_toml: {e}"),
+            Self::Validation(reason) => write!(f, "loader_toml: validation: {reason}"),
+            Self::Io(reason) => write!(f, "loader_toml: io: {reason}"),
+            Self::UnknownField(p) => write!(f, "loader_toml: unknown field: {p}"),
+            Self::TypeMismatch {
+                path,
+                expected,
+                got,
+            } => write!(
+                f,
+                "loader_toml: type mismatch at {path}: expected {expected}, got {got}"
+            ),
+        }
+    }
+}
+
+impl From<crate::toml::Error> for LoaderError {
+    fn from(e: crate::toml::Error) -> Self {
+        Self::Toml(e)
+    }
+}
+
+impl From<AtomicWriteError> for LoaderError {
+    fn from(e: AtomicWriteError) -> Self {
+        match e {
+            AtomicWriteError::NotImplemented => {
+                Self::Io("KernelAtomicWriter has no backend installed")
+            }
+            AtomicWriteError::Io(reason) => Self::Io(reason),
+            AtomicWriteError::InvalidPath => Self::Io("invalid path"),
+        }
+    }
+}
+
+impl From<LoaderError> for SurfaceError {
+    fn from(e: LoaderError) -> Self {
+        match e {
+            LoaderError::Missing { .. } => SurfaceError::Io("missing config file"),
+            LoaderError::ModeViolation { .. } => SurfaceError::Io("config mode violation"),
+            LoaderError::Toml(_) => SurfaceError::Io("toml parse error"),
+            LoaderError::Validation(reason) => SurfaceError::Validation(reason),
+            LoaderError::Io(reason) => SurfaceError::Io(reason),
+            LoaderError::UnknownField(_) => SurfaceError::NotFound,
+            LoaderError::TypeMismatch { expected, got, .. } => {
+                SurfaceError::TypeMismatch { expected, got }
+            }
+        }
+    }
+}
+
+// ─── Per-subsystem layout ────────────────────────────────────────────────────
+
+/// One row of the layout table: relative path under `base` + the
+/// declared file mode. Owner is always `kernel` per the spec.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LayoutEntry {
+    /// Relative path under `base` (e.g. `"system.toml"`).
+    pub relative: &'static str,
+    /// Declared POSIX mode (e.g. `0o644`, `0o640`).
+    pub declared_mode: u16,
+    /// Predicate: which top-level [`Config`] namespace's keys live in
+    /// this file. The path's first segment must equal this string.
+    pub namespace: Namespace,
+}
+
+/// Coarse mapping of layout files to top-level `Config` namespaces.
+/// `mgmt-config-layout` v1 maps:
+///
+/// - `system.toml` → `idle.*`, `password.*`, `flash.*`, `fs.*` (cross-cutting).
+/// - `mgmt/policy.toml` → `mgmt.*`, `audit.*`, `metrics.*`, `overlay.*`.
+///
+/// `mgmt/zenoh.toml`, `network/*.toml`, `update/policy.toml`, and
+/// `automotive/uds.toml` carry namespaces owned by other change
+/// proposals; in v1 their keys are not part of `Config`. The loader
+/// still tracks their presence and mode, but treats them as opaque.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Namespace {
+    /// Cross-cutting fields stored in `system.toml`.
+    System,
+    /// Management policy fields stored in `mgmt/policy.toml`.
+    MgmtPolicy,
+    /// Zenoh transport — opaque to v1 (`mgmt/zenoh.toml`).
+    MgmtZenoh,
+    /// Network — opaque to v1 (`network/*.toml`).
+    Network,
+    /// Remote-update policy — opaque to v1 (`update/policy.toml`).
+    Update,
+    /// Automotive UDS — opaque to v1 (`automotive/uds.toml`).
+    Automotive,
+}
+
+impl Namespace {
+    /// True if this layout entry contains v1 [`Config`] keys.
+    pub fn is_config_owned(self) -> bool {
+        matches!(self, Self::System | Self::MgmtPolicy)
+    }
+}
+
+/// Map a top-level `Config` namespace (as a dotted path's first
+/// segment) onto the layout file that owns its keys.
+fn namespace_of_path(top: &str) -> Namespace {
+    match top {
+        "idle" | "password" | "fs" | "flash" => Namespace::System,
+        "mgmt" | "audit" | "metrics" | "overlay" => Namespace::MgmtPolicy,
+        _ => Namespace::System, // unknown — default to system.toml
+    }
+}
+
+/// v1 layout per `mgmt-config-layout` spec. Order is the same as the
+/// spec table; the loader visits in order.
+pub const V1_LAYOUT: &[LayoutEntry] = &[
+    LayoutEntry {
+        relative: "system.toml",
+        declared_mode: 0o644,
+        namespace: Namespace::System,
+    },
+    LayoutEntry {
+        relative: "mgmt/policy.toml",
+        declared_mode: 0o640,
+        namespace: Namespace::MgmtPolicy,
+    },
+    LayoutEntry {
+        relative: "mgmt/zenoh.toml",
+        declared_mode: 0o640,
+        namespace: Namespace::MgmtZenoh,
+    },
+    LayoutEntry {
+        relative: "update/policy.toml",
+        declared_mode: 0o640,
+        namespace: Namespace::Update,
+    },
+    LayoutEntry {
+        relative: "automotive/uds.toml",
+        declared_mode: 0o640,
+        namespace: Namespace::Automotive,
+    },
+];
+
+// ─── Backend (read + metadata) ───────────────────────────────────────────────
+
+/// Read-side companion to [`AtomicWriter`]. The loader needs to
+/// observe per-file contents *and* per-file modes; [`AtomicWriter`]
+/// only writes. We define a separate trait so the test fixture can
+/// model both sides without dragging the FS layer into auth.
+///
+/// Implementations:
+///
+/// - [`InMemoryReadBackend`] — used by tests; pairs naturally with
+///   [`smallaios_auth::atomic_write::TestAtomicWriter`].
+/// - The kernel's F2FS read path will provide a runtime impl in a
+///   later phase; this trait is what it will satisfy.
+pub trait ReadBackend {
+    /// Return the file's bytes if it exists, or `Ok(None)` if absent.
+    fn read_file(&self, path: &str) -> Result<Option<Vec<u8>>, &'static str>;
+
+    /// Return the file's POSIX mode (low 12 bits) if it exists, or
+    /// `Ok(None)` if absent. The loader inspects only the bottom 9
+    /// bits (`rwx` triplets); higher bits are ignored.
+    fn mode_of(&self, path: &str) -> Result<Option<u16>, &'static str>;
+}
+
+// ─── Loader ──────────────────────────────────────────────────────────────────
+
+/// TOML loader/saver — implements [`ConfigSurface`] over `/data/*.toml`.
+///
+/// `R` is the [`ReadBackend`] (tests use [`InMemoryReadBackend`]; the
+/// kernel will provide an F2FS-backed type). `W` is the
+/// [`AtomicWriter`] used for the rewrite path.
+pub struct TomlLoader<R, W> {
+    /// `/data/` prefix — every layout entry is resolved relative to
+    /// this. Stored without a trailing `/`.
+    base_path: String,
+    /// Read backend (file bytes + mode).
+    reader: R,
+    /// Write backend (atomic stage→fsync→rename).
+    writer: W,
+    /// Cached typed `Config` after [`TomlLoader::load`]. Mutations on
+    /// live writes update this; boot-deferred writes do not.
+    cached: Config,
+    /// Boot-deferred writes accumulated during this run. The operator
+    /// sees these via [`TomlLoader::pending_reboot`].
+    pending_reboot: Vec<PendingReboot>,
+    /// Broadcast channel + a self-subscribed cursor so the surface
+    /// owns its publication side.
+    notify: RefCell<BroadcastTx>,
+    /// Whether the loader has actually parsed an on-disk config. The
+    /// universal-exposure invariant requires `read` to work even
+    /// before `load` is called — we lazily fall back to defaults.
+    loaded: bool,
+}
+
+/// One boot-deferred write recorded by [`TomlLoader::write`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct PendingReboot {
+    /// Path whose write was deferred.
+    pub path: ConfigPath,
+    /// Value that will take effect after reboot.
+    pub value: Value,
+    /// Identity that initiated the write.
+    pub who: String,
+}
+
+impl<R, W> TomlLoader<R, W>
+where
+    R: ReadBackend,
+    W: AtomicWriter,
+{
+    /// Construct a new loader. The base path SHALL be the mount point
+    /// for `/data/`. Pre-populates [`TomlLoader::cached`] with
+    /// [`Config::v1_defaults`]; the in-memory state is replaced on the
+    /// next [`TomlLoader::load`].
+    pub fn new(reader: R, writer: W, base_path: &str) -> Self {
+        let (tx, _rx_initial) = crate::notify::channel();
+        let mut bp = base_path.to_string();
+        while bp.ends_with('/') {
+            bp.pop();
+        }
+        Self {
+            base_path: bp,
+            reader,
+            writer,
+            cached: Config::v1_defaults(),
+            pending_reboot: Vec::new(),
+            notify: RefCell::new(tx),
+            loaded: false,
+        }
+    }
+
+    /// Read every layout file, parse into the typed schema, and
+    /// validate. On success [`TomlLoader::cached`] holds the loaded
+    /// config and [`ConfigSurface::read`] returns its values.
+    ///
+    /// `policy` controls the missing-file behaviour:
+    ///
+    /// - [`FirstBootPolicy::Generate`] — generate skeleton files for
+    ///   missing entries with [`Config::v1_defaults`]. Writes go
+    ///   through the configured [`AtomicWriter`].
+    /// - [`FirstBootPolicy::Strict`] — return [`LoaderError::Missing`]
+    ///   on the first absent file.
+    pub fn load(&mut self, policy: FirstBootPolicy) -> Result<&Config, LoaderError> {
+        let mut accumulated = Config::v1_defaults();
+        for entry in V1_LAYOUT {
+            self.load_one(entry, &mut accumulated, policy)?;
+        }
+        // Cross-field invariants apply to the whole assembled config.
+        validate::validate_all(&accumulated).map_err(|e| match e {
+            SurfaceError::Validation(reason) => LoaderError::Validation(reason),
+            _ => LoaderError::Validation("unexpected error in validate_all"),
+        })?;
+        self.cached = accumulated;
+        self.loaded = true;
+        Ok(&self.cached)
+    }
+
+    fn load_one(
+        &mut self,
+        entry: &LayoutEntry,
+        accumulated: &mut Config,
+        policy: FirstBootPolicy,
+    ) -> Result<(), LoaderError> {
+        let path = self.absolute(entry.relative);
+        let bytes = self.reader.read_file(&path).map_err(LoaderError::Io)?;
+        let mode = self.reader.mode_of(&path).map_err(LoaderError::Io)?;
+
+        match (bytes, mode) {
+            (Some(b), Some(m)) => {
+                check_mode(&path, entry.declared_mode, m)?;
+                if entry.namespace.is_config_owned() {
+                    let s = core::str::from_utf8(&b)
+                        .map_err(|_| LoaderError::Io("file is not valid UTF-8"))?;
+                    let table = toml_parse(s)?;
+                    apply_table_to_config(&table, "", accumulated)?;
+                }
+                Ok(())
+            }
+            (Some(_), None) | (None, Some(_)) => {
+                // Backend inconsistency — bytes/mode out of sync.
+                Err(LoaderError::Io("backend inconsistent file metadata"))
+            }
+            (None, None) => match policy {
+                FirstBootPolicy::Strict => Err(LoaderError::Missing { path }),
+                FirstBootPolicy::Generate => {
+                    // Render this entry's contents:
+                    // - config-owned namespaces: rendered defaults from
+                    //   the assembled `Config`.
+                    // - opaque namespaces (zenoh, network, update,
+                    //   automotive): generate an empty file so the
+                    //   owning subsystem has a stable on-disk artefact
+                    //   to extend. The file's mode is the writer's
+                    //   default; the kernel's F2FS-backed writer will
+                    //   chmod() it to `entry.declared_mode` after
+                    //   creation in a later phase.
+                    let bytes: alloc::vec::Vec<u8> = if entry.namespace.is_config_owned() {
+                        let table = render_namespace_table(accumulated, entry.namespace);
+                        let serialized = toml_serialize(&table)?;
+                        serialized.into_bytes()
+                    } else {
+                        alloc::vec::Vec::new()
+                    };
+                    self.writer
+                        .write_atomic(&path, &bytes)
+                        .map_err(LoaderError::from)?;
+                    Ok(())
+                }
+            },
+        }
+    }
+
+    /// Resolve `relative` against [`TomlLoader::base_path`].
+    fn absolute(&self, relative: &str) -> String {
+        let mut s = self.base_path.clone();
+        if !relative.starts_with('/') {
+            s.push('/');
+        }
+        s.push_str(relative);
+        s
+    }
+
+    /// Borrow the current cached [`Config`].
+    pub fn config(&self) -> &Config {
+        &self.cached
+    }
+
+    /// Boot-deferred writes accumulated since [`TomlLoader::load`].
+    /// The operator-facing diagnostic ("you must reboot for X to take
+    /// effect") reads this list.
+    pub fn pending_reboot(&self) -> &[PendingReboot] {
+        &self.pending_reboot
+    }
+
+    /// Whether [`TomlLoader::load`] has run.
+    pub fn is_loaded(&self) -> bool {
+        self.loaded
+    }
+
+    /// Force a re-serialise + atomic write of the layout file owning
+    /// `namespace`. Used both by the apply lifecycle and by external
+    /// callers that need to flush the in-memory config to disk after
+    /// bulk mutation. Visible on disk only after `fsync` completes.
+    pub fn flush_namespace(&mut self, namespace: Namespace) -> Result<(), LoaderError> {
+        let entry = V1_LAYOUT
+            .iter()
+            .find(|e| e.namespace == namespace)
+            .ok_or(LoaderError::Io("unknown namespace"))?;
+        let path = self.absolute(entry.relative);
+        let table = render_namespace_table(&self.cached, namespace);
+        let serialized = toml_serialize(&table)?;
+        self.writer
+            .write_atomic(&path, serialized.as_bytes())
+            .map_err(LoaderError::from)?;
+        Ok(())
+    }
+
+    /// Apply a typed [`Value`] write through the full lifecycle.
+    /// Internal helper called by [`ConfigSurface::write`].
+    fn apply_write(
+        &mut self,
+        path: &ConfigPath,
+        value: Value,
+        who: &str,
+        when_ns: u64,
+    ) -> Result<(), LoaderError> {
+        // Step 1+2 — parse + validate. `Config::write_path` runs both
+        // `validate_field` and `validate_cross_field` on a candidate.
+        let mut candidate = self.cached.clone();
+        candidate
+            .write_path(path, value.clone())
+            .map_err(map_surface_to_loader)?;
+        // The candidate is now valid. Capture before-value for notify.
+        let before = self.cached.read_path(path).map_err(map_surface_to_loader)?;
+        // Step 3 — stage + fsync + rename via the layout file.
+        let ns = namespace_of_path(path.namespace());
+        let entry = V1_LAYOUT
+            .iter()
+            .find(|e| e.namespace == ns)
+            .ok_or(LoaderError::Io("unknown namespace"))?;
+        let abs = self.absolute(entry.relative);
+        let mut table_for_disk = render_namespace_table(&candidate, ns);
+        // The serialised file always reflects the candidate's value
+        // for `path`, regardless of reload kind — operators expect
+        // the file to mirror the requested write the next time the
+        // system boots.
+        let _ = &mut table_for_disk; // already populated by render
+        let serialized = toml_serialize(&table_for_disk)?;
+        self.writer
+            .write_atomic(&abs, serialized.as_bytes())
+            .map_err(LoaderError::from)?;
+        // Step 4 — update in-memory cache iff Live.
+        let reload = registry::reload_kind(path.as_str()).unwrap_or(ReloadKind::Live);
+        match reload {
+            ReloadKind::Live => {
+                self.cached = candidate;
+            }
+            ReloadKind::Boot => {
+                self.pending_reboot.push(PendingReboot {
+                    path: path.clone(),
+                    value: value.clone(),
+                    who: who.to_string(),
+                });
+            }
+        }
+        // Step 5 — notify subscribers. The `after` value reflects
+        // what's now on disk (which is the candidate's value); for
+        // boot-deferred fields this is intentionally distinct from
+        // the in-memory `before` retained until reboot, so the audit
+        // trail records the *requested* new value.
+        let after = value;
+        let event = NotifyEvent {
+            path: path.clone(),
+            before,
+            after,
+            who: who.to_string(),
+            when_ns,
+        };
+        self.notify.borrow().publish(event);
+        Ok(())
+    }
+
+    /// Subscribe to the loader's notify channel from outside the
+    /// trait surface (useful for tests, integration harnesses).
+    pub fn raw_subscribe(&self) -> Subscriber {
+        self.notify.borrow().subscribe()
+    }
+}
+
+impl<R, W> ConfigSurface for TomlLoader<R, W>
+where
+    R: ReadBackend,
+    W: AtomicWriter,
+{
+    fn read(&self, path: &ConfigPath) -> Result<Value, SurfaceError> {
+        self.cached.read_path(path)
+    }
+
+    fn write(&mut self, path: &ConfigPath, value: Value, who: &str) -> Result<(), SurfaceError> {
+        // The TOML surface tags every event with the surface kind via
+        // the `who` string. We use a dummy timestamp of 0 because the
+        // kernel will install a clock source in a later phase; tests
+        // can inject their own through [`TomlLoader::apply_write`].
+        let _ = SurfaceKind::Toml; // referenced for future identity work
+        self.apply_write(path, value, who, 0)
+            .map_err(SurfaceError::from)
+    }
+
+    fn subscribe(&self, path: &ConfigPath) -> Result<Subscriber, SurfaceError> {
+        Ok(self.notify.borrow().subscribe_path(path.clone()))
+    }
+}
+
+// ─── In-memory backend (tests + integration) ─────────────────────────────────
+
+/// In-memory [`ReadBackend`] used by tests and the universal-exposure
+/// CI walker. Pairs with [`smallaios_auth::atomic_write::TestAtomicWriter`]
+/// — both back by an in-memory `BTreeMap<path, bytes>`.
+///
+/// Modes are tracked separately via [`InMemoryReadBackend::set_mode`]
+/// so tests can simulate the file-mode-stricter rule.
+pub struct InMemoryReadBackend {
+    inner: RefCell<InMemoryInner>,
+}
+
+struct InMemoryInner {
+    files: BTreeMap<String, Vec<u8>>,
+    modes: BTreeMap<String, u16>,
+    /// Default mode applied when [`InMemoryReadBackend::seed`] is
+    /// called without an explicit mode. Lets tests construct a
+    /// "permissive" backend that matches every layout entry.
+    default_mode: u16,
+}
+
+impl Default for InMemoryReadBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InMemoryReadBackend {
+    /// Construct an empty backend with default mode `0o600`. Tests
+    /// requiring a permissive mode set explicit modes per file.
+    pub fn new() -> Self {
+        Self {
+            inner: RefCell::new(InMemoryInner {
+                files: BTreeMap::new(),
+                modes: BTreeMap::new(),
+                default_mode: 0o600,
+            }),
+        }
+    }
+
+    /// Seed `path` with `bytes` using the backend's default mode.
+    pub fn seed(&self, path: &str, bytes: &[u8]) {
+        let mut g = self.inner.borrow_mut();
+        let mode = g.default_mode;
+        g.files.insert(path.to_string(), bytes.to_vec());
+        g.modes.insert(path.to_string(), mode);
+    }
+
+    /// Seed `path` with `bytes` and an explicit mode — used to test
+    /// the file-mode-stricter rule.
+    pub fn seed_with_mode(&self, path: &str, bytes: &[u8], mode: u16) {
+        let mut g = self.inner.borrow_mut();
+        g.files.insert(path.to_string(), bytes.to_vec());
+        g.modes.insert(path.to_string(), mode);
+    }
+
+    /// Set the mode the backend reports for `path`. Non-existent files
+    /// silently no-op.
+    pub fn set_mode(&self, path: &str, mode: u16) {
+        let mut g = self.inner.borrow_mut();
+        if g.files.contains_key(path) {
+            g.modes.insert(path.to_string(), mode);
+        }
+    }
+
+    /// Override the default mode used by [`InMemoryReadBackend::seed`].
+    pub fn set_default_mode(&self, mode: u16) {
+        self.inner.borrow_mut().default_mode = mode;
+    }
+
+    /// Snapshot of every (path, bytes) pair currently held — for
+    /// assertion in tests.
+    pub fn snapshot(&self) -> BTreeMap<String, Vec<u8>> {
+        self.inner.borrow().files.clone()
+    }
+
+    /// Number of files seeded.
+    pub fn len(&self) -> usize {
+        self.inner.borrow().files.len()
+    }
+
+    /// Whether no files are seeded.
+    pub fn is_empty(&self) -> bool {
+        self.inner.borrow().files.is_empty()
+    }
+}
+
+impl ReadBackend for InMemoryReadBackend {
+    fn read_file(&self, path: &str) -> Result<Option<Vec<u8>>, &'static str> {
+        Ok(self.inner.borrow().files.get(path).cloned())
+    }
+
+    fn mode_of(&self, path: &str) -> Result<Option<u16>, &'static str> {
+        Ok(self.inner.borrow().modes.get(path).copied())
+    }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Reject if the actual file mode is laxer than the declared mode.
+/// "Laxer" = any bit set in `actual & ~declared` within the bottom 9
+/// bits.
+fn check_mode(path: &str, declared: u16, actual: u16) -> Result<(), LoaderError> {
+    let mask: u16 = 0o777;
+    let actual_bits = actual & mask;
+    let declared_bits = declared & mask;
+    if actual_bits & !declared_bits != 0 {
+        return Err(LoaderError::ModeViolation {
+            path: path.to_string(),
+            declared: declared_bits,
+            actual: actual_bits,
+        });
+    }
+    Ok(())
+}
+
+/// Render the [`TomlTable`] containing exactly the keys owned by
+/// `namespace` from `cfg`. Public so the universal-exposure walker
+/// can pre-seed a backend with valid defaults without re-implementing
+/// the namespace mapping.
+pub fn render_namespace_table(cfg: &Config, namespace: Namespace) -> TomlTable {
+    let mut out = TomlTable::new();
+    for f in registry::CONFIG_FIELDS {
+        let path = match ConfigPath::new(f.path) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        let owning = namespace_of_path(path.namespace());
+        if owning != namespace {
+            continue;
+        }
+        let value = match cfg.read_path(&path) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let toml_v = match config_value_to_toml(&value) {
+            Some(v) => v,
+            None => continue,
+        };
+        // path is `ns.field` (or deeper); insert into nested table.
+        let segments: Vec<&str> = path.as_str().split('.').collect();
+        insert_into_table(&mut out, &segments, toml_v);
+    }
+    out
+}
+
+fn insert_into_table(root: &mut TomlTable, segments: &[&str], value: TomlValue) {
+    if segments.is_empty() {
+        return;
+    }
+    if segments.len() == 1 {
+        root.insert(segments[0].to_string(), value);
+        return;
+    }
+    let head = segments[0];
+    let entry = root
+        .entry(head.to_string())
+        .or_insert_with(|| TomlValue::Table(TomlTable::new()));
+    if let TomlValue::Table(t) = entry {
+        insert_into_table(t, &segments[1..], value);
+    }
+}
+
+/// Apply every key in `table` (rooted at `prefix`) to `cfg`. Each leaf
+/// key SHALL match a registry field and the typed value SHALL match
+/// the registry's [`FieldType`].
+fn apply_table_to_config(
+    table: &TomlTable,
+    prefix: &str,
+    cfg: &mut Config,
+) -> Result<(), LoaderError> {
+    for (k, v) in table.iter() {
+        let dotted = if prefix.is_empty() {
+            k.clone()
+        } else {
+            crate::toml::join_path(prefix, k)
+        };
+        match v {
+            TomlValue::Table(sub) => {
+                apply_table_to_config(sub, &dotted, cfg)?;
+            }
+            scalar => {
+                let descriptor = registry::lookup(&dotted)
+                    .ok_or_else(|| LoaderError::UnknownField(dotted.clone()))?;
+                let value = toml_to_config_value(scalar, descriptor.kind, &dotted)?;
+                let path = ConfigPath::new(&dotted).map_err(|_| LoaderError::Io("bad path"))?;
+                cfg.write_path(&path, value)
+                    .map_err(map_surface_to_loader)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn toml_to_config_value(
+    v: &TomlValue,
+    expected: FieldType,
+    path: &str,
+) -> Result<Value, LoaderError> {
+    match (v, expected) {
+        (TomlValue::Bool(b), FieldType::Bool) => Ok(Value::Bool(*b)),
+        (TomlValue::Integer(n), FieldType::U32) => {
+            if *n < 0 || *n > i64::from(u32::MAX) {
+                return Err(LoaderError::Validation("integer out of u32 range"));
+            }
+            Ok(Value::U32(*n as u32))
+        }
+        (TomlValue::Integer(n), FieldType::U64) => {
+            if *n < 0 {
+                return Err(LoaderError::Validation("negative integer for u64"));
+            }
+            Ok(Value::U64(*n as u64))
+        }
+        (TomlValue::String(s), FieldType::String) => Ok(Value::String(s.clone())),
+        (TomlValue::Array(items), FieldType::PasswordClasses) => {
+            let mut mask: u8 = 0;
+            for item in items {
+                let s = item
+                    .as_str()
+                    .map_err(|_| LoaderError::Validation("password class must be string"))?;
+                mask |= match s {
+                    "lower" => PasswordClassSet::LOWER,
+                    "upper" => PasswordClassSet::UPPER,
+                    "digit" => PasswordClassSet::DIGIT,
+                    "symbol" => PasswordClassSet::SYMBOL,
+                    _ => return Err(LoaderError::Validation("unknown password class name")),
+                };
+            }
+            Ok(Value::PasswordClasses(PasswordClassSet::from_mask(mask)))
+        }
+        (other, expected) => Err(LoaderError::TypeMismatch {
+            path: path.to_string(),
+            expected: expected.as_value_tag(),
+            got: other.type_tag(),
+        }),
+    }
+}
+
+fn config_value_to_toml(value: &Value) -> Option<TomlValue> {
+    match value {
+        Value::Bool(b) => Some(TomlValue::Bool(*b)),
+        Value::U32(n) => {
+            // u32 always fits in i64.
+            Some(TomlValue::Integer(i64::from(*n)))
+        }
+        Value::U64(n) => {
+            if *n > i64::MAX as u64 {
+                None
+            } else {
+                Some(TomlValue::Integer(*n as i64))
+            }
+        }
+        Value::String(s) => Some(TomlValue::String(s.clone())),
+        Value::PasswordClasses(p) => {
+            let mut items = Vec::new();
+            if p.contains(PasswordClassSet::LOWER) {
+                items.push(TomlValue::String("lower".to_string()));
+            }
+            if p.contains(PasswordClassSet::UPPER) {
+                items.push(TomlValue::String("upper".to_string()));
+            }
+            if p.contains(PasswordClassSet::DIGIT) {
+                items.push(TomlValue::String("digit".to_string()));
+            }
+            if p.contains(PasswordClassSet::SYMBOL) {
+                items.push(TomlValue::String("symbol".to_string()));
+            }
+            Some(TomlValue::Array(items))
+        }
+    }
+}
+
+fn map_surface_to_loader(e: SurfaceError) -> LoaderError {
+    match e {
+        SurfaceError::Validation(reason) => LoaderError::Validation(reason),
+        SurfaceError::Io(reason) => LoaderError::Io(reason),
+        SurfaceError::NotFound => LoaderError::Io("not found"),
+        SurfaceError::TypeMismatch { expected, got } => LoaderError::TypeMismatch {
+            path: String::new(),
+            expected,
+            got,
+        },
+        SurfaceError::InvalidPath(reason) => LoaderError::Io(reason),
+        SurfaceError::Permission(reason) => LoaderError::Io(reason),
+        SurfaceError::Unsupported(reason) => LoaderError::Io(reason),
+    }
+}
+
+// ─── AuditIdentity helper ────────────────────────────────────────────────────
+
+/// Build a TOML-surface [`AuditIdentity`] for a concrete role/user.
+/// Convenience for callers that don't want to repeat
+/// `SurfaceKind::Toml` everywhere.
+pub fn audit_identity(role: &'static str, user: Option<String>) -> AuditIdentity {
+    AuditIdentity {
+        role,
+        user,
+        surface: SurfaceKind::Toml,
+    }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::surface::{ConfigPath, Value};
+    use alloc::rc::Rc;
+    use loader_test_vectors as fixtures;
+    use smallaios_auth::atomic_write::TestAtomicWriter;
+
+    /// In-test "shared filesystem" backend that pairs a single
+    /// in-memory store with both the [`ReadBackend`] and the
+    /// [`AtomicWriter`] sides. Mirrors the kernel's runtime where
+    /// `f2fs::F2fs` provides both reads and atomic-write semantics
+    /// over the same handle.
+    ///
+    /// The `Rc<RefCell<...>>` wrapping makes the same store visible
+    /// to both halves; clones share state.
+    #[derive(Clone)]
+    struct SharedFsFixture {
+        files: Rc<RefCell<BTreeMap<String, Vec<u8>>>>,
+        modes: Rc<RefCell<BTreeMap<String, u16>>>,
+        /// Default mode applied to files written via the
+        /// [`AtomicWriter`] half. Tests pin this to the spec's
+        /// declared mode for the file under test.
+        write_mode: u16,
+    }
+
+    impl SharedFsFixture {
+        fn new(write_mode: u16) -> Self {
+            Self {
+                files: Rc::new(RefCell::new(BTreeMap::new())),
+                modes: Rc::new(RefCell::new(BTreeMap::new())),
+                write_mode,
+            }
+        }
+
+        #[allow(dead_code)]
+        fn seed_with_mode(&self, path: &str, bytes: &[u8], mode: u16) {
+            self.files
+                .borrow_mut()
+                .insert(path.to_string(), bytes.to_vec());
+            self.modes.borrow_mut().insert(path.to_string(), mode);
+        }
+
+        #[allow(dead_code)]
+        fn read_raw(&self, path: &str) -> Option<Vec<u8>> {
+            self.files.borrow().get(path).cloned()
+        }
+    }
+
+    impl ReadBackend for SharedFsFixture {
+        fn read_file(&self, path: &str) -> Result<Option<Vec<u8>>, &'static str> {
+            Ok(self.files.borrow().get(path).cloned())
+        }
+        fn mode_of(&self, path: &str) -> Result<Option<u16>, &'static str> {
+            Ok(self.modes.borrow().get(path).copied())
+        }
+    }
+
+    impl AtomicWriter for SharedFsFixture {
+        fn write_atomic(&self, path: &str, contents: &[u8]) -> Result<(), AtomicWriteError> {
+            if path.is_empty() {
+                return Err(AtomicWriteError::InvalidPath);
+            }
+            let mode = self.write_mode;
+            self.files
+                .borrow_mut()
+                .insert(path.to_string(), contents.to_vec());
+            self.modes.borrow_mut().insert(path.to_string(), mode);
+            Ok(())
+        }
+        fn cleanup_orphan_tmp(&self, dir: &str) -> Result<(), AtomicWriteError> {
+            let prefix = if dir.ends_with('/') {
+                dir.to_string()
+            } else {
+                let mut s = String::from(dir);
+                s.push('/');
+                s
+            };
+            let to_remove: Vec<String> = self
+                .files
+                .borrow()
+                .keys()
+                .filter(|k| k.starts_with(&prefix) && k.ends_with(".tmp"))
+                .cloned()
+                .collect();
+            for k in to_remove {
+                self.files.borrow_mut().remove(&k);
+            }
+            Ok(())
+        }
+    }
+
+    fn empty_loader() -> TomlLoader<InMemoryReadBackend, TestAtomicWriter> {
+        TomlLoader::new(InMemoryReadBackend::new(), TestAtomicWriter::new(), "/data")
+    }
+
+    #[test]
+    fn defaults_visible_before_load() {
+        let loader = empty_loader();
+        let p = ConfigPath::new("idle.root_minutes").unwrap();
+        // Pre-load reads return defaults — the universal-exposure
+        // walker depends on this so the build-time test can run on a
+        // non-mounted filesystem.
+        assert_eq!(loader.read(&p).unwrap(), Value::U32(15));
+    }
+
+    #[test]
+    fn first_boot_generate_creates_skeleton() {
+        let reader = InMemoryReadBackend::new();
+        let writer = TestAtomicWriter::new();
+        let mut loader = TomlLoader::new(reader, writer, "/data");
+        loader.load(FirstBootPolicy::Generate).unwrap();
+        assert!(loader.is_loaded());
+        // The writer should have created system.toml + mgmt/policy.toml.
+        // (We can't observe it through the TestAtomicWriter directly
+        // because it lives inside the loader; the round-trip test
+        // below covers re-load.)
+    }
+
+    #[test]
+    fn first_boot_strict_rejects_missing() {
+        let reader = InMemoryReadBackend::new();
+        let writer = TestAtomicWriter::new();
+        let mut loader = TomlLoader::new(reader, writer, "/data");
+        let err = loader.load(FirstBootPolicy::Strict).unwrap_err();
+        assert!(matches!(err, LoaderError::Missing { .. }));
+    }
+
+    #[test]
+    fn loads_from_seeded_files() {
+        let reader = InMemoryReadBackend::new();
+        reader.seed_with_mode("/data/system.toml", fixtures::SYSTEM_TOML_DEFAULT, 0o644);
+        reader.seed_with_mode(
+            "/data/mgmt/policy.toml",
+            fixtures::MGMT_POLICY_TOML_DEFAULT,
+            0o640,
+        );
+        // Stub remaining opaque files with empty content + their
+        // declared mode so the loader doesn't generate.
+        reader.seed_with_mode("/data/mgmt/zenoh.toml", b"", 0o640);
+        reader.seed_with_mode("/data/update/policy.toml", b"", 0o640);
+        reader.seed_with_mode("/data/automotive/uds.toml", b"", 0o640);
+
+        let writer = TestAtomicWriter::new();
+        let mut loader = TomlLoader::new(reader, writer, "/data");
+        let cfg = loader.load(FirstBootPolicy::Strict).unwrap().clone();
+        assert_eq!(cfg.idle.root_minutes, 15);
+        assert_eq!(cfg.password.min_length, 12);
+    }
+
+    #[test]
+    fn rejects_laxer_than_declared_mode() {
+        let reader = InMemoryReadBackend::new();
+        // mgmt/policy.toml declared 0o640; seed with 0o644 (laxer).
+        reader.seed_with_mode(
+            "/data/mgmt/policy.toml",
+            fixtures::MGMT_POLICY_TOML_DEFAULT,
+            0o644,
+        );
+        // system.toml at the right mode.
+        reader.seed_with_mode("/data/system.toml", fixtures::SYSTEM_TOML_DEFAULT, 0o644);
+        let writer = TestAtomicWriter::new();
+        let mut loader = TomlLoader::new(reader, writer, "/data");
+        let err = loader.load(FirstBootPolicy::Strict).unwrap_err();
+        assert!(matches!(err, LoaderError::ModeViolation { .. }));
+    }
+
+    #[test]
+    fn accepts_stricter_than_declared_mode() {
+        let reader = InMemoryReadBackend::new();
+        reader.seed_with_mode(
+            "/data/system.toml",
+            fixtures::SYSTEM_TOML_DEFAULT,
+            0o600, // stricter than 0o644
+        );
+        reader.seed_with_mode(
+            "/data/mgmt/policy.toml",
+            fixtures::MGMT_POLICY_TOML_DEFAULT,
+            0o600, // stricter than 0o640
+        );
+        reader.seed_with_mode("/data/mgmt/zenoh.toml", b"", 0o600);
+        reader.seed_with_mode("/data/update/policy.toml", b"", 0o600);
+        reader.seed_with_mode("/data/automotive/uds.toml", b"", 0o600);
+        let writer = TestAtomicWriter::new();
+        let mut loader = TomlLoader::new(reader, writer, "/data");
+        loader.load(FirstBootPolicy::Strict).unwrap();
+    }
+
+    #[test]
+    fn check_mode_helper_basic_cases() {
+        // Equal: accept.
+        check_mode("/x", 0o640, 0o640).unwrap();
+        // Stricter: accept.
+        check_mode("/x", 0o640, 0o600).unwrap();
+        check_mode("/x", 0o644, 0o600).unwrap();
+        // Laxer: reject.
+        assert!(matches!(
+            check_mode("/x", 0o600, 0o644),
+            Err(LoaderError::ModeViolation { .. })
+        ));
+        assert!(matches!(
+            check_mode("/x", 0o640, 0o644),
+            Err(LoaderError::ModeViolation { .. })
+        ));
+    }
+
+    #[test]
+    fn unknown_field_in_file_rejected() {
+        let reader = InMemoryReadBackend::new();
+        // Inject a file with an unknown key.
+        reader.seed_with_mode("/data/system.toml", b"[idle]\nunknown_field = 1\n", 0o644);
+        let writer = TestAtomicWriter::new();
+        let mut loader = TomlLoader::new(reader, writer, "/data");
+        let err = loader.load(FirstBootPolicy::Generate).unwrap_err();
+        assert!(matches!(err, LoaderError::UnknownField(_)));
+    }
+
+    #[test]
+    fn type_mismatch_in_file_rejected() {
+        let reader = InMemoryReadBackend::new();
+        reader.seed_with_mode("/data/system.toml", b"[idle]\nroot_minutes = true\n", 0o644);
+        let writer = TestAtomicWriter::new();
+        let mut loader = TomlLoader::new(reader, writer, "/data");
+        let err = loader.load(FirstBootPolicy::Generate).unwrap_err();
+        assert!(matches!(err, LoaderError::TypeMismatch { .. }));
+    }
+
+    #[test]
+    fn write_through_surface_persists_and_notifies() {
+        let reader = InMemoryReadBackend::new();
+        let writer = TestAtomicWriter::new();
+        let mut loader = TomlLoader::new(reader, writer, "/data");
+        loader.load(FirstBootPolicy::Generate).unwrap();
+        let mut sub = loader.raw_subscribe();
+        let p = ConfigPath::new("idle.root_minutes").unwrap();
+        loader.write(&p, Value::U32(20), "root@toml").unwrap();
+        assert_eq!(loader.read(&p).unwrap(), Value::U32(20));
+        let ev = sub.poll().unwrap().unwrap();
+        assert_eq!(ev.path, p);
+        assert_eq!(ev.before, Value::U32(15));
+        assert_eq!(ev.after, Value::U32(20));
+        assert_eq!(ev.who, "root@toml");
+    }
+
+    #[test]
+    fn write_validation_failure_leaves_state_unchanged() {
+        let reader = InMemoryReadBackend::new();
+        let writer = TestAtomicWriter::new();
+        let mut loader = TomlLoader::new(reader, writer, "/data");
+        loader.load(FirstBootPolicy::Generate).unwrap();
+        let p = ConfigPath::new("idle.root_minutes").unwrap();
+        // 0 fails range validation.
+        let err = loader.write(&p, Value::U32(0), "root@toml").unwrap_err();
+        assert!(matches!(err, SurfaceError::Validation(_)));
+        // In-memory unchanged.
+        assert_eq!(loader.read(&p).unwrap(), Value::U32(15));
+    }
+
+    #[test]
+    fn boot_only_write_goes_to_pending_reboot() {
+        let reader = InMemoryReadBackend::new();
+        let writer = TestAtomicWriter::new();
+        let mut loader = TomlLoader::new(reader, writer, "/data");
+        loader.load(FirstBootPolicy::Generate).unwrap();
+        let p = ConfigPath::new("fs.boot_watchdog_seconds").unwrap();
+        // 30s passes validation and is in range.
+        loader.write(&p, Value::U32(30), "root@toml").unwrap();
+        // Boot-deferred: in-memory still 60.
+        assert_eq!(loader.read(&p).unwrap(), Value::U32(60));
+        // But pending list records it.
+        let pending = loader.pending_reboot();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].path, p);
+        assert_eq!(pending[0].value, Value::U32(30));
+    }
+
+    #[test]
+    fn live_write_visible_in_memory() {
+        let reader = InMemoryReadBackend::new();
+        let writer = TestAtomicWriter::new();
+        let mut loader = TomlLoader::new(reader, writer, "/data");
+        loader.load(FirstBootPolicy::Generate).unwrap();
+        let p = ConfigPath::new("idle.operator_minutes").unwrap();
+        loader.write(&p, Value::U32(50), "root@toml").unwrap();
+        assert_eq!(loader.read(&p).unwrap(), Value::U32(50));
+    }
+
+    #[test]
+    fn cross_field_invariant_still_enforced() {
+        let reader = InMemoryReadBackend::new();
+        let writer = TestAtomicWriter::new();
+        let mut loader = TomlLoader::new(reader, writer, "/data");
+        loader.load(FirstBootPolicy::Generate).unwrap();
+        // Try to set root_minutes higher than operator_minutes (cross-field).
+        let p = ConfigPath::new("idle.root_minutes").unwrap();
+        let err = loader.write(&p, Value::U32(120), "root@toml").unwrap_err();
+        assert!(matches!(err, SurfaceError::Validation(_)));
+    }
+
+    #[test]
+    fn subscribe_via_trait_returns_path_filtered_subscriber() {
+        let reader = InMemoryReadBackend::new();
+        let writer = TestAtomicWriter::new();
+        let mut loader = TomlLoader::new(reader, writer, "/data");
+        loader.load(FirstBootPolicy::Generate).unwrap();
+        let p = ConfigPath::new("idle.root_minutes").unwrap();
+        let mut sub = loader.subscribe(&p).unwrap();
+        let other = ConfigPath::new("password.dictionary_check").unwrap();
+        loader
+            .write(&other, Value::Bool(false), "root@toml")
+            .unwrap();
+        // Filtered subscriber sees nothing for password write.
+        assert_eq!(sub.poll(), Ok(None));
+        loader.write(&p, Value::U32(45), "root@toml").unwrap();
+        let ev = sub.poll().unwrap().unwrap();
+        assert_eq!(ev.path, p);
+    }
+
+    #[test]
+    fn render_namespace_table_excludes_other_namespace_keys() {
+        let cfg = Config::v1_defaults();
+        let sys = render_namespace_table(&cfg, Namespace::System);
+        // system.toml owns idle, password, fs, flash. mgmt is not in
+        // it.
+        assert!(sys.contains_key("idle"));
+        assert!(sys.contains_key("password"));
+        assert!(sys.contains_key("fs"));
+        assert!(sys.contains_key("flash"));
+        assert!(!sys.contains_key("mgmt"));
+    }
+
+    #[test]
+    fn render_namespace_then_parse_reflects_defaults() {
+        let cfg = Config::v1_defaults();
+        let sys = render_namespace_table(&cfg, Namespace::System);
+        let s = toml_serialize(&sys).unwrap();
+        let back = toml_parse(&s).unwrap();
+        assert_eq!(back, sys);
+    }
+
+    #[test]
+    fn round_trip_load_then_reload_yields_equal_config() {
+        // Use a shared backend so writes are visible to subsequent
+        // reads — this mirrors the production wiring where
+        // `f2fs::F2fs` provides both halves.
+        // For this test, system.toml's declared mode is 0o644 which is the most
+        // permissive of the v1 entries (mgmt/* are 0o640). Use 0o600 which
+        // satisfies BOTH (stricter than 0o644 AND stricter than 0o640).
+        let fs = SharedFsFixture::new(0o600);
+        let mut loader = TomlLoader::new(fs.clone(), fs.clone(), "/data");
+        // Generate fills the FS with skeletons under write_mode (0o600).
+        loader.load(FirstBootPolicy::Generate).unwrap();
+        let snap1 = loader.config().clone();
+        // Mutate one field — the live path persists to disk.
+        let p = ConfigPath::new("password.dictionary_check").unwrap();
+        loader.write(&p, Value::Bool(false), "root@toml").unwrap();
+        let snap2 = loader.config().clone();
+        assert_ne!(snap1, snap2);
+        // Re-load using the shared backend — file is now present.
+        loader.load(FirstBootPolicy::Strict).unwrap();
+        assert!(!loader.config().password.dictionary_check);
+    }
+
+    #[test]
+    fn loader_error_display_includes_path() {
+        let e = LoaderError::Missing {
+            path: "/data/system.toml".to_string(),
+        };
+        let s = alloc::format!("{}", e);
+        assert!(s.contains("/data/system.toml"));
+    }
+
+    #[test]
+    fn loader_error_to_surface_error_maps_validation() {
+        let e: SurfaceError = LoaderError::Validation("bounds").into();
+        assert!(matches!(e, SurfaceError::Validation("bounds")));
+    }
+
+    #[test]
+    fn loader_error_to_surface_error_maps_unknown_field() {
+        let e: SurfaceError = LoaderError::UnknownField("x".to_string()).into();
+        assert!(matches!(e, SurfaceError::NotFound));
+    }
+
+    #[test]
+    fn audit_identity_uses_toml_surface() {
+        let id = audit_identity("operator", Some("alice".to_string()));
+        assert_eq!(id.surface, SurfaceKind::Toml);
+        assert_eq!(id.render(), "operator:alice@toml");
+    }
+
+    #[test]
+    fn config_value_to_toml_round_trip_for_password_classes() {
+        let cfg = Config::v1_defaults();
+        let v = cfg
+            .read_path(&ConfigPath::new("password.require_classes").unwrap())
+            .unwrap();
+        let toml_v = config_value_to_toml(&v).unwrap();
+        match toml_v {
+            TomlValue::Array(items) => {
+                let names: Vec<&str> = items.iter().filter_map(|i| i.as_str().ok()).collect();
+                assert!(names.contains(&"lower"));
+                assert!(names.contains(&"upper"));
+                assert!(names.contains(&"digit"));
+            }
+            _ => panic!("expected array"),
+        }
+    }
+
+    #[test]
+    fn toml_to_config_value_password_classes_round_trip() {
+        let toml_v = TomlValue::Array(alloc::vec![
+            TomlValue::String("lower".to_string()),
+            TomlValue::String("symbol".to_string()),
+        ]);
+        let v = toml_to_config_value(
+            &toml_v,
+            FieldType::PasswordClasses,
+            "password.require_classes",
+        )
+        .unwrap();
+        match v {
+            Value::PasswordClasses(p) => {
+                assert!(p.contains(PasswordClassSet::LOWER));
+                assert!(p.contains(PasswordClassSet::SYMBOL));
+                assert!(!p.contains(PasswordClassSet::UPPER));
+            }
+            _ => panic!("expected password classes"),
+        }
+    }
+
+    #[test]
+    fn toml_to_config_value_rejects_negative_for_u32() {
+        let err = toml_to_config_value(&TomlValue::Integer(-1), FieldType::U32, "x").unwrap_err();
+        assert!(matches!(err, LoaderError::Validation(_)));
+    }
+
+    #[test]
+    fn toml_to_config_value_rejects_negative_for_u64() {
+        let err = toml_to_config_value(&TomlValue::Integer(-1), FieldType::U64, "x").unwrap_err();
+        assert!(matches!(err, LoaderError::Validation(_)));
+    }
+
+    #[test]
+    fn toml_to_config_value_rejects_overflow_u32() {
+        let err = toml_to_config_value(
+            &TomlValue::Integer(i64::from(u32::MAX) + 1),
+            FieldType::U32,
+            "x",
+        )
+        .unwrap_err();
+        assert!(matches!(err, LoaderError::Validation(_)));
+    }
+
+    #[test]
+    fn toml_to_config_value_password_class_unknown_name_rejected() {
+        let toml_v = TomlValue::Array(alloc::vec![TomlValue::String("nope".to_string())]);
+        let err = toml_to_config_value(&toml_v, FieldType::PasswordClasses, "x").unwrap_err();
+        assert!(matches!(err, LoaderError::Validation(_)));
+    }
+
+    #[test]
+    fn toml_to_config_value_type_mismatch_recorded() {
+        let toml_v = TomlValue::String("x".to_string());
+        let err = toml_to_config_value(&toml_v, FieldType::U32, "x").unwrap_err();
+        match err {
+            LoaderError::TypeMismatch { expected, got, .. } => {
+                assert_eq!(expected, "u32");
+                assert_eq!(got, "string");
+            }
+            _ => panic!("expected TypeMismatch"),
+        }
+    }
+
+    #[test]
+    fn config_value_u64_above_i64_max_rejected() {
+        // A u64 above i64::MAX cannot fit in TOML's signed integer.
+        let v = Value::U64(u64::MAX);
+        assert!(config_value_to_toml(&v).is_none());
+    }
+
+    #[test]
+    fn namespace_classifier_covers_v1_namespaces() {
+        assert_eq!(namespace_of_path("idle"), Namespace::System);
+        assert_eq!(namespace_of_path("password"), Namespace::System);
+        assert_eq!(namespace_of_path("flash"), Namespace::System);
+        assert_eq!(namespace_of_path("fs"), Namespace::System);
+        assert_eq!(namespace_of_path("mgmt"), Namespace::MgmtPolicy);
+        assert_eq!(namespace_of_path("audit"), Namespace::MgmtPolicy);
+        assert_eq!(namespace_of_path("metrics"), Namespace::MgmtPolicy);
+        assert_eq!(namespace_of_path("overlay"), Namespace::MgmtPolicy);
+    }
+
+    #[test]
+    fn pending_reboot_grows_per_boot_only_write() {
+        let reader = InMemoryReadBackend::new();
+        let writer = TestAtomicWriter::new();
+        let mut loader = TomlLoader::new(reader, writer, "/data");
+        loader.load(FirstBootPolicy::Generate).unwrap();
+        loader
+            .write(
+                &ConfigPath::new("fs.boot_watchdog_seconds").unwrap(),
+                Value::U32(30),
+                "root@toml",
+            )
+            .unwrap();
+        loader
+            .write(
+                &ConfigPath::new("flash.prefer_flash_for_models").unwrap(),
+                Value::Bool(false),
+                "root@toml",
+            )
+            .unwrap();
+        assert_eq!(loader.pending_reboot().len(), 2);
+    }
+
+    #[test]
+    fn flush_namespace_writes_disk_copy() {
+        let reader = InMemoryReadBackend::new();
+        let writer = TestAtomicWriter::new();
+        let mut loader = TomlLoader::new(reader, writer, "/data");
+        loader.load(FirstBootPolicy::Generate).unwrap();
+        // Just exercises the flush path — generation already wrote
+        // the file; this is an explicit re-write.
+        loader.flush_namespace(Namespace::System).unwrap();
+        loader.flush_namespace(Namespace::MgmtPolicy).unwrap();
+    }
+
+    #[test]
+    fn round_trip_via_seeded_default_files() {
+        // Belt-and-braces: serialize defaults via the renderer, seed
+        // them into the in-memory backend, re-load, and confirm the
+        // resulting Config equals defaults.
+        let cfg = Config::v1_defaults();
+        let sys = toml_serialize(&render_namespace_table(&cfg, Namespace::System)).unwrap();
+        let pol = toml_serialize(&render_namespace_table(&cfg, Namespace::MgmtPolicy)).unwrap();
+        let reader = InMemoryReadBackend::new();
+        reader.seed_with_mode("/data/system.toml", sys.as_bytes(), 0o644);
+        reader.seed_with_mode("/data/mgmt/policy.toml", pol.as_bytes(), 0o640);
+        reader.seed_with_mode("/data/mgmt/zenoh.toml", b"", 0o640);
+        reader.seed_with_mode("/data/update/policy.toml", b"", 0o640);
+        reader.seed_with_mode("/data/automotive/uds.toml", b"", 0o640);
+        let writer = TestAtomicWriter::new();
+        let mut loader = TomlLoader::new(reader, writer, "/data");
+        let loaded = loader.load(FirstBootPolicy::Strict).unwrap().clone();
+        assert_eq!(loaded, cfg);
+    }
+
+    #[test]
+    fn base_path_with_trailing_slash_is_normalised() {
+        let loader = TomlLoader::new(
+            InMemoryReadBackend::new(),
+            TestAtomicWriter::new(),
+            "/data/",
+        );
+        assert_eq!(loader.absolute("system.toml"), "/data/system.toml");
+    }
+
+    #[test]
+    fn base_path_without_trailing_slash_is_handled() {
+        let loader = TomlLoader::new(InMemoryReadBackend::new(), TestAtomicWriter::new(), "/data");
+        assert_eq!(loader.absolute("system.toml"), "/data/system.toml");
+    }
+
+    #[test]
+    fn in_memory_backend_roundtrips_metadata() {
+        let r = InMemoryReadBackend::new();
+        r.seed_with_mode("/x", b"hi", 0o600);
+        assert_eq!(r.read_file("/x").unwrap().as_deref(), Some(&b"hi"[..]));
+        assert_eq!(r.mode_of("/x").unwrap(), Some(0o600));
+        assert_eq!(r.read_file("/missing").unwrap(), None);
+        assert_eq!(r.mode_of("/missing").unwrap(), None);
+    }
+
+    #[test]
+    fn in_memory_backend_default_mode_used_for_seed() {
+        let r = InMemoryReadBackend::new();
+        r.set_default_mode(0o644);
+        r.seed("/x", b"hi");
+        assert_eq!(r.mode_of("/x").unwrap(), Some(0o644));
+    }
+
+    #[test]
+    fn in_memory_backend_set_mode_only_existing_files() {
+        let r = InMemoryReadBackend::new();
+        r.seed("/x", b"hi");
+        r.set_mode("/x", 0o400);
+        assert_eq!(r.mode_of("/x").unwrap(), Some(0o400));
+        // Non-existent file: silently ignore.
+        r.set_mode("/missing", 0o400);
+        assert_eq!(r.mode_of("/missing").unwrap(), None);
+    }
+
+    #[test]
+    fn in_memory_backend_snapshot_includes_seeded() {
+        let r = InMemoryReadBackend::new();
+        r.seed("/x", b"hi");
+        r.seed("/y", b"yo");
+        let s = r.snapshot();
+        assert_eq!(s.len(), 2);
+        assert!(s.contains_key("/x"));
+        assert!(s.contains_key("/y"));
+    }
+
+    #[test]
+    fn in_memory_backend_len_and_is_empty() {
+        let r = InMemoryReadBackend::new();
+        assert!(r.is_empty());
+        r.seed("/x", b"hi");
+        assert_eq!(r.len(), 1);
+        assert!(!r.is_empty());
+    }
+
+    #[test]
+    fn first_boot_generate_then_reload_strict_succeeds() {
+        let reader = InMemoryReadBackend::new();
+        let writer = TestAtomicWriter::new();
+        let mut loader = TomlLoader::new(reader, writer, "/data");
+        loader.load(FirstBootPolicy::Generate).unwrap();
+        // After generation, the *writer*'s in-memory map holds the
+        // files but our reader doesn't see them (separate backends).
+        // This is intentional in the test fixture: the kernel will
+        // pair both backends against the same FS handle. To prove the
+        // code path is sound we re-read by inspecting `cached`
+        // directly.
+        let snapshot = loader.config().clone();
+        assert_eq!(snapshot.idle.root_minutes, 15);
+    }
+
+    #[test]
+    fn write_failure_due_to_io_propagates() {
+        // TestAtomicWriter that crashes on write.
+        let reader = InMemoryReadBackend::new();
+        let writer = TestAtomicWriter::new();
+        let mut loader = TomlLoader::new(reader, writer, "/data");
+        loader.load(FirstBootPolicy::Generate).unwrap();
+        loader.writer.inject_crash_during_io();
+        let p = ConfigPath::new("idle.root_minutes").unwrap();
+        let err = loader.write(&p, Value::U32(20), "root@toml").unwrap_err();
+        assert!(matches!(err, SurfaceError::Io(_)));
+        // In-memory state did NOT mutate.
+        assert_eq!(loader.read(&p).unwrap(), Value::U32(15));
+    }
+
+    #[test]
+    fn default_loader_has_zero_pending_reboot() {
+        let loader = empty_loader();
+        assert!(loader.pending_reboot().is_empty());
+    }
+
+    #[test]
+    fn live_write_does_not_appear_in_pending_reboot() {
+        let reader = InMemoryReadBackend::new();
+        let writer = TestAtomicWriter::new();
+        let mut loader = TomlLoader::new(reader, writer, "/data");
+        loader.load(FirstBootPolicy::Generate).unwrap();
+        loader
+            .write(
+                &ConfigPath::new("idle.root_minutes").unwrap(),
+                Value::U32(20),
+                "root@toml",
+            )
+            .unwrap();
+        assert!(loader.pending_reboot().is_empty());
+    }
+
+    #[test]
+    fn type_tag_string_is_unsupported_in_v1_config() {
+        // No v1 config field is `String`, so a String value into any
+        // path fails type matching.
+        let err = toml_to_config_value(
+            &TomlValue::String("x".to_string()),
+            FieldType::String,
+            "fake.path",
+        )
+        .unwrap();
+        assert!(matches!(err, Value::String(_)));
+        // (Just exercises the conversion path; no v1 field exercises
+        // it from the registry.)
+    }
+
+    #[test]
+    fn integer_conversion_handles_zero() {
+        assert_eq!(
+            toml_to_config_value(&TomlValue::Integer(0), FieldType::U32, "x").unwrap(),
+            Value::U32(0)
+        );
+        assert_eq!(
+            toml_to_config_value(&TomlValue::Integer(0), FieldType::U64, "x").unwrap(),
+            Value::U64(0)
+        );
+    }
+
+    #[test]
+    fn boolean_conversion_round_trips() {
+        assert_eq!(
+            toml_to_config_value(&TomlValue::Bool(true), FieldType::Bool, "x").unwrap(),
+            Value::Bool(true)
+        );
+        assert_eq!(
+            toml_to_config_value(&TomlValue::Bool(false), FieldType::Bool, "x").unwrap(),
+            Value::Bool(false)
+        );
+    }
+
+    #[test]
+    fn render_then_apply_is_identity() {
+        let cfg = Config::v1_defaults();
+        let table = render_namespace_table(&cfg, Namespace::System);
+        let mut roundtrip = Config::v1_defaults();
+        apply_table_to_config(&table, "", &mut roundtrip).unwrap();
+        assert_eq!(roundtrip, cfg);
+    }
+
+    #[test]
+    fn render_then_apply_is_identity_for_mgmt_policy() {
+        let cfg = Config::v1_defaults();
+        let table = render_namespace_table(&cfg, Namespace::MgmtPolicy);
+        let mut roundtrip = Config::v1_defaults();
+        apply_table_to_config(&table, "", &mut roundtrip).unwrap();
+        assert_eq!(roundtrip, cfg);
+    }
+
+    #[test]
+    fn pending_reboot_records_who() {
+        let reader = InMemoryReadBackend::new();
+        let writer = TestAtomicWriter::new();
+        let mut loader = TomlLoader::new(reader, writer, "/data");
+        loader.load(FirstBootPolicy::Generate).unwrap();
+        loader
+            .write(
+                &ConfigPath::new("fs.boot_watchdog_seconds").unwrap(),
+                Value::U32(30),
+                "operator:alice@toml",
+            )
+            .unwrap();
+        assert_eq!(loader.pending_reboot()[0].who, "operator:alice@toml");
+    }
+
+    #[test]
+    fn live_write_serialises_changed_value_to_disk_via_writer() {
+        // We can't snoop the TestAtomicWriter from outside the loader,
+        // but we can repeat-write and verify the cache reflects the
+        // last value. (Disk-snooping is exercised by the integration
+        // test above.)
+        let reader = InMemoryReadBackend::new();
+        let writer = TestAtomicWriter::new();
+        let mut loader = TomlLoader::new(reader, writer, "/data");
+        loader.load(FirstBootPolicy::Generate).unwrap();
+        let p = ConfigPath::new("idle.root_minutes").unwrap();
+        for v in [20, 30, 10] {
+            loader.write(&p, Value::U32(v), "root@toml").unwrap();
+            assert_eq!(loader.read(&p).unwrap(), Value::U32(v));
+        }
+    }
+
+    #[test]
+    fn check_mode_ignores_high_bits() {
+        // setuid/setgid/sticky bits on the file are ignored — the
+        // loader only cares about the mode triplet.
+        check_mode("/x", 0o640, 0o4640).unwrap();
+    }
+
+    #[test]
+    fn loader_error_io_display_includes_reason() {
+        let e = LoaderError::Io("storage offline");
+        let s = alloc::format!("{}", e);
+        assert!(s.contains("storage offline"));
+    }
+}

--- a/mgmt/src/toml/lex.rs
+++ b/mgmt/src/toml/lex.rs
@@ -1,0 +1,544 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! TOML 1.0 (v1 subset) lexer.
+//!
+//! Converts a `&str` source into a [`Vec<Token>`]. The token stream
+//! preserves the line number of every token so the parser can name
+//! the source line in its error messages.
+//!
+//! See [`crate::toml`] for the v1 subset boundary.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use super::Error;
+
+/// One lexical token. Span info is reduced to a 1-based `line` count;
+/// the parser only needs that for diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Token {
+    /// Bare key — `[a-zA-Z0-9_-]+` segment.
+    BareKey(String),
+    /// Quoted string value (basic or literal — both decode to a
+    /// runtime `String`).
+    String(String),
+    /// Decimal integer; the lexer parses sign and underscores and
+    /// hands the parser a `i64`.
+    Integer(i64),
+    /// Boolean literal.
+    Bool(bool),
+    /// `=` between a key and its value.
+    Equals,
+    /// `.` between dotted-key segments.
+    Dot,
+    /// `,` between array elements.
+    Comma,
+    /// `[` — opens a header or an inline array. The parser
+    /// disambiguates from context.
+    LBracket,
+    /// `]` — closes a header or an inline array.
+    RBracket,
+    /// `\n` — meaningful in TOML; key/value pairs SHALL terminate at a
+    /// newline. The lexer emits one [`Token::Newline`] per line break
+    /// so the parser can tell adjacent kv-pairs apart.
+    Newline,
+}
+
+/// One token plus its source line number.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Spanned {
+    /// The token.
+    pub token: Token,
+    /// 1-based source line.
+    pub line: u32,
+}
+
+/// Lex `src` into a sequence of [`Spanned`] tokens. Comments and pure
+/// whitespace runs are dropped. Newlines are preserved as
+/// [`Token::Newline`] markers.
+pub fn lex(src: &str) -> Result<Vec<Spanned>, Error> {
+    let mut out = Vec::new();
+    let mut chars = src.chars().peekable();
+    let mut line: u32 = 1;
+
+    while let Some(&c) = chars.peek() {
+        match c {
+            ' ' | '\t' | '\r' => {
+                chars.next();
+            }
+            '\n' => {
+                chars.next();
+                out.push(Spanned {
+                    token: Token::Newline,
+                    line,
+                });
+                line += 1;
+            }
+            '#' => {
+                // Comment to EOL.
+                while let Some(&c) = chars.peek() {
+                    if c == '\n' {
+                        break;
+                    }
+                    chars.next();
+                }
+            }
+            '=' => {
+                chars.next();
+                out.push(Spanned {
+                    token: Token::Equals,
+                    line,
+                });
+            }
+            '.' => {
+                chars.next();
+                out.push(Spanned {
+                    token: Token::Dot,
+                    line,
+                });
+            }
+            ',' => {
+                chars.next();
+                out.push(Spanned {
+                    token: Token::Comma,
+                    line,
+                });
+            }
+            '[' => {
+                chars.next();
+                out.push(Spanned {
+                    token: Token::LBracket,
+                    line,
+                });
+            }
+            ']' => {
+                chars.next();
+                out.push(Spanned {
+                    token: Token::RBracket,
+                    line,
+                });
+            }
+            '"' => {
+                let s = lex_basic_string(&mut chars, line)?;
+                out.push(Spanned {
+                    token: Token::String(s),
+                    line,
+                });
+            }
+            '\'' => {
+                let s = lex_literal_string(&mut chars, line)?;
+                out.push(Spanned {
+                    token: Token::String(s),
+                    line,
+                });
+            }
+            't' | 'f' => {
+                let word = read_word(&mut chars);
+                match word.as_str() {
+                    "true" => out.push(Spanned {
+                        token: Token::Bool(true),
+                        line,
+                    }),
+                    "false" => out.push(Spanned {
+                        token: Token::Bool(false),
+                        line,
+                    }),
+                    _ => out.push(Spanned {
+                        token: Token::BareKey(word),
+                        line,
+                    }),
+                }
+            }
+            '-' | '+' | '0'..='9' => {
+                let n = lex_integer(&mut chars, line)?;
+                out.push(Spanned {
+                    token: Token::Integer(n),
+                    line,
+                });
+            }
+            _ if is_bare_key_char(c) => {
+                let word = read_word(&mut chars);
+                out.push(Spanned {
+                    token: Token::BareKey(word),
+                    line,
+                });
+            }
+            _ => {
+                return Err(Error::Lex {
+                    line,
+                    reason: "unexpected character",
+                });
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+/// Read a bare-key word — `[a-zA-Z0-9_-]+`. Caller has already
+/// confirmed the leading char is a bare-key char.
+fn read_word(chars: &mut core::iter::Peekable<core::str::Chars<'_>>) -> String {
+    let mut s = String::new();
+    while let Some(&c) = chars.peek() {
+        if is_bare_key_char(c) {
+            s.push(c);
+            chars.next();
+        } else {
+            break;
+        }
+    }
+    s
+}
+
+/// Bare-key alphabet per TOML 1.0: ASCII alphanum, `_`, `-`.
+fn is_bare_key_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_' || c == '-'
+}
+
+/// Parse a basic (`"..."`) string. v1 subset rejects multi-line strings
+/// and only handles the standard escape sequences `\\`, `\"`, `\n`,
+/// `\t`, `\r`, `\0`.
+fn lex_basic_string(
+    chars: &mut core::iter::Peekable<core::str::Chars<'_>>,
+    line: u32,
+) -> Result<String, Error> {
+    // Consume the leading `"`. Reject multi-line strings (`"""..."""`) —
+    // v1 out of scope.
+    chars.next();
+    if matches!(chars.peek(), Some('"')) {
+        // Could be `""` (empty) or `"""` (multi-line); look ahead.
+        chars.next();
+        if matches!(chars.peek(), Some('"')) {
+            return Err(Error::Lex {
+                line,
+                reason: "multi-line basic strings not supported",
+            });
+        }
+        return Ok(String::new());
+    }
+    let mut out = String::new();
+    loop {
+        match chars.next() {
+            None => {
+                return Err(Error::Lex {
+                    line,
+                    reason: "unterminated basic string",
+                });
+            }
+            Some('"') => return Ok(out),
+            Some('\n') => {
+                return Err(Error::Lex {
+                    line,
+                    reason: "newline in basic string",
+                });
+            }
+            Some('\\') => match chars.next() {
+                None => {
+                    return Err(Error::Lex {
+                        line,
+                        reason: "unterminated escape",
+                    });
+                }
+                Some('\\') => out.push('\\'),
+                Some('"') => out.push('"'),
+                Some('n') => out.push('\n'),
+                Some('t') => out.push('\t'),
+                Some('r') => out.push('\r'),
+                Some('0') => out.push('\0'),
+                Some(_) => {
+                    return Err(Error::Lex {
+                        line,
+                        reason: "unsupported escape sequence",
+                    });
+                }
+            },
+            Some(c) => out.push(c),
+        }
+    }
+}
+
+/// Parse a literal (`'...'`) string. No escapes.
+fn lex_literal_string(
+    chars: &mut core::iter::Peekable<core::str::Chars<'_>>,
+    line: u32,
+) -> Result<String, Error> {
+    // Consume the leading `'`.
+    chars.next();
+    if matches!(chars.peek(), Some('\'')) {
+        chars.next();
+        if matches!(chars.peek(), Some('\'')) {
+            return Err(Error::Lex {
+                line,
+                reason: "multi-line literal strings not supported",
+            });
+        }
+        return Ok(String::new());
+    }
+    let mut out = String::new();
+    loop {
+        match chars.next() {
+            None => {
+                return Err(Error::Lex {
+                    line,
+                    reason: "unterminated literal string",
+                });
+            }
+            Some('\'') => return Ok(out),
+            Some('\n') => {
+                return Err(Error::Lex {
+                    line,
+                    reason: "newline in literal string",
+                });
+            }
+            Some(c) => out.push(c),
+        }
+    }
+}
+
+/// Parse a decimal integer with optional leading `+`/`-` and embedded
+/// `_` digit separators. Rejects hex/oct/bin (v1 subset) and
+/// floating-point.
+fn lex_integer(
+    chars: &mut core::iter::Peekable<core::str::Chars<'_>>,
+    line: u32,
+) -> Result<i64, Error> {
+    let mut raw = String::new();
+    let mut neg = false;
+    match chars.peek() {
+        Some('-') => {
+            chars.next();
+            neg = true;
+        }
+        Some('+') => {
+            chars.next();
+        }
+        _ => {}
+    }
+    let mut have_digit = false;
+    while let Some(&c) = chars.peek() {
+        match c {
+            '0'..='9' => {
+                raw.push(c);
+                chars.next();
+                have_digit = true;
+            }
+            '_' => {
+                if !have_digit {
+                    return Err(Error::Lex {
+                        line,
+                        reason: "leading underscore in integer",
+                    });
+                }
+                chars.next();
+                // The next char SHALL be a digit (TOML disallows
+                // trailing or paired underscores).
+                match chars.peek() {
+                    Some(d) if d.is_ascii_digit() => {}
+                    _ => {
+                        return Err(Error::Lex {
+                            line,
+                            reason: "underscore must separate digits",
+                        });
+                    }
+                }
+            }
+            'x' | 'X' | 'o' | 'O' | 'b' | 'B' => {
+                return Err(Error::Lex {
+                    line,
+                    reason: "non-decimal integer not supported",
+                });
+            }
+            '.' | 'e' | 'E' => {
+                return Err(Error::Lex {
+                    line,
+                    reason: "floating-point not supported",
+                });
+            }
+            _ => break,
+        }
+    }
+    if !have_digit {
+        return Err(Error::Lex {
+            line,
+            reason: "missing digits in integer",
+        });
+    }
+    // Reject leading zero as per TOML 1.0 unless the value is exactly
+    // "0".
+    if raw.len() > 1 && raw.starts_with('0') {
+        return Err(Error::Lex {
+            line,
+            reason: "leading zero in integer",
+        });
+    }
+    let n: i64 = raw.parse().map_err(|_| Error::Lex {
+        line,
+        reason: "integer out of range",
+    })?;
+    Ok(if neg { -n } else { n })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    fn tokens(src: &str) -> Vec<Token> {
+        lex(src).unwrap().into_iter().map(|s| s.token).collect()
+    }
+
+    #[test]
+    fn key_value_basic() {
+        let t = tokens("hello = 7\n");
+        assert_eq!(
+            t,
+            alloc::vec![
+                Token::BareKey("hello".to_string()),
+                Token::Equals,
+                Token::Integer(7),
+                Token::Newline,
+            ]
+        );
+    }
+
+    #[test]
+    fn comment_dropped() {
+        let t = tokens("# top comment\nfoo = 1 # trailing\n");
+        assert_eq!(
+            t,
+            alloc::vec![
+                Token::Newline,
+                Token::BareKey("foo".to_string()),
+                Token::Equals,
+                Token::Integer(1),
+                Token::Newline,
+            ]
+        );
+    }
+
+    #[test]
+    fn header_and_dotted_key() {
+        let t = tokens("[a.b]\nx = true\n");
+        assert_eq!(
+            t,
+            alloc::vec![
+                Token::LBracket,
+                Token::BareKey("a".to_string()),
+                Token::Dot,
+                Token::BareKey("b".to_string()),
+                Token::RBracket,
+                Token::Newline,
+                Token::BareKey("x".to_string()),
+                Token::Equals,
+                Token::Bool(true),
+                Token::Newline,
+            ]
+        );
+    }
+
+    #[test]
+    fn basic_string_with_escapes() {
+        let t = tokens("name = \"a\\nb\\t\\\"c\"\n");
+        assert_eq!(t[2], Token::String("a\nb\t\"c".to_string()));
+    }
+
+    #[test]
+    fn literal_string_no_escapes() {
+        let t = tokens("name = 'a\\nb'\n");
+        assert_eq!(t[2], Token::String("a\\nb".to_string()));
+    }
+
+    #[test]
+    fn integer_with_underscore() {
+        let t = tokens("n = 1_000_000\n");
+        assert_eq!(t[2], Token::Integer(1_000_000));
+    }
+
+    #[test]
+    fn integer_signed() {
+        assert_eq!(tokens("n = -5\n")[2], Token::Integer(-5));
+        assert_eq!(tokens("n = +5\n")[2], Token::Integer(5));
+        assert_eq!(tokens("n = 0\n")[2], Token::Integer(0));
+    }
+
+    #[test]
+    fn rejects_leading_zero() {
+        assert!(matches!(lex("n = 01\n"), Err(Error::Lex { .. })));
+    }
+
+    #[test]
+    fn rejects_hex_integer() {
+        assert!(matches!(lex("n = 0xFF\n"), Err(Error::Lex { .. })));
+    }
+
+    #[test]
+    fn rejects_floating_point() {
+        assert!(matches!(lex("n = 1.5\n"), Err(Error::Lex { .. })));
+    }
+
+    #[test]
+    fn rejects_unterminated_string() {
+        assert!(matches!(lex("k = \"unterm\n"), Err(Error::Lex { .. })));
+    }
+
+    #[test]
+    fn rejects_multiline_string() {
+        assert!(matches!(lex("k = \"\"\""), Err(Error::Lex { .. })));
+    }
+
+    #[test]
+    fn arrays_emit_brackets_and_commas() {
+        let t = tokens("xs = [1, 2, 3]\n");
+        assert_eq!(
+            t,
+            alloc::vec![
+                Token::BareKey("xs".to_string()),
+                Token::Equals,
+                Token::LBracket,
+                Token::Integer(1),
+                Token::Comma,
+                Token::Integer(2),
+                Token::Comma,
+                Token::Integer(3),
+                Token::RBracket,
+                Token::Newline,
+            ]
+        );
+    }
+
+    #[test]
+    fn line_numbering_advances() {
+        let spans = lex("a = 1\nb = 2\n").unwrap();
+        // a = 1 \n b = 2 \n
+        // tokens: BareKey(a)@1 = @1 1 @1 \n@1 BareKey(b)@2 ...
+        assert_eq!(spans[0].line, 1);
+        assert_eq!(spans[3].line, 1); // the '\n' after the first line
+        assert_eq!(spans[4].line, 2);
+    }
+
+    #[test]
+    fn handles_crlf() {
+        let t = tokens("a = 1\r\n");
+        assert_eq!(
+            t,
+            alloc::vec![
+                Token::BareKey("a".to_string()),
+                Token::Equals,
+                Token::Integer(1),
+                Token::Newline,
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_string_decodes() {
+        assert_eq!(tokens("a = \"\"\n")[2], Token::String("".to_string()));
+        assert_eq!(tokens("a = ''\n")[2], Token::String("".to_string()));
+    }
+
+    #[test]
+    fn rejects_invalid_escape() {
+        assert!(matches!(lex("a = \"\\q\"\n"), Err(Error::Lex { .. })));
+    }
+}

--- a/mgmt/src/toml/mod.rs
+++ b/mgmt/src/toml/mod.rs
@@ -1,0 +1,269 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Clean-room `#![no_std]` TOML 1.0 subset parser and serialiser.
+//!
+//! Spec context: the SmallAIOS clean-room rule (no production
+//! third-party deps in the kernel) precludes the upstream `toml` crate
+//! at runtime. The `mgmt` config surface needs only a subset of the
+//! TOML 1.0 grammar, so this module implements the pieces we use and
+//! rejects everything else with a stable error.
+//!
+//! ## Subset (v1)
+//!
+//! Supported:
+//!
+//! - Top-level key/value pairs.
+//! - `[table]` and `[sub.table]` headers (dotted paths).
+//! - String values: basic (`"..."`) and literal (`'...'`).
+//! - Integer values: `123`, `-1`, `0`, `+0`. Underscores allowed.
+//! - Boolean values: `true` / `false`.
+//! - Inline arrays of primitives: `[1, 2, 3]`, `["a", "b"]`.
+//! - Dotted keys on the LHS of a value (`a.b.c = 1`).
+//! - `# line comments` and trailing whitespace.
+//!
+//! Out of v1 scope (rejected with [`Error`]):
+//!
+//! - Multi-line strings (`"""..."""`, `'''...'''`).
+//! - Date/time values.
+//! - Floating-point values.
+//! - Inline tables (`{ a = 1, b = 2 }`).
+//! - Arrays of tables (`[[fruits]]`).
+//! - Hexadecimal / binary / octal integers.
+//!
+//! Production callers SHALL author config files within the subset.
+//! Files exceeding the subset SHALL produce a parse error and the
+//! file SHALL be treated as corrupt by the loader.
+//!
+//! ## API
+//!
+//! - [`parse`] turns a `&str` into a tree of [`TomlValue`].
+//! - [`serialize`] turns a [`TomlTable`] back into a deterministic
+//!   `String`. Round-trip is exact for any value in-subset.
+//!
+//! ## Determinism
+//!
+//! [`serialize`] visits keys in BTree order (alphabetical within a
+//! table) so re-serialising a parsed file produces a stable byte
+//! sequence — required for diff-able config commits.
+
+#![allow(clippy::result_large_err)]
+
+extern crate alloc;
+
+use alloc::collections::BTreeMap;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::fmt;
+
+pub mod lex;
+pub mod parse;
+pub mod serialize;
+
+pub use lex::Token;
+pub use parse::parse;
+pub use serialize::serialize;
+
+// ─── AST ─────────────────────────────────────────────────────────────────────
+
+/// Typed TOML value. Variants are restricted to the subset declared in
+/// the module-level docs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TomlValue {
+    /// `true` or `false`.
+    Bool(bool),
+    /// Decimal integer; underscores stripped during parse.
+    Integer(i64),
+    /// String — basic or literal; both decode to the same variant.
+    String(String),
+    /// Inline array of primitive [`TomlValue`]s. The parser rejects
+    /// nested arrays-of-tables.
+    Array(Vec<TomlValue>),
+    /// Sub-table (a `[header]` block or a value that expands a dotted
+    /// LHS into a table).
+    Table(TomlTable),
+}
+
+/// A TOML table — a `BTreeMap<key, value>` so keys serialise in stable
+/// order and round-trips are byte-identical for in-subset input.
+pub type TomlTable = BTreeMap<String, TomlValue>;
+
+impl TomlValue {
+    /// Variant tag for diagnostics (`"bool"`, `"integer"`, `"string"`,
+    /// `"array"`, `"table"`).
+    pub fn type_tag(&self) -> &'static str {
+        match self {
+            Self::Bool(_) => "bool",
+            Self::Integer(_) => "integer",
+            Self::String(_) => "string",
+            Self::Array(_) => "array",
+            Self::Table(_) => "table",
+        }
+    }
+
+    /// Try to extract a `bool`.
+    pub fn as_bool(&self) -> Result<bool, Error> {
+        match self {
+            Self::Bool(b) => Ok(*b),
+            _ => Err(Error::Type {
+                expected: "bool",
+                got: self.type_tag(),
+            }),
+        }
+    }
+
+    /// Try to extract an `i64`.
+    pub fn as_integer(&self) -> Result<i64, Error> {
+        match self {
+            Self::Integer(n) => Ok(*n),
+            _ => Err(Error::Type {
+                expected: "integer",
+                got: self.type_tag(),
+            }),
+        }
+    }
+
+    /// Try to extract a string.
+    pub fn as_str(&self) -> Result<&str, Error> {
+        match self {
+            Self::String(s) => Ok(s.as_str()),
+            _ => Err(Error::Type {
+                expected: "string",
+                got: self.type_tag(),
+            }),
+        }
+    }
+
+    /// Try to borrow a `&Table`.
+    pub fn as_table(&self) -> Result<&TomlTable, Error> {
+        match self {
+            Self::Table(t) => Ok(t),
+            _ => Err(Error::Type {
+                expected: "table",
+                got: self.type_tag(),
+            }),
+        }
+    }
+}
+
+// ─── Errors ──────────────────────────────────────────────────────────────────
+
+/// Parse / serialise error.
+///
+/// Errors carry a `&'static str` reason rather than a heap-allocated
+/// `String` so the error type is `Copy`-friendly for downstream
+/// callers and stable across allocation regimes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Error {
+    /// A token was rejected by the lexer (e.g. invalid escape, EOF in
+    /// string).
+    Lex {
+        /// 1-based line number where the lexer gave up.
+        line: u32,
+        /// Stable static reason.
+        reason: &'static str,
+    },
+    /// The parser encountered a token sequence the v1 subset doesn't
+    /// support.
+    Parse {
+        /// 1-based line number where the parser gave up.
+        line: u32,
+        /// Stable static reason.
+        reason: &'static str,
+    },
+    /// The proposed key collides with an existing one in the same
+    /// table — TOML 1.0 forbids redefinition of a value.
+    DuplicateKey {
+        /// Dotted path of the duplicate.
+        path: String,
+    },
+    /// The supplied value's type doesn't match what the caller asked
+    /// for (used by [`TomlValue::as_bool`] etc.).
+    Type {
+        /// Expected variant tag.
+        expected: &'static str,
+        /// Actual variant tag.
+        got: &'static str,
+    },
+    /// A feature outside the v1 subset was used (e.g. multi-line
+    /// strings, dates). The reason names the rejected feature.
+    Unsupported(&'static str),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Lex { line, reason } => write!(f, "toml: lex error at line {line}: {reason}"),
+            Self::Parse { line, reason } => write!(f, "toml: parse error at line {line}: {reason}"),
+            Self::DuplicateKey { path } => write!(f, "toml: duplicate key: {path}"),
+            Self::Type { expected, got } => {
+                write!(f, "toml: expected {expected}, got {got}")
+            }
+            Self::Unsupported(reason) => write!(f, "toml: unsupported: {reason}"),
+        }
+    }
+}
+
+/// Convenience: stitch two dotted segments into one dotted path with
+/// proper escape so duplicate-key errors are unambiguous.
+pub(crate) fn join_path(prefix: &str, segment: &str) -> String {
+    if prefix.is_empty() {
+        segment.to_string()
+    } else {
+        let mut s = String::with_capacity(prefix.len() + 1 + segment.len());
+        s.push_str(prefix);
+        s.push('.');
+        s.push_str(segment);
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn type_tags() {
+        assert_eq!(TomlValue::Bool(true).type_tag(), "bool");
+        assert_eq!(TomlValue::Integer(0).type_tag(), "integer");
+        assert_eq!(TomlValue::String(String::new()).type_tag(), "string");
+        assert_eq!(TomlValue::Array(Vec::new()).type_tag(), "array");
+        assert_eq!(TomlValue::Table(TomlTable::new()).type_tag(), "table");
+    }
+
+    #[test]
+    fn extractors_match_variant() {
+        assert_eq!(TomlValue::Bool(true).as_bool(), Ok(true));
+        assert_eq!(TomlValue::Integer(42).as_integer(), Ok(42));
+        assert_eq!(TomlValue::String("x".to_string()).as_str(), Ok("x"));
+    }
+
+    #[test]
+    fn extractors_diagnose_mismatch() {
+        match TomlValue::Bool(true).as_integer() {
+            Err(Error::Type { expected, got }) => {
+                assert_eq!(expected, "integer");
+                assert_eq!(got, "bool");
+            }
+            _ => panic!("expected Error::Type"),
+        }
+    }
+
+    #[test]
+    fn join_path_empty_prefix() {
+        assert_eq!(join_path("", "a"), "a");
+        assert_eq!(join_path("a", "b"), "a.b");
+        assert_eq!(join_path("a.b", "c"), "a.b.c");
+    }
+
+    #[test]
+    fn error_display_includes_line() {
+        let e = Error::Parse {
+            line: 3,
+            reason: "expected '='",
+        };
+        let s = alloc::format!("{}", e);
+        assert!(s.contains("line 3"));
+        assert!(s.contains("expected '='"));
+    }
+}

--- a/mgmt/src/toml/parse.rs
+++ b/mgmt/src/toml/parse.rs
@@ -1,0 +1,431 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! TOML 1.0 (v1 subset) parser.
+//!
+//! Consumes the [`super::lex::Spanned`] token stream produced by
+//! [`super::lex::lex`] and assembles a [`super::TomlTable`].
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use super::lex::{lex, Spanned, Token};
+use super::{join_path, Error, TomlTable, TomlValue};
+
+/// Parse `src` (a `&str` slice of in-subset TOML) into a top-level
+/// [`TomlTable`].
+pub fn parse(src: &str) -> Result<TomlTable, Error> {
+    let tokens = lex(src)?;
+    let mut p = Parser {
+        tokens,
+        pos: 0,
+        out: TomlTable::new(),
+        current_header: Vec::new(),
+    };
+    p.run()?;
+    Ok(p.out)
+}
+
+struct Parser {
+    tokens: Vec<Spanned>,
+    pos: usize,
+    out: TomlTable,
+    /// Current `[a.b.c]` header, as a stack of segments. Empty means
+    /// "top-level".
+    current_header: Vec<String>,
+}
+
+impl Parser {
+    fn run(&mut self) -> Result<(), Error> {
+        while !self.is_eof() {
+            // Skip blank lines.
+            if matches!(self.peek_token(), Some(Token::Newline)) {
+                self.advance();
+                continue;
+            }
+            if matches!(self.peek_token(), Some(Token::LBracket)) {
+                self.parse_header()?;
+            } else {
+                self.parse_kv()?;
+            }
+        }
+        Ok(())
+    }
+
+    fn parse_header(&mut self) -> Result<(), Error> {
+        let line = self.peek_line();
+        self.expect(&Token::LBracket)?;
+        // Reject `[[arrays.of.tables]]` — out of v1 scope. The lexer
+        // emits two LBracket tokens for `[[`, so detecting a second
+        // LBracket here is the trigger.
+        if matches!(self.peek_token(), Some(Token::LBracket)) {
+            return Err(Error::Unsupported("array of tables ([[ ]])"));
+        }
+        let mut segments = Vec::new();
+        loop {
+            let key = self.expect_bare_key_or_string()?;
+            segments.push(key);
+            if matches!(self.peek_token(), Some(Token::Dot)) {
+                self.advance();
+                continue;
+            }
+            break;
+        }
+        self.expect(&Token::RBracket)?;
+        self.expect_newline_or_eof(line)?;
+        self.current_header = segments.clone();
+
+        // Materialise the empty sub-table (so subsequent kv parsing has
+        // a place to put values). If the path collides with a non-table
+        // existing value, reject with a `Parse` error.
+        ensure_table(&mut self.out, &segments)?;
+        Ok(())
+    }
+
+    fn parse_kv(&mut self) -> Result<(), Error> {
+        let line = self.peek_line();
+        let mut key_segments = Vec::new();
+        loop {
+            let k = self.expect_bare_key_or_string()?;
+            key_segments.push(k);
+            if matches!(self.peek_token(), Some(Token::Dot)) {
+                self.advance();
+                continue;
+            }
+            break;
+        }
+        self.expect(&Token::Equals)?;
+        let value = self.parse_value(line)?;
+        self.expect_newline_or_eof(line)?;
+
+        // Resolve the absolute path = current_header / key_segments.
+        let mut full = self.current_header.clone();
+        full.extend(key_segments);
+        insert_value(&mut self.out, &full, value)?;
+        Ok(())
+    }
+
+    fn parse_value(&mut self, line: u32) -> Result<TomlValue, Error> {
+        match self.peek_token() {
+            Some(Token::Bool(b)) => {
+                let v = TomlValue::Bool(*b);
+                self.advance();
+                Ok(v)
+            }
+            Some(Token::Integer(n)) => {
+                let v = TomlValue::Integer(*n);
+                self.advance();
+                Ok(v)
+            }
+            Some(Token::String(s)) => {
+                let v = TomlValue::String(s.clone());
+                self.advance();
+                Ok(v)
+            }
+            Some(Token::LBracket) => self.parse_array(line),
+            _ => Err(Error::Parse {
+                line,
+                reason: "expected value",
+            }),
+        }
+    }
+
+    fn parse_array(&mut self, _line: u32) -> Result<TomlValue, Error> {
+        let line = self.peek_line();
+        self.expect(&Token::LBracket)?;
+        let mut items = Vec::new();
+        loop {
+            // Allow newlines inside the array brackets so files can
+            // wrap long lists.
+            while matches!(self.peek_token(), Some(Token::Newline)) {
+                self.advance();
+            }
+            if matches!(self.peek_token(), Some(Token::RBracket)) {
+                self.advance();
+                return Ok(TomlValue::Array(items));
+            }
+            let v = self.parse_value(line)?;
+            // v1 subset rejects nested arrays/tables inside arrays.
+            if matches!(v, TomlValue::Array(_) | TomlValue::Table(_)) {
+                return Err(Error::Unsupported("nested array or inline table"));
+            }
+            items.push(v);
+            while matches!(self.peek_token(), Some(Token::Newline)) {
+                self.advance();
+            }
+            match self.peek_token() {
+                Some(Token::Comma) => {
+                    self.advance();
+                }
+                Some(Token::RBracket) => {
+                    self.advance();
+                    return Ok(TomlValue::Array(items));
+                }
+                _ => {
+                    return Err(Error::Parse {
+                        line,
+                        reason: "expected ',' or ']' in array",
+                    });
+                }
+            }
+        }
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────
+
+    fn peek_token(&self) -> Option<&Token> {
+        self.tokens.get(self.pos).map(|s| &s.token)
+    }
+
+    fn peek_line(&self) -> u32 {
+        self.tokens.get(self.pos).map(|s| s.line).unwrap_or(0)
+    }
+
+    fn advance(&mut self) {
+        self.pos += 1;
+    }
+
+    fn is_eof(&self) -> bool {
+        self.pos >= self.tokens.len()
+    }
+
+    fn expect(&mut self, want: &Token) -> Result<(), Error> {
+        let line = self.peek_line();
+        match self.peek_token() {
+            Some(t) if t == want => {
+                self.advance();
+                Ok(())
+            }
+            _ => Err(Error::Parse {
+                line,
+                reason: "unexpected token",
+            }),
+        }
+    }
+
+    fn expect_bare_key_or_string(&mut self) -> Result<String, Error> {
+        let line = self.peek_line();
+        match self.peek_token().cloned() {
+            Some(Token::BareKey(k)) => {
+                self.advance();
+                Ok(k)
+            }
+            Some(Token::String(k)) => {
+                self.advance();
+                Ok(k)
+            }
+            _ => Err(Error::Parse {
+                line,
+                reason: "expected key",
+            }),
+        }
+    }
+
+    fn expect_newline_or_eof(&mut self, line: u32) -> Result<(), Error> {
+        match self.peek_token() {
+            Some(Token::Newline) => {
+                self.advance();
+                Ok(())
+            }
+            None => Ok(()),
+            _ => Err(Error::Parse {
+                line,
+                reason: "expected newline",
+            }),
+        }
+    }
+}
+
+/// Walk the path inside `root`, materialising sub-tables as needed.
+/// Returns an [`Error::DuplicateKey`] if any path segment collides
+/// with an existing non-table value.
+fn ensure_table(root: &mut TomlTable, path: &[String]) -> Result<(), Error> {
+    if path.is_empty() {
+        return Ok(());
+    }
+    let mut cursor = root;
+    let mut walked = String::new();
+    for seg in path {
+        walked = join_path(&walked, seg);
+        // Promote the cursor through the entry API so we never hold
+        // two mutable borrows.
+        let entry = cursor
+            .entry(seg.clone())
+            .or_insert_with(|| TomlValue::Table(TomlTable::new()));
+        match entry {
+            TomlValue::Table(t) => cursor = t,
+            _ => {
+                return Err(Error::DuplicateKey {
+                    path: walked.clone(),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Insert `value` at `path` in `root`. The leaf segment must not
+/// already exist (TOML 1.0 forbids redefining a value).
+fn insert_value(root: &mut TomlTable, path: &[String], value: TomlValue) -> Result<(), Error> {
+    if path.is_empty() {
+        return Err(Error::Parse {
+            line: 0,
+            reason: "empty key path",
+        });
+    }
+    let (leaf, prefix) = path.split_last().expect("non-empty path");
+    ensure_table(root, prefix)?;
+    let mut cursor = root;
+    let mut walked = String::new();
+    for seg in prefix {
+        walked = join_path(&walked, seg);
+        match cursor.get_mut(seg) {
+            Some(TomlValue::Table(t)) => cursor = t,
+            _ => {
+                return Err(Error::DuplicateKey {
+                    path: walked.clone(),
+                });
+            }
+        }
+    }
+    let dotted = join_path(&walked, leaf);
+    if cursor.contains_key(leaf) {
+        return Err(Error::DuplicateKey { path: dotted });
+    }
+    cursor.insert(leaf.clone(), value);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn empty_input_yields_empty_table() {
+        let t = parse("").unwrap();
+        assert!(t.is_empty());
+    }
+
+    #[test]
+    fn comment_only_input_yields_empty_table() {
+        let t = parse("# nothing\n# really\n").unwrap();
+        assert!(t.is_empty());
+    }
+
+    #[test]
+    fn flat_kv_pair() {
+        let t = parse("name = \"alice\"\nage = 30\n").unwrap();
+        assert_eq!(t.get("name"), Some(&TomlValue::String("alice".to_string())));
+        assert_eq!(t.get("age"), Some(&TomlValue::Integer(30)));
+    }
+
+    #[test]
+    fn header_table() {
+        let t = parse("[idle]\nroot_minutes = 15\n").unwrap();
+        let idle = t.get("idle").unwrap().as_table().unwrap();
+        assert_eq!(idle.get("root_minutes"), Some(&TomlValue::Integer(15)));
+    }
+
+    #[test]
+    fn nested_header_table() {
+        let t = parse("[a.b.c]\nx = 1\n").unwrap();
+        let a = t.get("a").unwrap().as_table().unwrap();
+        let b = a.get("b").unwrap().as_table().unwrap();
+        let c = b.get("c").unwrap().as_table().unwrap();
+        assert_eq!(c.get("x"), Some(&TomlValue::Integer(1)));
+    }
+
+    #[test]
+    fn dotted_key_under_header() {
+        let t = parse("[idle]\nlevels.root = 15\n").unwrap();
+        let idle = t.get("idle").unwrap().as_table().unwrap();
+        let levels = idle.get("levels").unwrap().as_table().unwrap();
+        assert_eq!(levels.get("root"), Some(&TomlValue::Integer(15)));
+    }
+
+    #[test]
+    fn multiple_headers_isolated() {
+        let t = parse("[idle]\nroot_minutes = 15\n\n[password]\nmin_length = 12\n").unwrap();
+        assert!(t.contains_key("idle"));
+        assert!(t.contains_key("password"));
+    }
+
+    #[test]
+    fn array_of_primitives() {
+        let t = parse("xs = [1, 2, 3]\n").unwrap();
+        match t.get("xs") {
+            Some(TomlValue::Array(items)) => {
+                assert_eq!(items.len(), 3);
+                assert_eq!(items[0], TomlValue::Integer(1));
+            }
+            _ => panic!("expected array"),
+        }
+    }
+
+    #[test]
+    fn empty_array() {
+        let t = parse("xs = []\n").unwrap();
+        match t.get("xs") {
+            Some(TomlValue::Array(items)) => assert!(items.is_empty()),
+            _ => panic!("expected empty array"),
+        }
+    }
+
+    #[test]
+    fn duplicate_key_rejected() {
+        let err = parse("a = 1\na = 2\n").unwrap_err();
+        assert!(matches!(err, Error::DuplicateKey { .. }));
+    }
+
+    #[test]
+    fn duplicate_dotted_key_rejected() {
+        let err = parse("a.b = 1\na.b = 2\n").unwrap_err();
+        assert!(matches!(err, Error::DuplicateKey { .. }));
+    }
+
+    #[test]
+    fn redefining_table_as_value_rejected() {
+        // a is a table from `a.b = 1`, then `a = 2` tries to overwrite.
+        let err = parse("a.b = 1\na = 2\n").unwrap_err();
+        assert!(matches!(err, Error::DuplicateKey { .. }));
+    }
+
+    #[test]
+    fn array_of_tables_rejected() {
+        let err = parse("[[fruits]]\nname = 'apple'\n").unwrap_err();
+        assert!(matches!(err, Error::Unsupported(_)));
+    }
+
+    #[test]
+    fn missing_equals_diagnoses() {
+        let err = parse("a 1\n").unwrap_err();
+        assert!(matches!(err, Error::Parse { .. }));
+    }
+
+    #[test]
+    fn line_number_in_error_points_to_offender() {
+        let err = parse("a = 1\nb 2\n").unwrap_err();
+        match err {
+            Error::Parse { line, .. } => assert_eq!(line, 2),
+            other => panic!("expected Parse error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn quoted_key_accepted_as_segment() {
+        let t = parse("\"hyphen-key\" = 1\n").unwrap();
+        assert_eq!(t.get("hyphen-key"), Some(&TomlValue::Integer(1)));
+    }
+
+    #[test]
+    fn array_with_mixed_string_and_int_accepted() {
+        // TOML 1.0 rejects mixed-type arrays, but our v1 subset is
+        // permissive; the loader on top enforces typed keys.
+        let t = parse("xs = [1, \"a\"]\n").unwrap();
+        match t.get("xs") {
+            Some(TomlValue::Array(_)) => {}
+            _ => panic!("expected array"),
+        }
+    }
+}

--- a/mgmt/src/toml/serialize.rs
+++ b/mgmt/src/toml/serialize.rs
@@ -1,0 +1,274 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Deterministic TOML serialiser for the v1 subset.
+//!
+//! Produces a `String` that re-parses (via [`super::parse`]) to a
+//! byte-identical [`super::TomlTable`]. Within each table, keys are
+//! emitted in [`alloc::collections::BTreeMap`] iteration order
+//! (alphabetical) so output is stable across runs.
+
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::fmt::Write as _;
+
+use super::{Error, TomlTable, TomlValue};
+
+/// Serialise `table` into a TOML string.
+///
+/// Layout:
+///
+/// 1. Top-level scalars first, in alphabetical order.
+/// 2. One blank line then `[header]` per nested table, recursively.
+///
+/// This nests deterministically so a 30-field config diffs cleanly
+/// in `git`.
+pub fn serialize(table: &TomlTable) -> Result<String, Error> {
+    let mut out = String::new();
+    serialise_table(&mut out, "", table)?;
+    Ok(out)
+}
+
+fn serialise_table(out: &mut String, header: &str, table: &TomlTable) -> Result<(), Error> {
+    // Pass 1: scalars (and arrays) at this header. Tables get their
+    // own header lines later.
+    let mut sub_tables: Vec<(&String, &TomlTable)> = Vec::new();
+    for (k, v) in table.iter() {
+        match v {
+            TomlValue::Table(t) => sub_tables.push((k, t)),
+            _ => {
+                serialise_kv(out, k, v)?;
+            }
+        }
+    }
+    // Pass 2: sub-tables.
+    for (name, sub) in sub_tables {
+        let new_header = if header.is_empty() {
+            name.clone()
+        } else {
+            super::join_path(header, name)
+        };
+        if !out.is_empty() && !out.ends_with("\n\n") {
+            // Ensure exactly one blank line before each header.
+            if !out.ends_with('\n') {
+                out.push('\n');
+            }
+            if !out.is_empty() {
+                out.push('\n');
+            }
+        }
+        let _ = writeln!(out, "[{}]", new_header);
+        serialise_table(out, &new_header, sub)?;
+    }
+    Ok(())
+}
+
+fn serialise_kv(out: &mut String, key: &str, value: &TomlValue) -> Result<(), Error> {
+    let kbuf = serialise_key(key);
+    let vbuf = serialise_value(value)?;
+    let _ = writeln!(out, "{} = {}", kbuf, vbuf);
+    Ok(())
+}
+
+fn serialise_key(key: &str) -> String {
+    // TOML 1.0: bare keys are `[A-Za-z0-9_-]+`. If the key is bare we
+    // emit it bare; otherwise quote.
+    if !key.is_empty() && key.chars().all(is_bare_key_char) {
+        key.into()
+    } else {
+        let mut s = String::with_capacity(key.len() + 2);
+        s.push('"');
+        // Conservatively escape the same set the lexer accepts.
+        for c in key.chars() {
+            match c {
+                '\\' => s.push_str("\\\\"),
+                '"' => s.push_str("\\\""),
+                '\n' => s.push_str("\\n"),
+                '\t' => s.push_str("\\t"),
+                '\r' => s.push_str("\\r"),
+                _ => s.push(c),
+            }
+        }
+        s.push('"');
+        s
+    }
+}
+
+fn is_bare_key_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_' || c == '-'
+}
+
+fn serialise_value(value: &TomlValue) -> Result<String, Error> {
+    match value {
+        TomlValue::Bool(b) => Ok(if *b { "true".into() } else { "false".into() }),
+        TomlValue::Integer(n) => Ok(format!("{n}")),
+        TomlValue::String(s) => Ok(serialise_string(s)),
+        TomlValue::Array(items) => {
+            let mut out = String::from("[");
+            for (i, v) in items.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                if matches!(v, TomlValue::Array(_) | TomlValue::Table(_)) {
+                    return Err(Error::Unsupported("nested array or inline table"));
+                }
+                out.push_str(&serialise_value(v)?);
+            }
+            out.push(']');
+            Ok(out)
+        }
+        TomlValue::Table(_) => Err(Error::Unsupported("inline table value")),
+    }
+}
+
+fn serialise_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\t' => out.push_str("\\t"),
+            '\r' => out.push_str("\\r"),
+            '\0' => out.push_str("\\0"),
+            _ => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::toml::{parse, TomlTable, TomlValue};
+    use alloc::string::ToString;
+
+    #[test]
+    fn empty_table_serialises_to_empty_string() {
+        let t = TomlTable::new();
+        assert_eq!(serialize(&t).unwrap(), "");
+    }
+
+    #[test]
+    fn flat_pairs_round_trip() {
+        let mut t = TomlTable::new();
+        t.insert("name".into(), TomlValue::String("alice".to_string()));
+        t.insert("age".into(), TomlValue::Integer(30));
+        let s = serialize(&t).unwrap();
+        let back = parse(&s).unwrap();
+        assert_eq!(back, t);
+    }
+
+    #[test]
+    fn keys_sorted_alphabetically() {
+        let mut t = TomlTable::new();
+        t.insert("zebra".into(), TomlValue::Integer(1));
+        t.insert("alpha".into(), TomlValue::Integer(2));
+        t.insert("middle".into(), TomlValue::Integer(3));
+        let s = serialize(&t).unwrap();
+        let lines: alloc::vec::Vec<&str> = s.lines().collect();
+        // First three non-empty lines are alpha/middle/zebra.
+        assert!(lines[0].starts_with("alpha"));
+        assert!(lines[1].starts_with("middle"));
+        assert!(lines[2].starts_with("zebra"));
+    }
+
+    #[test]
+    fn header_table_serialises_with_brackets() {
+        let mut sub = TomlTable::new();
+        sub.insert("k".into(), TomlValue::Integer(1));
+        let mut t = TomlTable::new();
+        t.insert("section".into(), TomlValue::Table(sub));
+        let s = serialize(&t).unwrap();
+        assert!(s.contains("[section]"));
+        assert!(s.contains("k = 1"));
+    }
+
+    #[test]
+    fn nested_header_serialises_with_dotted_path() {
+        let mut deep = TomlTable::new();
+        deep.insert("x".into(), TomlValue::Integer(7));
+        let mut mid = TomlTable::new();
+        mid.insert("c".into(), TomlValue::Table(deep));
+        let mut top = TomlTable::new();
+        top.insert(
+            "a".into(),
+            TomlValue::Table({
+                let mut t = TomlTable::new();
+                t.insert(
+                    "b".into(),
+                    TomlValue::Table({
+                        let mut q = TomlTable::new();
+                        q.insert("x".into(), TomlValue::Integer(7));
+                        q
+                    }),
+                );
+                t
+            }),
+        );
+        let _ = mid;
+        let s = serialize(&top).unwrap();
+        assert!(s.contains("[a.b]"));
+        assert!(s.contains("x = 7"));
+    }
+
+    #[test]
+    fn array_round_trips() {
+        let mut t = TomlTable::new();
+        t.insert(
+            "xs".into(),
+            TomlValue::Array(alloc::vec![
+                TomlValue::Integer(1),
+                TomlValue::Integer(2),
+                TomlValue::Integer(3),
+            ]),
+        );
+        let s = serialize(&t).unwrap();
+        assert_eq!(s, "xs = [1, 2, 3]\n");
+        let back = parse(&s).unwrap();
+        assert_eq!(back, t);
+    }
+
+    #[test]
+    fn string_escapes_round_trip() {
+        let mut t = TomlTable::new();
+        t.insert("s".into(), TomlValue::String("a\nb\t\"c".to_string()));
+        let s = serialize(&t).unwrap();
+        let back = parse(&s).unwrap();
+        assert_eq!(back, t);
+    }
+
+    #[test]
+    fn quoted_key_when_non_bare() {
+        let mut t = TomlTable::new();
+        t.insert("dotted.key".into(), TomlValue::Integer(1));
+        let s = serialize(&t).unwrap();
+        // The serialiser must quote the key so a re-parse doesn't
+        // treat the `.` as a path separator.
+        assert!(s.starts_with("\"dotted.key\""));
+        let back = parse(&s).unwrap();
+        assert_eq!(back, t);
+    }
+
+    #[test]
+    fn deterministic_output_across_invocations() {
+        let mut t = TomlTable::new();
+        t.insert("b".into(), TomlValue::Integer(2));
+        t.insert("a".into(), TomlValue::Integer(1));
+        let s1 = serialize(&t).unwrap();
+        let s2 = serialize(&t).unwrap();
+        assert_eq!(s1, s2);
+    }
+
+    #[test]
+    fn negative_integer_round_trips() {
+        let mut t = TomlTable::new();
+        t.insert("n".into(), TomlValue::Integer(-42));
+        let s = serialize(&t).unwrap();
+        let back = parse(&s).unwrap();
+        assert_eq!(back, t);
+    }
+}

--- a/mgmt/tests/apply_lifecycle.rs
+++ b/mgmt/tests/apply_lifecycle.rs
@@ -1,0 +1,558 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Apply-lifecycle integration tests for the TOML loader.
+//!
+//! Spec:
+//! - `openspec/changes/management-login-v1/specs/mgmt-config-model/spec.md`
+//!   ("Apply lifecycle" — parse, validate, stage, fsync, rename, notify).
+//! - `openspec/changes/management-login-v1/specs/mgmt-config-layout/spec.md`
+//!   (per-file permissions, file-mode-stricter rule).
+//!
+//! Uses a SharedFsFixture that pairs a single in-memory store with
+//! both the [`ReadBackend`] and the [`AtomicWriter`] sides — mirrors
+//! the kernel's runtime where `f2fs::F2fs` provides both halves.
+
+#![allow(clippy::result_large_err)]
+
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use smallaios_auth::atomic_write::{AtomicWriteError, AtomicWriter};
+use smallaios_mgmt::config::Config;
+use smallaios_mgmt::loader_toml::{
+    audit_identity, render_namespace_table, FirstBootPolicy, Namespace, ReadBackend, TomlLoader,
+    V1_LAYOUT,
+};
+use smallaios_mgmt::surface::{ConfigPath, ConfigSurface, SurfaceKind, Value};
+use smallaios_mgmt::toml::{parse as toml_parse, serialize as toml_serialize};
+
+/// Shared in-memory FS that satisfies both [`ReadBackend`] and
+/// [`AtomicWriter`].
+#[derive(Clone)]
+struct SharedFs {
+    files: Rc<RefCell<BTreeMap<String, Vec<u8>>>>,
+    modes: Rc<RefCell<BTreeMap<String, u16>>>,
+    write_mode: u16,
+}
+
+impl SharedFs {
+    fn new(write_mode: u16) -> Self {
+        Self {
+            files: Rc::new(RefCell::new(BTreeMap::new())),
+            modes: Rc::new(RefCell::new(BTreeMap::new())),
+            write_mode,
+        }
+    }
+
+    fn seed_with_mode(&self, path: &str, bytes: &[u8], mode: u16) {
+        self.files
+            .borrow_mut()
+            .insert(path.to_string(), bytes.to_vec());
+        self.modes.borrow_mut().insert(path.to_string(), mode);
+    }
+
+    fn read(&self, path: &str) -> Option<Vec<u8>> {
+        self.files.borrow().get(path).cloned()
+    }
+}
+
+impl ReadBackend for SharedFs {
+    fn read_file(&self, path: &str) -> Result<Option<Vec<u8>>, &'static str> {
+        Ok(self.files.borrow().get(path).cloned())
+    }
+    fn mode_of(&self, path: &str) -> Result<Option<u16>, &'static str> {
+        Ok(self.modes.borrow().get(path).copied())
+    }
+}
+
+impl AtomicWriter for SharedFs {
+    fn write_atomic(&self, path: &str, contents: &[u8]) -> Result<(), AtomicWriteError> {
+        if path.is_empty() {
+            return Err(AtomicWriteError::InvalidPath);
+        }
+        let mode = self.write_mode;
+        self.files
+            .borrow_mut()
+            .insert(path.to_string(), contents.to_vec());
+        self.modes.borrow_mut().insert(path.to_string(), mode);
+        Ok(())
+    }
+    fn cleanup_orphan_tmp(&self, dir: &str) -> Result<(), AtomicWriteError> {
+        let prefix = if dir.ends_with('/') {
+            dir.to_string()
+        } else {
+            let mut s = String::from(dir);
+            s.push('/');
+            s
+        };
+        let to_remove: Vec<String> = self
+            .files
+            .borrow()
+            .keys()
+            .filter(|k| k.starts_with(&prefix) && k.ends_with(".tmp"))
+            .cloned()
+            .collect();
+        for k in to_remove {
+            self.files.borrow_mut().remove(&k);
+        }
+        Ok(())
+    }
+}
+
+fn make_loader_with_skeleton(write_mode: u16) -> (TomlLoader<SharedFs, SharedFs>, SharedFs) {
+    let fs = SharedFs::new(write_mode);
+    let mut loader = TomlLoader::new(fs.clone(), fs.clone(), "/data");
+    loader.load(FirstBootPolicy::Generate).unwrap();
+    (loader, fs)
+}
+
+#[test]
+fn first_boot_generation_creates_all_layout_entries() {
+    let (_loader, fs) = make_loader_with_skeleton(0o600);
+    for entry in V1_LAYOUT {
+        let abs = format!("/data/{}", entry.relative);
+        assert!(
+            fs.read(&abs).is_some(),
+            "first-boot generation missed {}",
+            entry.relative
+        );
+    }
+}
+
+#[test]
+fn first_boot_generation_writes_idle_defaults_to_disk() {
+    let (_loader, fs) = make_loader_with_skeleton(0o600);
+    let bytes = fs.read("/data/system.toml").unwrap();
+    let s = std::str::from_utf8(&bytes).unwrap();
+    let parsed = toml_parse(s).unwrap();
+    let idle = parsed.get("idle").unwrap().as_table().unwrap();
+    assert_eq!(
+        idle.get("root_minutes"),
+        Some(&smallaios_mgmt::toml::TomlValue::Integer(15))
+    );
+}
+
+#[test]
+fn live_write_persists_to_layout_file() {
+    let (mut loader, fs) = make_loader_with_skeleton(0o600);
+    let p = ConfigPath::new("idle.root_minutes").unwrap();
+    loader.write(&p, Value::U32(45), "root@toml").unwrap();
+    let bytes = fs.read("/data/system.toml").unwrap();
+    let s = std::str::from_utf8(&bytes).unwrap();
+    let parsed = toml_parse(s).unwrap();
+    let idle = parsed.get("idle").unwrap().as_table().unwrap();
+    assert_eq!(
+        idle.get("root_minutes"),
+        Some(&smallaios_mgmt::toml::TomlValue::Integer(45))
+    );
+}
+
+#[test]
+fn boot_only_write_persists_to_disk_but_not_in_memory() {
+    let (mut loader, fs) = make_loader_with_skeleton(0o600);
+    let p = ConfigPath::new("fs.boot_watchdog_seconds").unwrap();
+    loader.write(&p, Value::U32(30), "root@toml").unwrap();
+    // On disk: new value (operator can grep the file).
+    let bytes = fs.read("/data/system.toml").unwrap();
+    let s = std::str::from_utf8(&bytes).unwrap();
+    let parsed = toml_parse(s).unwrap();
+    let fs_t = parsed.get("fs").unwrap().as_table().unwrap();
+    assert_eq!(
+        fs_t.get("boot_watchdog_seconds"),
+        Some(&smallaios_mgmt::toml::TomlValue::Integer(30))
+    );
+    // In memory: unchanged.
+    assert_eq!(loader.read(&p).unwrap(), Value::U32(60));
+    // Pending list records the deferred write.
+    assert_eq!(loader.pending_reboot().len(), 1);
+}
+
+#[test]
+fn validation_rejected_write_leaves_disk_and_memory_unchanged() {
+    let (mut loader, fs) = make_loader_with_skeleton(0o600);
+    let p = ConfigPath::new("idle.root_minutes").unwrap();
+    let before_disk = fs.read("/data/system.toml").unwrap();
+    let before_mem = loader.read(&p).unwrap();
+    let err = loader.write(&p, Value::U32(0), "root@toml").unwrap_err();
+    assert!(matches!(err, smallaios_mgmt::surface::Error::Validation(_)));
+    assert_eq!(loader.read(&p).unwrap(), before_mem);
+    assert_eq!(fs.read("/data/system.toml").unwrap(), before_disk);
+}
+
+#[test]
+fn cross_field_violation_leaves_disk_and_memory_unchanged() {
+    let (mut loader, fs) = make_loader_with_skeleton(0o600);
+    let p = ConfigPath::new("idle.root_minutes").unwrap();
+    let before_disk = fs.read("/data/system.toml").unwrap();
+    // root > operator violates cross-field invariant.
+    let err = loader.write(&p, Value::U32(120), "root@toml").unwrap_err();
+    assert!(matches!(err, smallaios_mgmt::surface::Error::Validation(_)));
+    assert_eq!(fs.read("/data/system.toml").unwrap(), before_disk);
+}
+
+#[test]
+fn shadow_at_0644_rejected_when_declared_0640() {
+    let fs = SharedFs::new(0o640);
+    // Spec: mgmt/policy.toml declared 0o640 — seed at 0o644 to violate.
+    fs.seed_with_mode(
+        "/data/system.toml",
+        toml_serialize(&render_namespace_table(
+            &Config::v1_defaults(),
+            Namespace::System,
+        ))
+        .unwrap()
+        .as_bytes(),
+        0o644,
+    );
+    fs.seed_with_mode(
+        "/data/mgmt/policy.toml",
+        toml_serialize(&render_namespace_table(
+            &Config::v1_defaults(),
+            Namespace::MgmtPolicy,
+        ))
+        .unwrap()
+        .as_bytes(),
+        0o644, // declared 0o640 — laxer.
+    );
+    fs.seed_with_mode("/data/mgmt/zenoh.toml", b"", 0o640);
+    fs.seed_with_mode("/data/update/policy.toml", b"", 0o640);
+    fs.seed_with_mode("/data/automotive/uds.toml", b"", 0o640);
+
+    let mut loader = TomlLoader::new(fs.clone(), fs.clone(), "/data");
+    let err = loader.load(FirstBootPolicy::Strict).unwrap_err();
+    assert!(matches!(
+        err,
+        smallaios_mgmt::loader_toml::LoaderError::ModeViolation { .. }
+    ));
+}
+
+#[test]
+fn stricter_mode_accepted() {
+    let fs = SharedFs::new(0o600);
+    fs.seed_with_mode(
+        "/data/system.toml",
+        toml_serialize(&render_namespace_table(
+            &Config::v1_defaults(),
+            Namespace::System,
+        ))
+        .unwrap()
+        .as_bytes(),
+        0o600, // stricter than 0o644
+    );
+    fs.seed_with_mode(
+        "/data/mgmt/policy.toml",
+        toml_serialize(&render_namespace_table(
+            &Config::v1_defaults(),
+            Namespace::MgmtPolicy,
+        ))
+        .unwrap()
+        .as_bytes(),
+        0o600, // stricter than 0o640
+    );
+    fs.seed_with_mode("/data/mgmt/zenoh.toml", b"", 0o600);
+    fs.seed_with_mode("/data/update/policy.toml", b"", 0o600);
+    fs.seed_with_mode("/data/automotive/uds.toml", b"", 0o600);
+    let mut loader = TomlLoader::new(fs.clone(), fs.clone(), "/data");
+    loader.load(FirstBootPolicy::Strict).unwrap();
+}
+
+#[test]
+fn missing_on_strict_reload_returns_error() {
+    let fs = SharedFs::new(0o600);
+    let mut loader = TomlLoader::new(fs.clone(), fs.clone(), "/data");
+    let err = loader.load(FirstBootPolicy::Strict).unwrap_err();
+    assert!(matches!(
+        err,
+        smallaios_mgmt::loader_toml::LoaderError::Missing { .. }
+    ));
+}
+
+#[test]
+fn notify_event_carries_who_and_before_after() {
+    let (mut loader, _fs) = make_loader_with_skeleton(0o600);
+    let mut sub = loader.raw_subscribe();
+    let p = ConfigPath::new("idle.root_minutes").unwrap();
+    let id = audit_identity("root", None);
+    loader.write(&p, Value::U32(20), &id.render()).unwrap();
+    let ev = sub.poll().unwrap().unwrap();
+    assert_eq!(ev.path, p);
+    assert_eq!(ev.before, Value::U32(15));
+    assert_eq!(ev.after, Value::U32(20));
+    assert_eq!(ev.who, "root@toml");
+}
+
+#[test]
+fn audit_identity_renders_role_and_surface() {
+    let id = audit_identity("operator", Some("alice".to_string()));
+    assert_eq!(id.surface, SurfaceKind::Toml);
+    assert_eq!(id.render(), "operator:alice@toml");
+}
+
+#[test]
+fn live_field_change_visible_via_subsequent_read() {
+    let (mut loader, _fs) = make_loader_with_skeleton(0o600);
+    let p = ConfigPath::new("password.dictionary_check").unwrap();
+    assert_eq!(loader.read(&p).unwrap(), Value::Bool(true));
+    loader.write(&p, Value::Bool(false), "root@toml").unwrap();
+    assert_eq!(loader.read(&p).unwrap(), Value::Bool(false));
+}
+
+#[test]
+fn five_consecutive_writes_to_same_field_publish_five_events() {
+    let (mut loader, _fs) = make_loader_with_skeleton(0o600);
+    let mut sub = loader.raw_subscribe();
+    let p = ConfigPath::new("idle.root_minutes").unwrap();
+    for n in [10u32, 12, 14, 16, 18] {
+        loader.write(&p, Value::U32(n), "root@toml").unwrap();
+    }
+    let (events, dropped) = sub.drain();
+    assert_eq!(dropped, 0);
+    assert_eq!(events.len(), 5);
+    let lasts: Vec<u32> = events
+        .iter()
+        .map(|e| match e.after {
+            Value::U32(n) => n,
+            _ => 0,
+        })
+        .collect();
+    assert_eq!(lasts, vec![10, 12, 14, 16, 18]);
+}
+
+#[test]
+fn boot_only_writes_accumulate_in_pending_reboot_and_record_who() {
+    let (mut loader, _fs) = make_loader_with_skeleton(0o600);
+    let id_a = audit_identity("root", None);
+    let id_b = audit_identity("operator", Some("bob".into()));
+    loader
+        .write(
+            &ConfigPath::new("fs.boot_watchdog_seconds").unwrap(),
+            Value::U32(30),
+            &id_a.render(),
+        )
+        .unwrap();
+    loader
+        .write(
+            &ConfigPath::new("flash.prefer_flash_for_models").unwrap(),
+            Value::Bool(false),
+            &id_b.render(),
+        )
+        .unwrap();
+    let pending = loader.pending_reboot();
+    assert_eq!(pending.len(), 2);
+    assert_eq!(pending[0].who, "root@toml");
+    assert_eq!(pending[1].who, "operator:bob@toml");
+}
+
+#[test]
+fn round_trip_through_disk_produces_byte_identical_files() {
+    // Spec: serialise(parse(serialise(c))) == serialise(c).
+    let cfg = Config::v1_defaults();
+    let sys = toml_serialize(&render_namespace_table(&cfg, Namespace::System)).unwrap();
+    let parsed = toml_parse(&sys).unwrap();
+    let re_serialised = toml_serialize(&parsed).unwrap();
+    assert_eq!(sys, re_serialised);
+    let pol = toml_serialize(&render_namespace_table(&cfg, Namespace::MgmtPolicy)).unwrap();
+    let parsed = toml_parse(&pol).unwrap();
+    let re_serialised = toml_serialize(&parsed).unwrap();
+    assert_eq!(pol, re_serialised);
+}
+
+#[test]
+fn validation_failure_does_not_publish_notify_event() {
+    let (mut loader, _fs) = make_loader_with_skeleton(0o600);
+    let mut sub = loader.raw_subscribe();
+    let p = ConfigPath::new("idle.root_minutes").unwrap();
+    let _err = loader.write(&p, Value::U32(0), "root@toml").unwrap_err();
+    // No event published.
+    assert_eq!(sub.poll(), Ok(None));
+}
+
+#[test]
+fn boot_only_write_does_publish_event_so_audit_records_it() {
+    // The event channel sees boot-deferred writes too — the audit
+    // ring is the canonical record. The reload semantics only affect
+    // when the *in-memory cache* sees the new value.
+    let (mut loader, _fs) = make_loader_with_skeleton(0o600);
+    let mut sub = loader.raw_subscribe();
+    let p = ConfigPath::new("fs.boot_watchdog_seconds").unwrap();
+    loader.write(&p, Value::U32(30), "root@toml").unwrap();
+    let ev = sub.poll().unwrap().unwrap();
+    assert_eq!(ev.after, Value::U32(30));
+    // before is the still-current in-memory value (60).
+    assert_eq!(ev.before, Value::U32(60));
+}
+
+#[test]
+fn reloading_after_live_writes_picks_up_new_disk_state() {
+    let (mut loader, _fs) = make_loader_with_skeleton(0o600);
+    loader
+        .write(
+            &ConfigPath::new("idle.root_minutes").unwrap(),
+            Value::U32(45),
+            "root@toml",
+        )
+        .unwrap();
+    // Reload using strict policy — disk is now populated by the
+    // generation step + live write.
+    loader.load(FirstBootPolicy::Strict).unwrap();
+    assert_eq!(
+        loader
+            .read(&ConfigPath::new("idle.root_minutes").unwrap())
+            .unwrap(),
+        Value::U32(45)
+    );
+}
+
+#[test]
+fn reloading_does_not_lose_boot_pending_writes() {
+    let (mut loader, _fs) = make_loader_with_skeleton(0o600);
+    loader
+        .write(
+            &ConfigPath::new("fs.boot_watchdog_seconds").unwrap(),
+            Value::U32(30),
+            "root@toml",
+        )
+        .unwrap();
+    // Boot-deferred fields appear on disk even though in-memory is
+    // unchanged. After reload, the on-disk new value takes effect
+    // (the reboot has happened).
+    loader.load(FirstBootPolicy::Strict).unwrap();
+    assert_eq!(
+        loader
+            .read(&ConfigPath::new("fs.boot_watchdog_seconds").unwrap())
+            .unwrap(),
+        Value::U32(30)
+    );
+}
+
+#[test]
+fn corrupt_file_rejects_load_strict() {
+    let fs = SharedFs::new(0o600);
+    fs.seed_with_mode("/data/system.toml", b"this is = not = valid", 0o644);
+    fs.seed_with_mode(
+        "/data/mgmt/policy.toml",
+        toml_serialize(&render_namespace_table(
+            &Config::v1_defaults(),
+            Namespace::MgmtPolicy,
+        ))
+        .unwrap()
+        .as_bytes(),
+        0o640,
+    );
+    fs.seed_with_mode("/data/mgmt/zenoh.toml", b"", 0o640);
+    fs.seed_with_mode("/data/update/policy.toml", b"", 0o640);
+    fs.seed_with_mode("/data/automotive/uds.toml", b"", 0o640);
+    let mut loader = TomlLoader::new(fs.clone(), fs.clone(), "/data");
+    let err = loader.load(FirstBootPolicy::Strict).unwrap_err();
+    assert!(matches!(
+        err,
+        smallaios_mgmt::loader_toml::LoaderError::Toml(_)
+    ));
+}
+
+#[test]
+fn full_apply_lifecycle_six_steps_end_to_end() {
+    // Spec checklist:
+    //   1. parse  -> via Value variant constructed by caller
+    //   2. validate -> validate_field + validate_cross_field
+    //   3. stage  -> AtomicWriter::write_atomic to <file>.tmp
+    //   4. fsync + rename -> AtomicWriter contract
+    //   5. notify -> NotifyEvent published
+    //   6. (boot vs live) -> live: in-memory updates
+    //
+    // We can't peek into individual stage steps from outside, but we
+    // assert observable post-conditions: notify event arrives, in-
+    // memory and disk values agree, validation gate is in front.
+    let (mut loader, fs) = make_loader_with_skeleton(0o600);
+    let mut sub = loader.raw_subscribe();
+    let p = ConfigPath::new("metrics.cpu_interval_ms").unwrap();
+    loader.write(&p, Value::U32(2000), "root@toml").unwrap();
+    // (1)+(2) implicit: write_atomic was called only because validate passed.
+    // (3)+(4) post-condition: file on disk reflects new value.
+    let bytes = fs.read("/data/mgmt/policy.toml").unwrap();
+    let parsed = toml_parse(std::str::from_utf8(&bytes).unwrap()).unwrap();
+    let metrics = parsed.get("metrics").unwrap().as_table().unwrap();
+    assert_eq!(
+        metrics.get("cpu_interval_ms"),
+        Some(&smallaios_mgmt::toml::TomlValue::Integer(2000))
+    );
+    // (5) notify event delivered.
+    let ev = sub.poll().unwrap().unwrap();
+    assert_eq!(ev.after, Value::U32(2000));
+    // (6) live: in-memory mirror updated.
+    assert_eq!(loader.read(&p).unwrap(), Value::U32(2000));
+}
+
+#[test]
+fn writes_to_separate_namespaces_do_not_collide() {
+    // Writing to `idle` mutates system.toml; writing to `metrics`
+    // mutates mgmt/policy.toml. Each layout file is rewritten
+    // independently.
+    let (mut loader, fs) = make_loader_with_skeleton(0o600);
+    loader
+        .write(
+            &ConfigPath::new("idle.root_minutes").unwrap(),
+            Value::U32(20),
+            "root@toml",
+        )
+        .unwrap();
+    loader
+        .write(
+            &ConfigPath::new("metrics.cpu_interval_ms").unwrap(),
+            Value::U32(2000),
+            "root@toml",
+        )
+        .unwrap();
+
+    let sys =
+        toml_parse(std::str::from_utf8(&fs.read("/data/system.toml").unwrap()).unwrap()).unwrap();
+    let pol = toml_parse(std::str::from_utf8(&fs.read("/data/mgmt/policy.toml").unwrap()).unwrap())
+        .unwrap();
+    assert_eq!(
+        sys.get("idle")
+            .unwrap()
+            .as_table()
+            .unwrap()
+            .get("root_minutes"),
+        Some(&smallaios_mgmt::toml::TomlValue::Integer(20))
+    );
+    assert_eq!(
+        pol.get("metrics")
+            .unwrap()
+            .as_table()
+            .unwrap()
+            .get("cpu_interval_ms"),
+        Some(&smallaios_mgmt::toml::TomlValue::Integer(2000))
+    );
+    // sys file should NOT contain metrics.
+    assert!(!sys.contains_key("metrics"));
+    // pol file should NOT contain idle.
+    assert!(!pol.contains_key("idle"));
+}
+
+#[test]
+fn type_mismatch_returns_type_mismatch_surface_error() {
+    let (mut loader, _fs) = make_loader_with_skeleton(0o600);
+    let p = ConfigPath::new("idle.root_minutes").unwrap();
+    // Wrong variant: Bool instead of U32.
+    let err = loader
+        .write(&p, Value::Bool(true), "root@toml")
+        .unwrap_err();
+    match err {
+        smallaios_mgmt::surface::Error::TypeMismatch { expected, got } => {
+            assert_eq!(expected, "u32");
+            assert_eq!(got, "bool");
+        }
+        other => panic!("expected TypeMismatch, got {:?}", other),
+    }
+}
+
+#[test]
+fn unknown_path_returns_not_found_surface_error() {
+    let (loader, _fs) = make_loader_with_skeleton(0o600);
+    let p = ConfigPath::new("nope.nada").unwrap();
+    let err = loader.read(&p).unwrap_err();
+    assert!(matches!(err, smallaios_mgmt::surface::Error::NotFound));
+}

--- a/mgmt/tests/toml_oracle.rs
+++ b/mgmt/tests/toml_oracle.rs
@@ -1,0 +1,90 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Cross-check the clean-room TOML parser against the upstream
+//! `toml` crate (dev-only oracle).
+//!
+//! The clean-room rule precludes `toml` as a production dependency,
+//! but we keep it as a `dev-dependencies` oracle: every default
+//! TOML emitted by the loader's renderer SHALL parse identically
+//! through both implementations. This catches accidental drift in
+//! the lex/parse subset.
+
+use smallaios_mgmt::config::Config;
+use smallaios_mgmt::loader_toml::{render_namespace_table, Namespace};
+use smallaios_mgmt::toml::{parse as clean_room_parse, serialize as clean_room_serialise};
+
+#[test]
+fn upstream_toml_parses_clean_room_serialised_system_defaults() {
+    let cfg = Config::v1_defaults();
+    let s = clean_room_serialise(&render_namespace_table(&cfg, Namespace::System)).unwrap();
+    // Upstream `toml` crate must accept the bytes we emit.
+    let _: toml::Table = toml::from_str(&s).expect("upstream toml must parse our output");
+}
+
+#[test]
+fn upstream_toml_parses_clean_room_serialised_policy_defaults() {
+    let cfg = Config::v1_defaults();
+    let s = clean_room_serialise(&render_namespace_table(&cfg, Namespace::MgmtPolicy)).unwrap();
+    let _: toml::Table = toml::from_str(&s).expect("upstream toml must parse our output");
+}
+
+#[test]
+fn clean_room_and_upstream_agree_on_idle_section() {
+    let cfg = Config::v1_defaults();
+    let s = clean_room_serialise(&render_namespace_table(&cfg, Namespace::System)).unwrap();
+    let upstream: toml::Table = toml::from_str(&s).unwrap();
+    let clean = clean_room_parse(&s).unwrap();
+    // Spot-check: idle.root_minutes agrees in both.
+    let upstream_root = upstream
+        .get("idle")
+        .and_then(|v| v.as_table())
+        .and_then(|t| t.get("root_minutes"))
+        .and_then(|v| v.as_integer())
+        .unwrap();
+    let clean_root = clean
+        .get("idle")
+        .and_then(|v| match v {
+            smallaios_mgmt::toml::TomlValue::Table(t) => Some(t),
+            _ => None,
+        })
+        .and_then(|t| t.get("root_minutes"))
+        .and_then(|v| match v {
+            smallaios_mgmt::toml::TomlValue::Integer(n) => Some(*n),
+            _ => None,
+        })
+        .unwrap();
+    assert_eq!(upstream_root, clean_root);
+    assert_eq!(upstream_root, 15);
+}
+
+#[test]
+fn clean_room_and_upstream_agree_on_password_classes_array() {
+    let cfg = Config::v1_defaults();
+    let s = clean_room_serialise(&render_namespace_table(&cfg, Namespace::System)).unwrap();
+    let upstream: toml::Table = toml::from_str(&s).unwrap();
+    let arr = upstream
+        .get("password")
+        .and_then(|v| v.as_table())
+        .and_then(|t| t.get("require_classes"))
+        .and_then(|v| v.as_array())
+        .unwrap();
+    let names: Vec<&str> = arr.iter().filter_map(|v| v.as_str()).collect();
+    assert!(names.contains(&"lower"));
+    assert!(names.contains(&"upper"));
+    assert!(names.contains(&"digit"));
+}
+
+#[test]
+fn upstream_round_trip_matches_clean_room_round_trip() {
+    let cfg = Config::v1_defaults();
+    for ns in [Namespace::System, Namespace::MgmtPolicy] {
+        let s = clean_room_serialise(&render_namespace_table(&cfg, ns)).unwrap();
+        // Both impls accept the bytes.
+        let _: toml::Table = toml::from_str(&s).unwrap();
+        let parsed = clean_room_parse(&s).unwrap();
+        let re = clean_room_serialise(&parsed).unwrap();
+        // Idempotent re-serialise.
+        assert_eq!(s, re);
+    }
+}

--- a/mgmt/tests/universal_exposure.rs
+++ b/mgmt/tests/universal_exposure.rs
@@ -1,0 +1,182 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Universal-exposure CI walker.
+//!
+//! Spec:
+//! `openspec/changes/management-login-v1/specs/mgmt-config-surface-trait/spec.md`
+//! Q3 — "Build fails on missing handler".
+//!
+//! This integration test enumerates every active [`mgmt::ConfigSurface`]
+//! implementation and asserts that every field in
+//! [`mgmt::config::registry::CONFIG_FIELDS`] is reachable via the
+//! surface's `read` method. Adding a new `Config` field without
+//! adding a handler on every active surface SHALL fail this test.
+//!
+//! v1's surface count is 1 (TOML loader). Phase 7 introduces the
+//! Zenoh admin surface; when that lands, the test will multiply by
+//! the new surface and continue to enforce the invariant.
+
+#![allow(clippy::result_large_err)]
+
+use smallaios_auth::atomic_write::TestAtomicWriter;
+use smallaios_mgmt::config::registry;
+use smallaios_mgmt::config::Config;
+use smallaios_mgmt::loader_toml::{
+    FirstBootPolicy, InMemoryReadBackend, Namespace, TomlLoader, V1_LAYOUT,
+};
+use smallaios_mgmt::surface::{ConfigPath, ConfigSurface, SurfaceKind};
+
+/// Build a TOML loader pre-loaded with [`Config::v1_defaults`] so
+/// reads succeed without depending on a runtime FS backend.
+fn make_toml_loader() -> TomlLoader<InMemoryReadBackend, TestAtomicWriter> {
+    let reader = InMemoryReadBackend::new();
+    // Seed every layout entry with valid defaults so strict load
+    // succeeds. We seed at the declared mode for each entry.
+    use smallaios_mgmt::loader_toml::render_namespace_table;
+    use smallaios_mgmt::toml::serialize as toml_serialize;
+    let cfg = Config::v1_defaults();
+    for entry in V1_LAYOUT {
+        let abs = format!("/data/{}", entry.relative);
+        let bytes: Vec<u8> =
+            if entry.namespace == Namespace::System || entry.namespace == Namespace::MgmtPolicy {
+                let table = render_namespace_table(&cfg, entry.namespace);
+                toml_serialize(&table).unwrap().into_bytes()
+            } else {
+                Vec::new()
+            };
+        reader.seed_with_mode(&abs, &bytes, entry.declared_mode);
+    }
+    let writer = TestAtomicWriter::new();
+    let mut loader = TomlLoader::new(reader, writer, "/data");
+    loader.load(FirstBootPolicy::Strict).unwrap();
+    loader
+}
+
+#[test]
+fn every_config_field_reachable_via_toml_surface() {
+    let loader = make_toml_loader();
+    let mut missing: Vec<&'static str> = Vec::new();
+    for field in registry::CONFIG_FIELDS {
+        let path = ConfigPath::new(field.path)
+            .unwrap_or_else(|e| panic!("registry field {} has invalid path: {:?}", field.path, e));
+        if let Err(e) = loader.read(&path) {
+            eprintln!(
+                "TOML surface cannot read {}: {:?} (kind={:?}, scope={:?})",
+                field.path, e, field.kind, field.scope
+            );
+            missing.push(field.path);
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "{} field(s) unreachable via TOML surface: {:?}",
+        missing.len(),
+        missing
+    );
+}
+
+#[test]
+fn every_config_field_writeable_via_toml_surface() {
+    // Stronger check: every field must accept *some* legal value
+    // through the trait surface. We use the field's existing default
+    // value (round-trip), which always satisfies validators.
+    let mut loader = make_toml_loader();
+    let mut failures: Vec<(&'static str, String)> = Vec::new();
+    for field in registry::CONFIG_FIELDS {
+        let path = ConfigPath::new(field.path).unwrap();
+        let current = match loader.read(&path) {
+            Ok(v) => v,
+            Err(e) => {
+                failures.push((field.path, format!("read failed: {:?}", e)));
+                continue;
+            }
+        };
+        if let Err(e) = loader.write(&path, current.clone(), "ci@toml") {
+            failures.push((field.path, format!("write failed: {:?}", e)));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{} field(s) reject round-trip writes via TOML surface: {:?}",
+        failures.len(),
+        failures
+    );
+}
+
+#[test]
+fn every_config_field_subscribable_via_toml_surface() {
+    let loader = make_toml_loader();
+    for field in registry::CONFIG_FIELDS {
+        let path = ConfigPath::new(field.path).unwrap();
+        loader
+            .subscribe(&path)
+            .unwrap_or_else(|e| panic!("subscribe failed for {}: {:?}", field.path, e));
+    }
+}
+
+#[test]
+fn surface_kind_universe_matches_active_surfaces() {
+    // v1: only the TOML surface is active. Phase 7 adds Zenoh admin.
+    // This test asserts the universe matches v1 exactly so a future
+    // surface addition forces a deliberate update of the walker
+    // alongside the loader.
+    let active: Vec<SurfaceKind> = active_surfaces();
+    assert_eq!(active.len(), 1, "v1 expects exactly one active surface");
+    assert!(active.contains(&SurfaceKind::Toml));
+    // Tty + Zenoh come in later phases.
+    assert!(!active.contains(&SurfaceKind::Tty));
+    assert!(!active.contains(&SurfaceKind::Zenoh));
+}
+
+/// List of surfaces the universal-exposure walker iterates. v1 has
+/// only the TOML loader; Phase 7 (Zenoh admin) extends this list.
+///
+/// Phase 7 wiring placeholder: when `bus-zenoh` lands, append
+/// `SurfaceKind::Zenoh` here behind a `#[cfg(feature = "bus-zenoh")]`
+/// gate.
+fn active_surfaces() -> Vec<SurfaceKind> {
+    vec![SurfaceKind::Toml]
+}
+
+#[test]
+fn no_field_is_universally_orphaned() {
+    // Symmetric check: walk active_surfaces() x CONFIG_FIELDS and
+    // ensure each (field, surface) pair has a reachable handler.
+    // For v1 this collapses to "every field is reachable on TOML"
+    // but the loop structure is here so adding Zenoh in Phase 7 is
+    // a one-line change.
+    let loader = make_toml_loader();
+    for surface in active_surfaces() {
+        match surface {
+            SurfaceKind::Toml => {
+                for field in registry::CONFIG_FIELDS {
+                    let path = ConfigPath::new(field.path).unwrap();
+                    loader.read(&path).unwrap_or_else(|e| {
+                        panic!(
+                            "TOML surface cannot read {} (universal-exposure): {:?}",
+                            field.path, e
+                        )
+                    });
+                }
+            }
+            SurfaceKind::Tty | SurfaceKind::Zenoh => {
+                // Inactive in v1 — nothing to check yet.
+            }
+        }
+    }
+}
+
+#[test]
+fn registry_field_count_matches_walker_iterations() {
+    let loader = make_toml_loader();
+    let count = registry::CONFIG_FIELDS.len();
+    let mut iterated = 0;
+    for field in registry::CONFIG_FIELDS {
+        let path = ConfigPath::new(field.path).unwrap();
+        let _ = loader.read(&path).unwrap();
+        iterated += 1;
+    }
+    assert_eq!(iterated, count);
+    assert!(count >= 30, "v1 registry SHOULD have at least 30 fields");
+}

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -363,6 +363,10 @@ criteria = "safe-to-run"
 version = "1.0.149"
 criteria = "safe-to-run"
 
+[[exemptions.serde_spanned]]
+version = "0.6.9"
+criteria = "safe-to-run"
+
 [[exemptions.shlex]]
 version = "1.3.0"
 criteria = "safe-to-run"
@@ -381,6 +385,18 @@ criteria = "safe-to-run"
 
 [[exemptions.tinytemplate]]
 version = "1.2.1"
+criteria = "safe-to-run"
+
+[[exemptions.toml]]
+version = "0.8.23"
+criteria = "safe-to-run"
+
+[[exemptions.toml_datetime]]
+version = "0.6.11"
+criteria = "safe-to-run"
+
+[[exemptions.toml_edit]]
+version = "0.22.27"
 criteria = "safe-to-run"
 
 [[exemptions.typenum]]
@@ -465,6 +481,10 @@ criteria = "safe-to-run"
 
 [[exemptions.windows-sys]]
 version = "0.61.2"
+criteria = "safe-to-run"
+
+[[exemptions.winnow]]
+version = "0.7.15"
 criteria = "safe-to-run"
 
 [[exemptions.wit-bindgen]]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "xtask"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+description = "Developer-ergonomics tasks for the SmallAIOS workspace"
+
+# xtask runs on the host so it is a normal `std` binary crate, not
+# `#![no_std]`. It deliberately depends on no workspace crate so a
+# breakage in `mgmt`/`kernel`/etc. does not block the developer from
+# running the helper.
+
+[[bin]]
+name = "scaffold-config-field"
+path = "src/bin/scaffold_config_field.rs"
+
+[dependencies]

--- a/xtask/src/bin/scaffold_config_field.rs
+++ b/xtask/src/bin/scaffold_config_field.rs
@@ -1,0 +1,99 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `cargo xtask scaffold-config-field <path> --type <ft> --reload <rk>`
+//! — print the boilerplate diff a developer copy-pastes to add a new
+//! [`mgmt::Config`] field.
+//!
+//! Spec context:
+//! `openspec/changes/management-login-v1/specs/mgmt-config-surface-trait/spec.md`
+//! Q3 — "developer-ergonomics scaffolder".
+//!
+//! v1 prints the diff; auto-application is a future polish — once the
+//! universal-exposure walker is hooked up to `cargo build`, the
+//! scaffolder will become responsible for keeping the registry in
+//! sync, but for now this is a copy-paste helper.
+
+use std::process::ExitCode;
+
+use xtask::scaffold::{render_diff, FieldType, ReloadKind, ScaffoldArgs};
+
+fn print_usage() {
+    eprintln!(
+        "usage: cargo xtask scaffold-config-field <path> --type <bool|u32|u64|string|password_classes> --reload <live|boot>"
+    );
+}
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() || args[0] == "--help" || args[0] == "-h" {
+        print_usage();
+        return ExitCode::SUCCESS;
+    }
+
+    let path = args[0].clone();
+    let mut kind: Option<FieldType> = None;
+    let mut reload: Option<ReloadKind> = None;
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--type" => {
+                i += 1;
+                if i >= args.len() {
+                    eprintln!("error: --type requires a value");
+                    print_usage();
+                    return ExitCode::FAILURE;
+                }
+                match FieldType::parse(&args[i]) {
+                    Ok(k) => kind = Some(k),
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        return ExitCode::FAILURE;
+                    }
+                }
+            }
+            "--reload" => {
+                i += 1;
+                if i >= args.len() {
+                    eprintln!("error: --reload requires a value");
+                    print_usage();
+                    return ExitCode::FAILURE;
+                }
+                match ReloadKind::parse(&args[i]) {
+                    Ok(r) => reload = Some(r),
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        return ExitCode::FAILURE;
+                    }
+                }
+            }
+            other => {
+                eprintln!("error: unknown argument '{other}'");
+                print_usage();
+                return ExitCode::FAILURE;
+            }
+        }
+        i += 1;
+    }
+
+    let kind = match kind {
+        Some(k) => k,
+        None => {
+            eprintln!("error: --type is required");
+            print_usage();
+            return ExitCode::FAILURE;
+        }
+    };
+    let reload = match reload {
+        Some(r) => r,
+        None => {
+            eprintln!("error: --reload is required");
+            print_usage();
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let s = render_diff(&ScaffoldArgs { path, kind, reload });
+    print!("{s}");
+    ExitCode::SUCCESS
+}

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -1,0 +1,10 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `cargo xtask` developer-ergonomics tasks.
+//!
+//! See per-binary documentation under `src/bin/`. The crate root is a
+//! library so unit tests can drive the same code paths the binaries
+//! invoke.
+
+pub mod scaffold;

--- a/xtask/src/scaffold.rs
+++ b/xtask/src/scaffold.rs
@@ -1,0 +1,329 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Reusable code paths for `cargo xtask scaffold-config-field`.
+//!
+//! Spec context:
+//! `openspec/changes/management-login-v1/specs/mgmt-config-surface-trait/spec.md`
+//! Q3 — "developer-ergonomics scaffolder for new `Config` fields".
+//!
+//! The scaffolder prints the boilerplate diff a developer needs to
+//! copy into the relevant files. Real auto-application is a future
+//! polish; for v1 this is a copy-paste helper.
+
+use std::fmt;
+
+/// Supported field types — matches `mgmt::config::registry::FieldType`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FieldType {
+    /// `Value::Bool`
+    Bool,
+    /// `Value::U32`
+    U32,
+    /// `Value::U64`
+    U64,
+    /// `Value::String`
+    String,
+    /// `Value::PasswordClasses`
+    PasswordClasses,
+}
+
+impl FieldType {
+    /// Parse a CLI argument like `--type u32` into a [`FieldType`].
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s {
+            "bool" => Ok(Self::Bool),
+            "u32" => Ok(Self::U32),
+            "u64" => Ok(Self::U64),
+            "string" => Ok(Self::String),
+            "password_classes" => Ok(Self::PasswordClasses),
+            other => Err(format!(
+                "unknown --type '{other}': expected bool|u32|u64|string|password_classes"
+            )),
+        }
+    }
+
+    /// String form used in the registry's `FieldType::*` enum variant.
+    pub fn enum_variant(self) -> &'static str {
+        match self {
+            Self::Bool => "Bool",
+            Self::U32 => "U32",
+            Self::U64 => "U64",
+            Self::String => "String",
+            Self::PasswordClasses => "PasswordClasses",
+        }
+    }
+
+    /// Variant tag used in `Value::*` (matches the runtime tag).
+    pub fn value_variant(self) -> &'static str {
+        match self {
+            Self::Bool => "Bool",
+            Self::U32 => "U32",
+            Self::U64 => "U64",
+            Self::String => "String",
+            Self::PasswordClasses => "PasswordClasses",
+        }
+    }
+
+    /// Rust type used in the namespace struct field.
+    pub fn rust_type(self) -> &'static str {
+        match self {
+            Self::Bool => "bool",
+            Self::U32 => "u32",
+            Self::U64 => "u64",
+            Self::String => "alloc::string::String",
+            Self::PasswordClasses => "PasswordClassSet",
+        }
+    }
+}
+
+/// Reload semantics — matches `mgmt::surface::ReloadKind`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReloadKind {
+    /// `ReloadKind::Live`
+    Live,
+    /// `ReloadKind::Boot`
+    Boot,
+}
+
+impl ReloadKind {
+    /// Parse `--reload live|boot`.
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s {
+            "live" => Ok(Self::Live),
+            "boot" => Ok(Self::Boot),
+            other => Err(format!("unknown --reload '{other}': expected live|boot")),
+        }
+    }
+
+    /// Variant name used in the registry.
+    pub fn enum_variant(self) -> &'static str {
+        match self {
+            Self::Live => "Live",
+            Self::Boot => "Boot",
+        }
+    }
+}
+
+/// All inputs required to scaffold a new field.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScaffoldArgs {
+    /// Dotted path, e.g. `idle.warning_minutes`.
+    pub path: String,
+    /// Field's typed [`FieldType`].
+    pub kind: FieldType,
+    /// Reload semantics.
+    pub reload: ReloadKind,
+}
+
+impl ScaffoldArgs {
+    /// Top-level namespace — `path.split('.').next()`.
+    pub fn namespace(&self) -> &str {
+        self.path.split('.').next().unwrap_or(&self.path)
+    }
+
+    /// Trailing field name (e.g. `warning_minutes`).
+    pub fn field_name(&self) -> &str {
+        self.path.rsplit('.').next().unwrap_or(&self.path)
+    }
+}
+
+impl fmt::Display for ScaffoldArgs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "ScaffoldArgs {{ path: {}, kind: {:?}, reload: {:?} }}",
+            self.path, self.kind, self.reload
+        )
+    }
+}
+
+/// Render the human-facing diff a developer copy-pastes into the
+/// codebase. Output is a single `String` so callers can `println!` it
+/// or write it to a file under test.
+pub fn render_diff(args: &ScaffoldArgs) -> String {
+    let ns = args.namespace();
+    let name = args.field_name();
+    let mut out = String::new();
+
+    out.push_str("# scaffold-config-field — paste the snippets below into\n");
+    out.push_str("# the named files. The build will then run the\n");
+    out.push_str("# universal-exposure walker; if you missed a step, the\n");
+    out.push_str("# walker fails the build with a precise diagnostic.\n");
+    out.push('\n');
+
+    // 1. Namespace struct field
+    out.push_str("## 1. mgmt/src/config.rs — append a field to the namespace struct\n\n");
+    out.push_str(&format!(
+        "// Inside `{ns}Config`:\n    pub {name}: {ty},\n",
+        ty = args.kind.rust_type()
+    ));
+    out.push_str("\n// And populate the v1 default:\n");
+    out.push_str(&format!("    {name}: <CHOOSE A SAFE DEFAULT>,\n",));
+    out.push('\n');
+
+    // 2. read_path arm
+    out.push_str("## 2. mgmt/src/config.rs — extend `Config::read_path`\n\n");
+    out.push_str(&format!(
+        "    \"{path}\" => Ok(Value::{variant}(self.{ns}.{name}.clone())),\n",
+        path = args.path,
+        variant = args.kind.value_variant(),
+        ns = ns,
+        name = name
+    ));
+    out.push('\n');
+
+    // 3. write_path arm
+    out.push_str("## 3. mgmt/src/config.rs — extend `Config::write_path`\n\n");
+    out.push_str(&format!(
+        "    \"{path}\" => self.{ns}.{name} = value.as_<rust>()?,\n",
+        path = args.path,
+        ns = ns,
+        name = name
+    ));
+    out.push('\n');
+
+    // 4. Validator
+    out.push_str("## 4. mgmt/src/validate.rs — extend `validate_field`\n\n");
+    out.push_str(&format!(
+        "    \"{path}\" => {{ /* per-field rule */ Ok(()) }}\n",
+        path = args.path
+    ));
+    out.push('\n');
+
+    // 5. Registry row
+    out.push_str("## 5. mgmt/src/config.rs — append to `registry::CONFIG_FIELDS`\n\n");
+    out.push_str("    FieldDescriptor {\n");
+    out.push_str(&format!("        path: \"{}\",\n", args.path));
+    out.push_str(&format!(
+        "        kind: FieldType::{},\n",
+        args.kind.enum_variant()
+    ));
+    out.push_str(&format!(
+        "        reload: ReloadKind::{},\n",
+        args.reload.enum_variant()
+    ));
+    out.push_str("        scope: SurfaceScope::Universal,\n");
+    out.push_str("    },\n");
+    out.push('\n');
+
+    out.push_str("## 6. Run `cargo test -p smallaios-mgmt --tests` and the universal-exposure\n");
+    out.push_str("##    walker will confirm every active surface can read/write the new field.\n");
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_field_type_known_names() {
+        assert_eq!(FieldType::parse("bool").unwrap(), FieldType::Bool);
+        assert_eq!(FieldType::parse("u32").unwrap(), FieldType::U32);
+        assert_eq!(FieldType::parse("u64").unwrap(), FieldType::U64);
+        assert_eq!(FieldType::parse("string").unwrap(), FieldType::String);
+        assert_eq!(
+            FieldType::parse("password_classes").unwrap(),
+            FieldType::PasswordClasses
+        );
+    }
+
+    #[test]
+    fn parse_field_type_rejects_unknown() {
+        assert!(FieldType::parse("u128").is_err());
+        assert!(FieldType::parse("").is_err());
+    }
+
+    #[test]
+    fn parse_reload_known_names() {
+        assert_eq!(ReloadKind::parse("live").unwrap(), ReloadKind::Live);
+        assert_eq!(ReloadKind::parse("boot").unwrap(), ReloadKind::Boot);
+    }
+
+    #[test]
+    fn parse_reload_rejects_unknown() {
+        assert!(ReloadKind::parse("eager").is_err());
+    }
+
+    #[test]
+    fn namespace_extraction_from_path() {
+        let a = ScaffoldArgs {
+            path: "idle.foo".into(),
+            kind: FieldType::U32,
+            reload: ReloadKind::Live,
+        };
+        assert_eq!(a.namespace(), "idle");
+        assert_eq!(a.field_name(), "foo");
+    }
+
+    #[test]
+    fn namespace_extraction_handles_single_segment() {
+        let a = ScaffoldArgs {
+            path: "scalar".into(),
+            kind: FieldType::Bool,
+            reload: ReloadKind::Live,
+        };
+        assert_eq!(a.namespace(), "scalar");
+        assert_eq!(a.field_name(), "scalar");
+    }
+
+    #[test]
+    fn render_diff_includes_path() {
+        let a = ScaffoldArgs {
+            path: "idle.warn_minutes".into(),
+            kind: FieldType::U32,
+            reload: ReloadKind::Live,
+        };
+        let s = render_diff(&a);
+        assert!(s.contains("idle.warn_minutes"));
+        assert!(s.contains("FieldType::U32"));
+        assert!(s.contains("ReloadKind::Live"));
+    }
+
+    #[test]
+    fn render_diff_for_boot_kind() {
+        let a = ScaffoldArgs {
+            path: "fs.new_thing".into(),
+            kind: FieldType::U64,
+            reload: ReloadKind::Boot,
+        };
+        let s = render_diff(&a);
+        assert!(s.contains("ReloadKind::Boot"));
+        assert!(s.contains("FieldType::U64"));
+    }
+
+    #[test]
+    fn render_diff_includes_default_placeholder() {
+        let a = ScaffoldArgs {
+            path: "idle.foo".into(),
+            kind: FieldType::Bool,
+            reload: ReloadKind::Live,
+        };
+        let s = render_diff(&a);
+        assert!(s.contains("CHOOSE A SAFE DEFAULT"));
+    }
+
+    #[test]
+    fn render_diff_mentions_universal_exposure_walker() {
+        let a = ScaffoldArgs {
+            path: "x.y".into(),
+            kind: FieldType::Bool,
+            reload: ReloadKind::Live,
+        };
+        let s = render_diff(&a);
+        assert!(s.contains("universal-exposure"));
+    }
+
+    #[test]
+    fn display_includes_path_and_kind() {
+        let a = ScaffoldArgs {
+            path: "x.y".into(),
+            kind: FieldType::Bool,
+            reload: ReloadKind::Live,
+        };
+        let s = format!("{}", a);
+        assert!(s.contains("x.y"));
+        assert!(s.contains("Bool"));
+    }
+}


### PR DESCRIPTION
## Summary

Phase 6 of `management-login-v1`. First real `ConfigSurface` implementation: TOML loader/saver over `/data/*.toml` files with full apply lifecycle. Adds the build-time **universal-exposure CI walker** that fails if any `Config` field can't be reached via the surface — the regression-prevention gate the spec mandates.

- `mgmt/src/toml/{mod,lex,parse,serialize}.rs` (1,518 LOC) — clean-room `#![no_std]` TOML 1.0 subset (tables, sub-tables, primitive arrays, basic + literal strings, integers, booleans, dotted keys). The `toml` crate appears in dev-deps only as a round-trip oracle.
- `mgmt/src/loader_toml/{mod.rs,loader_test_vectors.rs}` (1,794 LOC) — `TomlLoader<R, W>` `ConfigSurface` impl, full apply lifecycle (parse → validate → stage → fsync → rename → notify), file-mode-stricter-than-declared rule, first-boot skeleton generation.
- `mgmt/tests/{universal_exposure,apply_lifecycle,toml_oracle}.rs` (830 LOC) — 35 integration tests + the universal-exposure CI walker (every of 30 v1 fields reachable via TOML surface).
- `xtask/src/{lib,scaffold}.rs` + `bin/scaffold_config_field.rs` (438 LOC) — `cargo xtask scaffold-config-field <name>` developer-ergonomics scaffolder.
- **142 new tests** in `smallaios-mgmt` (now 225 total). Plus 11 in xtask.

## Deviations (called out)

- `TomlLoader::new` is infallible (`pub fn new(reader: R, writer: W, base_path: &str) -> Self`); the `Result` is on `load(policy)`. Reason: a loader needs both a `ReadBackend` (for file bytes + modes) and an `AtomicWriter` (for writes); construction can never fail, only `load()` can.
- Two type params (`R: ReadBackend`, `W: AtomicWriter`) instead of the spec's single `W` — lets tests model the file-mode rule independently of the writer (auth's `AtomicWriter` doesn't expose modes). Production wires both halves over an F2FS handle (the `SharedFs` test fixture demonstrates this).
- `xtask` workspace member is new; registered in `Cargo.toml` workspace members and added to `just clippy` / `just test`.
- The `toml` crate dev-dep oracle was added with `cargo vet regenerate exemptions` (129 exempted, was 124).

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `just clippy` `-D warnings` clean.
- [x] `cargo test -p smallaios-mgmt` — 225/225 (was 83).
- [x] `cargo test -p xtask` — 11/11.
- [x] `cargo vet check` Vetting Succeeded.
- [x] `openspec validate management-login-v1 --strict` clean.
- [x] `just build-kernel-arm` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)