### PR TITLE
refactor(onnx-rt): reduce cognitive complexity below 15 on cuda dispatch + conv + kernels

### DIFF
--- a/onnx-rt/src/cuda/conv.rs
+++ b/onnx-rt/src/cuda/conv.rs
@@ -194,6 +194,261 @@ impl Drop for ConvDesc {
     }
 }
 
+/// Selected cuDNN dtype configuration for a 2-D convolution.
+///
+/// Encapsulates the BF16-vs-F32 fork so [`gpu_conv2d`] does not have to
+/// re-branch on `is_bf16` for each downstream concern (descriptor dtype,
+/// element size, output tensor dtype, bias path).
+struct ConvDtype {
+    is_bf16: bool,
+    dnn_dtype: ffi::cudnnDataType_t,
+    elem_size: usize,
+    out_data_type: DataType,
+}
+
+impl ConvDtype {
+    /// Choose the cuDNN dtype config for the given input + weight tensors.
+    ///
+    /// Returns `None` if the dtype combination is not supported (mixed
+    /// dtypes, or anything other than `Float`/`BFloat16`).
+    fn pick(input: &Tensor, weight: &Tensor) -> Option<Self> {
+        let is_bf16 =
+            input.data_type == DataType::BFloat16 && weight.data_type == DataType::BFloat16;
+        if !is_bf16 && (input.data_type != DataType::Float || weight.data_type != DataType::Float) {
+            return None;
+        }
+        let (dnn_dtype, elem_size, out_data_type) = if is_bf16 {
+            (
+                ffi::cudnnDataType_t::CUDNN_DATA_BFLOAT16,
+                2usize,
+                DataType::BFloat16,
+            )
+        } else {
+            (
+                ffi::cudnnDataType_t::CUDNN_DATA_FLOAT,
+                4usize,
+                DataType::Float,
+            )
+        };
+        Some(Self {
+            is_bf16,
+            dnn_dtype,
+            elem_size,
+            out_data_type,
+        })
+    }
+}
+
+/// Validated shape parameters for a 2-D convolution.
+struct ConvParams {
+    n: i32,
+    c_in: i32,
+    h_in: i32,
+    w_in: i32,
+    k: i32,
+    c_w: i32,
+    kh: i32,
+    kw: i32,
+    pad_h: i32,
+    pad_w: i32,
+    stride_h: i32,
+    stride_w: i32,
+    dil_h: i32,
+    dil_w: i32,
+    h_out: i32,
+    w_out: i32,
+}
+
+/// Parse a `Conv` attribute pair into `(h, w)` with `default` if missing.
+fn pair_or(values: &[i32], default: i32) -> (i32, i32) {
+    let h = values.first().copied().unwrap_or(default);
+    let w = values.get(1).copied().unwrap_or(default);
+    (h, w)
+}
+
+impl ConvParams {
+    /// Validate shapes and compute output dimensions for a 2-D conv.
+    ///
+    /// Returns `None` if the configuration is unsupported (non-4D inputs,
+    /// invalid group, non-positive output). The cuDNN dispatcher falls
+    /// back to CPU on `None`.
+    fn build(
+        input: &Tensor,
+        weight: &Tensor,
+        pads: &[i32],
+        strides: &[i32],
+        dilations: &[i32],
+        group: i32,
+    ) -> Option<Self> {
+        let x_dims = &input.shape.dims;
+        let w_dims = &weight.shape.dims;
+        if x_dims.len() != 4 || w_dims.len() != 4 || group < 1 {
+            return None;
+        }
+
+        let n = x_dims[0] as i32;
+        let c_in = x_dims[1] as i32;
+        let h_in = x_dims[2] as i32;
+        let w_in = x_dims[3] as i32;
+
+        let k = w_dims[0] as i32;
+        let c_w = w_dims[1] as i32;
+        let kh = w_dims[2] as i32;
+        let kw = w_dims[3] as i32;
+
+        if c_in != c_w * group || k % group != 0 {
+            return None;
+        }
+
+        // Padding supports both 2-element [h, w] and 4-element [t, l, b, r] forms.
+        let (pad_h, pad_w) = if pads.len() >= 2 {
+            (pads[0], pads[1])
+        } else {
+            (0, 0)
+        };
+        let (stride_h, stride_w) = pair_or(strides, 1);
+        let (dil_h, dil_w) = pair_or(dilations, 1);
+
+        let h_out = (h_in + 2 * pad_h - dil_h * (kh - 1) - 1) / stride_h + 1;
+        let w_out = (w_in + 2 * pad_w - dil_w * (kw - 1) - 1) / stride_w + 1;
+        if h_out <= 0 || w_out <= 0 {
+            return None;
+        }
+        Some(Self {
+            n,
+            c_in,
+            h_in,
+            w_in,
+            k,
+            c_w,
+            kh,
+            kw,
+            pad_h,
+            pad_w,
+            stride_h,
+            stride_w,
+            dil_h,
+            dil_w,
+            h_out,
+            w_out,
+        })
+    }
+}
+
+/// Decode the bias tensor (F32 or BF16) to an F32 vector of length `k`.
+///
+/// Returns an empty vector if the bias dtype or byte length does not
+/// match what we expect — the caller treats that as "skip the bias add",
+/// matching the original byte-for-byte behaviour.
+fn decode_bias_to_f32(bias: &Tensor, k: usize) -> Vec<f32> {
+    match bias.data_type {
+        DataType::Float if bias.raw_data.len() == k * 4 => bias
+            .raw_data
+            .chunks_exact(4)
+            .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+            .collect(),
+        DataType::BFloat16 if bias.raw_data.len() == k * 2 => {
+            crate::tensor::bf16_to_f32(&bias.raw_data)
+        }
+        _ => Vec::new(),
+    }
+}
+
+/// In-place add `bias` to one F32 channel slab inside `result_bytes`.
+fn add_bias_channel_f32(result_bytes: &mut [u8], base: usize, spatial: usize, add: f32) {
+    for s in 0..spatial {
+        let offset = (base + s) * 4;
+        let val = f32::from_le_bytes([
+            result_bytes[offset],
+            result_bytes[offset + 1],
+            result_bytes[offset + 2],
+            result_bytes[offset + 3],
+        ]);
+        let biased = val + add;
+        result_bytes[offset..offset + 4].copy_from_slice(&biased.to_le_bytes());
+    }
+}
+
+/// In-place add `bias` to one BF16 channel slab inside `result_bytes`.
+fn add_bias_channel_bf16(result_bytes: &mut [u8], base: usize, spatial: usize, add: f32) {
+    for s in 0..spatial {
+        let offset = (base + s) * 2;
+        let lo = result_bytes[offset] as u32;
+        let hi = result_bytes[offset + 1] as u32;
+        let bits = ((hi << 8) | lo) << 16;
+        let val = f32::from_bits(bits) + add;
+        let enc = f32_to_bf16(&[val]);
+        result_bytes[offset] = enc[0];
+        result_bytes[offset + 1] = enc[1];
+    }
+}
+
+/// Apply per-channel bias on the host-side conv output.
+///
+/// Skips silently if the bias element count or dtype does not match the
+/// expected `[k]` shape — the original code did the same.
+fn apply_bias(result_bytes: &mut [u8], bias: &Tensor, params: &ConvParams, is_bf16: bool) {
+    let k = params.k as usize;
+    if bias.shape.total_elements() != k {
+        return;
+    }
+    let bias_f32 = decode_bias_to_f32(bias, k);
+    if bias_f32.len() != k {
+        return;
+    }
+    let spatial = (params.h_out * params.w_out) as usize;
+    for b_idx in 0..params.n as usize {
+        for (c_idx, &add) in bias_f32.iter().enumerate().take(k) {
+            let base = (b_idx * k + c_idx) * spatial;
+            if is_bf16 {
+                add_bias_channel_bf16(result_bytes, base, spatial, add);
+            } else {
+                add_bias_channel_f32(result_bytes, base, spatial, add);
+            }
+        }
+    }
+}
+
+/// Run `cudnnConvolutionForward` on the prepared descriptors / buffers.
+#[allow(clippy::too_many_arguments)]
+fn run_conv_forward(
+    runtime: &CudaRuntime,
+    x_desc: &TensorDesc,
+    w_desc: &FilterDesc,
+    conv_desc: &ConvDesc,
+    y_desc: &TensorDesc,
+    x_buf: &DeviceBuffer,
+    w_buf: &DeviceBuffer,
+    y_buf: &DeviceBuffer,
+) -> Result<(), CudaError> {
+    let alpha: f32 = 1.0;
+    let beta: f32 = 0.0;
+    let err = unsafe {
+        ffi::cudnnConvolutionForward(
+            runtime.cudnn.raw(),
+            &alpha as *const f32 as *const core::ffi::c_void,
+            x_desc.desc,
+            x_buf.as_ptr(),
+            w_desc.desc,
+            w_buf.as_ptr(),
+            conv_desc.desc,
+            ffi::cudnnConvolutionFwdAlgo_t::CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM,
+            core::ptr::null_mut(),
+            0,
+            &beta as *const f32 as *const core::ffi::c_void,
+            y_desc.desc,
+            y_buf.as_mut_ptr(),
+        )
+    };
+    if err != ffi::CUDNN_STATUS_SUCCESS {
+        return Err(CudaError::DnnError {
+            op: "cudnnConvolutionForward",
+            code: err,
+        });
+    }
+    Ok(())
+}
+
 /// Execute a 2D convolution on GPU via cuDNN.
 ///
 /// Input format: NCHW (batch, channels, height, width).
@@ -211,83 +466,52 @@ pub fn gpu_conv2d(
     dilations: &[i32],     // [dilation_h, dilation_w]
     group: i32,
 ) -> Result<Option<Tensor>, CudaError> {
-    let x_dims = &input.shape.dims;
-    let w_dims = &weight.shape.dims;
-
-    if x_dims.len() != 4 || w_dims.len() != 4 {
-        return Ok(None); // Not a 4D conv, fall back to CPU
-    }
-
     // Pick cuDNN I/O dtype. BF16 inputs stay in BF16 end-to-end (f32
     // accumulation in the convolution descriptor); anything else uses the
     // f32 path. Mixed input/weight dtypes fall back to CPU.
-    let is_bf16 = input.data_type == DataType::BFloat16 && weight.data_type == DataType::BFloat16;
-    if !is_bf16 && (input.data_type != DataType::Float || weight.data_type != DataType::Float) {
+    let Some(dtype) = ConvDtype::pick(input, weight) else {
         return Ok(None);
-    }
-    let dnn_dtype = if is_bf16 {
-        ffi::cudnnDataType_t::CUDNN_DATA_BFLOAT16
-    } else {
-        ffi::cudnnDataType_t::CUDNN_DATA_FLOAT
-    };
-    let elem_size: usize = if is_bf16 { 2 } else { 4 };
-    let out_data_type = if is_bf16 {
-        DataType::BFloat16
-    } else {
-        DataType::Float
     };
 
-    let n = x_dims[0] as i32;
-    let c_in = x_dims[1] as i32;
-    let h_in = x_dims[2] as i32;
-    let w_in = x_dims[3] as i32;
-
-    let k = w_dims[0] as i32; // output channels
-    let c_w = w_dims[1] as i32; // c_in / group — filter in-channel count
-    let kh = w_dims[2] as i32;
-    let kw = w_dims[3] as i32;
-
-    // Validate group relationship with input and output channels.
-    if group < 1 {
+    // Validate shapes and compute output dimensions.
+    let Some(params) = ConvParams::build(input, weight, pads, strides, dilations, group) else {
         return Ok(None);
-    }
-    if c_in != c_w * group || k % group != 0 {
-        return Ok(None);
-    }
-
-    // Parse padding (support both 2-element and 4-element forms).
-    let (pad_h, pad_w) = if pads.len() >= 2 {
-        (pads[0], pads[1])
-    } else {
-        (0, 0)
     };
-
-    let stride_h = strides.first().copied().unwrap_or(1);
-    let stride_w = strides.get(1).copied().unwrap_or(1);
-    let dil_h = dilations.first().copied().unwrap_or(1);
-    let dil_w = dilations.get(1).copied().unwrap_or(1);
-
-    // Compute output dimensions.
-    let h_out = (h_in + 2 * pad_h - dil_h * (kh - 1) - 1) / stride_h + 1;
-    let w_out = (w_in + 2 * pad_w - dil_w * (kw - 1) - 1) / stride_w + 1;
-
-    if h_out <= 0 || w_out <= 0 {
-        return Ok(None);
-    }
 
     // Create cuDNN descriptors. Input/filter/output use dnn_dtype (BF16 or
     // f32); the convolution descriptor itself uses f32 accumulation regardless
     // so BF16 inputs get the same accuracy guarantees as BF16 cuBLAS GEMM.
-    let x_desc = TensorDesc::new_4d_dtype(n, c_in, h_in, w_in, dnn_dtype)?;
+    let x_desc = TensorDesc::new_4d_dtype(
+        params.n,
+        params.c_in,
+        params.h_in,
+        params.w_in,
+        dtype.dnn_dtype,
+    )?;
     // Filter descriptor uses per-group input channels (c_w = c_in / group).
-    let w_desc = FilterDesc::new_4d_dtype(k, c_w, kh, kw, dnn_dtype)?;
-    let conv_desc = ConvDesc::new_2d(pad_h, pad_w, stride_h, stride_w, dil_h, dil_w, group)?;
-    let y_desc = TensorDesc::new_4d_dtype(n, k, h_out, w_out, dnn_dtype)?;
+    let w_desc =
+        FilterDesc::new_4d_dtype(params.k, params.c_w, params.kh, params.kw, dtype.dnn_dtype)?;
+    let conv_desc = ConvDesc::new_2d(
+        params.pad_h,
+        params.pad_w,
+        params.stride_h,
+        params.stride_w,
+        params.dil_h,
+        params.dil_w,
+        group,
+    )?;
+    let y_desc = TensorDesc::new_4d_dtype(
+        params.n,
+        params.k,
+        params.h_out,
+        params.w_out,
+        dtype.dnn_dtype,
+    )?;
 
     // Allocate device buffers.
     let x_bytes = input.raw_data.len();
     let w_bytes = weight.raw_data.len();
-    let y_bytes = (n * k * h_out * w_out) as usize * elem_size;
+    let y_bytes = (params.n * params.k * params.h_out * params.w_out) as usize * dtype.elem_size;
 
     let x_buf = DeviceBuffer::alloc(x_bytes)?;
     let w_buf = DeviceBuffer::alloc(w_bytes)?;
@@ -297,33 +521,9 @@ pub fn gpu_conv2d(
     w_buf.copy_from_host(&weight.raw_data)?;
     y_buf.copy_from_host(&vec![0u8; y_bytes])?;
 
-    // Run convolution.
-    let alpha: f32 = 1.0;
-    let beta: f32 = 0.0;
-
-    let err = unsafe {
-        ffi::cudnnConvolutionForward(
-            runtime.cudnn.raw(),
-            &alpha as *const f32 as *const core::ffi::c_void,
-            x_desc.desc,
-            x_buf.as_ptr(),
-            w_desc.desc,
-            w_buf.as_ptr(),
-            conv_desc.desc,
-            ffi::cudnnConvolutionFwdAlgo_t::CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM,
-            core::ptr::null_mut(), // no workspace
-            0,                     // workspace size = 0
-            &beta as *const f32 as *const core::ffi::c_void,
-            y_desc.desc,
-            y_buf.as_mut_ptr(),
-        )
-    };
-    if err != ffi::CUDNN_STATUS_SUCCESS {
-        return Err(CudaError::DnnError {
-            op: "cudnnConvolutionForward",
-            code: err,
-        });
-    }
+    run_conv_forward(
+        runtime, &x_desc, &w_desc, &conv_desc, &y_desc, &x_buf, &w_buf, &y_buf,
+    )?;
 
     super::synchronize()?;
 
@@ -336,61 +536,17 @@ pub fn gpu_conv2d(
     // not directly addable, and the intermediate accumulation is done in f32
     // anyway. For f32 output this matches the original behaviour exactly.
     if let Some(bias_tensor) = bias {
-        let bias_elems = bias_tensor.shape.total_elements();
-        if bias_elems == k as usize {
-            // Decode bias to f32 regardless of its native dtype. BF16 bias
-            // is converted once; f32 bias is read directly.
-            let bias_f32: Vec<f32> = match bias_tensor.data_type {
-                DataType::Float if bias_tensor.raw_data.len() == (k as usize) * 4 => bias_tensor
-                    .raw_data
-                    .chunks_exact(4)
-                    .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
-                    .collect(),
-                DataType::BFloat16 if bias_tensor.raw_data.len() == (k as usize) * 2 => {
-                    crate::tensor::bf16_to_f32(&bias_tensor.raw_data)
-                }
-                _ => Vec::new(),
-            };
-            if bias_f32.len() == k as usize {
-                let spatial = (h_out * w_out) as usize;
-                for b_idx in 0..n as usize {
-                    for (c_idx, &add) in bias_f32.iter().enumerate().take(k as usize) {
-                        let base = (b_idx * k as usize + c_idx) * spatial;
-                        if is_bf16 {
-                            // Decode one BF16 element, add, re-encode.
-                            for s in 0..spatial {
-                                let offset = (base + s) * 2;
-                                let lo = result_bytes[offset] as u32;
-                                let hi = result_bytes[offset + 1] as u32;
-                                let bits = ((hi << 8) | lo) << 16;
-                                let val = f32::from_bits(bits) + add;
-                                let enc = f32_to_bf16(&[val]);
-                                result_bytes[offset] = enc[0];
-                                result_bytes[offset + 1] = enc[1];
-                            }
-                        } else {
-                            for s in 0..spatial {
-                                let offset = (base + s) * 4;
-                                let val = f32::from_le_bytes([
-                                    result_bytes[offset],
-                                    result_bytes[offset + 1],
-                                    result_bytes[offset + 2],
-                                    result_bytes[offset + 3],
-                                ]);
-                                let biased = val + add;
-                                result_bytes[offset..offset + 4]
-                                    .copy_from_slice(&biased.to_le_bytes());
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        apply_bias(&mut result_bytes, bias_tensor, &params, dtype.is_bf16);
     }
 
     Ok(Some(Tensor {
-        data_type: out_data_type,
-        shape: TensorShape::new(vec![n as i64, k as i64, h_out as i64, w_out as i64]),
+        data_type: dtype.out_data_type,
+        shape: TensorShape::new(vec![
+            params.n as i64,
+            params.k as i64,
+            params.h_out as i64,
+            params.w_out as i64,
+        ]),
         name: String::new(),
         raw_data: result_bytes,
     }))

--- a/onnx-rt/src/cuda/dispatch.rs
+++ b/onnx-rt/src/cuda/dispatch.rs
@@ -15,6 +15,114 @@ use super::memory::DeviceBuffer;
 use super::{CudaError, CudaRuntime};
 use crate::tensor::{f32_to_bf16, DataType, Tensor, TensorShape};
 
+/// Output dtype selection for [`gpu_gemm`].
+struct GemmDtype {
+    is_bf16: bool,
+    elem_size: usize,
+    io_dtype: ffi::cudaDataType_t,
+    out_data_type: DataType,
+}
+
+impl GemmDtype {
+    fn pick(a: &Tensor, b: &Tensor) -> Self {
+        let is_bf16 = a.data_type == DataType::BFloat16 && b.data_type == DataType::BFloat16;
+        if is_bf16 {
+            Self {
+                is_bf16,
+                elem_size: 2,
+                io_dtype: ffi::cudaDataType_t::CUDA_R_16BF,
+                out_data_type: DataType::BFloat16,
+            }
+        } else {
+            Self {
+                is_bf16,
+                elem_size: 4,
+                io_dtype: ffi::cudaDataType_t::CUDA_R_32F,
+                out_data_type: DataType::Float,
+            }
+        }
+    }
+}
+
+/// Extract the trailing `[M, K]` (or transposed) dims from a Gemm input.
+fn gemm_mk_dims(dims: &[i64], transpose: bool) -> (usize, usize) {
+    let last = dims.len() - 1;
+    if transpose {
+        (dims[last] as usize, dims[last - 1] as usize)
+    } else {
+        (dims[last - 1] as usize, dims[last] as usize)
+    }
+}
+
+/// Re-encode a bias byte slice into the cuBLAS output dtype.
+///
+/// For BF16 output: F32 bias is converted; BF16 bias is passed through;
+/// anything else is an error. For F32 output the bias is returned as-is
+/// (since the executor only routes F32/BF16 to this path).
+fn encode_bias_for_output(bias: &Tensor, is_bf16: bool) -> Result<alloc::vec::Vec<u8>, CudaError> {
+    if !is_bf16 {
+        return Ok(bias.raw_data.clone());
+    }
+    match bias.data_type {
+        DataType::BFloat16 => Ok(bias.raw_data.clone()),
+        DataType::Float => {
+            let f32_vals: alloc::vec::Vec<f32> = bias
+                .raw_data
+                .chunks_exact(4)
+                .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+                .collect();
+            Ok(f32_to_bf16(&f32_vals))
+        }
+        _ => Err(CudaError::RuntimeError {
+            op: "gpu_gemm: unsupported bias dtype for BF16 output",
+            code: -3,
+        }),
+    }
+}
+
+/// Initialise the cuBLAS C buffer to either a (broadcast) bias or zeros.
+///
+/// Mirrors the original semantics:
+/// - `beta == 0` or no bias → zero-fill.
+/// - bias is `[N]` (row vector) → broadcast across `M` rows.
+/// - bias byte length matches `c_bytes` → copy as-is.
+/// - any other mismatch → zero-fill (silent fallback).
+#[allow(clippy::too_many_arguments)]
+fn init_c_buffer(
+    c_buf: &DeviceBuffer,
+    c_bias: Option<&Tensor>,
+    beta: f32,
+    m: usize,
+    n: usize,
+    c_bytes: usize,
+    elem_size: usize,
+    is_bf16: bool,
+) -> Result<(), CudaError> {
+    if beta == 0.0 {
+        return c_buf.copy_from_host(&vec![0u8; c_bytes]);
+    }
+    let Some(bias) = c_bias else {
+        return c_buf.copy_from_host(&vec![0u8; c_bytes]);
+    };
+
+    let bias_bytes = encode_bias_for_output(bias, is_bf16)?;
+    let bias_elements = bias.shape.total_elements();
+    if bias_elements == n {
+        // Row-broadcast bias vector to full C matrix.
+        let row_bytes = n * elem_size;
+        let mut c_data = vec![0u8; c_bytes];
+        for row in 0..m {
+            let dst_start = row * row_bytes;
+            c_data[dst_start..dst_start + row_bytes].copy_from_slice(&bias_bytes[..row_bytes]);
+        }
+        c_buf.copy_from_host(&c_data)
+    } else if bias_bytes.len() == c_bytes {
+        c_buf.copy_from_host(&bias_bytes)
+    } else {
+        c_buf.copy_from_host(&vec![0u8; c_bytes])
+    }
+}
+
 /// Execute a MatMul/Gemm on GPU via cuBLAS, returning the result tensor.
 ///
 /// Handles 2D matrix multiply: C[M,N] = alpha * op(A)[M,K] * op(B)[K,N] + beta * C_bias.
@@ -40,28 +148,8 @@ pub fn gpu_gemm(
         });
     }
 
-    let (m, k_a) = if trans_a {
-        (
-            a_dims[a_dims.len() - 1] as usize,
-            a_dims[a_dims.len() - 2] as usize,
-        )
-    } else {
-        (
-            a_dims[a_dims.len() - 2] as usize,
-            a_dims[a_dims.len() - 1] as usize,
-        )
-    };
-    let (k_b, n) = if trans_b {
-        (
-            b_dims[b_dims.len() - 1] as usize,
-            b_dims[b_dims.len() - 2] as usize,
-        )
-    } else {
-        (
-            b_dims[b_dims.len() - 2] as usize,
-            b_dims[b_dims.len() - 1] as usize,
-        )
-    };
+    let (m, k_a) = gemm_mk_dims(a_dims, trans_a);
+    let (k_b, n) = gemm_mk_dims(b_dims, trans_b);
 
     if k_a != k_b {
         return Err(CudaError::RuntimeError {
@@ -75,22 +163,11 @@ pub fn gpu_gemm(
     // CUBLAS_COMPUTE_32F_FAST_16BF. Falls back to f32 path for all other
     // (and mixed) input combinations — the executor routes non-f32/non-BF16
     // combinations to the CPU before reaching this function.
-    let is_bf16 = a.data_type == DataType::BFloat16 && b.data_type == DataType::BFloat16;
-    let elem_size = if is_bf16 { 2 } else { 4 };
-    let io_dtype = if is_bf16 {
-        ffi::cudaDataType_t::CUDA_R_16BF
-    } else {
-        ffi::cudaDataType_t::CUDA_R_32F
-    };
-    let out_data_type = if is_bf16 {
-        DataType::BFloat16
-    } else {
-        DataType::Float
-    };
+    let dtype = GemmDtype::pick(a, b);
 
     let a_bytes = a.raw_data.len();
     let b_bytes = b.raw_data.len();
-    let c_bytes = m * n * elem_size;
+    let c_bytes = m * n * dtype.elem_size;
 
     let a_buf = DeviceBuffer::alloc(a_bytes)?;
     let b_buf = DeviceBuffer::alloc(b_bytes)?;
@@ -102,53 +179,16 @@ pub fn gpu_gemm(
     // Initialize C with bias or zeros. For BF16 dispatch the bias must be
     // materialized in BF16 inside the output buffer before the cuBLAS call
     // — convert from f32 if necessary so callers can pass either dtype.
-    if beta != 0.0 {
-        if let Some(bias) = c_bias {
-            // Produce a BF16-or-f32 byte vector matching the output dtype.
-            let bias_bytes_in_out_dtype: alloc::vec::Vec<u8> = if is_bf16 {
-                match bias.data_type {
-                    DataType::BFloat16 => bias.raw_data.clone(),
-                    DataType::Float => {
-                        let f32_vals: alloc::vec::Vec<f32> = bias
-                            .raw_data
-                            .chunks_exact(4)
-                            .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
-                            .collect();
-                        f32_to_bf16(&f32_vals)
-                    }
-                    _ => {
-                        return Err(CudaError::RuntimeError {
-                            op: "gpu_gemm: unsupported bias dtype for BF16 output",
-                            code: -3,
-                        });
-                    }
-                }
-            } else {
-                bias.raw_data.clone()
-            };
-
-            let bias_elements = bias.shape.total_elements();
-            if bias_elements == n {
-                // Row-broadcast bias vector to full C matrix.
-                let row_bytes = n * elem_size;
-                let mut c_data = vec![0u8; c_bytes];
-                for row in 0..m {
-                    let dst_start = row * row_bytes;
-                    c_data[dst_start..dst_start + row_bytes]
-                        .copy_from_slice(&bias_bytes_in_out_dtype[..row_bytes]);
-                }
-                c_buf.copy_from_host(&c_data)?;
-            } else if bias_bytes_in_out_dtype.len() == c_bytes {
-                c_buf.copy_from_host(&bias_bytes_in_out_dtype)?;
-            } else {
-                c_buf.copy_from_host(&vec![0u8; c_bytes])?;
-            }
-        } else {
-            c_buf.copy_from_host(&vec![0u8; c_bytes])?;
-        }
-    } else {
-        c_buf.copy_from_host(&vec![0u8; c_bytes])?;
-    }
+    init_c_buffer(
+        &c_buf,
+        c_bias,
+        beta,
+        m,
+        n,
+        c_bytes,
+        dtype.elem_size,
+        dtype.is_bf16,
+    )?;
 
     // cuBLAS uses column-major. For row-major ONNX tensors:
     //   C_row = alpha * op(A) * op(B) + beta * C
@@ -174,7 +214,7 @@ pub fn gpu_gemm(
     // For BF16 inputs we hard-pin the compute type to 32F_FAST_16BF (f32
     // accumulation, BF16 tensor cores) regardless of runtime.precision, since
     // BF16 inputs cannot be computed in a non-BF16 tensor-core mode anyway.
-    let compute_type = if is_bf16 {
+    let compute_type = if dtype.is_bf16 {
         ffi::cublasComputeType_t::CUBLAS_COMPUTE_32F_FAST_16BF
     } else {
         runtime.precision.to_cublas_compute_type()
@@ -187,14 +227,14 @@ pub fn gpu_gemm(
         k as i32,
         &alpha as *const f32 as *const core::ffi::c_void,
         &b_buf,
-        io_dtype,
+        dtype.io_dtype,
         lda,
         &a_buf,
-        io_dtype,
+        dtype.io_dtype,
         ldb,
         &beta as *const f32 as *const core::ffi::c_void,
         &c_buf,
-        io_dtype,
+        dtype.io_dtype,
         ldc,
         compute_type,
     )?;
@@ -205,7 +245,7 @@ pub fn gpu_gemm(
     c_buf.copy_to_host(&mut result_bytes)?;
 
     Ok(Tensor {
-        data_type: out_data_type,
+        data_type: dtype.out_data_type,
         shape: TensorShape::new(vec![m as i64, n as i64]),
         name: String::new(),
         raw_data: result_bytes,
@@ -487,6 +527,80 @@ pub fn gpu_gemm_fp8(
 ///
 /// The call synchronizes on the default stream before returning so
 /// callers can chain it with non-cuBLAS kernels safely.
+/// Map a Float/BFloat16 `DataType` to its cuBLAS dtype + element size.
+///
+/// `op` is embedded into the error message so the dispatcher's two callers
+/// (`a/b dtype` and `out_dtype`) get distinct labels.
+fn map_gemm_dtype(
+    dt: DataType,
+    op: &'static str,
+) -> Result<(ffi::cudaDataType_t, usize), CudaError> {
+    match dt {
+        DataType::BFloat16 => Ok((ffi::cudaDataType_t::CUDA_R_16BF, 2)),
+        DataType::Float => Ok((ffi::cudaDataType_t::CUDA_R_32F, 4)),
+        _ => Err(CudaError::RuntimeError { op, code: -1 }),
+    }
+}
+
+/// Validated batched-GEMM shape parameters.
+struct BatchedGemmShape {
+    batch_i64: i64,
+    m_i64: i64,
+    n_i64: i64,
+    k_i64: i64,
+}
+
+impl BatchedGemmShape {
+    fn validate(
+        a: &super::gpu_executor::DeviceTensor,
+        b: &super::gpu_executor::DeviceTensor,
+        trans_a: bool,
+        trans_b: bool,
+    ) -> Result<Self, CudaError> {
+        if a.shape.len() != 3 || b.shape.len() != 3 {
+            return Err(CudaError::RuntimeError {
+                op: "gpu_gemm_strided_batched_ex: both inputs must be rank-3",
+                code: -1,
+            });
+        }
+        let batch_i64 = a.shape[0];
+        if b.shape[0] != batch_i64 {
+            return Err(CudaError::RuntimeError {
+                op: "gpu_gemm_strided_batched_ex: batch dimensions differ",
+                code: -1,
+            });
+        }
+        let (m_i64, k_a_i64) = if trans_a {
+            (a.shape[2], a.shape[1])
+        } else {
+            (a.shape[1], a.shape[2])
+        };
+        let (k_b_i64, n_i64) = if trans_b {
+            (b.shape[2], b.shape[1])
+        } else {
+            (b.shape[1], b.shape[2])
+        };
+        if k_a_i64 != k_b_i64 {
+            return Err(CudaError::RuntimeError {
+                op: "gpu_gemm_strided_batched_ex: K dimensions differ",
+                code: -1,
+            });
+        }
+        if batch_i64 < 0 || m_i64 < 0 || n_i64 < 0 || k_a_i64 < 0 {
+            return Err(CudaError::RuntimeError {
+                op: "gpu_gemm_strided_batched_ex: negative dimension",
+                code: -1,
+            });
+        }
+        Ok(Self {
+            batch_i64,
+            m_i64,
+            n_i64,
+            k_i64: k_a_i64,
+        })
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn gpu_gemm_strided_batched_ex(
     runtime: &CudaRuntime,
@@ -502,61 +616,19 @@ pub fn gpu_gemm_strided_batched_ex(
             code: -1,
         });
     }
-    let (a_cuda, _a_elem_size) = match a.dtype {
-        DataType::BFloat16 => (ffi::cudaDataType_t::CUDA_R_16BF, 2usize),
-        DataType::Float => (ffi::cudaDataType_t::CUDA_R_32F, 4usize),
-        _ => {
-            return Err(CudaError::RuntimeError {
-                op: "gpu_gemm_strided_batched_ex: a/b must be Float or BFloat16",
-                code: -1,
-            });
-        }
-    };
-    let (c_cuda, c_elem_size) = match out_dtype {
-        DataType::BFloat16 => (ffi::cudaDataType_t::CUDA_R_16BF, 2usize),
-        DataType::Float => (ffi::cudaDataType_t::CUDA_R_32F, 4usize),
-        _ => {
-            return Err(CudaError::RuntimeError {
-                op: "gpu_gemm_strided_batched_ex: out_dtype must be Float or BFloat16",
-                code: -1,
-            });
-        }
-    };
-    if a.shape.len() != 3 || b.shape.len() != 3 {
-        return Err(CudaError::RuntimeError {
-            op: "gpu_gemm_strided_batched_ex: both inputs must be rank-3",
-            code: -1,
-        });
-    }
-    let batch_i64 = a.shape[0];
-    if b.shape[0] != batch_i64 {
-        return Err(CudaError::RuntimeError {
-            op: "gpu_gemm_strided_batched_ex: batch dimensions differ",
-            code: -1,
-        });
-    }
-    let (m_i64, k_a_i64) = if trans_a {
-        (a.shape[2], a.shape[1])
-    } else {
-        (a.shape[1], a.shape[2])
-    };
-    let (k_b_i64, n_i64) = if trans_b {
-        (b.shape[2], b.shape[1])
-    } else {
-        (b.shape[1], b.shape[2])
-    };
-    if k_a_i64 != k_b_i64 {
-        return Err(CudaError::RuntimeError {
-            op: "gpu_gemm_strided_batched_ex: K dimensions differ",
-            code: -1,
-        });
-    }
-    if batch_i64 < 0 || m_i64 < 0 || n_i64 < 0 || k_a_i64 < 0 {
-        return Err(CudaError::RuntimeError {
-            op: "gpu_gemm_strided_batched_ex: negative dimension",
-            code: -1,
-        });
-    }
+    let (a_cuda, _a_elem_size) = map_gemm_dtype(
+        a.dtype,
+        "gpu_gemm_strided_batched_ex: a/b must be Float or BFloat16",
+    )?;
+    let (c_cuda, c_elem_size) = map_gemm_dtype(
+        out_dtype,
+        "gpu_gemm_strided_batched_ex: out_dtype must be Float or BFloat16",
+    )?;
+    let shape = BatchedGemmShape::validate(a, b, trans_a, trans_b)?;
+    let batch_i64 = shape.batch_i64;
+    let m_i64 = shape.m_i64;
+    let n_i64 = shape.n_i64;
+    let k_a_i64 = shape.k_i64;
 
     let batch = batch_i64 as i32;
     let m = m_i64 as i32;

--- a/onnx-rt/src/cuda/kernels/attention.rs
+++ b/onnx-rt/src/cuda/kernels/attention.rs
@@ -677,6 +677,115 @@ pub fn cast_f32_to_bf16_gpu(
 
 // ── Section 6.12: top-level gpu_gqa ────────────────────────────────
 
+/// Validated rank-4 GQA shape parameters extracted from Q/K/V.
+struct GqaShape {
+    num_q_heads_i64: i64,
+    seq_q_i64: i64,
+    head_dim_i64: i64,
+    num_kv_heads_i64: i64,
+    seq_kv_i64: i64,
+}
+
+/// Reject rank-3 Q/K/V at this entry point — `gpu_gqa_rank3` is the
+/// supported path for the gemma builder's `[1, Sq, H*head_dim]` layout.
+fn reject_rank3_gqa(q: &DeviceTensor, k: &DeviceTensor, v: &DeviceTensor) -> Result<(), CudaError> {
+    if q.shape.len() != 3 || k.shape.len() != 3 || v.shape.len() != 3 {
+        return Ok(());
+    }
+    let q_hidden = q.shape[2];
+    let kv_hidden = k.shape[2];
+    // Validate the q/kv hidden ratio before suggesting the rank-3 entry
+    // point — preserves the original error precedence.
+    if q_hidden == 0 || kv_hidden == 0 || q_hidden % kv_hidden != 0 {
+        let kv_divides = kv_hidden != 0 && q_hidden % kv_hidden == 0;
+        let mha = q_hidden == kv_hidden;
+        if !kv_divides && !mha {
+            return Err(CudaError::RuntimeError {
+                op: "gpu_gqa: rank-3 q/kv hidden ratio is not integer",
+                code: -1,
+            });
+        }
+    }
+    Err(CudaError::RuntimeError {
+        op: "gpu_gqa: rank-3 input requires head-count attributes — use gpu_gqa_rank3",
+        code: -1,
+    })
+}
+
+/// Validate dtype + rank-4 shape for Q/K/V and return the GQA shape descriptor.
+fn validate_gqa_rank4(
+    q: &DeviceTensor,
+    k: &DeviceTensor,
+    v: &DeviceTensor,
+) -> Result<GqaShape, CudaError> {
+    if q.dtype != k.dtype || q.dtype != v.dtype {
+        return Err(CudaError::RuntimeError {
+            op: "gpu_gqa: q/k/v dtypes must match",
+            code: -1,
+        });
+    }
+    if q.dtype != DataType::Float && q.dtype != DataType::BFloat16 {
+        return Err(CudaError::RuntimeError {
+            op: "gpu_gqa: dtype must be Float or BFloat16",
+            code: -1,
+        });
+    }
+    if q.shape.len() != 4 || k.shape.len() != 4 || v.shape.len() != 4 {
+        return Err(CudaError::RuntimeError {
+            op: "gpu_gqa: q/k/v must each be rank-4 [B, H, S, head_dim]",
+            code: -1,
+        });
+    }
+    if q.shape[0] != 1 || k.shape[0] != 1 || v.shape[0] != 1 {
+        return Err(CudaError::RuntimeError {
+            op: "gpu_gqa: only batch=1 is supported in v1",
+            code: -1,
+        });
+    }
+    if k.shape != v.shape {
+        return Err(CudaError::RuntimeError {
+            op: "gpu_gqa: k and v must share shape",
+            code: -1,
+        });
+    }
+    if v.shape[3] != q.shape[3] {
+        return Err(CudaError::RuntimeError {
+            op: "gpu_gqa: head_dim mismatch",
+            code: -1,
+        });
+    }
+    let num_q_heads_i64 = q.shape[1];
+    let num_kv_heads_i64 = k.shape[1];
+    if num_q_heads_i64 <= 0 || num_kv_heads_i64 <= 0 || num_q_heads_i64 % num_kv_heads_i64 != 0 {
+        return Err(CudaError::RuntimeError {
+            op: "gpu_gqa: num_q_heads must be a positive multiple of num_kv_heads",
+            code: -1,
+        });
+    }
+    Ok(GqaShape {
+        num_q_heads_i64,
+        seq_q_i64: q.shape[2],
+        head_dim_i64: q.shape[3],
+        num_kv_heads_i64,
+        seq_kv_i64: k.shape[2],
+    })
+}
+
+/// Reject attention requests whose F32 scratch buffer exceeds the runtime cap.
+fn check_attention_scratch_cap(runtime: &CudaRuntime, shape: &GqaShape) -> Result<(), CudaError> {
+    let scratch_bytes: usize = (shape.num_q_heads_i64 as usize)
+        .saturating_mul(shape.seq_q_i64 as usize)
+        .saturating_mul(shape.seq_kv_i64 as usize)
+        .saturating_mul(4);
+    if scratch_bytes > runtime.attention_scratch_cap() {
+        return Err(CudaError::RuntimeError {
+            op: "gpu_gqa: attention scratch exceeds runtime cap (set_attention_scratch_cap)",
+            code: -1,
+        });
+    }
+    Ok(())
+}
+
 /// Group-query attention on the GPU.
 ///
 /// Composes the cuBLAS strided batched GEMMs and the custom kernels
@@ -718,105 +827,28 @@ pub fn gpu_gqa(
     scale: Option<f32>,
 ) -> Result<DeviceTensor, CudaError> {
     // Rank-3 fallback: the gemma builder emits Q/K/V directly from its
-    // projection Gemms in `[1, Sq, H*head_dim]` layout. Transpose to
-    // the canonical rank-4 head-major form before proceeding. The
-    // `num_heads` for K/V is derived from the two shapes' ratio.
-    if q.shape.len() == 3 && k.shape.len() == 3 && v.shape.len() == 3 {
-        let q_hidden = q.shape[2];
-        let kv_hidden = k.shape[2];
-        if q_hidden == 0 || kv_hidden == 0 || q_hidden % kv_hidden != 0 {
-            // Allow equal-hidden for MHA; for GQA require that q_hidden
-            // is a multiple of kv_hidden so head_dim matches.
-            let kv_divides = kv_hidden != 0 && q_hidden % kv_hidden == 0;
-            let mha = q_hidden == kv_hidden;
-            if !kv_divides && !mha {
-                return Err(CudaError::RuntimeError {
-                    op: "gpu_gqa: rank-3 q/kv hidden ratio is not integer",
-                    code: -1,
-                });
-            }
-        }
-        // Infer head_dim from (q_hidden / num_q_heads) via the
-        // attention-head ratio. For rank-3 we need num_heads to be
-        // supplied by the caller — the dispatcher reads it from the
-        // GQA node attributes. Here we fall back to the simplest case
-        // where num_q_heads can be inferred from shape alone:
-        // kv_hidden must equal num_kv_heads * head_dim and q_hidden
-        // must equal num_q_heads * head_dim, with the same head_dim.
-        // Without the attribute this is ambiguous, so defer to the
-        // `gpu_gqa_rank3` entry point which takes explicit counts.
-        return Err(CudaError::RuntimeError {
-            op: "gpu_gqa: rank-3 input requires head-count attributes — use gpu_gqa_rank3",
-            code: -1,
-        });
-    }
-    if q.dtype != k.dtype || q.dtype != v.dtype {
-        return Err(CudaError::RuntimeError {
-            op: "gpu_gqa: q/k/v dtypes must match",
-            code: -1,
-        });
-    }
-    let dt = q.dtype;
-    if dt != DataType::Float && dt != DataType::BFloat16 {
-        return Err(CudaError::RuntimeError {
-            op: "gpu_gqa: dtype must be Float or BFloat16",
-            code: -1,
-        });
-    }
-    if q.shape.len() != 4 || k.shape.len() != 4 || v.shape.len() != 4 {
-        return Err(CudaError::RuntimeError {
-            op: "gpu_gqa: q/k/v must each be rank-4 [B, H, S, head_dim]",
-            code: -1,
-        });
-    }
-    if q.shape[0] != 1 || k.shape[0] != 1 || v.shape[0] != 1 {
-        return Err(CudaError::RuntimeError {
-            op: "gpu_gqa: only batch=1 is supported in v1",
-            code: -1,
-        });
-    }
-    let num_q_heads_i64 = q.shape[1];
-    let seq_q_i64 = q.shape[2];
-    let head_dim_i64 = q.shape[3];
-    let num_kv_heads_i64 = k.shape[1];
-    let seq_kv_i64 = k.shape[2];
+    // projection Gemms in `[1, Sq, H*head_dim]` layout. Defer to the
+    // dedicated rank-3 entry point — it needs explicit head counts.
+    reject_rank3_gqa(q, k, v)?;
 
-    if k.shape != v.shape {
-        return Err(CudaError::RuntimeError {
-            op: "gpu_gqa: k and v must share shape",
-            code: -1,
-        });
-    }
-    if v.shape[3] != head_dim_i64 {
-        return Err(CudaError::RuntimeError {
-            op: "gpu_gqa: head_dim mismatch",
-            code: -1,
-        });
-    }
-    if num_q_heads_i64 <= 0 || num_kv_heads_i64 <= 0 || num_q_heads_i64 % num_kv_heads_i64 != 0 {
-        return Err(CudaError::RuntimeError {
-            op: "gpu_gqa: num_q_heads must be a positive multiple of num_kv_heads",
-            code: -1,
-        });
-    }
+    let shape = validate_gqa_rank4(q, k, v)?;
+    let dt = q.dtype;
+
+    // §6.13: enforce the attention-scratch cap up front so a
+    // pathological seq_kv doesn't try to allocate hundreds of GiB.
+    check_attention_scratch_cap(runtime, &shape)?;
+
+    let GqaShape {
+        num_q_heads_i64,
+        seq_q_i64,
+        head_dim_i64,
+        num_kv_heads_i64,
+        seq_kv_i64,
+    } = shape;
     let expand_factor = (num_q_heads_i64 / num_kv_heads_i64) as i32;
     let seq_q = seq_q_i64 as i32;
     let seq_kv = seq_kv_i64 as i32;
     let head_dim = head_dim_i64 as i32;
-
-    // §6.13: enforce the attention-scratch cap up front so a
-    // pathological seq_kv doesn't try to allocate hundreds of GiB.
-    let scratch_bytes: usize = (num_q_heads_i64 as usize)
-        .saturating_mul(seq_q_i64 as usize)
-        .saturating_mul(seq_kv_i64 as usize)
-        .saturating_mul(4);
-    let cap = runtime.attention_scratch_cap();
-    if scratch_bytes > cap {
-        return Err(CudaError::RuntimeError {
-            op: "gpu_gqa: attention scratch exceeds runtime cap (set_attention_scratch_cap)",
-            code: -1,
-        });
-    }
 
     // 1) Expand KV heads to per-attention-head replicas.
     let k_full = kv_expand_gpu(runtime, k, expand_factor)?;

--- a/onnx-rt/src/cuda/kernels/elementwise.rs
+++ b/onnx-rt/src/cuda/kernels/elementwise.rs
@@ -199,71 +199,71 @@ extern "C" __global__ void silu_bf16(const __nv_bfloat16* x, __nv_bfloat16* y, i
 /// Result of broadcasting two shapes: `(output_shape, stride_a, stride_b)`.
 type BroadcastLayout = (Vec<i64>, Vec<i32>, Vec<i32>);
 
+/// Compute row-major strides for a shape (used by [`broadcast_shapes`]).
+fn row_major_strides(shape: &[i64]) -> Vec<i64> {
+    let n = shape.len();
+    let mut s = alloc::vec![1i64; n];
+    for i in (0..n.saturating_sub(1)).rev() {
+        s[i] = s[i + 1] * shape[i + 1];
+    }
+    s
+}
+
+/// Combine two broadcast-aligned dims into the output dim or fail.
+fn combine_broadcast_dim(da: i64, db: i64) -> Result<i64, CudaError> {
+    if da == db || da == 1 || db == 1 {
+        Ok(core::cmp::max(da, db))
+    } else {
+        Err(CudaError::RuntimeError {
+            op: "elementwise: incompatible broadcast shapes",
+            code: -1,
+        })
+    }
+}
+
+/// Project an input shape's row-major stride onto the output axis layout.
+///
+/// Padded-in axes (`i < pad`) and original-dim-1 axes broadcast (stride 0);
+/// otherwise pass through the unbroadcast row-major stride.
+fn projected_stride(i: usize, pad: usize, shape: &[i64], base_strides: &[i64]) -> i32 {
+    if i < pad || shape[i - pad] == 1 {
+        0
+    } else {
+        base_strides[i - pad] as i32
+    }
+}
+
 fn broadcast_shapes(a_shape: &[i64], b_shape: &[i64]) -> Result<BroadcastLayout, CudaError> {
     let ndim = core::cmp::max(a_shape.len(), b_shape.len());
-    let mut out_shape: Vec<i64> = Vec::with_capacity(ndim);
     // Right-align: pad the shorter shape on the left with 1s.
     let a_pad = ndim - a_shape.len();
     let b_pad = ndim - b_shape.len();
 
-    let get_a = |i: usize| -> i64 {
-        if i < a_pad {
+    let dim_or_one = |shape: &[i64], pad: usize, i: usize| -> i64 {
+        if i < pad {
             1
         } else {
-            a_shape[i - a_pad]
-        }
-    };
-    let get_b = |i: usize| -> i64 {
-        if i < b_pad {
-            1
-        } else {
-            b_shape[i - b_pad]
+            shape[i - pad]
         }
     };
 
+    let mut out_shape: Vec<i64> = Vec::with_capacity(ndim);
     for i in 0..ndim {
-        let da = get_a(i);
-        let db = get_b(i);
-        if da == db || da == 1 || db == 1 {
-            out_shape.push(core::cmp::max(da, db));
-        } else {
-            return Err(CudaError::RuntimeError {
-                op: "elementwise: incompatible broadcast shapes",
-                code: -1,
-            });
-        }
+        let da = dim_or_one(a_shape, a_pad, i);
+        let db = dim_or_one(b_shape, b_pad, i);
+        out_shape.push(combine_broadcast_dim(da, db)?);
     }
 
     // Compute row-major strides for the original (un-broadcast) input
     // shapes first, then project onto the output's axis layout.
-    fn row_major_strides(shape: &[i64]) -> Vec<i64> {
-        let n = shape.len();
-        let mut s = alloc::vec![1i64; n];
-        for i in (0..n.saturating_sub(1)).rev() {
-            s[i] = s[i + 1] * shape[i + 1];
-        }
-        s
-    }
-
     let a_base = row_major_strides(a_shape);
     let b_base = row_major_strides(b_shape);
 
     let mut stride_a: Vec<i32> = Vec::with_capacity(ndim);
     let mut stride_b: Vec<i32> = Vec::with_capacity(ndim);
     for i in 0..ndim {
-        // For input A: if the padded/original dim was 1 (or padded-in),
-        // its contribution for this output axis is zero (broadcast);
-        // otherwise use its real row-major stride.
-        if i < a_pad || a_shape[i - a_pad] == 1 {
-            stride_a.push(0);
-        } else {
-            stride_a.push(a_base[i - a_pad] as i32);
-        }
-        if i < b_pad || b_shape[i - b_pad] == 1 {
-            stride_b.push(0);
-        } else {
-            stride_b.push(b_base[i - b_pad] as i32);
-        }
+        stride_a.push(projected_stride(i, a_pad, a_shape, &a_base));
+        stride_b.push(projected_stride(i, b_pad, b_shape, &b_base));
     }
 
     Ok((out_shape, stride_a, stride_b))

--- a/onnx-rt/src/cuda/kernels/rotary.rs
+++ b/onnx-rt/src/cuda/kernels/rotary.rs
@@ -170,81 +170,79 @@ extern "C" __global__ void rotary_bf16(
 ///
 /// The call is asynchronous on the default stream; use
 /// [`super::synchronize`] before reading the output on the host.
-pub fn rotary_gpu(
-    runtime: &CudaRuntime,
+/// Parsed RoPE layout: `(batch, heads, seq_len, head_dim, h_per_seq)`.
+type RotaryLayout = (i64, i64, i64, i64, i64);
+
+/// Select the kernel name for the given input dtype.
+fn pick_rotary_kernel(dtype: DataType) -> Result<&'static str, CudaError> {
+    match dtype {
+        DataType::Float => Ok("rotary_f32"),
+        DataType::BFloat16 => Ok("rotary_bf16"),
+        _ => Err(CudaError::RuntimeError {
+            op: "rotary_gpu: unsupported dtype (need Float or BFloat16)",
+            code: -1,
+        }),
+    }
+}
+
+/// Resolve the rank-3 RoPE layout from `[B, Sq, H*head_dim]` shape.
+fn rotary_layout_rank3(
     x: &DeviceTensor,
+    num_heads_for_rank3: Option<i64>,
+) -> Result<RotaryLayout, CudaError> {
+    let n = num_heads_for_rank3.ok_or(CudaError::RuntimeError {
+        op: "rotary_gpu: rank-3 input requires num_heads_for_rank3",
+        code: -1,
+    })?;
+    if n <= 0 {
+        return Err(CudaError::RuntimeError {
+            op: "rotary_gpu: num_heads must be > 0 for rank-3 input",
+            code: -1,
+        });
+    }
+    let b = x.shape[0];
+    let sq = x.shape[1];
+    let hidden = x.shape[2];
+    if hidden % n != 0 {
+        return Err(CudaError::RuntimeError {
+            op: "rotary_gpu: hidden not divisible by num_heads (rank-3)",
+            code: -1,
+        });
+    }
+    Ok((b, n, sq, hidden / n, n))
+}
+
+/// Resolve the RoPE input layout for either rank-3 or rank-4 inputs.
+fn resolve_rotary_layout(
+    x: &DeviceTensor,
+    num_heads_for_rank3: Option<i64>,
+) -> Result<RotaryLayout, CudaError> {
+    match x.shape.len() {
+        4 => Ok((x.shape[0], x.shape[1], x.shape[2], x.shape[3], 1i64)),
+        3 => rotary_layout_rank3(x, num_heads_for_rank3),
+        _ => Err(CudaError::RuntimeError {
+            op: "rotary_gpu: x must be rank-3 or rank-4",
+            code: -1,
+        }),
+    }
+}
+
+/// Validate cos/sin tables against the resolved `head_dim` and `seq_len`.
+///
+/// Returns the shared `max_seq_len` of the two tables.
+fn validate_rotary_tables(
     cos_table: &DeviceTensor,
     sin_table: &DeviceTensor,
+    half_i64: i64,
+    seq_len_i64: i64,
     position: i32,
-    interleaved: bool,
-    num_heads_for_rank3: Option<i64>,
-) -> Result<DeviceTensor, CudaError> {
-    let kernel_name = match x.dtype {
-        DataType::Float => "rotary_f32",
-        DataType::BFloat16 => "rotary_bf16",
-        _ => {
-            return Err(CudaError::RuntimeError {
-                op: "rotary_gpu: unsupported dtype (need Float or BFloat16)",
-                code: -1,
-            });
-        }
-    };
+) -> Result<(), CudaError> {
     if cos_table.dtype != DataType::Float || sin_table.dtype != DataType::Float {
         return Err(CudaError::RuntimeError {
             op: "rotary_gpu: cos/sin tables must be Float",
             code: -1,
         });
     }
-    // Two accepted input layouts:
-    //   - rank-4 [B, H, Sq, head_dim] (qi stride = 1 row, `h_per_seq = 1`)
-    //   - rank-3 [B, Sq, H*head_dim]   (qi stride = H rows, `h_per_seq = H`)
-    let (batch_i64, heads_i64, seq_len_i64, head_dim_i64, h_per_seq_i64) = match x.shape.len() {
-        4 => {
-            let b = x.shape[0];
-            let h = x.shape[1];
-            let sq = x.shape[2];
-            let d = x.shape[3];
-            (b, h, sq, d, 1i64)
-        }
-        3 => {
-            let n = num_heads_for_rank3.ok_or(CudaError::RuntimeError {
-                op: "rotary_gpu: rank-3 input requires num_heads_for_rank3",
-                code: -1,
-            })?;
-            if n <= 0 {
-                return Err(CudaError::RuntimeError {
-                    op: "rotary_gpu: num_heads must be > 0 for rank-3 input",
-                    code: -1,
-                });
-            }
-            let b = x.shape[0];
-            let sq = x.shape[1];
-            let hidden = x.shape[2];
-            if hidden % n != 0 {
-                return Err(CudaError::RuntimeError {
-                    op: "rotary_gpu: hidden not divisible by num_heads (rank-3)",
-                    code: -1,
-                });
-            }
-            let d = hidden / n;
-            (b, n, sq, d, n)
-        }
-        _ => {
-            return Err(CudaError::RuntimeError {
-                op: "rotary_gpu: x must be rank-3 or rank-4",
-                code: -1,
-            });
-        }
-    };
-
-    if head_dim_i64 <= 0 || head_dim_i64 % 2 != 0 {
-        return Err(CudaError::RuntimeError {
-            op: "rotary_gpu: head_dim must be a positive even integer",
-            code: -1,
-        });
-    }
-    let half_i64 = head_dim_i64 / 2;
-
     if cos_table.shape.len() != 2 || sin_table.shape.len() != 2 {
         return Err(CudaError::RuntimeError {
             op: "rotary_gpu: cos/sin tables must be rank-2",
@@ -270,6 +268,34 @@ pub fn rotary_gpu(
             code: -1,
         });
     }
+    Ok(())
+}
+
+pub fn rotary_gpu(
+    runtime: &CudaRuntime,
+    x: &DeviceTensor,
+    cos_table: &DeviceTensor,
+    sin_table: &DeviceTensor,
+    position: i32,
+    interleaved: bool,
+    num_heads_for_rank3: Option<i64>,
+) -> Result<DeviceTensor, CudaError> {
+    let kernel_name = pick_rotary_kernel(x.dtype)?;
+    // Two accepted input layouts:
+    //   - rank-4 [B, H, Sq, head_dim] (qi stride = 1 row, `h_per_seq = 1`)
+    //   - rank-3 [B, Sq, H*head_dim]   (qi stride = H rows, `h_per_seq = H`)
+    let (batch_i64, heads_i64, seq_len_i64, head_dim_i64, h_per_seq_i64) =
+        resolve_rotary_layout(x, num_heads_for_rank3)?;
+
+    if head_dim_i64 <= 0 || head_dim_i64 % 2 != 0 {
+        return Err(CudaError::RuntimeError {
+            op: "rotary_gpu: head_dim must be a positive even integer",
+            code: -1,
+        });
+    }
+    let half_i64 = head_dim_i64 / 2;
+
+    validate_rotary_tables(cos_table, sin_table, half_i64, seq_len_i64, position)?;
 
     let out = DeviceTensor::alloc(x.shape.clone(), x.dtype)?;
 


### PR DESCRIPTION
## Summary

Extract decision branches in six SonarCloud `rust:S3776` hotspots in
the `onnx-rt/src/cuda/` subsystem into focused private helpers so the
top-level entry points drop below the cognitive-complexity threshold of
15. Behaviour is unchanged: helpers are private `fn` / `impl`, public
API is untouched.

| File | Function | Before | After (est) |
|---|---|---:|---:|
| `onnx-rt/src/cuda/conv.rs` | `gpu_conv2d` | 59 | ~4 |
| `onnx-rt/src/cuda/dispatch.rs` | `gpu_gemm` | 46 | ~7 |
| `onnx-rt/src/cuda/dispatch.rs` | `gpu_gemm_strided_batched_ex` | 25 | ~7 |
| `onnx-rt/src/cuda/kernels/attention.rs` | `gpu_gqa` | 25 | ~4 |
| `onnx-rt/src/cuda/kernels/elementwise.rs` | `broadcast_shapes` | 22 | ~5 |
| `onnx-rt/src/cuda/kernels/rotary.rs` | `rotary_gpu` | 19 | ~3 |

Key extracted helpers per function:

- `gpu_conv2d` -> `ConvDtype::pick`, `ConvParams::build`,
  `decode_bias_to_f32`, `add_bias_channel_{f32,bf16}`, `apply_bias`,
  `run_conv_forward`, `pair_or`.
- `gpu_gemm` -> `GemmDtype::pick`, `gemm_mk_dims`,
  `encode_bias_for_output`, `init_c_buffer`.
- `gpu_gemm_strided_batched_ex` -> `map_gemm_dtype`,
  `BatchedGemmShape::validate`.
- `gpu_gqa` -> `reject_rank3_gqa`, `validate_gqa_rank4`,
  `check_attention_scratch_cap` with a `GqaShape` carrier struct.
- `broadcast_shapes` -> `row_major_strides`, `combine_broadcast_dim`,
  `projected_stride`.
- `rotary_gpu` -> `pick_rotary_kernel`, `rotary_layout_rank3`,
  `resolve_rotary_layout`, `validate_rotary_tables`.

Scope note: `onnx-rt/src/cuda/gpu_executor.rs` was intentionally left
untouched here (a parallel agent owns that file).

## Test plan

- [x] `just fmt-check` (via `cargo fmt -- --check`) -- clean
- [x] `cargo clippy -p smallaios-onnx-rt -- -D warnings` -- clean
- [x] `cargo clippy -p smallaios-onnx-rt --features cuda -- -D warnings` -- clean
- [x] `cargo test -p smallaios-onnx-rt --lib` -- 891 passed, 0 failed (same as `develop` baseline)
- [x] `cargo check -p smallaios-onnx-rt` -- clean
- [x] `cargo check -p smallaios-onnx-rt --features cuda` -- clean (CUDA type-checking only; no GPU available on dev host)

Pre-existing arch crate compile errors on the workspace (`smallaios-arch-{x86_64,aarch64,riscv64}` need their bare-metal targets) are unrelated and present on `origin/develop`. Pre-existing `test_cuda.rs` integration tests have unrelated `Mutex::borrow` errors on the `cuda` feature -- not touched here.

CUDA runtime build was not exercised because no CUDA toolkit is
available on the dev host; the refactor preserves the exact same
cuBLAS / cuDNN calls and dtype routing, so behavioural equivalence on
GPU is by construction.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization and maintainability across CUDA operations including convolution, matrix multiplication, attention mechanisms, element-wise operations, and rotary position embeddings.
  * Centralized validation logic and parameter handling into dedicated helpers for better code clarity and consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SmallAIOS/SmallAIOS/pull/192)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->