### PR TITLE
feat(mgmt): Zenoh telemetry keyspace + per-key cadence + adaptive thresholds (management-login-v1 phase 8)

### DIFF
--- a/mgmt/src/surface_zenoh/mod.rs
+++ b/mgmt/src/surface_zenoh/mod.rs
@@ -9,8 +9,8 @@
 //!
 //! Phase 7 lands the admin keyspace, the bearer-token wrapper, the
 //! per-identity / total session caps, and the in-flight live flag.
-//! Phase 8 will land telemetry publications under
-//! `smallaios/metrics/**`.
+//! Phase 8 lands telemetry publications under
+//! `smallaios/metrics/**` (see [`telemetry`]).
 //!
 //! ## Module map
 //!
@@ -22,6 +22,9 @@
 //! - [`token`] — opaque + ML-DSA-65 / Ed25519-legacy token modes.
 //! - [`admin`] — verb dispatcher and bearer-token wrapper.
 //! - [`errors`] — POSIX errno table shared with the syscall surface.
+//! - [`telemetry`] — periodic + event-driven publishers under
+//!   `smallaios/metrics/**` with per-key cadence + adaptive
+//!   thresholds.
 //!
 //! ## ZenohSurface
 //!
@@ -39,6 +42,7 @@ pub mod admin;
 pub mod errors;
 pub mod json;
 pub mod session;
+pub mod telemetry;
 pub mod token;
 
 #[cfg(test)]

--- a/mgmt/src/surface_zenoh/telemetry/cadence.rs
+++ b/mgmt/src/surface_zenoh/telemetry/cadence.rs
@@ -1,0 +1,288 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-key cadence resolver: clamps the configured interval and
+//! applies an optional adaptive override.
+//!
+//! Spec:
+//! `openspec/changes/management-login-v1/specs/mgmt-zenoh-telemetry/spec.md`
+//! Requirement "Per-key configurable cadence with adaptive option".
+//!
+//! ## Adaptive cadence
+//!
+//! When a metric crosses `threshold` (e.g. any CPU core > 80%), the
+//! publisher upgrades to `fast_hz` and remains there until the metric
+//! falls back below the threshold, at which point it reverts to
+//! `slow_hz`. Hysteresis is **single-step** by design — the spec does
+//! not call for separate enter/exit thresholds.
+
+use super::clamp_interval;
+
+/// Adaptive cadence overrides. When attached to a [`CadenceState`],
+/// the publisher rebuilds its effective interval each tick from the
+/// caller's metric input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AdaptiveCadence {
+    /// Threshold value the publisher's metric is compared against.
+    /// For CPU, this is `peak_util_pct` in `0..=100`.
+    pub threshold: u32,
+    /// Cadence in Hz when above threshold (1..=10 typical). Translated
+    /// to `1000 / fast_hz` ms internally and clamped to the publisher
+    /// floor.
+    pub fast_hz: u32,
+    /// Cadence in Hz when at or below threshold.
+    pub slow_hz: u32,
+}
+
+impl AdaptiveCadence {
+    /// Construct from a triple. Helper for tests and for constructing
+    /// from the typed `Config`.
+    pub const fn new(threshold: u32, fast_hz: u32, slow_hz: u32) -> Self {
+        Self {
+            threshold,
+            fast_hz,
+            slow_hz,
+        }
+    }
+
+    /// Translate `fast_hz` to a publisher interval (ms), clamped to
+    /// the publisher's legal window.
+    pub fn fast_interval_ms(&self) -> u32 {
+        clamp_interval(hz_to_ms(self.fast_hz))
+    }
+
+    /// Translate `slow_hz` to a publisher interval (ms), clamped to
+    /// the publisher's legal window.
+    pub fn slow_interval_ms(&self) -> u32 {
+        clamp_interval(hz_to_ms(self.slow_hz))
+    }
+}
+
+/// Per-key publisher cadence state. Built once at start, updated each
+/// tick with the latest metric reading.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CadenceState {
+    /// Configured baseline interval in ms — used when no adaptive
+    /// override is attached.
+    pub base_interval_ms: u32,
+    /// Optional adaptive override.
+    pub adaptive: Option<AdaptiveCadence>,
+    /// `true` iff the publisher is currently in the fast-hz tier.
+    /// Tracked across ticks so threshold-cross hysteresis is stable.
+    pub in_fast_tier: bool,
+}
+
+impl CadenceState {
+    /// Build a non-adaptive state.
+    pub const fn fixed(base_interval_ms: u32) -> Self {
+        Self {
+            base_interval_ms,
+            adaptive: None,
+            in_fast_tier: false,
+        }
+    }
+
+    /// Build an adaptive state.
+    pub const fn adaptive(base_interval_ms: u32, adaptive: AdaptiveCadence) -> Self {
+        Self {
+            base_interval_ms,
+            adaptive: Some(adaptive),
+            in_fast_tier: false,
+        }
+    }
+
+    /// Update the in-fast-tier flag from a fresh metric reading and
+    /// return the resolved [`EffectiveCadence`] for the next tick.
+    pub fn update(&mut self, metric: u32) -> EffectiveCadence {
+        let Some(adapt) = self.adaptive else {
+            return EffectiveCadence {
+                interval_ms: self.base_interval_ms,
+                fast_tier: false,
+            };
+        };
+
+        // Cross above threshold → fast. At or below → slow.
+        // Hysteresis keeps the tier stable until the metric crosses
+        // the threshold in the opposite direction.
+        self.in_fast_tier = metric > adapt.threshold;
+
+        let interval_ms = if self.in_fast_tier {
+            adapt.fast_interval_ms()
+        } else {
+            adapt.slow_interval_ms()
+        };
+        EffectiveCadence {
+            interval_ms,
+            fast_tier: self.in_fast_tier,
+        }
+    }
+
+    /// Resolve the current effective cadence without updating the
+    /// in-fast-tier flag — used for diagnostic queries.
+    pub fn current(&self) -> EffectiveCadence {
+        match self.adaptive {
+            Some(adapt) if self.in_fast_tier => EffectiveCadence {
+                interval_ms: adapt.fast_interval_ms(),
+                fast_tier: true,
+            },
+            Some(adapt) => EffectiveCadence {
+                interval_ms: adapt.slow_interval_ms(),
+                fast_tier: false,
+            },
+            None => EffectiveCadence {
+                interval_ms: self.base_interval_ms,
+                fast_tier: false,
+            },
+        }
+    }
+}
+
+/// Snapshot of the effective cadence for a single key after an update.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EffectiveCadence {
+    /// Interval in milliseconds the publisher SHALL use for its next
+    /// deadline.
+    pub interval_ms: u32,
+    /// `true` iff the adaptive fast tier is engaged. `false` for
+    /// non-adaptive keys.
+    pub fast_tier: bool,
+}
+
+/// Convert `hz` to a publisher interval in milliseconds. Zero is
+/// treated as 1 Hz (defensive — the validator rejects zero before this
+/// runs in production paths).
+pub fn hz_to_ms(hz: u32) -> u32 {
+    if hz == 0 {
+        return 1000;
+    }
+    let ms = 1000u64 / hz as u64;
+    if ms == 0 {
+        1
+    } else if ms > u32::MAX as u64 {
+        u32::MAX
+    } else {
+        ms as u32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{MAX_INTERVAL_MS, MIN_INTERVAL_MS};
+    use super::*;
+
+    #[test]
+    fn hz_to_ms_basic_conversions() {
+        assert_eq!(hz_to_ms(1), 1000);
+        assert_eq!(hz_to_ms(10), 100);
+        assert_eq!(hz_to_ms(2), 500);
+        assert_eq!(hz_to_ms(4), 250);
+    }
+
+    #[test]
+    fn hz_to_ms_zero_defaults_to_one_hz() {
+        assert_eq!(hz_to_ms(0), 1000);
+    }
+
+    #[test]
+    fn hz_to_ms_high_hz_floors_at_one_ms() {
+        assert_eq!(hz_to_ms(2000), 1);
+    }
+
+    #[test]
+    fn fixed_cadence_returns_base_interval() {
+        let mut s = CadenceState::fixed(750);
+        let eff = s.update(0);
+        assert_eq!(eff.interval_ms, 750);
+        assert!(!eff.fast_tier);
+    }
+
+    #[test]
+    fn fixed_cadence_metric_value_is_ignored() {
+        let mut s = CadenceState::fixed(1000);
+        // Crossing any threshold-shaped value SHALL not flip tiers
+        // when adaptive is not configured.
+        let eff = s.update(99);
+        assert_eq!(eff.interval_ms, 1000);
+        let eff = s.update(0);
+        assert_eq!(eff.interval_ms, 1000);
+    }
+
+    #[test]
+    fn adaptive_above_threshold_engages_fast_tier() {
+        let mut s = CadenceState::adaptive(1000, AdaptiveCadence::new(80, 10, 1));
+        let eff = s.update(85);
+        // fast_hz = 10 → 100 ms (clamped to floor).
+        assert_eq!(eff.interval_ms, 100);
+        assert!(eff.fast_tier);
+        assert!(s.in_fast_tier);
+    }
+
+    #[test]
+    fn adaptive_at_threshold_remains_slow_tier() {
+        // Spec: "exceeds 80" → fast. == 80 keeps slow.
+        let mut s = CadenceState::adaptive(1000, AdaptiveCadence::new(80, 10, 1));
+        let eff = s.update(80);
+        assert_eq!(eff.interval_ms, 1000);
+        assert!(!eff.fast_tier);
+    }
+
+    #[test]
+    fn adaptive_below_threshold_reverts_to_slow_tier() {
+        let mut s = CadenceState::adaptive(1000, AdaptiveCadence::new(80, 10, 1));
+        // Engage fast.
+        s.update(90);
+        assert!(s.in_fast_tier);
+        // Drop back below.
+        let eff = s.update(50);
+        assert_eq!(eff.interval_ms, 1000);
+        assert!(!eff.fast_tier);
+    }
+
+    #[test]
+    fn adaptive_fast_interval_clamped_to_floor() {
+        // fast_hz = 100 would imply 10 ms; clamped to 100 ms floor.
+        let a = AdaptiveCadence::new(80, 100, 1);
+        assert_eq!(a.fast_interval_ms(), MIN_INTERVAL_MS);
+    }
+
+    #[test]
+    fn adaptive_slow_interval_clamped_to_ceiling() {
+        // slow_hz < 1 (i.e. zero) → defaults to 1 Hz which is in
+        // range; we instead use a value high enough to test the
+        // ceiling: hz_to_ms(0) is 1000, which is far below ceiling.
+        // Force the path by constructing a slow_hz that yields
+        // > 60s — there's no integer-Hz value that does so without
+        // hitting the zero branch, so we explicitly verify clamp via
+        // the `clamp_interval` helper.
+        let a = AdaptiveCadence::new(80, 10, 1);
+        // slow_hz = 1 → 1000ms, which is in range.
+        assert_eq!(a.slow_interval_ms(), 1000);
+        // Confirm ceiling clamp via direct call.
+        assert_eq!(super::super::clamp_interval(120_000), MAX_INTERVAL_MS);
+    }
+
+    #[test]
+    fn adaptive_current_reflects_fast_tier_without_updating() {
+        let mut s = CadenceState::adaptive(1000, AdaptiveCadence::new(80, 10, 1));
+        s.update(90); // engage fast
+        let cur = s.current();
+        assert!(cur.fast_tier);
+        assert_eq!(cur.interval_ms, 100);
+    }
+
+    #[test]
+    fn adaptive_state_carries_tier_across_ticks() {
+        let mut s = CadenceState::adaptive(1000, AdaptiveCadence::new(80, 10, 1));
+        s.update(90);
+        // Same metric value (still > threshold) → still fast.
+        s.update(90);
+        assert!(s.in_fast_tier);
+    }
+
+    #[test]
+    fn adaptive_threshold_zero_always_fast_above_zero() {
+        let mut s = CadenceState::adaptive(1000, AdaptiveCadence::new(0, 10, 1));
+        let eff = s.update(1);
+        assert!(eff.fast_tier);
+    }
+}

--- a/mgmt/src/surface_zenoh/telemetry/mod.rs
+++ b/mgmt/src/surface_zenoh/telemetry/mod.rs
@@ -1,0 +1,177 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Zenoh telemetry keyspace — periodic + event-driven publishers under
+//! `smallaios/metrics/**`.
+//!
+//! Spec:
+//! `openspec/changes/management-login-v1/specs/mgmt-zenoh-telemetry/spec.md`
+//! Requirements:
+//!
+//! - "Telemetry keyspace schema"
+//! - "Per-key configurable cadence with adaptive option"
+//!
+//! ## Keyspace
+//!
+//! Phase 8 v1 keys (every payload is a JSON object):
+//!
+//! | Key                                  | Cadence | Shape                                                                                |
+//! |--------------------------------------|---------|--------------------------------------------------------------------------------------|
+//! | `smallaios/metrics/cpu`              | 1 Hz    | `{ ts, per_core: [{ id, util_pct }] }`                                               |
+//! | `smallaios/metrics/mem`              | 1 Hz    | `{ ts, heap_used_bytes, heap_cap_bytes, page_alloc_count, page_free_count }`         |
+//! | `smallaios/metrics/inference`        | 1 Hz    | `{ ts, per_model: [{ name, qps, p50_us, p99_us, error_count }] }`                    |
+//! | `smallaios/metrics/log`              | event   | `{ ts, level, target, msg, fields }`                                                 |
+//! | `smallaios/metrics/audit_fingerprint`| event   | `{ ts, hex_fingerprint, record_count }`                                              |
+//!
+//! ## Module map
+//!
+//! - [`source`] — `MetricsSource` trait and the synthetic
+//!   `StubMetricsSource` used by tests + integration smoke.
+//! - [`schema`] — strongly-typed `*Stat` records and their
+//!   `to_json` projections through the existing
+//!   [`super::json::JsonValue`] codec.
+//! - [`cadence`] — per-key cadence resolver: clamps interval bounds
+//!   (100 ms..=60 s) and applies an optional adaptive override.
+//! - [`publisher`] — the cooperative driver: holds per-key deadlines,
+//!   pulls from a [`MetricsSource`], routes to a [`PublishSink`].
+//!
+//! ## Transport-agnostic by design
+//!
+//! Mirroring [`super::AdminDispatcher`], `TelemetryPublisher` does not
+//! own a Zenoh session — it accepts a [`PublishSink`] callback so the
+//! same driver runs against the in-flight `ipc-zenoh` transport in
+//! production and a synthetic `Vec`-backed sink in tests. The
+//! production glue (a future [`smallaios-ipc`] phase) supplies the
+//! Zenoh-backed implementation.
+
+pub mod cadence;
+pub mod publisher;
+pub mod schema;
+pub mod source;
+
+#[cfg(test)]
+mod telemetry_test_vectors;
+
+pub use cadence::{CadenceState, EffectiveCadence};
+pub use publisher::{
+    MetricKey, PublishRecord, PublishSink, TelemetryError, TelemetryPublisher, METRIC_KEYS,
+};
+pub use schema::{
+    AuditFingerprint, CpuStat, InferenceStat, LogLevel, LogRecord, MemStat, PerCpuUtil,
+};
+pub use source::{MetricsSource, StubMetricsSource};
+
+use crate::config::MetricsConfig;
+
+/// Default cadence for every metric key, per the spec — 1 Hz.
+pub const DEFAULT_INTERVAL_MS: u32 = 1000;
+
+/// Lower bound on per-key interval. Mirrors
+/// [`crate::validate::METRICS_MIN_INTERVAL_MS`]; re-exported here so
+/// callers don't have to reach across modules.
+pub const MIN_INTERVAL_MS: u32 = crate::validate::METRICS_MIN_INTERVAL_MS;
+
+/// Upper bound on per-key interval (60 s).
+pub const MAX_INTERVAL_MS: u32 = crate::validate::METRICS_MAX_INTERVAL_MS;
+
+/// Resolve the configured interval (in ms) for `key` from a
+/// [`MetricsConfig`]. Falls back to [`DEFAULT_INTERVAL_MS`] when the
+/// `Config` does not have a dedicated field for `key` (e.g. the
+/// event-driven keys).
+pub fn config_interval_ms(key: MetricKey, config: &MetricsConfig) -> u32 {
+    match key {
+        MetricKey::Cpu => config.cpu_interval_ms,
+        MetricKey::Mem => config.memory_interval_ms,
+        MetricKey::Inference => config.inference_interval_ms,
+        // Event-driven keys ignore periodic cadence — but the
+        // publisher still uses the value as a sanity floor when the
+        // caller asks for periodic publication on those keys (used
+        // only by tests).
+        MetricKey::Log | MetricKey::AuditFingerprint => DEFAULT_INTERVAL_MS,
+    }
+}
+
+/// Clamp `ms` to the [`MIN_INTERVAL_MS`]..=[`MAX_INTERVAL_MS`] window.
+/// Out-of-range inputs return `Err`. Callers that want best-effort
+/// clamping should use [`clamp_interval`].
+pub fn validate_interval_ms(ms: u32) -> Result<u32, TelemetryError> {
+    if ms < MIN_INTERVAL_MS {
+        return Err(TelemetryError::IntervalBelowFloor);
+    }
+    if ms > MAX_INTERVAL_MS {
+        return Err(TelemetryError::IntervalAboveCeiling);
+    }
+    Ok(ms)
+}
+
+/// Clamp `ms` to the legal window without erroring. Used internally by
+/// the publisher when a runtime override (e.g. adaptive `fast_hz`)
+/// translates into an interval below the floor.
+pub fn clamp_interval(ms: u32) -> u32 {
+    ms.clamp(MIN_INTERVAL_MS, MAX_INTERVAL_MS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_interval_resolves_cpu_mem_inference() {
+        let mut c = MetricsConfig::v1_defaults();
+        c.cpu_interval_ms = 500;
+        c.memory_interval_ms = 750;
+        c.inference_interval_ms = 250;
+        assert_eq!(config_interval_ms(MetricKey::Cpu, &c), 500);
+        assert_eq!(config_interval_ms(MetricKey::Mem, &c), 750);
+        assert_eq!(config_interval_ms(MetricKey::Inference, &c), 250);
+    }
+
+    #[test]
+    fn config_interval_event_driven_falls_back_to_default() {
+        let c = MetricsConfig::v1_defaults();
+        assert_eq!(config_interval_ms(MetricKey::Log, &c), DEFAULT_INTERVAL_MS);
+        assert_eq!(
+            config_interval_ms(MetricKey::AuditFingerprint, &c),
+            DEFAULT_INTERVAL_MS
+        );
+    }
+
+    #[test]
+    fn validate_interval_ms_accepts_legal_values() {
+        assert_eq!(validate_interval_ms(MIN_INTERVAL_MS).unwrap(), 100);
+        assert_eq!(validate_interval_ms(1000).unwrap(), 1000);
+        assert_eq!(validate_interval_ms(MAX_INTERVAL_MS).unwrap(), 60_000);
+    }
+
+    #[test]
+    fn validate_interval_ms_rejects_below_floor() {
+        assert_eq!(
+            validate_interval_ms(99),
+            Err(TelemetryError::IntervalBelowFloor)
+        );
+        assert_eq!(
+            validate_interval_ms(0),
+            Err(TelemetryError::IntervalBelowFloor)
+        );
+    }
+
+    #[test]
+    fn validate_interval_ms_rejects_above_ceiling() {
+        assert_eq!(
+            validate_interval_ms(60_001),
+            Err(TelemetryError::IntervalAboveCeiling)
+        );
+        assert_eq!(
+            validate_interval_ms(u32::MAX),
+            Err(TelemetryError::IntervalAboveCeiling)
+        );
+    }
+
+    #[test]
+    fn clamp_interval_clips_below_and_above() {
+        assert_eq!(clamp_interval(0), MIN_INTERVAL_MS);
+        assert_eq!(clamp_interval(50), MIN_INTERVAL_MS);
+        assert_eq!(clamp_interval(1000), 1000);
+        assert_eq!(clamp_interval(120_000), MAX_INTERVAL_MS);
+    }
+}

--- a/mgmt/src/surface_zenoh/telemetry/publisher.rs
+++ b/mgmt/src/surface_zenoh/telemetry/publisher.rs
@@ -1,0 +1,1271 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Cooperative telemetry publisher.
+//!
+//! Spec:
+//! `openspec/changes/management-login-v1/specs/mgmt-zenoh-telemetry/spec.md`.
+//!
+//! [`TelemetryPublisher`] is transport-agnostic — it emits
+//! [`PublishRecord`] values to a [`PublishSink`] callback the caller
+//! supplies. Production wires this to a Zenoh publisher; tests wire
+//! it to a `Vec`-backed sink so cadence + content can be asserted.
+//!
+//! ## Cooperative driver
+//!
+//! The publisher does not spawn its own thread or own a timer. The
+//! Core 0 cooperative scheduler calls [`TelemetryPublisher::tick`] with
+//! the current monotonic-now-millis. The publisher walks per-key
+//! deadlines: any key whose `next_due_ms <= now_ms` is sampled and
+//! published, then has its deadline rolled forward by the resolved
+//! interval. This keeps the publisher allocation-light and re-entrant.
+//!
+//! ## Per-key deadlines
+//!
+//! Each [`MetricKey`] carries:
+//!
+//! - a [`super::CadenceState`] (clamped, optional adaptive),
+//! - a `next_due_ms` deadline,
+//! - an `enabled` flag (toggled by [`TelemetryPublisher::stop`] and
+//!   re-enabled by [`TelemetryPublisher::start`]).
+
+use alloc::collections::BTreeMap;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use super::cadence::{AdaptiveCadence, CadenceState, EffectiveCadence};
+use super::schema::{
+    inference_stats_to_json, AuditFingerprint, CpuStat, InferenceStat, LogRecord, MemStat,
+};
+use super::source::MetricsSource;
+use super::{config_interval_ms, validate_interval_ms};
+use crate::config::MetricsConfig;
+use crate::surface_zenoh::json::{encode, JsonValue};
+
+// ─── Keys ────────────────────────────────────────────────────────────────────
+
+/// One enum per Phase 8 telemetry key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum MetricKey {
+    /// `smallaios/metrics/cpu` — periodic.
+    Cpu,
+    /// `smallaios/metrics/mem` — periodic.
+    Mem,
+    /// `smallaios/metrics/inference` — periodic.
+    Inference,
+    /// `smallaios/metrics/log` — event-driven (drained on every tick
+    /// when records are pending).
+    Log,
+    /// `smallaios/metrics/audit_fingerprint` — event-driven (republished
+    /// when the chain head changes).
+    AuditFingerprint,
+}
+
+impl MetricKey {
+    /// Full Zenoh keyspace.
+    pub const fn keyspace(self) -> &'static str {
+        match self {
+            Self::Cpu => "smallaios/metrics/cpu",
+            Self::Mem => "smallaios/metrics/mem",
+            Self::Inference => "smallaios/metrics/inference",
+            Self::Log => "smallaios/metrics/log",
+            Self::AuditFingerprint => "smallaios/metrics/audit_fingerprint",
+        }
+    }
+
+    /// `true` iff the key publishes on a periodic cadence (CPU, mem,
+    /// inference). Event-driven keys (`Log`, `AuditFingerprint`)
+    /// return `false`.
+    pub const fn is_periodic(self) -> bool {
+        matches!(self, Self::Cpu | Self::Mem | Self::Inference)
+    }
+
+    /// All known keys, in declaration order.
+    pub const fn all() -> &'static [MetricKey] {
+        &METRIC_KEYS
+    }
+}
+
+/// Stable iteration order for every [`MetricKey`]. Re-exported so
+/// production glue (the future Zenoh wiring) can register publishers
+/// in a deterministic sequence.
+pub const METRIC_KEYS: [MetricKey; 5] = [
+    MetricKey::Cpu,
+    MetricKey::Mem,
+    MetricKey::Inference,
+    MetricKey::Log,
+    MetricKey::AuditFingerprint,
+];
+
+// ─── Errors ──────────────────────────────────────────────────────────────────
+
+/// Errors returnable by the publisher's user-facing entry points.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TelemetryError {
+    /// Configured `interval_ms` was below [`super::MIN_INTERVAL_MS`].
+    IntervalBelowFloor,
+    /// Configured `interval_ms` was above [`super::MAX_INTERVAL_MS`].
+    IntervalAboveCeiling,
+    /// `start` called twice without an intervening `stop`.
+    AlreadyRunning,
+    /// `publish_now` called against a stopped publisher.
+    NotRunning,
+    /// Sink callback returned an error.
+    SinkError,
+}
+
+// ─── Sink ────────────────────────────────────────────────────────────────────
+
+/// One published record handed to the sink. The `body` field is the
+/// final UTF-8 JSON bytes ready for the Zenoh wire — the sink does
+/// not need to re-encode.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublishRecord {
+    /// Full Zenoh keyspace (`smallaios/metrics/<key>`).
+    pub keyspace: &'static str,
+    /// Encoded JSON payload.
+    pub body: String,
+}
+
+/// Sink trait — the publisher routes every record to a `&mut Sink`.
+/// Implementations SHALL return `Err(TelemetryError::SinkError)` only
+/// on transport failure; bookkeeping bugs are the sink's concern.
+pub trait PublishSink {
+    /// Hand off `record` for transport. The publisher does not retain
+    /// `record` — the sink may consume it directly.
+    fn publish(&mut self, record: PublishRecord) -> Result<(), TelemetryError>;
+}
+
+/// `Vec`-backed sink for tests and the integration smoke. Records are
+/// pushed in publication order.
+#[derive(Debug, Default)]
+pub struct CapturingSink {
+    /// Captured records, in publication order.
+    pub records: Vec<PublishRecord>,
+}
+
+impl CapturingSink {
+    /// Construct an empty capturing sink.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of captured records.
+    pub fn len(&self) -> usize {
+        self.records.len()
+    }
+
+    /// `true` iff no records have been captured.
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    /// Records published to `keyspace`, in publication order.
+    pub fn for_key(&self, keyspace: &str) -> Vec<&PublishRecord> {
+        self.records
+            .iter()
+            .filter(|r| r.keyspace == keyspace)
+            .collect()
+    }
+
+    /// Drop all captured records.
+    pub fn clear(&mut self) {
+        self.records.clear();
+    }
+}
+
+impl PublishSink for CapturingSink {
+    fn publish(&mut self, record: PublishRecord) -> Result<(), TelemetryError> {
+        self.records.push(record);
+        Ok(())
+    }
+}
+
+// ─── Per-key state ───────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct KeyState {
+    cadence: CadenceState,
+    next_due_ms: u64,
+    enabled: bool,
+}
+
+impl KeyState {
+    fn new(cadence: CadenceState, start_ms: u64) -> Self {
+        Self {
+            cadence,
+            next_due_ms: start_ms.saturating_add(cadence.base_interval_ms as u64),
+            enabled: true,
+        }
+    }
+}
+
+// ─── Publisher ───────────────────────────────────────────────────────────────
+
+/// Cooperative telemetry publisher.
+pub struct TelemetryPublisher {
+    keys: BTreeMap<MetricKey, KeyState>,
+    started_at_ms: u64,
+    running: bool,
+    /// Soft cap on log records drained per tick. Prevents a noisy
+    /// burst from monopolising the cooperative slot.
+    log_drain_max_per_tick: usize,
+}
+
+impl TelemetryPublisher {
+    /// Default soft cap on log drain per tick.
+    pub const DEFAULT_LOG_DRAIN_PER_TICK: usize = 64;
+
+    /// Build a stopped publisher. Call [`Self::start`] to engage.
+    pub fn new() -> Self {
+        Self {
+            keys: BTreeMap::new(),
+            started_at_ms: 0,
+            running: false,
+            log_drain_max_per_tick: Self::DEFAULT_LOG_DRAIN_PER_TICK,
+        }
+    }
+
+    /// Replace the soft per-tick log drain cap. Bounded to `[1, 1024]`
+    /// — out-of-range values clamp to the nearest endpoint.
+    pub fn set_log_drain_max_per_tick(&mut self, max: usize) {
+        self.log_drain_max_per_tick = max.clamp(1, 1024);
+    }
+
+    /// `true` iff [`Self::start`] has been called and [`Self::stop`]
+    /// has not been called since.
+    pub fn is_running(&self) -> bool {
+        self.running
+    }
+
+    /// Resolve the per-key cadence from `config` and engage the
+    /// publisher. Subsequent calls return [`TelemetryError::AlreadyRunning`].
+    pub fn start(&mut self, config: &MetricsConfig, now_ms: u64) -> Result<(), TelemetryError> {
+        if self.running {
+            return Err(TelemetryError::AlreadyRunning);
+        }
+        self.start_at(config, now_ms, None)
+    }
+
+    /// Variant of [`Self::start`] that lets the caller attach an
+    /// adaptive override to specific keys. Used by the production
+    /// glue when `metrics.cpu.adaptive` is set in `mgmt/policy.toml`.
+    pub fn start_with_adaptive(
+        &mut self,
+        config: &MetricsConfig,
+        now_ms: u64,
+        cpu_adaptive: Option<AdaptiveCadence>,
+    ) -> Result<(), TelemetryError> {
+        if self.running {
+            return Err(TelemetryError::AlreadyRunning);
+        }
+        self.start_at(config, now_ms, cpu_adaptive)
+    }
+
+    fn start_at(
+        &mut self,
+        config: &MetricsConfig,
+        now_ms: u64,
+        cpu_adaptive: Option<AdaptiveCadence>,
+    ) -> Result<(), TelemetryError> {
+        let mut keys = BTreeMap::new();
+        for &k in METRIC_KEYS.iter() {
+            let interval = config_interval_ms(k, config);
+            let interval = validate_interval_ms(interval)?;
+            let cadence = if k == MetricKey::Cpu {
+                if let Some(a) = cpu_adaptive {
+                    CadenceState::adaptive(interval, a)
+                } else {
+                    CadenceState::fixed(interval)
+                }
+            } else {
+                CadenceState::fixed(interval)
+            };
+            keys.insert(k, KeyState::new(cadence, now_ms));
+        }
+        self.keys = keys;
+        self.started_at_ms = now_ms;
+        self.running = true;
+        Ok(())
+    }
+
+    /// Disable the publisher. After `stop`, [`Self::tick`] becomes a
+    /// no-op. The internal state is preserved so a subsequent
+    /// [`Self::start`] can resume — but note that `start` rebuilds
+    /// the deadlines from the supplied `now_ms`.
+    pub fn stop(&mut self) {
+        self.running = false;
+        for ks in self.keys.values_mut() {
+            ks.enabled = false;
+        }
+    }
+
+    /// Disable a single key without stopping the whole publisher.
+    pub fn disable_key(&mut self, key: MetricKey) {
+        if let Some(ks) = self.keys.get_mut(&key) {
+            ks.enabled = false;
+        }
+    }
+
+    /// Re-enable a single key. The next [`Self::tick`] call will
+    /// reset the key's deadline.
+    pub fn enable_key(&mut self, key: MetricKey, now_ms: u64) {
+        if let Some(ks) = self.keys.get_mut(&key) {
+            ks.enabled = true;
+            ks.next_due_ms = now_ms.saturating_add(ks.cadence.base_interval_ms as u64);
+        }
+    }
+
+    /// Replace the cadence for `key`. The new cadence takes effect on
+    /// the next deadline. Returns `Err(TelemetryError::NotRunning)`
+    /// if the publisher has not been started.
+    pub fn set_cadence(
+        &mut self,
+        key: MetricKey,
+        cadence: CadenceState,
+    ) -> Result<(), TelemetryError> {
+        if !self.running {
+            return Err(TelemetryError::NotRunning);
+        }
+        validate_interval_ms(cadence.base_interval_ms)?;
+        if let Some(ks) = self.keys.get_mut(&key) {
+            ks.cadence = cadence;
+        }
+        Ok(())
+    }
+
+    /// Diagnostic — read the configured cadence for `key`.
+    pub fn cadence(&self, key: MetricKey) -> Option<CadenceState> {
+        self.keys.get(&key).map(|k| k.cadence)
+    }
+
+    /// Diagnostic — read the next deadline for `key` (in `now_ms`
+    /// units).
+    pub fn next_due_ms(&self, key: MetricKey) -> Option<u64> {
+        self.keys.get(&key).map(|k| k.next_due_ms)
+    }
+
+    /// Cooperative tick. Walks every key, publishes any that are due,
+    /// rolls deadlines forward, and updates adaptive state. Returns
+    /// the number of records published.
+    pub fn tick<S, K>(
+        &mut self,
+        now_ms: u64,
+        source: &mut S,
+        sink: &mut K,
+    ) -> Result<usize, TelemetryError>
+    where
+        S: MetricsSource,
+        K: PublishSink,
+    {
+        if !self.running {
+            return Ok(0);
+        }
+        let mut published = 0usize;
+        // Iterate a stable order — METRIC_KEYS — to keep test
+        // assertions reproducible.
+        for &key in METRIC_KEYS.iter() {
+            let due = matches!(
+                self.keys.get(&key),
+                Some(ks) if ks.enabled && ks.next_due_ms <= now_ms
+            );
+            if !due && !key.is_event_driven() {
+                continue;
+            }
+            // Event-driven keys publish only when there's actually
+            // something to send, regardless of deadline.
+            if key.is_event_driven() {
+                published += self.publish_event_key(key, now_ms, source, sink)?;
+                self.advance_deadline(key, now_ms);
+            } else if due {
+                published += self.publish_periodic_key(key, now_ms, source, sink)?;
+                self.advance_deadline(key, now_ms);
+            }
+        }
+        Ok(published)
+    }
+
+    /// Force-publish every periodic key now, ignoring deadlines.
+    /// Returns the count.
+    pub fn publish_now<S, K>(
+        &mut self,
+        now_ms: u64,
+        source: &mut S,
+        sink: &mut K,
+    ) -> Result<usize, TelemetryError>
+    where
+        S: MetricsSource,
+        K: PublishSink,
+    {
+        if !self.running {
+            return Err(TelemetryError::NotRunning);
+        }
+        let mut published = 0usize;
+        for &key in METRIC_KEYS.iter() {
+            if !key.is_periodic() {
+                continue;
+            }
+            let enabled = self.keys.get(&key).map(|k| k.enabled).unwrap_or(false);
+            if !enabled {
+                continue;
+            }
+            published += self.publish_periodic_key(key, now_ms, source, sink)?;
+            self.advance_deadline(key, now_ms);
+        }
+        Ok(published)
+    }
+
+    fn publish_periodic_key<S, K>(
+        &mut self,
+        key: MetricKey,
+        now_ms: u64,
+        source: &mut S,
+        sink: &mut K,
+    ) -> Result<usize, TelemetryError>
+    where
+        S: MetricsSource,
+        K: PublishSink,
+    {
+        match key {
+            MetricKey::Cpu => self.publish_cpu(now_ms, source, sink),
+            MetricKey::Mem => self.publish_mem(source, sink),
+            MetricKey::Inference => self.publish_inference(source, sink),
+            // Periodic dispatch never reaches event-driven keys.
+            MetricKey::Log | MetricKey::AuditFingerprint => Ok(0),
+        }
+    }
+
+    fn publish_event_key<S, K>(
+        &mut self,
+        key: MetricKey,
+        _now_ms: u64,
+        source: &mut S,
+        sink: &mut K,
+    ) -> Result<usize, TelemetryError>
+    where
+        S: MetricsSource,
+        K: PublishSink,
+    {
+        match key {
+            MetricKey::Log => self.publish_logs(source, sink),
+            MetricKey::AuditFingerprint => self.publish_audit_fingerprint(source, sink),
+            MetricKey::Cpu | MetricKey::Mem | MetricKey::Inference => Ok(0),
+        }
+    }
+
+    fn publish_cpu<S, K>(
+        &mut self,
+        _now_ms: u64,
+        source: &mut S,
+        sink: &mut K,
+    ) -> Result<usize, TelemetryError>
+    where
+        S: MetricsSource,
+        K: PublishSink,
+    {
+        let stat: CpuStat = source.cpu();
+        let metric = stat.peak_util_pct();
+        // Cadence reacts AFTER we capture this sample so the next
+        // deadline reflects the latest reading.
+        if let Some(ks) = self.keys.get_mut(&MetricKey::Cpu) {
+            let _ = ks.cadence.update(metric);
+        }
+        let body = encode(&stat.to_json());
+        sink.publish(PublishRecord {
+            keyspace: MetricKey::Cpu.keyspace(),
+            body,
+        })?;
+        Ok(1)
+    }
+
+    fn publish_mem<S, K>(&mut self, source: &mut S, sink: &mut K) -> Result<usize, TelemetryError>
+    where
+        S: MetricsSource,
+        K: PublishSink,
+    {
+        let stat: MemStat = source.mem();
+        let body = encode(&stat.to_json());
+        sink.publish(PublishRecord {
+            keyspace: MetricKey::Mem.keyspace(),
+            body,
+        })?;
+        Ok(1)
+    }
+
+    fn publish_inference<S, K>(
+        &mut self,
+        source: &mut S,
+        sink: &mut K,
+    ) -> Result<usize, TelemetryError>
+    where
+        S: MetricsSource,
+        K: PublishSink,
+    {
+        let per_model: Vec<InferenceStat> = source.inference();
+        let stat = source.mem();
+        let body = encode(&inference_stats_to_json(stat.ts_ns, &per_model));
+        sink.publish(PublishRecord {
+            keyspace: MetricKey::Inference.keyspace(),
+            body,
+        })?;
+        Ok(1)
+    }
+
+    fn publish_logs<S, K>(&mut self, source: &mut S, sink: &mut K) -> Result<usize, TelemetryError>
+    where
+        S: MetricsSource,
+        K: PublishSink,
+    {
+        let drained: Vec<LogRecord> = source.drain_logs(self.log_drain_max_per_tick);
+        let mut count = 0usize;
+        for record in drained {
+            let body = encode(&record.to_json());
+            sink.publish(PublishRecord {
+                keyspace: MetricKey::Log.keyspace(),
+                body,
+            })?;
+            count += 1;
+        }
+        Ok(count)
+    }
+
+    fn publish_audit_fingerprint<S, K>(
+        &mut self,
+        source: &mut S,
+        sink: &mut K,
+    ) -> Result<usize, TelemetryError>
+    where
+        S: MetricsSource,
+        K: PublishSink,
+    {
+        if !source.audit_dirty() {
+            return Ok(0);
+        }
+        let Some(fp): Option<AuditFingerprint> = source.audit_fingerprint() else {
+            return Ok(0);
+        };
+        let body = encode(&fp.to_json());
+        sink.publish(PublishRecord {
+            keyspace: MetricKey::AuditFingerprint.keyspace(),
+            body,
+        })?;
+        Ok(1)
+    }
+
+    fn advance_deadline(&mut self, key: MetricKey, now_ms: u64) {
+        if let Some(ks) = self.keys.get_mut(&key) {
+            // Use the current effective interval (post-update for
+            // adaptive keys).
+            let eff: EffectiveCadence = ks.cadence.current();
+            let next = now_ms.saturating_add(eff.interval_ms as u64);
+            // Catch up if we drifted: never schedule the deadline in
+            // the past or the publisher would burn CPU until it
+            // recovered.
+            ks.next_due_ms = next.max(now_ms.saturating_add(eff.interval_ms as u64));
+        }
+    }
+}
+
+impl Default for TelemetryPublisher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ─── Internal helpers on MetricKey ───────────────────────────────────────────
+
+impl MetricKey {
+    /// `true` iff the key publishes only when there is something to
+    /// publish (logs, audit fingerprint).
+    pub const fn is_event_driven(self) -> bool {
+        matches!(self, Self::Log | Self::AuditFingerprint)
+    }
+
+    /// Decode a wire body assuming the key's documented schema. Used
+    /// by tests + by the production verifier to assert the wire
+    /// schema is stable.
+    pub fn decode(self, body: &[u8]) -> Result<JsonValue, TelemetryError> {
+        crate::surface_zenoh::json::decode(body).map_err(|_| TelemetryError::SinkError)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::schema::{LogLevel, PerCpuUtil};
+    use super::super::source::StubMetricsSource;
+    use super::super::DEFAULT_INTERVAL_MS;
+    use super::*;
+    use crate::config::MetricsConfig;
+    use alloc::string::ToString;
+
+    fn quiet_config() -> MetricsConfig {
+        // 1 Hz everywhere so the 1 Hz cadence sanity test is
+        // unambiguous.
+        let mut c = MetricsConfig::v1_defaults();
+        c.cpu_interval_ms = 1000;
+        c.memory_interval_ms = 1000;
+        c.network_interval_ms = 1000;
+        c.inference_interval_ms = 1000;
+        c
+    }
+
+    #[test]
+    fn metric_key_keyspaces_match_spec() {
+        assert_eq!(MetricKey::Cpu.keyspace(), "smallaios/metrics/cpu");
+        assert_eq!(MetricKey::Mem.keyspace(), "smallaios/metrics/mem");
+        assert_eq!(
+            MetricKey::Inference.keyspace(),
+            "smallaios/metrics/inference"
+        );
+        assert_eq!(MetricKey::Log.keyspace(), "smallaios/metrics/log");
+        assert_eq!(
+            MetricKey::AuditFingerprint.keyspace(),
+            "smallaios/metrics/audit_fingerprint"
+        );
+    }
+
+    #[test]
+    fn metric_key_periodic_split() {
+        assert!(MetricKey::Cpu.is_periodic());
+        assert!(MetricKey::Mem.is_periodic());
+        assert!(MetricKey::Inference.is_periodic());
+        assert!(!MetricKey::Log.is_periodic());
+        assert!(!MetricKey::AuditFingerprint.is_periodic());
+    }
+
+    #[test]
+    fn metric_key_event_driven_split() {
+        assert!(!MetricKey::Cpu.is_event_driven());
+        assert!(!MetricKey::Mem.is_event_driven());
+        assert!(!MetricKey::Inference.is_event_driven());
+        assert!(MetricKey::Log.is_event_driven());
+        assert!(MetricKey::AuditFingerprint.is_event_driven());
+    }
+
+    #[test]
+    fn all_returns_five_keys() {
+        assert_eq!(MetricKey::all().len(), 5);
+        assert_eq!(METRIC_KEYS.len(), 5);
+    }
+
+    #[test]
+    fn new_publisher_is_stopped() {
+        let p = TelemetryPublisher::new();
+        assert!(!p.is_running());
+    }
+
+    #[test]
+    fn start_engages_publisher_and_initialises_keys() {
+        let mut p = TelemetryPublisher::new();
+        p.start(&quiet_config(), 0).unwrap();
+        assert!(p.is_running());
+        // All 5 keys present.
+        for &k in METRIC_KEYS.iter() {
+            assert!(p.cadence(k).is_some());
+        }
+    }
+
+    #[test]
+    fn start_twice_returns_already_running() {
+        let mut p = TelemetryPublisher::new();
+        p.start(&quiet_config(), 0).unwrap();
+        let err = p.start(&quiet_config(), 0).unwrap_err();
+        assert_eq!(err, TelemetryError::AlreadyRunning);
+    }
+
+    #[test]
+    fn start_below_floor_rejected() {
+        let mut c = MetricsConfig::v1_defaults();
+        c.cpu_interval_ms = 50;
+        let mut p = TelemetryPublisher::new();
+        let err = p.start(&c, 0).unwrap_err();
+        assert_eq!(err, TelemetryError::IntervalBelowFloor);
+        assert!(!p.is_running());
+    }
+
+    #[test]
+    fn start_above_ceiling_rejected() {
+        let mut c = MetricsConfig::v1_defaults();
+        c.memory_interval_ms = 60_001;
+        let mut p = TelemetryPublisher::new();
+        let err = p.start(&c, 0).unwrap_err();
+        assert_eq!(err, TelemetryError::IntervalAboveCeiling);
+    }
+
+    #[test]
+    fn stop_disables_publisher() {
+        let mut p = TelemetryPublisher::new();
+        p.start(&quiet_config(), 0).unwrap();
+        p.stop();
+        assert!(!p.is_running());
+    }
+
+    #[test]
+    fn stop_then_start_resumes() {
+        let mut p = TelemetryPublisher::new();
+        p.start(&quiet_config(), 0).unwrap();
+        p.stop();
+        // Resume.
+        p.start(&quiet_config(), 5_000).unwrap();
+        assert!(p.is_running());
+        // Deadlines reset relative to the new start time.
+        assert_eq!(p.next_due_ms(MetricKey::Cpu), Some(6_000));
+    }
+
+    #[test]
+    fn publish_now_against_stopped_returns_not_running() {
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        let mut sink = CapturingSink::new();
+        let err = p.publish_now(0, &mut src, &mut sink).unwrap_err();
+        assert_eq!(err, TelemetryError::NotRunning);
+    }
+
+    #[test]
+    fn publish_now_emits_three_periodic_records() {
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        let mut sink = CapturingSink::new();
+        p.start(&quiet_config(), 0).unwrap();
+        let n = p.publish_now(0, &mut src, &mut sink).unwrap();
+        assert_eq!(n, 3);
+        assert_eq!(sink.records.len(), 3);
+    }
+
+    #[test]
+    fn publish_now_records_each_key_exactly_once() {
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        let mut sink = CapturingSink::new();
+        p.start(&quiet_config(), 0).unwrap();
+        p.publish_now(0, &mut src, &mut sink).unwrap();
+        assert_eq!(sink.for_key("smallaios/metrics/cpu").len(), 1);
+        assert_eq!(sink.for_key("smallaios/metrics/mem").len(), 1);
+        assert_eq!(sink.for_key("smallaios/metrics/inference").len(), 1);
+    }
+
+    #[test]
+    fn tick_does_nothing_when_stopped() {
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        let mut sink = CapturingSink::new();
+        let n = p.tick(0, &mut src, &mut sink).unwrap();
+        assert_eq!(n, 0);
+        assert!(sink.is_empty());
+    }
+
+    #[test]
+    fn tick_below_deadline_publishes_nothing_periodic() {
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        let mut sink = CapturingSink::new();
+        p.start(&quiet_config(), 0).unwrap();
+        // 999 ms < 1000 ms deadline.
+        let n = p.tick(999, &mut src, &mut sink).unwrap();
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn tick_at_deadline_publishes_periodic_keys() {
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        let mut sink = CapturingSink::new();
+        p.start(&quiet_config(), 0).unwrap();
+        let n = p.tick(1000, &mut src, &mut sink).unwrap();
+        assert_eq!(n, 3); // cpu + mem + inference
+    }
+
+    #[test]
+    fn tick_advances_deadlines_to_next_window() {
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        let mut sink = CapturingSink::new();
+        p.start(&quiet_config(), 0).unwrap();
+        p.tick(1000, &mut src, &mut sink).unwrap();
+        assert_eq!(p.next_due_ms(MetricKey::Cpu), Some(2000));
+    }
+
+    #[test]
+    fn five_second_window_yields_five_cpu_publications_at_1_hz() {
+        // Spec scenario "Default 1 Hz cadence": exactly once per
+        // 1000 ms.
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        let mut sink = CapturingSink::new();
+        p.start(&quiet_config(), 0).unwrap();
+        for ms in (0..=5000).step_by(100) {
+            p.tick(ms, &mut src, &mut sink).unwrap();
+        }
+        let cpu = sink.for_key("smallaios/metrics/cpu").len();
+        // Deadlines: 1000, 2000, 3000, 4000, 5000 → 5 publications.
+        assert_eq!(cpu, 5);
+    }
+
+    #[test]
+    fn ten_hz_inference_override_yields_50_publications_in_5s() {
+        // Spec scenario "Operator tunes inference cadence":
+        // metrics.inference.interval_ms = 100 → 10 Hz.
+        let mut c = quiet_config();
+        c.inference_interval_ms = 100;
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        let mut sink = CapturingSink::new();
+        p.start(&c, 0).unwrap();
+        for ms in (0..=5000).step_by(50) {
+            p.tick(ms, &mut src, &mut sink).unwrap();
+        }
+        let inference = sink.for_key("smallaios/metrics/inference").len();
+        assert_eq!(inference, 50);
+    }
+
+    #[test]
+    fn cpu_publication_round_trips_per_core_array() {
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        src.set_cpu(CpuStat {
+            ts_ns: 1,
+            per_core: alloc::vec![
+                PerCpuUtil { id: 0, util_pct: 1 },
+                PerCpuUtil { id: 1, util_pct: 2 },
+                PerCpuUtil { id: 2, util_pct: 3 },
+                PerCpuUtil { id: 3, util_pct: 4 },
+            ],
+        });
+        let mut sink = CapturingSink::new();
+        p.start(&quiet_config(), 0).unwrap();
+        p.publish_now(0, &mut src, &mut sink).unwrap();
+        let recs = sink.for_key("smallaios/metrics/cpu");
+        assert_eq!(recs.len(), 1);
+        let parsed = MetricKey::Cpu.decode(recs[0].body.as_bytes()).unwrap();
+        let arr = match parsed.get("per_core").unwrap() {
+            JsonValue::Array(a) => a,
+            _ => panic!("array expected"),
+        };
+        assert_eq!(arr.len(), 4);
+    }
+
+    #[test]
+    fn mem_publication_round_trips_all_fields() {
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        src.set_mem(MemStat {
+            ts_ns: 999,
+            heap_used_bytes: 4096,
+            heap_cap_bytes: 8192,
+            page_alloc_count: 11,
+            page_free_count: 9,
+        });
+        let mut sink = CapturingSink::new();
+        p.start(&quiet_config(), 0).unwrap();
+        p.publish_now(0, &mut src, &mut sink).unwrap();
+        let recs = sink.for_key("smallaios/metrics/mem");
+        let parsed = MetricKey::Mem.decode(recs[0].body.as_bytes()).unwrap();
+        assert_eq!(
+            parsed.get("heap_used_bytes").unwrap().as_int().unwrap(),
+            4096
+        );
+    }
+
+    #[test]
+    fn inference_publication_round_trips_per_model_array() {
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        src.set_inference(alloc::vec![
+            InferenceStat {
+                name: "a".to_string(),
+                qps: 10,
+                p50_us: 100,
+                p99_us: 200,
+                error_count: 0,
+            },
+            InferenceStat {
+                name: "b".to_string(),
+                qps: 5,
+                p50_us: 50,
+                p99_us: 75,
+                error_count: 1,
+            },
+        ]);
+        let mut sink = CapturingSink::new();
+        p.start(&quiet_config(), 0).unwrap();
+        p.publish_now(0, &mut src, &mut sink).unwrap();
+        let recs = sink.for_key("smallaios/metrics/inference");
+        let parsed = MetricKey::Inference
+            .decode(recs[0].body.as_bytes())
+            .unwrap();
+        let arr = match parsed.get("per_model").unwrap() {
+            JsonValue::Array(a) => a,
+            _ => panic!(),
+        };
+        assert_eq!(arr.len(), 2);
+    }
+
+    #[test]
+    fn log_records_drained_on_tick() {
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        src.push_log(LogLevel::Info, "t", "first");
+        src.push_log(LogLevel::Warn, "t", "second");
+        let mut sink = CapturingSink::new();
+        p.start(&quiet_config(), 0).unwrap();
+        p.tick(0, &mut src, &mut sink).unwrap();
+        let logs = sink.for_key("smallaios/metrics/log");
+        assert_eq!(logs.len(), 2);
+        assert_eq!(src.log_pending(), 0);
+    }
+
+    #[test]
+    fn log_drain_respects_per_tick_cap() {
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        for i in 0..200 {
+            src.push_log(LogLevel::Info, "t", &alloc::format!("m{}", i));
+        }
+        let mut sink = CapturingSink::new();
+        p.set_log_drain_max_per_tick(10);
+        p.start(&quiet_config(), 0).unwrap();
+        p.tick(0, &mut src, &mut sink).unwrap();
+        assert_eq!(sink.for_key("smallaios/metrics/log").len(), 10);
+        assert_eq!(src.log_pending(), 190);
+    }
+
+    #[test]
+    fn log_drain_cap_clamps_to_one() {
+        let mut p = TelemetryPublisher::new();
+        p.set_log_drain_max_per_tick(0);
+        // log_drain_max_per_tick is private; observe via behaviour.
+        let mut src = StubMetricsSource::new();
+        for _ in 0..3 {
+            src.push_log(LogLevel::Info, "t", "x");
+        }
+        let mut sink = CapturingSink::new();
+        p.start(&quiet_config(), 0).unwrap();
+        p.tick(0, &mut src, &mut sink).unwrap();
+        assert_eq!(sink.for_key("smallaios/metrics/log").len(), 1);
+    }
+
+    #[test]
+    fn log_drain_cap_clamps_to_max_1024() {
+        let mut p = TelemetryPublisher::new();
+        p.set_log_drain_max_per_tick(usize::MAX);
+        let mut src = StubMetricsSource::new();
+        for _ in 0..2000 {
+            src.push_log(LogLevel::Info, "t", "x");
+        }
+        let mut sink = CapturingSink::new();
+        p.start(&quiet_config(), 0).unwrap();
+        p.tick(0, &mut src, &mut sink).unwrap();
+        assert_eq!(sink.for_key("smallaios/metrics/log").len(), 1024);
+    }
+
+    #[test]
+    fn audit_fingerprint_silent_when_chain_empty() {
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        let mut sink = CapturingSink::new();
+        p.start(&quiet_config(), 0).unwrap();
+        p.tick(0, &mut src, &mut sink).unwrap();
+        assert!(sink
+            .for_key("smallaios/metrics/audit_fingerprint")
+            .is_empty());
+    }
+
+    #[test]
+    fn audit_fingerprint_publishes_on_first_record() {
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        src.push_audit("aabb", 1);
+        let mut sink = CapturingSink::new();
+        p.start(&quiet_config(), 0).unwrap();
+        p.tick(0, &mut src, &mut sink).unwrap();
+        let fps = sink.for_key("smallaios/metrics/audit_fingerprint");
+        assert_eq!(fps.len(), 1);
+    }
+
+    #[test]
+    fn audit_fingerprint_skipped_when_clean() {
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        src.push_audit("aabb", 1);
+        let mut sink = CapturingSink::new();
+        p.start(&quiet_config(), 0).unwrap();
+        p.tick(0, &mut src, &mut sink).unwrap();
+        sink.clear();
+        // Second tick — no new audit records.
+        p.tick(0, &mut src, &mut sink).unwrap();
+        assert!(sink
+            .for_key("smallaios/metrics/audit_fingerprint")
+            .is_empty());
+    }
+
+    #[test]
+    fn audit_fingerprint_publishes_again_after_new_record() {
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        src.push_audit("aa", 1);
+        let mut sink = CapturingSink::new();
+        p.start(&quiet_config(), 0).unwrap();
+        p.tick(0, &mut src, &mut sink).unwrap();
+        // Second record → fingerprint changes.
+        src.push_audit("bb", 2);
+        sink.clear();
+        p.tick(0, &mut src, &mut sink).unwrap();
+        let fps = sink.for_key("smallaios/metrics/audit_fingerprint");
+        assert_eq!(fps.len(), 1);
+        let parsed = MetricKey::AuditFingerprint
+            .decode(fps[0].body.as_bytes())
+            .unwrap();
+        assert_eq!(
+            parsed.get("hex_fingerprint").unwrap().as_str().unwrap(),
+            "bb"
+        );
+        assert_eq!(parsed.get("record_count").unwrap().as_int().unwrap(), 2);
+    }
+
+    #[test]
+    fn adaptive_cpu_engages_on_threshold_cross() {
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        let mut sink = CapturingSink::new();
+        p.start_with_adaptive(&quiet_config(), 0, Some(AdaptiveCadence::new(80, 10, 1)))
+            .unwrap();
+        // Below threshold → slow tier.
+        src.set_cpu(CpuStat {
+            ts_ns: 0,
+            per_core: alloc::vec![PerCpuUtil {
+                id: 0,
+                util_pct: 50,
+            }],
+        });
+        p.tick(1000, &mut src, &mut sink).unwrap();
+        // After tick the cadence should still be slow.
+        let cur = p.cadence(MetricKey::Cpu).unwrap().current();
+        assert!(!cur.fast_tier);
+        assert_eq!(cur.interval_ms, 1000);
+
+        // Above threshold → fast tier.
+        src.set_cpu(CpuStat {
+            ts_ns: 0,
+            per_core: alloc::vec![PerCpuUtil {
+                id: 0,
+                util_pct: 95,
+            }],
+        });
+        p.tick(2000, &mut src, &mut sink).unwrap();
+        let cur = p.cadence(MetricKey::Cpu).unwrap().current();
+        assert!(cur.fast_tier);
+        assert_eq!(cur.interval_ms, 100);
+    }
+
+    #[test]
+    fn adaptive_cpu_reverts_to_slow_below_threshold() {
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        let mut sink = CapturingSink::new();
+        p.start_with_adaptive(&quiet_config(), 0, Some(AdaptiveCadence::new(80, 10, 1)))
+            .unwrap();
+        src.set_cpu(CpuStat {
+            ts_ns: 0,
+            per_core: alloc::vec![PerCpuUtil {
+                id: 0,
+                util_pct: 95,
+            }],
+        });
+        p.tick(1000, &mut src, &mut sink).unwrap();
+        assert!(p.cadence(MetricKey::Cpu).unwrap().current().fast_tier);
+        // Drop below.
+        src.set_cpu(CpuStat {
+            ts_ns: 0,
+            per_core: alloc::vec![PerCpuUtil {
+                id: 0,
+                util_pct: 30,
+            }],
+        });
+        p.tick(2000, &mut src, &mut sink).unwrap();
+        assert!(!p.cadence(MetricKey::Cpu).unwrap().current().fast_tier);
+    }
+
+    #[test]
+    fn adaptive_fast_tier_publishes_at_10hz() {
+        let mut c = quiet_config();
+        c.cpu_interval_ms = 1000;
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        // Engage fast tier from the start by setting the metric.
+        src.set_cpu(CpuStat {
+            ts_ns: 0,
+            per_core: alloc::vec![PerCpuUtil {
+                id: 0,
+                util_pct: 99,
+            }],
+        });
+        let mut sink = CapturingSink::new();
+        p.start_with_adaptive(&c, 0, Some(AdaptiveCadence::new(80, 10, 1)))
+            .unwrap();
+        // Force the first publication to lock in the fast tier.
+        p.publish_now(0, &mut src, &mut sink).unwrap();
+        sink.clear();
+        for ms in 100..=1100 {
+            if ms % 10 == 0 {
+                p.tick(ms, &mut src, &mut sink).unwrap();
+            }
+        }
+        // Approximately 10 publications in the 1000ms window. The
+        // exact value can be 10 or 11 depending on alignment of the
+        // first deadline; assert a reasonable range.
+        let cpu = sink.for_key("smallaios/metrics/cpu").len();
+        assert!(
+            (9..=11).contains(&cpu),
+            "expected ~10 cpu publications, got {}",
+            cpu
+        );
+    }
+
+    #[test]
+    fn set_cadence_takes_effect_after_next_tick() {
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        let mut sink = CapturingSink::new();
+        p.start(&quiet_config(), 0).unwrap();
+        p.set_cadence(MetricKey::Cpu, CadenceState::fixed(500))
+            .unwrap();
+        // Advance to first publication then reset.
+        p.tick(1000, &mut src, &mut sink).unwrap();
+        sink.clear();
+        // Now at 500ms cadence: advance by 500ms, expect 1 cpu pub.
+        p.tick(1500, &mut src, &mut sink).unwrap();
+        assert_eq!(sink.for_key("smallaios/metrics/cpu").len(), 1);
+    }
+
+    #[test]
+    fn set_cadence_below_floor_rejected() {
+        let mut p = TelemetryPublisher::new();
+        p.start(&quiet_config(), 0).unwrap();
+        let err = p
+            .set_cadence(MetricKey::Cpu, CadenceState::fixed(50))
+            .unwrap_err();
+        assert_eq!(err, TelemetryError::IntervalBelowFloor);
+    }
+
+    #[test]
+    fn set_cadence_when_stopped_returns_not_running() {
+        let mut p = TelemetryPublisher::new();
+        let err = p
+            .set_cadence(MetricKey::Cpu, CadenceState::fixed(1000))
+            .unwrap_err();
+        assert_eq!(err, TelemetryError::NotRunning);
+    }
+
+    #[test]
+    fn disable_key_suppresses_periodic_publication() {
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        let mut sink = CapturingSink::new();
+        p.start(&quiet_config(), 0).unwrap();
+        p.disable_key(MetricKey::Cpu);
+        for ms in (0..=5000).step_by(100) {
+            p.tick(ms, &mut src, &mut sink).unwrap();
+        }
+        assert!(sink.for_key("smallaios/metrics/cpu").is_empty());
+        // Other periodic keys still publish.
+        assert_eq!(sink.for_key("smallaios/metrics/mem").len(), 5);
+    }
+
+    #[test]
+    fn enable_key_resets_deadline_relative_to_now() {
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        let mut sink = CapturingSink::new();
+        p.start(&quiet_config(), 0).unwrap();
+        p.disable_key(MetricKey::Cpu);
+        p.tick(2000, &mut src, &mut sink).unwrap();
+        sink.clear();
+        p.enable_key(MetricKey::Cpu, 2000);
+        assert_eq!(p.next_due_ms(MetricKey::Cpu), Some(3000));
+    }
+
+    #[test]
+    fn periodic_publish_tracks_drift_after_late_tick() {
+        // If the cooperative scheduler is late, the publisher
+        // SHALL not schedule the next deadline in the past.
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        let mut sink = CapturingSink::new();
+        p.start(&quiet_config(), 0).unwrap();
+        // Fire a tick 5s late. The publisher emits one record (it
+        // does not catch up multiple intervals) and reschedules
+        // based on now_ms + interval.
+        p.tick(5000, &mut src, &mut sink).unwrap();
+        assert_eq!(p.next_due_ms(MetricKey::Cpu), Some(6000));
+    }
+
+    #[test]
+    fn record_keyspace_is_static_str() {
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        let mut sink = CapturingSink::new();
+        p.start(&quiet_config(), 0).unwrap();
+        p.publish_now(0, &mut src, &mut sink).unwrap();
+        // All keyspaces match METRIC_KEYS entries (compile-time
+        // static strings).
+        for r in &sink.records {
+            let mut found = false;
+            for &k in METRIC_KEYS.iter() {
+                if r.keyspace == k.keyspace() {
+                    found = true;
+                    break;
+                }
+            }
+            assert!(found, "unknown keyspace {}", r.keyspace);
+        }
+    }
+
+    #[test]
+    fn publisher_does_not_publish_log_when_no_records() {
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        let mut sink = CapturingSink::new();
+        p.start(&quiet_config(), 0).unwrap();
+        p.tick(1000, &mut src, &mut sink).unwrap();
+        assert!(sink.for_key("smallaios/metrics/log").is_empty());
+    }
+
+    #[test]
+    fn default_publisher_has_drain_cap_64() {
+        assert_eq!(TelemetryPublisher::DEFAULT_LOG_DRAIN_PER_TICK, 64);
+    }
+
+    #[test]
+    fn custom_drain_cap_round_trips() {
+        let mut p = TelemetryPublisher::new();
+        let mut src = StubMetricsSource::new();
+        for _ in 0..100 {
+            src.push_log(LogLevel::Info, "t", "x");
+        }
+        let mut sink = CapturingSink::new();
+        p.set_log_drain_max_per_tick(50);
+        p.start(&quiet_config(), 0).unwrap();
+        p.tick(0, &mut src, &mut sink).unwrap();
+        assert_eq!(sink.for_key("smallaios/metrics/log").len(), 50);
+    }
+
+    #[test]
+    fn cadence_returns_none_for_unknown_key_after_stop() {
+        let mut p = TelemetryPublisher::new();
+        // Before start, no keys initialised.
+        assert!(p.cadence(MetricKey::Cpu).is_none());
+        p.start(&quiet_config(), 0).unwrap();
+        assert!(p.cadence(MetricKey::Cpu).is_some());
+    }
+
+    #[test]
+    fn next_due_ms_for_unknown_key_is_none_before_start() {
+        let p = TelemetryPublisher::new();
+        assert!(p.next_due_ms(MetricKey::Mem).is_none());
+    }
+
+    #[test]
+    fn default_interval_constant_matches_spec() {
+        assert_eq!(DEFAULT_INTERVAL_MS, 1000);
+    }
+}

--- a/mgmt/src/surface_zenoh/telemetry/schema.rs
+++ b/mgmt/src/surface_zenoh/telemetry/schema.rs
@@ -1,0 +1,452 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Strongly-typed metric records and their JSON projections.
+//!
+//! Spec:
+//! `openspec/changes/management-login-v1/specs/mgmt-zenoh-telemetry/spec.md`
+//! Requirement "Telemetry keyspace schema".
+//!
+//! Every record has a `to_json` method that yields a
+//! [`super::super::json::JsonValue::Object`] in the shape the spec
+//! mandates. The schema is **additive** — new optional fields may be
+//! appended; existing fields SHALL NOT be renamed or repurposed.
+
+use alloc::collections::BTreeMap;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use super::super::json::JsonValue;
+
+// ─── CPU ─────────────────────────────────────────────────────────────────────
+
+/// Per-core CPU utilisation sample.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PerCpuUtil {
+    /// Logical core id (0-based).
+    pub id: u32,
+    /// Utilisation in `0..=100` percent.
+    pub util_pct: u32,
+}
+
+impl PerCpuUtil {
+    /// Project to a flat JSON object.
+    pub fn to_json(&self) -> JsonValue {
+        let mut m = BTreeMap::new();
+        m.insert("id".to_string(), JsonValue::from(self.id));
+        m.insert("util_pct".to_string(), JsonValue::from(self.util_pct));
+        JsonValue::Object(m)
+    }
+}
+
+/// `smallaios/metrics/cpu` payload — `{ ts, per_core: [...] }`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CpuStat {
+    /// Wall-clock timestamp in nanoseconds since UNIX epoch (or
+    /// monotonic-since-boot when no RTC is available).
+    pub ts_ns: u64,
+    /// Per-core utilisation samples in core-id order.
+    pub per_core: Vec<PerCpuUtil>,
+}
+
+impl CpuStat {
+    /// Project to the on-wire JSON shape.
+    pub fn to_json(&self) -> JsonValue {
+        let mut m = BTreeMap::new();
+        m.insert("ts".to_string(), JsonValue::from(self.ts_ns));
+        let arr: Vec<JsonValue> = self.per_core.iter().map(PerCpuUtil::to_json).collect();
+        m.insert("per_core".to_string(), JsonValue::Array(arr));
+        JsonValue::Object(m)
+    }
+
+    /// Highest `util_pct` observed in this sample. Returns `0` when
+    /// `per_core` is empty.
+    pub fn peak_util_pct(&self) -> u32 {
+        self.per_core.iter().map(|c| c.util_pct).max().unwrap_or(0)
+    }
+}
+
+// ─── Memory ──────────────────────────────────────────────────────────────────
+
+/// `smallaios/metrics/mem` payload —
+/// `{ ts, heap_used_bytes, heap_cap_bytes, page_alloc_count, page_free_count }`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MemStat {
+    /// Timestamp (ns since epoch).
+    pub ts_ns: u64,
+    /// Bytes currently in use by the kernel heap.
+    pub heap_used_bytes: u64,
+    /// Total heap capacity in bytes.
+    pub heap_cap_bytes: u64,
+    /// Cumulative page allocations since boot.
+    pub page_alloc_count: u64,
+    /// Cumulative page frees since boot.
+    pub page_free_count: u64,
+}
+
+impl MemStat {
+    /// Project to JSON.
+    pub fn to_json(&self) -> JsonValue {
+        let mut m = BTreeMap::new();
+        m.insert("ts".to_string(), JsonValue::from(self.ts_ns));
+        m.insert(
+            "heap_used_bytes".to_string(),
+            JsonValue::from(self.heap_used_bytes),
+        );
+        m.insert(
+            "heap_cap_bytes".to_string(),
+            JsonValue::from(self.heap_cap_bytes),
+        );
+        m.insert(
+            "page_alloc_count".to_string(),
+            JsonValue::from(self.page_alloc_count),
+        );
+        m.insert(
+            "page_free_count".to_string(),
+            JsonValue::from(self.page_free_count),
+        );
+        JsonValue::Object(m)
+    }
+}
+
+// ─── Inference ───────────────────────────────────────────────────────────────
+
+/// Per-model inference statistics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InferenceStat {
+    /// Model name (matches the `/models/<name>.onnx` basename).
+    pub name: String,
+    /// Queries-per-second over the most recent sample window.
+    pub qps: u32,
+    /// p50 inference latency in microseconds.
+    pub p50_us: u32,
+    /// p99 inference latency in microseconds.
+    pub p99_us: u32,
+    /// Cumulative error count.
+    pub error_count: u64,
+}
+
+impl InferenceStat {
+    /// Project to JSON.
+    pub fn to_json(&self) -> JsonValue {
+        let mut m = BTreeMap::new();
+        m.insert("name".to_string(), JsonValue::String(self.name.clone()));
+        m.insert("qps".to_string(), JsonValue::from(self.qps));
+        m.insert("p50_us".to_string(), JsonValue::from(self.p50_us));
+        m.insert("p99_us".to_string(), JsonValue::from(self.p99_us));
+        m.insert("error_count".to_string(), JsonValue::from(self.error_count));
+        JsonValue::Object(m)
+    }
+}
+
+/// Build the wrapper `{ ts, per_model: [...] }` payload for
+/// `smallaios/metrics/inference`.
+pub fn inference_stats_to_json(ts_ns: u64, per_model: &[InferenceStat]) -> JsonValue {
+    let mut m = BTreeMap::new();
+    m.insert("ts".to_string(), JsonValue::from(ts_ns));
+    let arr: Vec<JsonValue> = per_model.iter().map(InferenceStat::to_json).collect();
+    m.insert("per_model".to_string(), JsonValue::Array(arr));
+    JsonValue::Object(m)
+}
+
+// ─── Logs ────────────────────────────────────────────────────────────────────
+
+/// Severity of a `smallaios/metrics/log` record. Mirrors the
+/// five-level `tracing` ladder.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogLevel {
+    /// Verbose internal traces.
+    Trace,
+    /// Routine debug output.
+    Debug,
+    /// Informational messages.
+    Info,
+    /// Warning conditions.
+    Warn,
+    /// Error conditions.
+    Error,
+}
+
+impl LogLevel {
+    /// Static lowercase name used on the wire.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Trace => "trace",
+            Self::Debug => "debug",
+            Self::Info => "info",
+            Self::Warn => "warn",
+            Self::Error => "error",
+        }
+    }
+}
+
+/// A single structured log record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogRecord {
+    /// Wall-clock timestamp (ns since epoch).
+    pub ts_ns: u64,
+    /// Severity.
+    pub level: LogLevel,
+    /// `tracing`-style target (module path).
+    pub target: String,
+    /// Human-readable message.
+    pub msg: String,
+    /// Structured key-value pairs. Values are coerced to JSON strings
+    /// to keep the wire schema flat — callers SHALL pre-format
+    /// numbers if they want them numeric.
+    pub fields: Vec<(String, String)>,
+}
+
+impl LogRecord {
+    /// Project to JSON.
+    pub fn to_json(&self) -> JsonValue {
+        let mut m = BTreeMap::new();
+        m.insert("ts".to_string(), JsonValue::from(self.ts_ns));
+        m.insert(
+            "level".to_string(),
+            JsonValue::String(self.level.as_str().to_string()),
+        );
+        m.insert("target".to_string(), JsonValue::String(self.target.clone()));
+        m.insert("msg".to_string(), JsonValue::String(self.msg.clone()));
+        let mut fields = BTreeMap::new();
+        for (k, v) in &self.fields {
+            fields.insert(k.clone(), JsonValue::String(v.clone()));
+        }
+        m.insert("fields".to_string(), JsonValue::Object(fields));
+        JsonValue::Object(m)
+    }
+}
+
+// ─── Audit fingerprint ───────────────────────────────────────────────────────
+
+/// `smallaios/metrics/audit_fingerprint` payload —
+/// `{ ts, hex_fingerprint, record_count }`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditFingerprint {
+    /// Timestamp (ns since epoch).
+    pub ts_ns: u64,
+    /// Lowercase-hex SHA-3-256 chain head (64 chars). The all-zeroes
+    /// fingerprint represents an empty chain.
+    pub hex_fingerprint: String,
+    /// Cumulative count of audit records committed to the chain.
+    pub record_count: u64,
+}
+
+impl AuditFingerprint {
+    /// Project to JSON.
+    pub fn to_json(&self) -> JsonValue {
+        let mut m = BTreeMap::new();
+        m.insert("ts".to_string(), JsonValue::from(self.ts_ns));
+        m.insert(
+            "hex_fingerprint".to_string(),
+            JsonValue::String(self.hex_fingerprint.clone()),
+        );
+        m.insert(
+            "record_count".to_string(),
+            JsonValue::from(self.record_count),
+        );
+        JsonValue::Object(m)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::json::{decode, encode};
+    use super::*;
+
+    fn round_trip(v: &JsonValue) -> JsonValue {
+        let s = encode(v);
+        decode(s.as_bytes()).unwrap()
+    }
+
+    #[test]
+    fn cpu_stat_round_trip_preserves_per_core() {
+        let s = CpuStat {
+            ts_ns: 12_345_678,
+            per_core: alloc::vec![
+                PerCpuUtil {
+                    id: 0,
+                    util_pct: 12,
+                },
+                PerCpuUtil {
+                    id: 1,
+                    util_pct: 88,
+                },
+            ],
+        };
+        let v = s.to_json();
+        let back = round_trip(&v);
+        let obj = back.as_object().unwrap();
+        assert_eq!(obj.get("ts").unwrap().as_int().unwrap(), 12_345_678);
+        let per_core = match obj.get("per_core").unwrap() {
+            JsonValue::Array(a) => a,
+            _ => panic!("per_core must be array"),
+        };
+        assert_eq!(per_core.len(), 2);
+        let core1 = per_core[1].as_object().unwrap();
+        assert_eq!(core1.get("id").unwrap().as_int().unwrap(), 1);
+        assert_eq!(core1.get("util_pct").unwrap().as_int().unwrap(), 88);
+    }
+
+    #[test]
+    fn cpu_stat_peak_util_pct_picks_max() {
+        let s = CpuStat {
+            ts_ns: 0,
+            per_core: alloc::vec![
+                PerCpuUtil { id: 0, util_pct: 5 },
+                PerCpuUtil {
+                    id: 1,
+                    util_pct: 90,
+                },
+                PerCpuUtil {
+                    id: 2,
+                    util_pct: 50,
+                },
+            ],
+        };
+        assert_eq!(s.peak_util_pct(), 90);
+    }
+
+    #[test]
+    fn cpu_stat_peak_util_pct_empty_returns_zero() {
+        let s = CpuStat {
+            ts_ns: 0,
+            per_core: alloc::vec![],
+        };
+        assert_eq!(s.peak_util_pct(), 0);
+    }
+
+    #[test]
+    fn cpu_stat_emits_four_cores_when_supplied() {
+        let s = CpuStat {
+            ts_ns: 1,
+            per_core: (0..4)
+                .map(|i| PerCpuUtil {
+                    id: i,
+                    util_pct: 10 * i,
+                })
+                .collect(),
+        };
+        let v = s.to_json();
+        let arr = match v.get("per_core").unwrap() {
+            JsonValue::Array(a) => a,
+            _ => panic!("expected array"),
+        };
+        assert_eq!(arr.len(), 4);
+    }
+
+    #[test]
+    fn mem_stat_round_trip_preserves_all_fields() {
+        let s = MemStat {
+            ts_ns: 999,
+            heap_used_bytes: 1024,
+            heap_cap_bytes: 8192,
+            page_alloc_count: 10,
+            page_free_count: 5,
+        };
+        let v = s.to_json();
+        let back = round_trip(&v);
+        let obj = back.as_object().unwrap();
+        assert_eq!(obj.get("ts").unwrap().as_int().unwrap(), 999);
+        assert_eq!(obj.get("heap_used_bytes").unwrap().as_int().unwrap(), 1024);
+        assert_eq!(obj.get("heap_cap_bytes").unwrap().as_int().unwrap(), 8192);
+        assert_eq!(obj.get("page_alloc_count").unwrap().as_int().unwrap(), 10);
+        assert_eq!(obj.get("page_free_count").unwrap().as_int().unwrap(), 5);
+    }
+
+    #[test]
+    fn inference_stat_round_trip_preserves_name_and_metrics() {
+        let s = InferenceStat {
+            name: "resnet50".to_string(),
+            qps: 200,
+            p50_us: 1500,
+            p99_us: 9000,
+            error_count: 2,
+        };
+        let v = s.to_json();
+        let back = round_trip(&v);
+        let obj = back.as_object().unwrap();
+        assert_eq!(obj.get("name").unwrap().as_str().unwrap(), "resnet50");
+        assert_eq!(obj.get("qps").unwrap().as_int().unwrap(), 200);
+        assert_eq!(obj.get("p50_us").unwrap().as_int().unwrap(), 1500);
+        assert_eq!(obj.get("p99_us").unwrap().as_int().unwrap(), 9000);
+        assert_eq!(obj.get("error_count").unwrap().as_int().unwrap(), 2);
+    }
+
+    #[test]
+    fn inference_wrapper_emits_per_model_array() {
+        let stats = alloc::vec![
+            InferenceStat {
+                name: "a".to_string(),
+                qps: 1,
+                p50_us: 1,
+                p99_us: 1,
+                error_count: 0,
+            },
+            InferenceStat {
+                name: "b".to_string(),
+                qps: 2,
+                p50_us: 2,
+                p99_us: 2,
+                error_count: 0,
+            },
+        ];
+        let v = inference_stats_to_json(123, &stats);
+        let obj = v.as_object().unwrap();
+        assert_eq!(obj.get("ts").unwrap().as_int().unwrap(), 123);
+        let arr = match obj.get("per_model").unwrap() {
+            JsonValue::Array(a) => a,
+            _ => panic!("array expected"),
+        };
+        assert_eq!(arr.len(), 2);
+    }
+
+    #[test]
+    fn log_level_renders_lowercase() {
+        assert_eq!(LogLevel::Trace.as_str(), "trace");
+        assert_eq!(LogLevel::Debug.as_str(), "debug");
+        assert_eq!(LogLevel::Info.as_str(), "info");
+        assert_eq!(LogLevel::Warn.as_str(), "warn");
+        assert_eq!(LogLevel::Error.as_str(), "error");
+    }
+
+    #[test]
+    fn log_record_round_trip_preserves_fields() {
+        let r = LogRecord {
+            ts_ns: 42,
+            level: LogLevel::Warn,
+            target: "kernel::sched".to_string(),
+            msg: "queue contention".to_string(),
+            fields: alloc::vec![
+                ("queue".to_string(), "core1".to_string()),
+                ("depth".to_string(), "17".to_string()),
+            ],
+        };
+        let back = round_trip(&r.to_json());
+        let obj = back.as_object().unwrap();
+        assert_eq!(obj.get("level").unwrap().as_str().unwrap(), "warn");
+        assert_eq!(
+            obj.get("target").unwrap().as_str().unwrap(),
+            "kernel::sched"
+        );
+        let f = obj.get("fields").unwrap().as_object().unwrap();
+        assert_eq!(f.get("queue").unwrap().as_str().unwrap(), "core1");
+        assert_eq!(f.get("depth").unwrap().as_str().unwrap(), "17");
+    }
+
+    #[test]
+    fn audit_fingerprint_round_trip_preserves_hex() {
+        let f = AuditFingerprint {
+            ts_ns: 100,
+            hex_fingerprint: "deadbeef".to_string(),
+            record_count: 7,
+        };
+        let back = round_trip(&f.to_json());
+        let obj = back.as_object().unwrap();
+        assert_eq!(
+            obj.get("hex_fingerprint").unwrap().as_str().unwrap(),
+            "deadbeef"
+        );
+        assert_eq!(obj.get("record_count").unwrap().as_int().unwrap(), 7);
+    }
+}

--- a/mgmt/src/surface_zenoh/telemetry/source.rs
+++ b/mgmt/src/surface_zenoh/telemetry/source.rs
@@ -1,0 +1,272 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Source of metric samples consumed by the telemetry publisher.
+//!
+//! `MetricsSource` is the seam between the in-kernel counters
+//! (kernel-side phase, not Phase 8) and the Zenoh telemetry surface.
+//! Phase 8 ships:
+//!
+//! - the trait,
+//! - a [`StubMetricsSource`] used by tests + integration smoke,
+//! - a [`PendingLogs`] FIFO and [`PendingAudit`] latest-fingerprint
+//!   slot the trait exposes for event-driven keys.
+//!
+//! Production wiring (a `KernelMetricsSource`) lands in a future
+//! `kernel-stats` phase.
+
+use alloc::collections::VecDeque;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+
+use super::schema::{AuditFingerprint, CpuStat, InferenceStat, LogLevel, LogRecord, MemStat};
+
+/// Source of metric samples. Each periodic key has a dedicated getter
+/// returning the **current** sample. Event-driven keys (`log`,
+/// `audit_fingerprint`) read from FIFO / slot accessors that the
+/// publisher drains on each pass.
+///
+/// All methods are infallible — sources are expected to fall back to
+/// safe defaults (zeros, empty slices) when the underlying counter is
+/// not yet initialised.
+pub trait MetricsSource {
+    /// Per-core CPU utilisation snapshot.
+    fn cpu(&self) -> CpuStat;
+
+    /// Memory snapshot.
+    fn mem(&self) -> MemStat;
+
+    /// Per-model inference snapshot.
+    fn inference(&self) -> Vec<InferenceStat>;
+
+    /// Drain pending log records. The implementation SHALL return at
+    /// most `max` records and remove the returned ones from any
+    /// internal queue. Order SHALL be FIFO.
+    fn drain_logs(&mut self, max: usize) -> Vec<LogRecord>;
+
+    /// Latest audit fingerprint. Returns `None` if the chain is empty
+    /// (no records have been committed). The publisher uses this
+    /// alongside [`Self::audit_dirty`] to decide whether to publish.
+    fn audit_fingerprint(&self) -> Option<AuditFingerprint>;
+
+    /// Has the audit fingerprint changed since the last call?
+    /// Implementations SHALL clear the dirty flag when this returns
+    /// `true`. Used by the publisher's event-driven sweep so a flat
+    /// chain is not republished every tick.
+    fn audit_dirty(&mut self) -> bool;
+}
+
+// ─── Stub source ─────────────────────────────────────────────────────────────
+
+/// Synthetic metric source — drives unit tests and the integration
+/// smoke binary. Mutating helpers let tests inject specific samples
+/// then poke the publisher.
+#[derive(Debug, Default)]
+pub struct StubMetricsSource {
+    /// Current CPU stat. Tests overwrite this directly; the sample
+    /// returned from [`MetricsSource::cpu`] is a clone.
+    pub cpu: CpuStat,
+    /// Current mem stat.
+    pub mem: MemStat,
+    /// Per-model inference stats.
+    pub inference: Vec<InferenceStat>,
+    /// Pending log records, FIFO. [`MetricsSource::drain_logs`] pops
+    /// from the front.
+    pub logs: VecDeque<LogRecord>,
+    /// Latest audit fingerprint. `None` means the chain is empty.
+    pub audit: Option<AuditFingerprint>,
+    /// Set by [`Self::set_audit`] / [`Self::push_audit`]; cleared by
+    /// [`MetricsSource::audit_dirty`] when the publisher reads it.
+    audit_dirty_flag: bool,
+}
+
+impl StubMetricsSource {
+    /// Construct a fresh stub with empty samples.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Replace the current CPU sample.
+    pub fn set_cpu(&mut self, cpu: CpuStat) {
+        self.cpu = cpu;
+    }
+
+    /// Replace the current mem sample.
+    pub fn set_mem(&mut self, mem: MemStat) {
+        self.mem = mem;
+    }
+
+    /// Replace the per-model inference list.
+    pub fn set_inference(&mut self, stats: Vec<InferenceStat>) {
+        self.inference = stats;
+    }
+
+    /// Push a log record onto the FIFO.
+    pub fn push_log(&mut self, level: LogLevel, target: &str, msg: &str) {
+        self.logs.push_back(LogRecord {
+            ts_ns: 0,
+            level,
+            target: target.to_string(),
+            msg: msg.to_string(),
+            fields: Vec::new(),
+        });
+    }
+
+    /// Push a structured log record with explicit `ts_ns` + fields.
+    pub fn push_log_record(&mut self, record: LogRecord) {
+        self.logs.push_back(record);
+    }
+
+    /// Set the latest audit fingerprint and mark the dirty flag.
+    pub fn set_audit(&mut self, fp: AuditFingerprint) {
+        self.audit = Some(fp);
+        self.audit_dirty_flag = true;
+    }
+
+    /// Update only the chain head + record count, reusing the last
+    /// timestamp. Convenience for tests that simulate appending audit
+    /// records.
+    pub fn push_audit(&mut self, hex_fingerprint: &str, record_count: u64) {
+        let ts = self.audit.as_ref().map(|a| a.ts_ns).unwrap_or(0);
+        self.set_audit(AuditFingerprint {
+            ts_ns: ts,
+            hex_fingerprint: hex_fingerprint.to_string(),
+            record_count,
+        });
+    }
+
+    /// Number of pending log records.
+    pub fn log_pending(&self) -> usize {
+        self.logs.len()
+    }
+}
+
+impl MetricsSource for StubMetricsSource {
+    fn cpu(&self) -> CpuStat {
+        self.cpu.clone()
+    }
+
+    fn mem(&self) -> MemStat {
+        self.mem
+    }
+
+    fn inference(&self) -> Vec<InferenceStat> {
+        self.inference.clone()
+    }
+
+    fn drain_logs(&mut self, max: usize) -> Vec<LogRecord> {
+        let take = max.min(self.logs.len());
+        let mut out = Vec::with_capacity(take);
+        for _ in 0..take {
+            if let Some(r) = self.logs.pop_front() {
+                out.push(r);
+            }
+        }
+        out
+    }
+
+    fn audit_fingerprint(&self) -> Option<AuditFingerprint> {
+        self.audit.clone()
+    }
+
+    fn audit_dirty(&mut self) -> bool {
+        let v = self.audit_dirty_flag;
+        self.audit_dirty_flag = false;
+        v
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::schema::PerCpuUtil;
+    use super::*;
+
+    #[test]
+    fn stub_returns_cloned_cpu_sample() {
+        let mut s = StubMetricsSource::new();
+        s.set_cpu(CpuStat {
+            ts_ns: 1,
+            per_core: alloc::vec![PerCpuUtil {
+                id: 0,
+                util_pct: 42,
+            }],
+        });
+        let snap = s.cpu();
+        assert_eq!(snap.peak_util_pct(), 42);
+    }
+
+    #[test]
+    fn drain_logs_respects_fifo_order() {
+        let mut s = StubMetricsSource::new();
+        s.push_log(LogLevel::Info, "t", "first");
+        s.push_log(LogLevel::Warn, "t", "second");
+        s.push_log(LogLevel::Error, "t", "third");
+        let drained = s.drain_logs(10);
+        assert_eq!(drained.len(), 3);
+        assert_eq!(drained[0].msg, "first");
+        assert_eq!(drained[1].msg, "second");
+        assert_eq!(drained[2].msg, "third");
+        assert_eq!(s.log_pending(), 0);
+    }
+
+    #[test]
+    fn drain_logs_caps_at_max() {
+        let mut s = StubMetricsSource::new();
+        for i in 0..10 {
+            s.push_log(LogLevel::Info, "t", &alloc::format!("m{}", i));
+        }
+        let drained = s.drain_logs(3);
+        assert_eq!(drained.len(), 3);
+        assert_eq!(drained[0].msg, "m0");
+        assert_eq!(s.log_pending(), 7);
+    }
+
+    #[test]
+    fn drain_logs_zero_max_returns_empty() {
+        let mut s = StubMetricsSource::new();
+        s.push_log(LogLevel::Info, "t", "x");
+        let drained = s.drain_logs(0);
+        assert!(drained.is_empty());
+        assert_eq!(s.log_pending(), 1);
+    }
+
+    #[test]
+    fn audit_dirty_set_and_cleared_on_read() {
+        let mut s = StubMetricsSource::new();
+        assert!(!s.audit_dirty());
+        s.push_audit("abc", 1);
+        assert!(s.audit_dirty());
+        // Second call clears.
+        assert!(!s.audit_dirty());
+    }
+
+    #[test]
+    fn audit_fingerprint_starts_empty() {
+        let s = StubMetricsSource::new();
+        assert!(s.audit_fingerprint().is_none());
+    }
+
+    #[test]
+    fn audit_push_increments_record_count() {
+        let mut s = StubMetricsSource::new();
+        s.push_audit("aa", 1);
+        s.push_audit("bb", 2);
+        let fp = s.audit_fingerprint().unwrap();
+        assert_eq!(fp.hex_fingerprint, "bb");
+        assert_eq!(fp.record_count, 2);
+    }
+
+    #[test]
+    fn inference_stats_default_empty() {
+        let s = StubMetricsSource::new();
+        assert!(s.inference().is_empty());
+    }
+
+    #[test]
+    fn mem_default_zero() {
+        let s = StubMetricsSource::new();
+        let m = s.mem();
+        assert_eq!(m.heap_used_bytes, 0);
+        assert_eq!(m.heap_cap_bytes, 0);
+    }
+}

--- a/mgmt/src/surface_zenoh/telemetry/telemetry_test_vectors.rs
+++ b/mgmt/src/surface_zenoh/telemetry/telemetry_test_vectors.rs
@@ -1,0 +1,221 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Test fixtures for the Zenoh telemetry surface — sample audit
+// fingerprints, canonical CPU/mem/inference snapshots, sample log
+// records. Lives in a `*_test_vectors.rs` file so CodeQL's byte-array
+// / hex-constant scanners (`paths-ignored` rule in
+// `.github/codeql/codeql-config.yml`) skip the file. Production code
+// never references these constants; only `#[cfg(test)]` consumers in
+// this module tree do.
+
+#![cfg(test)]
+
+use alloc::string::ToString;
+use alloc::vec;
+
+use super::schema::{
+    AuditFingerprint, CpuStat, InferenceStat, LogLevel, LogRecord, MemStat, PerCpuUtil,
+};
+
+/// Worked-example all-zeroes fingerprint used to exercise the empty
+/// chain path. Not a real fingerprint for any production audit chain.
+pub const SAMPLE_FINGERPRINT_ZERO_HEX: &str =
+    "0000000000000000000000000000000000000000000000000000000000000000";
+
+/// Worked-example "deadbeef" prefix fingerprint used to assert the
+/// publisher's hex pass-through. The last 56 chars are arbitrary
+/// padding.
+pub const SAMPLE_FINGERPRINT_DEADBEEF_HEX: &str =
+    "deadbeefcafebabefeedfacedeadbeefcafebabefeedfacedeadbeefcafebabe";
+
+/// Construct a 4-core CPU sample with monotonically rising util_pct.
+/// Used by the schema round-trip test to assert per-core ordering is
+/// preserved by the JSON codec.
+pub fn sample_cpu_stat_4core(ts_ns: u64) -> CpuStat {
+    CpuStat {
+        ts_ns,
+        per_core: vec![
+            PerCpuUtil {
+                id: 0,
+                util_pct: 10,
+            },
+            PerCpuUtil {
+                id: 1,
+                util_pct: 25,
+            },
+            PerCpuUtil {
+                id: 2,
+                util_pct: 50,
+            },
+            PerCpuUtil {
+                id: 3,
+                util_pct: 75,
+            },
+        ],
+    }
+}
+
+/// Construct a memory sample with arbitrary-but-stable counters.
+pub fn sample_mem_stat() -> MemStat {
+    MemStat {
+        ts_ns: 1_700_000_000_000_000_000,
+        heap_used_bytes: 4 * 1024 * 1024,
+        heap_cap_bytes: 16 * 1024 * 1024,
+        page_alloc_count: 1024,
+        page_free_count: 512,
+    }
+}
+
+/// Construct two inference-stat fixtures.
+pub fn sample_inference_stats() -> alloc::vec::Vec<InferenceStat> {
+    vec![
+        InferenceStat {
+            name: "resnet50".to_string(),
+            qps: 250,
+            p50_us: 1500,
+            p99_us: 9500,
+            error_count: 0,
+        },
+        InferenceStat {
+            name: "yolov8n".to_string(),
+            qps: 60,
+            p50_us: 5000,
+            p99_us: 32000,
+            error_count: 3,
+        },
+    ]
+}
+
+/// Construct a log record with structured fields.
+pub fn sample_log_record() -> LogRecord {
+    LogRecord {
+        ts_ns: 42_000_000,
+        level: LogLevel::Warn,
+        target: "kernel::sched".to_string(),
+        msg: "queue contention".to_string(),
+        fields: vec![
+            ("queue".to_string(), "core1".to_string()),
+            ("depth".to_string(), "17".to_string()),
+        ],
+    }
+}
+
+/// Construct an audit fingerprint fixture using the deadbeef sample.
+pub fn sample_audit_fingerprint() -> AuditFingerprint {
+    AuditFingerprint {
+        ts_ns: 1_700_000_000_000_000_000,
+        hex_fingerprint: SAMPLE_FINGERPRINT_DEADBEEF_HEX.to_string(),
+        record_count: 1024,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::publisher::{CapturingSink, MetricKey, PublishSink, TelemetryPublisher};
+    use super::super::source::StubMetricsSource;
+    use super::*;
+    use crate::config::MetricsConfig;
+    use crate::surface_zenoh::json::{decode, JsonValue};
+
+    #[test]
+    fn cpu_fixture_has_four_cores() {
+        let s = sample_cpu_stat_4core(1);
+        assert_eq!(s.per_core.len(), 4);
+        assert_eq!(s.peak_util_pct(), 75);
+    }
+
+    #[test]
+    fn mem_fixture_capacity_exceeds_used() {
+        let m = sample_mem_stat();
+        assert!(m.heap_cap_bytes > m.heap_used_bytes);
+    }
+
+    #[test]
+    fn inference_fixture_has_two_models() {
+        let s = sample_inference_stats();
+        assert_eq!(s.len(), 2);
+        assert_eq!(s[0].name, "resnet50");
+        assert_eq!(s[1].name, "yolov8n");
+    }
+
+    #[test]
+    fn log_fixture_has_two_fields() {
+        let r = sample_log_record();
+        assert_eq!(r.fields.len(), 2);
+    }
+
+    #[test]
+    fn fingerprint_zero_constant_is_64_chars() {
+        assert_eq!(SAMPLE_FINGERPRINT_ZERO_HEX.len(), 64);
+    }
+
+    #[test]
+    fn fingerprint_deadbeef_constant_is_64_chars() {
+        assert_eq!(SAMPLE_FINGERPRINT_DEADBEEF_HEX.len(), 64);
+    }
+
+    #[test]
+    fn full_round_trip_of_cpu_fixture_through_publisher() {
+        // End-to-end: stub source → publisher → capturing sink → JSON
+        // decode → assert per_core length matches fixture.
+        let mut src = StubMetricsSource::new();
+        src.set_cpu(sample_cpu_stat_4core(1_700_000_000_000_000_000));
+        let mut sink = CapturingSink::new();
+        let mut p = TelemetryPublisher::new();
+        let cfg = MetricsConfig::v1_defaults();
+        p.start(&cfg, 0).unwrap();
+        p.publish_now(0, &mut src, &mut sink).unwrap();
+        let recs = sink.for_key("smallaios/metrics/cpu");
+        assert_eq!(recs.len(), 1);
+        let parsed = decode(recs[0].body.as_bytes()).unwrap();
+        let arr = match parsed.get("per_core").unwrap() {
+            JsonValue::Array(a) => a,
+            _ => panic!(),
+        };
+        assert_eq!(arr.len(), 4);
+    }
+
+    #[test]
+    fn audit_fingerprint_fixture_round_trips() {
+        let fp = sample_audit_fingerprint();
+        let v = fp.to_json();
+        let s = crate::surface_zenoh::json::encode(&v);
+        let back = decode(s.as_bytes()).unwrap();
+        let obj = back.as_object().unwrap();
+        assert_eq!(
+            obj.get("hex_fingerprint").unwrap().as_str().unwrap(),
+            SAMPLE_FINGERPRINT_DEADBEEF_HEX
+        );
+        assert_eq!(obj.get("record_count").unwrap().as_int().unwrap(), 1024);
+    }
+
+    #[test]
+    fn audit_fingerprint_zero_fixture_round_trips() {
+        let fp = AuditFingerprint {
+            ts_ns: 0,
+            hex_fingerprint: SAMPLE_FINGERPRINT_ZERO_HEX.to_string(),
+            record_count: 0,
+        };
+        let v = fp.to_json();
+        let s = crate::surface_zenoh::json::encode(&v);
+        let back = decode(s.as_bytes()).unwrap();
+        let obj = back.as_object().unwrap();
+        assert_eq!(
+            obj.get("hex_fingerprint").unwrap().as_str().unwrap(),
+            SAMPLE_FINGERPRINT_ZERO_HEX
+        );
+    }
+
+    #[test]
+    fn capturing_sink_round_trips_records() {
+        let mut sink = CapturingSink::new();
+        let r = super::super::publisher::PublishRecord {
+            keyspace: MetricKey::Cpu.keyspace(),
+            body: "{}".to_string(),
+        };
+        sink.publish(r.clone()).unwrap();
+        assert_eq!(sink.len(), 1);
+        assert_eq!(sink.records[0], r);
+    }
+}

--- a/openspec/changes/management-login-v1/tasks.md
+++ b/openspec/changes/management-login-v1/tasks.md
@@ -99,12 +99,12 @@
 
 ## 8. Phase 8 — Zenoh telemetry
 
-- [ ] 8.1 `mgmt/src/telemetry.rs` — publishers for `cpu`, `mem`, `inference`, `log`, `audit_fingerprint`
-- [ ] 8.2 Per-key configurable cadence (`metrics.<key>.interval_ms`), bounds 100 ms–60 s
-- [ ] 8.3 Adaptive cadence (`metrics.<key>.adaptive = { threshold, fast_hz, slow_hz }`)
-- [ ] 8.4 Schema round-trip tests (each metric publishes and parses cleanly)
-- [ ] 8.5 Adaptive-mode test (cross threshold → fast_hz, fall below → slow_hz)
-- [ ] 8.6 Log streaming integration with existing `tracing` / `defmt` infrastructure
+- [x] 8.1 `mgmt/src/surface_zenoh/telemetry/` — publishers for `cpu`, `mem`, `inference`, `log`, `audit_fingerprint` (sibling to `surface_zenoh/admin.rs`; transport-agnostic via `PublishSink` trait)
+- [x] 8.2 Per-key configurable cadence (`metrics.<key>.interval_ms`), bounds 100 ms–60 s (`telemetry::validate_interval_ms`, `clamp_interval`)
+- [x] 8.3 Adaptive cadence (`metrics.<key>.adaptive = { threshold, fast_hz, slow_hz }`) (`telemetry::cadence::AdaptiveCadence` + `CadenceState::adaptive`)
+- [x] 8.4 Schema round-trip tests (each metric publishes and parses cleanly) (`schema::tests::*_round_trip_*`, `publisher::tests::*_publication_round_trips_*`)
+- [x] 8.5 Adaptive-mode test (cross threshold → fast_hz, fall below → slow_hz) (`publisher::tests::adaptive_cpu_*`)
+- [ ] 8.6 Log streaming integration with existing `tracing` / `defmt` infrastructure [DEFERRED — `tracing`/`defmt` adapters land alongside the kernel-side `KernelMetricsSource` in a future `kernel-stats` phase; Phase 8 ships the `LogRecord` schema, the `MetricsSource::drain_logs` hook, and the `StubMetricsSource` fixture used by tests]
 
 ## 9. Phase 9 — TOTP
 


### PR DESCRIPTION
## Summary

Phase 8 of `management-login-v1`. Adds five Zenoh telemetry streams alongside the Phase 7 admin keyspace.

- Five publishers at `smallaios/metrics/{cpu,mem,inference,log,audit_fingerprint}` with 1 Hz default cadence (configurable per key 100 ms–60 s).
- Adaptive cadence: `>threshold → fast_hz`, `≤threshold → slow_hz` per spec Q23.
- `MetricsSource` trait + `StubMetricsSource` (synthetic data for tests/integration; production-side `KernelMetricsSource` deferred to a future kernel-stats phase).
- 8 new files under `mgmt/src/surface_zenoh/telemetry/` (~2,685 LOC: schema, source, cadence, publisher, errors, test_vectors, mod, parent module wiring).
- 95 new tests; **387/387** mgmt lib tests pass (was 292).

## Deviations

- **Task 8.6** (`tracing`/`defmt` integration) is DEFERRED — Phase 8 ships the `LogRecord` schema and `MetricsSource::drain_logs` hook + `StubMetricsSource` fixture used by tests; the actual `tracing`/`defmt` adapters land alongside `KernelMetricsSource` in a future kernel-stats phase.
- `TelemetryPublisher` is transport-agnostic by design (mirrors `AdminDispatcher`); production wiring to a real `zenoh::Session` happens in the future glue phase. Tests + integration use a `Vec`-backed `CapturingSink`.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `just clippy` `-D warnings` clean.
- [x] `cargo test -p smallaios-mgmt --lib` — 387/387.
- [x] `cargo vet check` Vetting Succeeded (no new deps).
- [x] `openspec validate management-login-v1 --strict` clean.
- [x] `just build-kernel-arm` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Phase 8 telemetry subsystem supporting metrics publication for CPU, memory, inference, logs, and audit fingerprints.
  * Implemented adaptive cadence resolution for metrics with configurable thresholds and publishing intervals.
  * Introduced transport-agnostic publishing framework with configurable interval validation and clamping.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SmallAIOS/SmallAIOS/pull/179)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->