### PR TITLE
refactor(container): reduce cognitive complexity below 15 on container hotspots

### DIFF
--- a/container/src/handlers.rs
+++ b/container/src/handlers.rs
@@ -218,6 +218,54 @@ fn json_to_tensor(name: &str, val: &JsonValue) -> Result<Tensor, String> {
     Ok(tensor)
 }
 
+/// Append a tensor's shape dims as a comma-separated JSON array body
+/// (without the surrounding brackets).
+fn append_shape_dims(dims: &[i64], buf: &mut String) {
+    for (j, d) in dims.iter().enumerate() {
+        if j > 0 {
+            buf.push(',');
+        }
+        buf.push_str(&d.to_string());
+    }
+}
+
+/// Append a float32 tensor's raw little-endian bytes as a
+/// comma-separated JSON array body (without the surrounding brackets).
+/// Non-float tensors append nothing — callers only wire float32 today.
+fn append_float_tensor_data(tensor: &Tensor, buf: &mut String) {
+    if tensor.data_type != DataType::Float {
+        return;
+    }
+    let n = tensor.raw_data.len() / 4;
+    for k in 0..n {
+        if k > 0 {
+            buf.push(',');
+        }
+        let bytes = [
+            tensor.raw_data[k * 4],
+            tensor.raw_data[k * 4 + 1],
+            tensor.raw_data[k * 4 + 2],
+            tensor.raw_data[k * 4 + 3],
+        ];
+        let v = f32::from_le_bytes(bytes);
+        buf.push_str(&format!("{}", v));
+    }
+}
+
+/// Serialise a single `InferenceOutput` as a JSON object entry
+/// (key+value, without leading comma).
+fn append_output_entry(out: &smallaios_onnx_rt::session::InferenceOutput, buf: &mut String) {
+    buf.push('"');
+    buf.push_str(&out.name);
+    buf.push_str("\":{\"shape\":[");
+    append_shape_dims(&out.tensor.shape.dims, buf);
+    buf.push_str("],\"dtype\":\"");
+    buf.push_str(out.tensor.data_type.name());
+    buf.push_str("\",\"data\":[");
+    append_float_tensor_data(&out.tensor, buf);
+    buf.push_str("]}");
+}
+
 /// Serialise a slice of `InferenceOutput` (all assumed float32) into
 /// the JSON wire format.
 fn serialize_outputs(
@@ -229,39 +277,7 @@ fn serialize_outputs(
         if i > 0 {
             buf.push(',');
         }
-        buf.push('"');
-        buf.push_str(&out.name);
-        buf.push_str("\":{\"shape\":[");
-        for (j, d) in out.tensor.shape.dims.iter().enumerate() {
-            if j > 0 {
-                buf.push(',');
-            }
-            buf.push_str(&d.to_string());
-        }
-        buf.push_str("],\"dtype\":\"");
-        buf.push_str(out.tensor.data_type.name());
-        buf.push_str("\",\"data\":[");
-
-        // Serialise the raw_data as little-endian f32 array. Non-float
-        // tensors fall back to an empty array — callers only wire
-        // float32 for now.
-        if out.tensor.data_type == DataType::Float {
-            let n = out.tensor.raw_data.len() / 4;
-            for k in 0..n {
-                if k > 0 {
-                    buf.push(',');
-                }
-                let bytes = [
-                    out.tensor.raw_data[k * 4],
-                    out.tensor.raw_data[k * 4 + 1],
-                    out.tensor.raw_data[k * 4 + 2],
-                    out.tensor.raw_data[k * 4 + 3],
-                ];
-                let v = f32::from_le_bytes(bytes);
-                buf.push_str(&format!("{}", v));
-            }
-        }
-        buf.push_str("]}");
+        append_output_entry(out, &mut buf);
     }
     buf.push_str("},\"timing_us\":");
     buf.push_str(&elapsed_us.to_string());

--- a/container/src/json.rs
+++ b/container/src/json.rs
@@ -94,56 +94,73 @@ impl JsonValue {
 // Serializer
 // ---------------------------------------------------------------------------
 
+/// Serialize a JSON number, using integer formatting when the value
+/// is a whole number for cleaner output.
+fn serialize_number(n: f64, buf: &mut String) {
+    if n.fract() == 0.0 && n.is_finite() && n.abs() < (i64::MAX as f64) {
+        buf.push_str(&format!("{}", n as i64));
+    } else {
+        buf.push_str(&format!("{}", n));
+    }
+}
+
+/// Escape and write a single character into a JSON string body.
+fn push_escaped_char(ch: char, buf: &mut String) {
+    match ch {
+        '"' => buf.push_str("\\\""),
+        '\\' => buf.push_str("\\\\"),
+        '\n' => buf.push_str("\\n"),
+        '\r' => buf.push_str("\\r"),
+        '\t' => buf.push_str("\\t"),
+        c if c < '\x20' => buf.push_str(&format!("\\u{:04x}", c as u32)),
+        c => buf.push(c),
+    }
+}
+
+/// Serialize a string value as a quoted, escaped JSON string.
+fn serialize_string(s: &str, buf: &mut String) {
+    buf.push('"');
+    for ch in s.chars() {
+        push_escaped_char(ch, buf);
+    }
+    buf.push('"');
+}
+
+/// Serialize an array of JSON values.
+fn serialize_array(items: &[JsonValue], buf: &mut String) {
+    buf.push('[');
+    for (i, item) in items.iter().enumerate() {
+        if i > 0 {
+            buf.push(',');
+        }
+        serialize_value(item, buf);
+    }
+    buf.push(']');
+}
+
+/// Serialize an object's key/value entries.
+fn serialize_object(entries: &[(String, JsonValue)], buf: &mut String) {
+    buf.push('{');
+    for (i, (key, val)) in entries.iter().enumerate() {
+        if i > 0 {
+            buf.push(',');
+        }
+        serialize_string(key, buf);
+        buf.push(':');
+        serialize_value(val, buf);
+    }
+    buf.push('}');
+}
+
 fn serialize_value(value: &JsonValue, buf: &mut String) {
     match value {
         JsonValue::Null => buf.push_str("null"),
         JsonValue::Bool(true) => buf.push_str("true"),
         JsonValue::Bool(false) => buf.push_str("false"),
-        JsonValue::Number(n) => {
-            // Use integer formatting when the value is a whole number for cleaner output.
-            if n.fract() == 0.0 && n.is_finite() && n.abs() < (i64::MAX as f64) {
-                buf.push_str(&format!("{}", *n as i64));
-            } else {
-                buf.push_str(&format!("{}", n));
-            }
-        }
-        JsonValue::String(s) => {
-            buf.push('"');
-            for ch in s.chars() {
-                match ch {
-                    '"' => buf.push_str("\\\""),
-                    '\\' => buf.push_str("\\\\"),
-                    '\n' => buf.push_str("\\n"),
-                    '\r' => buf.push_str("\\r"),
-                    '\t' => buf.push_str("\\t"),
-                    c if c < '\x20' => buf.push_str(&format!("\\u{:04x}", c as u32)),
-                    c => buf.push(c),
-                }
-            }
-            buf.push('"');
-        }
-        JsonValue::Array(items) => {
-            buf.push('[');
-            for (i, item) in items.iter().enumerate() {
-                if i > 0 {
-                    buf.push(',');
-                }
-                serialize_value(item, buf);
-            }
-            buf.push(']');
-        }
-        JsonValue::Object(entries) => {
-            buf.push('{');
-            for (i, (key, val)) in entries.iter().enumerate() {
-                if i > 0 {
-                    buf.push(',');
-                }
-                serialize_value(&JsonValue::String(key.clone()), buf);
-                buf.push(':');
-                serialize_value(val, buf);
-            }
-            buf.push('}');
-        }
+        JsonValue::Number(n) => serialize_number(*n, buf),
+        JsonValue::String(s) => serialize_string(s, buf),
+        JsonValue::Array(items) => serialize_array(items, buf),
+        JsonValue::Object(entries) => serialize_object(entries, buf),
     }
 }
 
@@ -195,53 +212,109 @@ fn parse_bool(input: &str) -> Result<(JsonValue, &str), String> {
     }
 }
 
-fn parse_number(input: &str) -> Result<(JsonValue, &str), String> {
-    let mut end = 0;
-    let bytes = input.as_bytes();
-
-    // Optional leading minus
-    if end < bytes.len() && bytes[end] == b'-' {
-        end += 1;
+/// Consume contiguous ASCII digits starting at `pos`, returning the
+/// new cursor position.
+fn consume_digits(bytes: &[u8], mut pos: usize) -> usize {
+    while pos < bytes.len() && bytes[pos].is_ascii_digit() {
+        pos += 1;
     }
+    pos
+}
 
-    // Integer part
-    if end >= bytes.len() || !bytes[end].is_ascii_digit() {
+/// Consume an optional sign byte (`+` or `-`) at `pos`. Returns the
+/// (possibly unchanged) cursor.
+fn consume_optional_sign(bytes: &[u8], pos: usize) -> usize {
+    if pos < bytes.len() && (bytes[pos] == b'+' || bytes[pos] == b'-') {
+        pos + 1
+    } else {
+        pos
+    }
+}
+
+/// Parse the integer-digit portion of a number, requiring at least one
+/// digit. Returns the cursor after the digits or an error.
+fn parse_integer_digits(bytes: &[u8], pos: usize) -> Result<usize, String> {
+    if pos >= bytes.len() || !bytes[pos].is_ascii_digit() {
         return Err("invalid number".into());
     }
-    while end < bytes.len() && bytes[end].is_ascii_digit() {
-        end += 1;
-    }
+    Ok(consume_digits(bytes, pos))
+}
 
-    // Fractional part
-    if end < bytes.len() && bytes[end] == b'.' {
-        end += 1;
-        if end >= bytes.len() || !bytes[end].is_ascii_digit() {
-            return Err("invalid number: no digits after decimal point".into());
-        }
-        while end < bytes.len() && bytes[end].is_ascii_digit() {
-            end += 1;
-        }
+/// Parse an optional fractional part (`.<digits>`). Returns the new
+/// cursor or an error if a `.` is present but no digits follow.
+fn parse_fraction(bytes: &[u8], pos: usize) -> Result<usize, String> {
+    if pos >= bytes.len() || bytes[pos] != b'.' {
+        return Ok(pos);
     }
+    let after_dot = pos + 1;
+    if after_dot >= bytes.len() || !bytes[after_dot].is_ascii_digit() {
+        return Err("invalid number: no digits after decimal point".into());
+    }
+    Ok(consume_digits(bytes, after_dot))
+}
 
-    // Exponent
-    if end < bytes.len() && (bytes[end] == b'e' || bytes[end] == b'E') {
-        end += 1;
-        if end < bytes.len() && (bytes[end] == b'+' || bytes[end] == b'-') {
-            end += 1;
-        }
-        if end >= bytes.len() || !bytes[end].is_ascii_digit() {
-            return Err("invalid number: no digits in exponent".into());
-        }
-        while end < bytes.len() && bytes[end].is_ascii_digit() {
-            end += 1;
-        }
+/// Parse an optional exponent (`e[+-]?<digits>`). Returns the new
+/// cursor or an error if exponent digits are missing.
+fn parse_exponent(bytes: &[u8], pos: usize) -> Result<usize, String> {
+    if pos >= bytes.len() || (bytes[pos] != b'e' && bytes[pos] != b'E') {
+        return Ok(pos);
     }
+    let after_e = consume_optional_sign(bytes, pos + 1);
+    if after_e >= bytes.len() || !bytes[after_e].is_ascii_digit() {
+        return Err("invalid number: no digits in exponent".into());
+    }
+    Ok(consume_digits(bytes, after_e))
+}
+
+fn parse_number(input: &str) -> Result<(JsonValue, &str), String> {
+    let bytes = input.as_bytes();
+    let after_sign = if !bytes.is_empty() && bytes[0] == b'-' {
+        1
+    } else {
+        0
+    };
+
+    let after_int = parse_integer_digits(bytes, after_sign)?;
+    let after_frac = parse_fraction(bytes, after_int)?;
+    let end = parse_exponent(bytes, after_frac)?;
 
     let num_str = &input[..end];
     let n: f64 = num_str
         .parse()
         .map_err(|e| format!("invalid number {:?}: {}", num_str, e))?;
     Ok((JsonValue::Number(n), &input[end..]))
+}
+
+/// Decode a `\uXXXX` escape sequence starting at `i` (the position of
+/// the `u` byte). Returns the decoded char and the number of bytes
+/// consumed *after* the `u` (always 4 on success).
+fn parse_unicode_escape(input: &str, bytes: &[u8], i: usize) -> Result<char, String> {
+    if i + 4 >= bytes.len() {
+        return Err("incomplete unicode escape".into());
+    }
+    let hex = &input[i + 1..i + 5];
+    let cp =
+        u16::from_str_radix(hex, 16).map_err(|_| format!("invalid unicode escape: \\u{}", hex))?;
+    char::from_u32(cp as u32).ok_or_else(|| format!("invalid unicode codepoint: {}", cp))
+}
+
+/// Decode a single escape sequence starting at `i` (the position of
+/// the escape-introducer byte, e.g. `n` in `\n` or `u` in `\uXXXX`).
+/// Returns the decoded char and the number of bytes consumed *after*
+/// the escape-introducer.
+fn decode_escape(input: &str, bytes: &[u8], i: usize) -> Result<(char, usize), String> {
+    match bytes[i] {
+        b'"' => Ok(('"', 0)),
+        b'\\' => Ok(('\\', 0)),
+        b'/' => Ok(('/', 0)),
+        b'n' => Ok(('\n', 0)),
+        b'r' => Ok(('\r', 0)),
+        b't' => Ok(('\t', 0)),
+        b'b' => Ok(('\x08', 0)),
+        b'f' => Ok(('\x0c', 0)),
+        b'u' => parse_unicode_escape(input, bytes, i).map(|ch| (ch, 4)),
+        other => Err(format!("invalid escape character: {:?}", other as char)),
+    }
 }
 
 fn parse_string(input: &str) -> Result<(String, &str), String> {
@@ -260,31 +333,9 @@ fn parse_string(input: &str) -> Result<(String, &str), String> {
                 if i >= bytes.len() {
                     return Err("unexpected end of string escape".into());
                 }
-                match bytes[i] {
-                    b'"' => result.push('"'),
-                    b'\\' => result.push('\\'),
-                    b'/' => result.push('/'),
-                    b'n' => result.push('\n'),
-                    b'r' => result.push('\r'),
-                    b't' => result.push('\t'),
-                    b'b' => result.push('\x08'),
-                    b'f' => result.push('\x0c'),
-                    b'u' => {
-                        if i + 4 >= bytes.len() {
-                            return Err("incomplete unicode escape".into());
-                        }
-                        let hex = &input[i + 1..i + 5];
-                        let cp = u16::from_str_radix(hex, 16)
-                            .map_err(|_| format!("invalid unicode escape: \\u{}", hex))?;
-                        if let Some(ch) = char::from_u32(cp as u32) {
-                            result.push(ch);
-                        } else {
-                            return Err(format!("invalid unicode codepoint: {}", cp));
-                        }
-                        i += 4;
-                    }
-                    other => return Err(format!("invalid escape character: {:?}", other as char)),
-                }
+                let (ch, extra) = decode_escape(input, bytes, i)?;
+                result.push(ch);
+                i += extra;
             }
             _ => {
                 // Multi-byte UTF-8: find the char boundary

--- a/container/src/main.rs
+++ b/container/src/main.rs
@@ -354,6 +354,92 @@ fn start_dds_dataflow_runner(
     }))
 }
 
+/// Log a warning when a non-loopback CAN device spec falls back to the
+/// in-process mock controller. Loopback is silent because it is the
+/// only spec that maps cleanly to the mock today.
+fn warn_unwired_can_device(device: &CanDeviceSpec) {
+    match device {
+        CanDeviceSpec::Loopback => {}
+        CanDeviceSpec::Mcp2515(path) => {
+            eprintln!(
+                "  WARNING: MCP2515 driver ({}) not wired; using in-process mock",
+                path
+            );
+        }
+        CanDeviceSpec::AxiCan(addr) => {
+            eprintln!(
+                "  WARNING: AXI CAN driver (0x{:x}) not wired; using in-process mock",
+                addr
+            );
+        }
+    }
+}
+
+/// Construct and initialise a [`MockCanController`] in loopback mode.
+/// Returns `None` and logs the error if init or set_mode fails.
+fn init_mock_can_controller() -> Option<MockCanController> {
+    let mut controller = MockCanController::new();
+    if let Err(e) = controller.init() {
+        eprintln!("  CAN controller init failed: {:?}", e);
+        return None;
+    }
+    if let Err(e) = controller.set_mode(CanMode::Loopback) {
+        eprintln!("  CAN controller set_mode failed: {:?}", e);
+        return None;
+    }
+    Some(controller)
+}
+
+/// Run inference on a single decoded CAN topic+payload and transmit
+/// any resulting frames back through the controller.
+fn handle_can_inference(
+    runner: &DataflowRunner,
+    adapter: &mut CanInferenceAdapter,
+    controller: &mut MockCanController,
+    topic: &str,
+    payload: &[u8],
+) {
+    let Ok(output_bytes) = runner.process_message(topic, payload) else {
+        return;
+    };
+    let output_topic = runner.output_topic(topic);
+    for frame in adapter.on_inference_output(&output_topic, &output_bytes) {
+        let _ = controller.transmit(&frame);
+    }
+}
+
+/// Outcome of a single controller receive: continue draining, stop
+/// draining, or terminate the runner loop entirely.
+enum CanReceiveOutcome {
+    Continue,
+    StopDrain,
+}
+
+/// Process a single frame from the controller, dispatching to the
+/// inference path when the adapter accepts it. Returns whether the
+/// drain loop should continue.
+fn process_can_receive(
+    runner: &DataflowRunner,
+    adapter: &mut CanInferenceAdapter,
+    controller: &mut MockCanController,
+    timestamp_us: &mut u64,
+) -> CanReceiveOutcome {
+    match controller.receive() {
+        Ok(Some(frame)) => {
+            if let Some((topic, payload)) = adapter.process_frame(&frame, *timestamp_us) {
+                handle_can_inference(runner, adapter, controller, &topic, &payload);
+            }
+            *timestamp_us = timestamp_us.wrapping_add(100);
+            CanReceiveOutcome::Continue
+        }
+        Ok(None) => CanReceiveOutcome::StopDrain,
+        Err(e) => {
+            eprintln!("  CAN receive error: {:?}", e);
+            CanReceiveOutcome::StopDrain
+        }
+    }
+}
+
 /// Spawn a background thread for the CAN backend. Uses a
 /// [`MockCanController`] for loopback; for MCP2515 and AXI specs we
 /// also fall back to the mock for now, logging a clear warning. Real
@@ -373,31 +459,9 @@ fn start_can_dataflow_runner(
     );
 
     // Always use MockCanController until real drivers are wired in.
-    match device {
-        CanDeviceSpec::Loopback => {}
-        CanDeviceSpec::Mcp2515(ref path) => {
-            eprintln!(
-                "  WARNING: MCP2515 driver ({}) not wired; using in-process mock",
-                path
-            );
-        }
-        CanDeviceSpec::AxiCan(addr) => {
-            eprintln!(
-                "  WARNING: AXI CAN driver (0x{:x}) not wired; using in-process mock",
-                addr
-            );
-        }
-    }
+    warn_unwired_can_device(&device);
 
-    let mut controller = MockCanController::new();
-    if let Err(e) = controller.init() {
-        eprintln!("  CAN controller init failed: {:?}", e);
-        return None;
-    }
-    if let Err(e) = controller.set_mode(CanMode::Loopback) {
-        eprintln!("  CAN controller set_mode failed: {:?}", e);
-        return None;
-    }
+    let mut controller = init_mock_can_controller()?;
 
     // Hard-coded empty routing table — real routing-file loading is a
     // follow-up (see task group 4.2 notes). With no routes, incoming
@@ -410,29 +474,9 @@ fn start_can_dataflow_runner(
         let mut timestamp_us: u64 = 0;
         while !shutdown.load(Ordering::Relaxed) {
             // Drain anything the controller has for us.
-            loop {
-                match controller.receive() {
-                    Ok(Some(frame)) => {
-                        if let Some((topic, payload)) = adapter.process_frame(&frame, timestamp_us)
-                        {
-                            // Try to run inference for the topic's model.
-                            if let Ok(output_bytes) = runner.process_message(&topic, &payload) {
-                                let output_topic = runner.output_topic(&topic);
-                                let frames =
-                                    adapter.on_inference_output(&output_topic, &output_bytes);
-                                for frame in frames {
-                                    let _ = controller.transmit(&frame);
-                                }
-                            }
-                        }
-                        timestamp_us = timestamp_us.wrapping_add(100);
-                    }
-                    Ok(None) => break,
-                    Err(e) => {
-                        eprintln!("  CAN receive error: {:?}", e);
-                        break;
-                    }
-                }
+            while let CanReceiveOutcome::Continue =
+                process_can_receive(&runner, &mut adapter, &mut controller, &mut timestamp_us)
+            {
             }
             std::thread::sleep(Duration::from_millis(5));
         }

--- a/container/src/model_manager.rs
+++ b/container/src/model_manager.rs
@@ -74,83 +74,18 @@ impl ModelManager {
 
         let mut count = 0;
         for entry in dir.flatten() {
-            let path = entry.path();
-
-            // ONNX file path.
-            if path.extension().map(|e| e == "onnx").unwrap_or(false) {
-                let name = path
-                    .file_stem()
-                    .unwrap_or_default()
-                    .to_string_lossy()
-                    .to_string();
-                let file_size = entry.metadata().map(|m| m.len()).unwrap_or(0);
-
-                // Real ONNX files start with a protobuf varint field tag;
-                // field 1 (ir_version) wire-type 0 => tag byte 0x08.
-                let (loaded, error) = match fs::read(&path) {
-                    Ok(data) => {
-                        if data.len() >= 8 && data[0] == 0x08 {
-                            (true, None)
-                        } else {
-                            (false, Some("invalid ONNX magic byte".to_string()))
-                        }
-                    }
-                    Err(e) => (false, Some(format!("read error: {}", e))),
-                };
-
-                if loaded {
+            if let Some(info) = build_onnx_model_info(&entry) {
+                if info.loaded {
                     count += 1;
                 }
-                println!(
-                    "  Model '{}': {} bytes [onnx] {}",
-                    name,
-                    file_size,
-                    if loaded { "OK" } else { "FAILED" }
-                );
-
-                self.models.insert(
-                    name.clone(),
-                    ModelInfo {
-                        name,
-                        file_path: path.to_string_lossy().to_string(),
-                        file_size,
-                        loaded,
-                        error,
-                        kind: ModelKind::Onnx,
-                    },
-                );
+                self.models.insert(info.name.clone(), info);
                 continue;
             }
-
-            // Safetensors model directory path.
-            if path.is_dir() && is_safetensors_dir(&path) {
-                let name = path
-                    .file_name()
-                    .unwrap_or_default()
-                    .to_string_lossy()
-                    .to_string();
-                let (total_size, error) = safetensors_total_size(&path);
-                let loaded = error.is_none();
-                if loaded {
+            if let Some(info) = build_safetensors_model_info(&entry) {
+                if info.loaded {
                     count += 1;
                 }
-                println!(
-                    "  Model '{}': {} bytes [safetensors] {}",
-                    name,
-                    total_size,
-                    if loaded { "OK" } else { "FAILED" }
-                );
-                self.models.insert(
-                    name.clone(),
-                    ModelInfo {
-                        name,
-                        file_path: path.to_string_lossy().to_string(),
-                        file_size: total_size,
-                        loaded,
-                        error,
-                        kind: ModelKind::Safetensors,
-                    },
-                );
+                self.models.insert(info.name.clone(), info);
             }
         }
         count
@@ -170,6 +105,78 @@ impl ModelManager {
     pub fn model_count(&self) -> usize {
         self.models.values().filter(|m| m.loaded).count()
     }
+}
+
+/// Validate an ONNX file's protobuf header bytes. Real ONNX files
+/// start with field 1 (ir_version, wire-type 0) => tag byte 0x08, and
+/// have at least 8 bytes total.
+fn validate_onnx_header(path: &std::path::Path) -> (bool, Option<String>) {
+    match fs::read(path) {
+        Ok(data) if data.len() >= 8 && data[0] == 0x08 => (true, None),
+        Ok(_) => (false, Some("invalid ONNX magic byte".to_string())),
+        Err(e) => (false, Some(format!("read error: {}", e))),
+    }
+}
+
+/// Build a [`ModelInfo`] from a directory entry that is a `.onnx`
+/// file. Returns `None` if the entry is not an ONNX file.
+fn build_onnx_model_info(entry: &fs::DirEntry) -> Option<ModelInfo> {
+    let path = entry.path();
+    if !path.extension().map(|e| e == "onnx").unwrap_or(false) {
+        return None;
+    }
+    let name = path
+        .file_stem()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+    let file_size = entry.metadata().map(|m| m.len()).unwrap_or(0);
+    let (loaded, error) = validate_onnx_header(&path);
+    println!(
+        "  Model '{}': {} bytes [onnx] {}",
+        name,
+        file_size,
+        if loaded { "OK" } else { "FAILED" }
+    );
+    Some(ModelInfo {
+        name,
+        file_path: path.to_string_lossy().to_string(),
+        file_size,
+        loaded,
+        error,
+        kind: ModelKind::Onnx,
+    })
+}
+
+/// Build a [`ModelInfo`] from a directory entry that is a safetensors
+/// model directory. Returns `None` if the entry is not such a
+/// directory.
+fn build_safetensors_model_info(entry: &fs::DirEntry) -> Option<ModelInfo> {
+    let path = entry.path();
+    if !path.is_dir() || !is_safetensors_dir(&path) {
+        return None;
+    }
+    let name = path
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+    let (total_size, error) = safetensors_total_size(&path);
+    let loaded = error.is_none();
+    println!(
+        "  Model '{}': {} bytes [safetensors] {}",
+        name,
+        total_size,
+        if loaded { "OK" } else { "FAILED" }
+    );
+    Some(ModelInfo {
+        name,
+        file_path: path.to_string_lossy().to_string(),
+        file_size: total_size,
+        loaded,
+        error,
+        kind: ModelKind::Safetensors,
+    })
 }
 
 /// Returns `true` if `path` looks like a HuggingFace safetensors model


### PR DESCRIPTION
## Summary

Extract decision branches into named helpers across the container crate so each function clears the SonarCloud `rust:S3776` cognitive-complexity threshold of 15. No observable behavior changes — all 282 container tests pass.

| File | Function | Before | After |
|---|---|---|---|
| `container/src/main.rs` | `start_can_dataflow_runner` | 30 | ~7 |
| `container/src/json.rs` | `parse_number` | 27 | ~3 |
| `container/src/json.rs` | `serialize_value` | 20 | ~7 |
| `container/src/json.rs` | `parse_string` | 19 | ~10 |
| `container/src/model_manager.rs` | `load_directory` | 22 | ~6 |
| `container/src/handlers.rs` | `serialize_outputs` | 17 | ~3 |

Extracted helpers (all module-private):

- **`main.rs`** — `warn_unwired_can_device`, `init_mock_can_controller`, `handle_can_inference`, `process_can_receive` (returning a `CanReceiveOutcome` enum so the drain loop is a plain `while let`).
- **`json.rs`** — `serialize_number`, `push_escaped_char`, `serialize_string`, `serialize_array`, `serialize_object`; `consume_digits`, `consume_optional_sign`, `parse_integer_digits`, `parse_fraction`, `parse_exponent`; `parse_unicode_escape`, `decode_escape`.
- **`model_manager.rs`** — `validate_onnx_header`, `build_onnx_model_info`, `build_safetensors_model_info`.
- **`handlers.rs`** — `append_shape_dims`, `append_float_tensor_data`, `append_output_entry`.

## Test plan

- [x] `cargo fmt -p smallaios-container -- --check`
- [x] `cargo clippy -p smallaios-container --all-targets -- -D warnings`
- [x] `cargo test -p smallaios-container` — 282 passed, 0 failed
- [x] `cargo check -p smallaios-container --features formal-gate`
- [x] `cargo check -p smallaios-container --features bus-zenoh`
- [x] `cargo check -p smallaios-container --features bus-dds`
- [ ] SonarCloud verifies each touched function now scores < 15

Generated with [Claude Code](https://claude.com/claude-code)