### PR TITLE
refactor(onnx-rt): reduce cognitive complexity below 15 in model_loader + metal_dispatch + dhcp

### DIFF
--- a/net/src/dhcp.rs
+++ b/net/src/dhcp.rs
@@ -450,35 +450,61 @@ fn iter_dhcp_options(data: &[u8]) -> impl Iterator<Item = Result<(u8, &[u8]), Dh
         if done {
             return None;
         }
-        while pos < data.len() {
-            let code = data[pos];
-
-            // PAD option — skip
-            if code == OPT_PAD {
-                pos += 1;
-                continue;
-            }
-            // END option — stop
-            if code == OPT_END {
+        let step = next_dhcp_option(data, &mut pos);
+        match step {
+            DhcpOptionStep::Finished => {
                 done = true;
-                return None;
+                None
             }
-            // Other options have a length byte
-            if pos + 1 >= data.len() {
+            DhcpOptionStep::Error(e) => {
                 done = true;
-                return Some(Err(DhcpError::InvalidOptionLength));
+                Some(Err(e))
             }
-            let len = data[pos + 1] as usize;
-            if pos + 2 + len > data.len() {
-                done = true;
-                return Some(Err(DhcpError::InvalidOptionLength));
-            }
-            let value = &data[pos + 2..pos + 2 + len];
-            pos += 2 + len;
-            return Some(Ok((code, value)));
+            DhcpOptionStep::Yield(code, value) => Some(Ok((code, value))),
         }
-        None
     })
+}
+
+/// Outcome of a single advance through a DHCP options buffer.
+enum DhcpOptionStep<'a> {
+    /// No more options (END marker or buffer exhausted).
+    Finished,
+    /// One well-formed option ready to yield.
+    Yield(u8, &'a [u8]),
+    /// Truncated option — iteration must stop.
+    Error(DhcpError),
+}
+
+/// Advance `pos` past PAD bytes and return the next decoded option,
+/// END marker, or an error.
+fn next_dhcp_option<'a>(data: &'a [u8], pos: &mut usize) -> DhcpOptionStep<'a> {
+    while *pos < data.len() {
+        let code = data[*pos];
+        if code == OPT_PAD {
+            *pos += 1;
+            continue;
+        }
+        if code == OPT_END {
+            return DhcpOptionStep::Finished;
+        }
+        return decode_tlv_option(data, pos, code);
+    }
+    DhcpOptionStep::Finished
+}
+
+/// Decode a single TLV option starting at `*pos` (code already peeked).
+fn decode_tlv_option<'a>(data: &'a [u8], pos: &mut usize, code: u8) -> DhcpOptionStep<'a> {
+    if *pos + 1 >= data.len() {
+        return DhcpOptionStep::Error(DhcpError::InvalidOptionLength);
+    }
+    let len = data[*pos + 1] as usize;
+    let end = *pos + 2 + len;
+    if end > data.len() {
+        return DhcpOptionStep::Error(DhcpError::InvalidOptionLength);
+    }
+    let value = &data[*pos + 2..end];
+    *pos = end;
+    DhcpOptionStep::Yield(code, value)
 }
 
 /// Parse all TLV options from a raw options byte slice.

--- a/onnx-rt/src/metal_dispatch.rs
+++ b/onnx-rt/src/metal_dispatch.rs
@@ -1939,36 +1939,86 @@ mod tests {
             let mut out = vec![0.0f32; bh * sq * d];
             for h in 0..bh {
                 for qi in 0..sq {
-                    let q_base = h * sq * d + qi * d;
-                    let causal_limit = qi + (sk - sq) + 1;
-                    let mut scores = vec![f32::NEG_INFINITY; sk];
-                    for j in 0..sk {
-                        if j >= causal_limit {
-                            continue;
-                        }
-                        let mut dot = 0.0f32;
-                        for dd in 0..d {
-                            dot += q[q_base + dd] * k[h * sk * d + j * d + dd];
-                        }
-                        scores[j] = dot * scale;
-                    }
-                    let max_s = scores.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
-                    let exps: Vec<f32> = scores.iter().map(|s| (s - max_s).exp()).collect();
-                    let sum_exp: f32 = exps.iter().sum();
-                    for dd in 0..d {
-                        let mut acc = 0.0f32;
-                        for j in 0..sk {
-                            if j >= causal_limit {
-                                continue;
-                            }
-                            let prob = exps[j] / sum_exp;
-                            acc += prob * v[h * sk * d + j * d + dd];
-                        }
-                        out[h * sq * d + qi * d + dd] = acc;
-                    }
+                    cpu_sdpa_query(q, k, v, &mut out, h, qi, sq, sk, d, scale);
                 }
             }
             out
+        }
+
+        /// Compute the attention output for a single (head, query) position.
+        #[allow(clippy::too_many_arguments)]
+        fn cpu_sdpa_query(
+            q: &[f32],
+            k: &[f32],
+            v: &[f32],
+            out: &mut [f32],
+            h: usize,
+            qi: usize,
+            sq: usize,
+            sk: usize,
+            d: usize,
+            scale: f32,
+        ) {
+            let q_base = h * sq * d + qi * d;
+            let causal_limit = qi + (sk - sq) + 1;
+            let scores = cpu_sdpa_scores(q, k, h, sk, d, q_base, causal_limit, scale);
+            let (exps, sum_exp) = softmax_with_sum(&scores);
+            cpu_sdpa_weighted_values(v, &exps, sum_exp, out, h, qi, sq, sk, d, causal_limit);
+        }
+
+        /// Build the (masked) score vector for a single query position.
+        #[allow(clippy::too_many_arguments)]
+        fn cpu_sdpa_scores(
+            q: &[f32],
+            k: &[f32],
+            h: usize,
+            sk: usize,
+            d: usize,
+            q_base: usize,
+            causal_limit: usize,
+            scale: f32,
+        ) -> Vec<f32> {
+            let mut scores = vec![f32::NEG_INFINITY; sk];
+            for j in 0..sk.min(causal_limit) {
+                let mut dot = 0.0f32;
+                for dd in 0..d {
+                    dot += q[q_base + dd] * k[h * sk * d + j * d + dd];
+                }
+                scores[j] = dot * scale;
+            }
+            scores
+        }
+
+        /// Stable softmax over `scores`, returning the exp vector and its sum.
+        fn softmax_with_sum(scores: &[f32]) -> (Vec<f32>, f32) {
+            let max_s = scores.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+            let exps: Vec<f32> = scores.iter().map(|s| (s - max_s).exp()).collect();
+            let sum_exp: f32 = exps.iter().sum();
+            (exps, sum_exp)
+        }
+
+        /// Write `softmax(scores) @ V` for a single (head, query) into `out`.
+        #[allow(clippy::too_many_arguments)]
+        fn cpu_sdpa_weighted_values(
+            v: &[f32],
+            exps: &[f32],
+            sum_exp: f32,
+            out: &mut [f32],
+            h: usize,
+            qi: usize,
+            sq: usize,
+            sk: usize,
+            d: usize,
+            causal_limit: usize,
+        ) {
+            for dd in 0..d {
+                let mut acc = 0.0f32;
+                for j in 0..sk.min(causal_limit) {
+                    let prob = exps[j] / sum_exp;
+                    acc += prob * v[h * sk * d + j * d + dd];
+                }
+                out[h * sq * d + qi * d + dd] = acc;
+            }
         }
 
         #[test]

--- a/onnx-rt/src/model_loader/config.rs
+++ b/onnx-rt/src/model_loader/config.rs
@@ -380,6 +380,16 @@ enum JsonValue {
     Object(ConfigMap),
 }
 
+/// Convert a single ASCII hex digit to its numeric value.
+fn hex_digit_value(d: u8) -> Option<u8> {
+    match d {
+        b'0'..=b'9' => Some(d - b'0'),
+        b'a'..=b'f' => Some(d - b'a' + 10),
+        b'A'..=b'F' => Some(d - b'A' + 10),
+        _ => None,
+    }
+}
+
 fn parse_config_object(input: &str) -> Result<ConfigMap, LoaderError> {
     let mut p = ConfigJsonParser::new(input);
     p.skip_ws();
@@ -536,54 +546,7 @@ impl<'a> ConfigJsonParser<'a> {
         loop {
             match self.bump() {
                 Some(b'"') => return Ok(out),
-                Some(b'\\') => match self.bump() {
-                    Some(b'"') => out.push('"'),
-                    Some(b'\\') => out.push('\\'),
-                    Some(b'/') => out.push('/'),
-                    Some(b'n') => out.push('\n'),
-                    Some(b'r') => out.push('\r'),
-                    Some(b't') => out.push('\t'),
-                    Some(b'b') => out.push('\u{08}'),
-                    Some(b'f') => out.push('\u{0C}'),
-                    Some(b'u') => {
-                        let mut code: u32 = 0;
-                        for _ in 0..4 {
-                            let d = self.bump().ok_or_else(|| {
-                                LoaderError::InvalidConfig("truncated \\u escape".to_string())
-                            })?;
-                            let hv = match d {
-                                b'0'..=b'9' => d - b'0',
-                                b'a'..=b'f' => d - b'a' + 10,
-                                b'A'..=b'F' => d - b'A' + 10,
-                                _ => {
-                                    return Err(LoaderError::InvalidConfig(format!(
-                                        "bad hex digit '{}' in \\u escape",
-                                        d as char
-                                    )))
-                                }
-                            };
-                            code = (code << 4) | hv as u32;
-                        }
-                        if let Some(c) = char::from_u32(code) {
-                            out.push(c);
-                        } else {
-                            return Err(LoaderError::InvalidConfig(format!(
-                                "invalid unicode codepoint U+{code:04X}"
-                            )));
-                        }
-                    }
-                    Some(c) => {
-                        return Err(LoaderError::InvalidConfig(format!(
-                            "bad escape '\\{}'",
-                            c as char
-                        )))
-                    }
-                    None => {
-                        return Err(LoaderError::InvalidConfig(
-                            "unterminated escape".to_string(),
-                        ))
-                    }
-                },
+                Some(b'\\') => self.consume_escape(&mut out)?,
                 Some(b) => {
                     out.push(b as char);
                 }
@@ -596,41 +559,58 @@ impl<'a> ConfigJsonParser<'a> {
         }
     }
 
+    /// Consume one `\<x>` escape sequence (already past the backslash).
+    fn consume_escape(&mut self, out: &mut String) -> Result<(), LoaderError> {
+        match self.bump() {
+            Some(b'"') => out.push('"'),
+            Some(b'\\') => out.push('\\'),
+            Some(b'/') => out.push('/'),
+            Some(b'n') => out.push('\n'),
+            Some(b'r') => out.push('\r'),
+            Some(b't') => out.push('\t'),
+            Some(b'b') => out.push('\u{08}'),
+            Some(b'f') => out.push('\u{0C}'),
+            Some(b'u') => self.consume_unicode_escape(out)?,
+            Some(c) => {
+                return Err(LoaderError::InvalidConfig(format!(
+                    "bad escape '\\{}'",
+                    c as char
+                )))
+            }
+            None => {
+                return Err(LoaderError::InvalidConfig(
+                    "unterminated escape".to_string(),
+                ))
+            }
+        }
+        Ok(())
+    }
+
+    /// Consume the 4 hex digits of a `\uXXXX` escape.
+    fn consume_unicode_escape(&mut self, out: &mut String) -> Result<(), LoaderError> {
+        let mut code: u32 = 0;
+        for _ in 0..4 {
+            let d = self
+                .bump()
+                .ok_or_else(|| LoaderError::InvalidConfig("truncated \\u escape".to_string()))?;
+            let hv = hex_digit_value(d).ok_or_else(|| {
+                LoaderError::InvalidConfig(format!("bad hex digit '{}' in \\u escape", d as char))
+            })?;
+            code = (code << 4) | hv as u32;
+        }
+        let c = char::from_u32(code).ok_or_else(|| {
+            LoaderError::InvalidConfig(format!("invalid unicode codepoint U+{code:04X}"))
+        })?;
+        out.push(c);
+        Ok(())
+    }
+
     fn parse_number(&mut self) -> Result<JsonValue, LoaderError> {
         let start = self.pos;
-        if self.peek() == Some(b'-') {
-            self.pos += 1;
-        }
-        while let Some(b) = self.peek() {
-            if b.is_ascii_digit() {
-                self.pos += 1;
-            } else {
-                break;
-            }
-        }
-        if self.peek() == Some(b'.') {
-            self.pos += 1;
-            while let Some(b) = self.peek() {
-                if b.is_ascii_digit() {
-                    self.pos += 1;
-                } else {
-                    break;
-                }
-            }
-        }
-        if matches!(self.peek(), Some(b'e') | Some(b'E')) {
-            self.pos += 1;
-            if matches!(self.peek(), Some(b'+') | Some(b'-')) {
-                self.pos += 1;
-            }
-            while let Some(b) = self.peek() {
-                if b.is_ascii_digit() {
-                    self.pos += 1;
-                } else {
-                    break;
-                }
-            }
-        }
+        self.consume_optional_sign();
+        self.consume_digits();
+        self.consume_fraction_part();
+        self.consume_exponent_part();
         let slice = &self.bytes[start..self.pos];
         let s = core::str::from_utf8(slice)
             .map_err(|_| LoaderError::InvalidConfig("non-utf8 number".to_string()))?;
@@ -638,6 +618,43 @@ impl<'a> ConfigJsonParser<'a> {
             .parse()
             .map_err(|_| LoaderError::InvalidConfig(format!("bad number '{s}'")))?;
         Ok(JsonValue::Number(n))
+    }
+
+    fn consume_optional_sign(&mut self) {
+        if self.peek() == Some(b'-') {
+            self.pos += 1;
+        }
+    }
+
+    /// Advance past any run of ASCII digits.
+    fn consume_digits(&mut self) {
+        while let Some(b) = self.peek() {
+            if b.is_ascii_digit() {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Advance past `.<digits>` if present.
+    fn consume_fraction_part(&mut self) {
+        if self.peek() == Some(b'.') {
+            self.pos += 1;
+            self.consume_digits();
+        }
+    }
+
+    /// Advance past `(e|E)[+-]?<digits>` if present.
+    fn consume_exponent_part(&mut self) {
+        if !matches!(self.peek(), Some(b'e') | Some(b'E')) {
+            return;
+        }
+        self.pos += 1;
+        if matches!(self.peek(), Some(b'+') | Some(b'-')) {
+            self.pos += 1;
+        }
+        self.consume_digits();
     }
 
     fn parse_bool(&mut self) -> Result<JsonValue, LoaderError> {

--- a/onnx-rt/src/model_loader/graph_builder.rs
+++ b/onnx-rt/src/model_loader/graph_builder.rs
@@ -408,73 +408,13 @@ impl GraphBuilder {
             next_tensor_id: _,
         } = self;
 
-        // Validate every node's inputs resolve. Because nodes are
-        // appended in dependency order, we only need to check that the
-        // name is either a graph input, an initializer, or an earlier
-        // node's output. We also build each node's `dependencies` list
-        // so topological_sort has something to chew on.
-        let mut output_to_node: BTreeMap<String, NodeIndex> = BTreeMap::new();
         let initializer_names: BTreeSet<String> = initializers.keys().cloned().collect();
         let input_set: BTreeSet<String> = input_names.iter().cloned().collect();
 
-        let node_count = nodes.len();
-        #[allow(clippy::needless_range_loop)]
-        for i in 0..node_count {
-            let node_inputs = nodes[i].inputs.clone();
-            let mut deps: Vec<NodeIndex> = Vec::new();
-            for input in &node_inputs {
-                if input.is_empty() {
-                    // ONNX optional-input convention.
-                    continue;
-                }
-                if input_set.contains(input) {
-                    continue;
-                }
-                if initializer_names.contains(input) {
-                    continue;
-                }
-                match output_to_node.get(input) {
-                    Some(&prod) => {
-                        if !deps.iter().any(|d| d.index() == prod.index()) {
-                            deps.push(prod);
-                        }
-                    }
-                    None => {
-                        return Err(LoaderError::InvalidConfig(format!(
-                            "node '{}' references unknown input '{}'",
-                            nodes[i].name, input
-                        )));
-                    }
-                }
-            }
-            nodes[i].dependencies = deps;
+        let output_to_node = resolve_node_dependencies(&mut nodes, &input_set, &initializer_names)?;
+        validate_declared_outputs(&output_names, &output_to_node, &input_set)?;
 
-            // Register this node's outputs so later nodes can reference them.
-            for out in &nodes[i].outputs {
-                if !out.is_empty() {
-                    output_to_node.insert(out.clone(), nodes[i].node_index);
-                }
-            }
-        }
-
-        // Validate declared outputs are all produced.
-        for out in &output_names {
-            if !output_to_node.contains_key(out) && !input_set.contains(out) {
-                return Err(LoaderError::InvalidConfig(format!(
-                    "declared graph output '{out}' is not produced by any node"
-                )));
-            }
-        }
-
-        // Topo-sort (also surfaces any cycles — should never trigger
-        // for a well-formed sequential build, but we run it anyway to
-        // match the ONNX loader's invariants).
-        let topological_order = topological_sort(&nodes).map_err(|e| match e {
-            GraphError::CyclicGraph => {
-                LoaderError::InvalidConfig("graph contains a cycle".to_string())
-            }
-            other => LoaderError::InvalidConfig(format!("graph build failed: {other}")),
-        })?;
+        let topological_order = run_topo_sort(&nodes)?;
 
         let graph = ExecutionGraph {
             nodes,
@@ -537,6 +477,111 @@ impl GraphBuilder {
 // Attribute helpers — shape-compatible with the protobuf parser's
 // output so the existing executor can read them transparently.
 // ─────────────────────────────────────────────────────────────────────
+
+// ─────────────────────────────────────────────────────────────────────
+// `build()` helpers — extracted to keep cognitive complexity bounded.
+// ─────────────────────────────────────────────────────────────────────
+
+/// Walk each node, resolve its input names against graph inputs,
+/// initializers, and prior-node outputs, and populate `dependencies`.
+/// Returns a `name -> producing node` map used for later checks.
+fn resolve_node_dependencies(
+    nodes: &mut [ExecutionNode],
+    input_set: &BTreeSet<String>,
+    initializer_names: &BTreeSet<String>,
+) -> Result<BTreeMap<String, NodeIndex>, LoaderError> {
+    let mut output_to_node: BTreeMap<String, NodeIndex> = BTreeMap::new();
+    let node_count = nodes.len();
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..node_count {
+        let node_inputs = nodes[i].inputs.clone();
+        let deps = compute_node_deps(
+            &node_inputs,
+            &nodes[i].name,
+            input_set,
+            initializer_names,
+            &output_to_node,
+        )?;
+        nodes[i].dependencies = deps;
+        register_node_outputs(&mut output_to_node, &nodes[i].outputs, nodes[i].node_index);
+    }
+    Ok(output_to_node)
+}
+
+/// Resolve a single node's input list into a deduplicated dependency
+/// vector. Returns an error if any input name is unknown.
+fn compute_node_deps(
+    node_inputs: &[String],
+    node_name: &str,
+    input_set: &BTreeSet<String>,
+    initializer_names: &BTreeSet<String>,
+    output_to_node: &BTreeMap<String, NodeIndex>,
+) -> Result<Vec<NodeIndex>, LoaderError> {
+    let mut deps: Vec<NodeIndex> = Vec::new();
+    for input in node_inputs {
+        if is_externally_provided(input, input_set, initializer_names) {
+            continue;
+        }
+        let prod = output_to_node.get(input).copied().ok_or_else(|| {
+            LoaderError::InvalidConfig(format!(
+                "node '{node_name}' references unknown input '{input}'"
+            ))
+        })?;
+        if !deps.iter().any(|d| d.index() == prod.index()) {
+            deps.push(prod);
+        }
+    }
+    Ok(deps)
+}
+
+/// True if `input` is empty (ONNX optional-input convention), a graph
+/// input, or an initializer — i.e. not produced by a prior node.
+fn is_externally_provided(
+    input: &str,
+    input_set: &BTreeSet<String>,
+    initializer_names: &BTreeSet<String>,
+) -> bool {
+    input.is_empty() || input_set.contains(input) || initializer_names.contains(input)
+}
+
+/// Insert this node's non-empty outputs into the producer map.
+fn register_node_outputs(
+    output_to_node: &mut BTreeMap<String, NodeIndex>,
+    outputs: &[String],
+    node_index: NodeIndex,
+) {
+    for out in outputs {
+        if !out.is_empty() {
+            output_to_node.insert(out.clone(), node_index);
+        }
+    }
+}
+
+/// Ensure every declared graph output is either produced by a node or
+/// is a passthrough graph input.
+fn validate_declared_outputs(
+    output_names: &[String],
+    output_to_node: &BTreeMap<String, NodeIndex>,
+    input_set: &BTreeSet<String>,
+) -> Result<(), LoaderError> {
+    for out in output_names {
+        if !output_to_node.contains_key(out) && !input_set.contains(out) {
+            return Err(LoaderError::InvalidConfig(format!(
+                "declared graph output '{out}' is not produced by any node"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Run topological sort and translate any errors back into the loader's
+/// `InvalidConfig` family.
+fn run_topo_sort(nodes: &[ExecutionNode]) -> Result<Vec<NodeIndex>, LoaderError> {
+    topological_sort(nodes).map_err(|e| match e {
+        GraphError::CyclicGraph => LoaderError::InvalidConfig("graph contains a cycle".to_string()),
+        other => LoaderError::InvalidConfig(format!("graph build failed: {other}")),
+    })
+}
 
 fn float_attr(name: &str, value: f32) -> AttributeProto {
     AttributeProto {

--- a/onnx-rt/src/model_loader/safetensors.rs
+++ b/onnx-rt/src/model_loader/safetensors.rs
@@ -126,6 +126,22 @@ impl SafetensorsFile {
 
 /// Parse the 8-byte length prefix + JSON header region of a mmap'd file.
 fn parse_header(bytes: &[u8]) -> Result<BTreeMap<String, TensorEntry>, LoaderError> {
+    let (header_json, payload_start) = split_header_region(bytes)?;
+    let raw = parse_json_object(header_json)?;
+
+    let mut out = BTreeMap::new();
+    for (name, value) in raw {
+        if name == "__metadata__" {
+            continue;
+        }
+        let entry = build_tensor_entry(&name, value, payload_start, bytes.len())?;
+        out.insert(name, entry);
+    }
+    Ok(out)
+}
+
+/// Split a safetensors file into (header JSON, payload start offset).
+fn split_header_region(bytes: &[u8]) -> Result<(&str, usize), LoaderError> {
     if bytes.len() < 8 {
         return Err(LoaderError::InvalidHeader(
             "file smaller than 8-byte length prefix".to_string(),
@@ -146,126 +162,146 @@ fn parse_header(bytes: &[u8]) -> Result<BTreeMap<String, TensorEntry>, LoaderErr
     }
     let header_json = core::str::from_utf8(&bytes[header_start..header_end])
         .map_err(|e| LoaderError::InvalidHeader(format!("header not valid UTF-8: {e}")))?;
+    Ok((header_json, header_end))
+}
 
-    let payload_start = header_end;
-    let raw = parse_json_object(header_json)?;
-
-    let mut out = BTreeMap::new();
-    for (name, value) in raw {
-        if name == "__metadata__" {
-            continue;
-        }
-        let obj = match value {
-            JsonValue::Object(o) => o,
-            _ => {
-                return Err(LoaderError::InvalidHeader(format!(
-                    "tensor entry {name} is not a JSON object"
-                )))
-            }
-        };
-        let dtype_str = obj
-            .iter()
-            .find(|(k, _)| k == "dtype")
-            .map(|(_, v)| v)
-            .ok_or_else(|| LoaderError::InvalidHeader(format!("{name}: missing dtype")))?;
-        let dtype_str = match dtype_str {
-            JsonValue::String(s) => s.as_str(),
-            _ => {
-                return Err(LoaderError::InvalidHeader(format!(
-                    "{name}: dtype must be a string"
-                )))
-            }
-        };
-        let dtype = dtype_from_str(dtype_str)
-            .ok_or_else(|| LoaderError::UnsupportedDtype(dtype_str.to_string()))?;
-
-        let shape_val = obj
-            .iter()
-            .find(|(k, _)| k == "shape")
-            .map(|(_, v)| v)
-            .ok_or_else(|| LoaderError::InvalidHeader(format!("{name}: missing shape")))?;
-        let shape = match shape_val {
-            JsonValue::Array(arr) => {
-                let mut dims = Vec::with_capacity(arr.len());
-                for dim in arr {
-                    match dim {
-                        JsonValue::Number(n) => dims.push(*n),
-                        _ => {
-                            return Err(LoaderError::InvalidHeader(format!(
-                                "{name}: shape element not a number"
-                            )))
-                        }
-                    }
-                }
-                dims
-            }
-            _ => {
-                return Err(LoaderError::InvalidHeader(format!(
-                    "{name}: shape must be an array"
-                )))
-            }
-        };
-
-        let offsets_val = obj
-            .iter()
-            .find(|(k, _)| k == "data_offsets")
-            .map(|(_, v)| v)
-            .ok_or_else(|| LoaderError::InvalidHeader(format!("{name}: missing data_offsets")))?;
-        let (rel_start, rel_end) = match offsets_val {
-            JsonValue::Array(arr) if arr.len() == 2 => {
-                let a = match &arr[0] {
-                    JsonValue::Number(n) => *n,
-                    _ => {
-                        return Err(LoaderError::InvalidHeader(format!(
-                            "{name}: data_offsets[0] not a number"
-                        )))
-                    }
-                };
-                let b = match &arr[1] {
-                    JsonValue::Number(n) => *n,
-                    _ => {
-                        return Err(LoaderError::InvalidHeader(format!(
-                            "{name}: data_offsets[1] not a number"
-                        )))
-                    }
-                };
-                (a, b)
-            }
-            _ => {
-                return Err(LoaderError::InvalidHeader(format!(
-                    "{name}: data_offsets must be a 2-element array"
-                )))
-            }
-        };
-        if rel_start < 0 || rel_end < rel_start {
+/// Build a single [`TensorEntry`] from the parsed JSON object value.
+fn build_tensor_entry(
+    name: &str,
+    value: JsonValue,
+    payload_start: usize,
+    file_len: usize,
+) -> Result<TensorEntry, LoaderError> {
+    let obj = match value {
+        JsonValue::Object(o) => o,
+        _ => {
             return Err(LoaderError::InvalidHeader(format!(
-                "{name}: invalid data_offsets [{rel_start}, {rel_end}]"
-            )));
+                "tensor entry {name} is not a JSON object"
+            )))
         }
-        let abs_start = payload_start
-            .checked_add(rel_start as usize)
-            .ok_or_else(|| LoaderError::InvalidHeader(format!("{name}: offset overflow")))?;
-        let abs_end = payload_start
-            .checked_add(rel_end as usize)
-            .ok_or_else(|| LoaderError::InvalidHeader(format!("{name}: offset overflow")))?;
-        if abs_end > bytes.len() {
-            return Err(LoaderError::InvalidHeader(format!(
-                "{name}: data_offsets end {abs_end} exceeds file size {}",
-                bytes.len()
-            )));
-        }
+    };
+    let dtype = decode_entry_dtype(name, &obj)?;
+    let shape = decode_entry_shape(name, &obj)?;
+    let (rel_start, rel_end) = decode_entry_offsets(name, &obj)?;
+    let (abs_start, abs_end) =
+        resolve_absolute_offsets(name, payload_start, file_len, rel_start, rel_end)?;
+    Ok(TensorEntry {
+        dtype,
+        shape,
+        data_offset_start: abs_start,
+        data_offset_end: abs_end,
+    })
+}
 
-        out.insert(
-            name,
-            TensorEntry {
-                dtype,
-                shape,
-                data_offset_start: abs_start,
-                data_offset_end: abs_end,
-            },
-        );
+/// Find a key in a JSON object payload, or fail with a helpful error.
+fn find_obj_field<'a>(
+    obj: &'a [(String, JsonValue)],
+    key: &str,
+    name: &str,
+) -> Result<&'a JsonValue, LoaderError> {
+    obj.iter()
+        .find(|(k, _)| k == key)
+        .map(|(_, v)| v)
+        .ok_or_else(|| LoaderError::InvalidHeader(format!("{name}: missing {key}")))
+}
+
+fn decode_entry_dtype(name: &str, obj: &[(String, JsonValue)]) -> Result<DataType, LoaderError> {
+    let dtype_val = find_obj_field(obj, "dtype", name)?;
+    let dtype_str = match dtype_val {
+        JsonValue::String(s) => s.as_str(),
+        _ => {
+            return Err(LoaderError::InvalidHeader(format!(
+                "{name}: dtype must be a string"
+            )))
+        }
+    };
+    dtype_from_str(dtype_str).ok_or_else(|| LoaderError::UnsupportedDtype(dtype_str.to_string()))
+}
+
+fn decode_entry_shape(name: &str, obj: &[(String, JsonValue)]) -> Result<Vec<i64>, LoaderError> {
+    let shape_val = find_obj_field(obj, "shape", name)?;
+    let arr = match shape_val {
+        JsonValue::Array(arr) => arr,
+        _ => {
+            return Err(LoaderError::InvalidHeader(format!(
+                "{name}: shape must be an array"
+            )))
+        }
+    };
+    let mut dims = Vec::with_capacity(arr.len());
+    for dim in arr {
+        match dim {
+            JsonValue::Number(n) => dims.push(*n),
+            _ => {
+                return Err(LoaderError::InvalidHeader(format!(
+                    "{name}: shape element not a number"
+                )))
+            }
+        }
     }
-    Ok(out)
+    Ok(dims)
+}
+
+fn decode_entry_offsets(
+    name: &str,
+    obj: &[(String, JsonValue)],
+) -> Result<(i64, i64), LoaderError> {
+    let offsets_val = find_obj_field(obj, "data_offsets", name)?;
+    match offsets_val {
+        JsonValue::Array(arr) if arr.len() == 2 => {
+            let a = offset_element(name, &arr[0], 0)?;
+            let b = offset_element(name, &arr[1], 1)?;
+            Ok((a, b))
+        }
+        _ => Err(LoaderError::InvalidHeader(format!(
+            "{name}: data_offsets must be a 2-element array"
+        ))),
+    }
+}
+
+fn offset_element(name: &str, value: &JsonValue, idx: usize) -> Result<i64, LoaderError> {
+    match value {
+        JsonValue::Number(n) => Ok(*n),
+        _ => Err(LoaderError::InvalidHeader(format!(
+            "{name}: data_offsets[{idx}] not a number"
+        ))),
+    }
+}
+
+fn resolve_absolute_offsets(
+    name: &str,
+    payload_start: usize,
+    file_len: usize,
+    rel_start: i64,
+    rel_end: i64,
+) -> Result<(usize, usize), LoaderError> {
+    if rel_start < 0 || rel_end < rel_start {
+        return Err(LoaderError::InvalidHeader(format!(
+            "{name}: invalid data_offsets [{rel_start}, {rel_end}]"
+        )));
+    }
+    let abs_start = payload_start
+        .checked_add(rel_start as usize)
+        .ok_or_else(|| LoaderError::InvalidHeader(format!("{name}: offset overflow")))?;
+    let abs_end = payload_start
+        .checked_add(rel_end as usize)
+        .ok_or_else(|| LoaderError::InvalidHeader(format!("{name}: offset overflow")))?;
+    if abs_end > file_len {
+        return Err(LoaderError::InvalidHeader(format!(
+            "{name}: data_offsets end {abs_end} exceeds file size {file_len}"
+        )));
+    }
+    Ok((abs_start, abs_end))
+}
+
+/// Convert a single ASCII hex digit to its numeric value.
+fn hex_digit_value(d: u8) -> Option<u8> {
+    match d {
+        b'0'..=b'9' => Some(d - b'0'),
+        b'a'..=b'f' => Some(d - b'a' + 10),
+        b'A'..=b'F' => Some(d - b'A' + 10),
+        _ => None,
+    }
 }
 
 /// Map safetensors dtype strings to ONNX-runtime `DataType`.
@@ -458,54 +494,7 @@ impl<'a> JsonParser<'a> {
         loop {
             match self.bump() {
                 Some(b'"') => return Ok(out),
-                Some(b'\\') => match self.bump() {
-                    Some(b'"') => out.push('"'),
-                    Some(b'\\') => out.push('\\'),
-                    Some(b'/') => out.push('/'),
-                    Some(b'n') => out.push('\n'),
-                    Some(b'r') => out.push('\r'),
-                    Some(b't') => out.push('\t'),
-                    Some(b'b') => out.push('\u{08}'),
-                    Some(b'f') => out.push('\u{0C}'),
-                    Some(b'u') => {
-                        let mut code: u32 = 0;
-                        for _ in 0..4 {
-                            let d = self.bump().ok_or_else(|| {
-                                LoaderError::InvalidHeader("truncated \\u escape".to_string())
-                            })?;
-                            let hv = match d {
-                                b'0'..=b'9' => d - b'0',
-                                b'a'..=b'f' => d - b'a' + 10,
-                                b'A'..=b'F' => d - b'A' + 10,
-                                _ => {
-                                    return Err(LoaderError::InvalidHeader(format!(
-                                        "bad hex digit '{}' in \\u escape",
-                                        d as char
-                                    )))
-                                }
-                            };
-                            code = (code << 4) | hv as u32;
-                        }
-                        if let Some(c) = char::from_u32(code) {
-                            out.push(c);
-                        } else {
-                            return Err(LoaderError::InvalidHeader(format!(
-                                "invalid unicode codepoint U+{code:04X}"
-                            )));
-                        }
-                    }
-                    Some(c) => {
-                        return Err(LoaderError::InvalidHeader(format!(
-                            "bad escape '\\{}'",
-                            c as char
-                        )))
-                    }
-                    None => {
-                        return Err(LoaderError::InvalidHeader(
-                            "unterminated escape".to_string(),
-                        ))
-                    }
-                },
+                Some(b'\\') => self.consume_escape(&mut out)?,
                 Some(b) => {
                     // Accept UTF-8 continuation bytes verbatim.
                     out.push(b as char);
@@ -517,6 +506,53 @@ impl<'a> JsonParser<'a> {
                 }
             }
         }
+    }
+
+    /// Consume one `\<x>` escape sequence (already past the backslash).
+    fn consume_escape(&mut self, out: &mut String) -> Result<(), LoaderError> {
+        match self.bump() {
+            Some(b'"') => out.push('"'),
+            Some(b'\\') => out.push('\\'),
+            Some(b'/') => out.push('/'),
+            Some(b'n') => out.push('\n'),
+            Some(b'r') => out.push('\r'),
+            Some(b't') => out.push('\t'),
+            Some(b'b') => out.push('\u{08}'),
+            Some(b'f') => out.push('\u{0C}'),
+            Some(b'u') => self.consume_unicode_escape(out)?,
+            Some(c) => {
+                return Err(LoaderError::InvalidHeader(format!(
+                    "bad escape '\\{}'",
+                    c as char
+                )))
+            }
+            None => {
+                return Err(LoaderError::InvalidHeader(
+                    "unterminated escape".to_string(),
+                ))
+            }
+        }
+        Ok(())
+    }
+
+    /// Consume the 4 hex digits of a `\uXXXX` escape and push the
+    /// resulting code point onto `out`.
+    fn consume_unicode_escape(&mut self, out: &mut String) -> Result<(), LoaderError> {
+        let mut code: u32 = 0;
+        for _ in 0..4 {
+            let d = self
+                .bump()
+                .ok_or_else(|| LoaderError::InvalidHeader("truncated \\u escape".to_string()))?;
+            let hv = hex_digit_value(d).ok_or_else(|| {
+                LoaderError::InvalidHeader(format!("bad hex digit '{}' in \\u escape", d as char))
+            })?;
+            code = (code << 4) | hv as u32;
+        }
+        let c = char::from_u32(code).ok_or_else(|| {
+            LoaderError::InvalidHeader(format!("invalid unicode codepoint U+{code:04X}"))
+        })?;
+        out.push(c);
+        Ok(())
     }
 
     fn parse_number(&mut self) -> Result<JsonValue, LoaderError> {


### PR DESCRIPTION
## Summary

Extracts independent decision branches into named helpers to bring each SonarCloud-flagged function below the `rust:S3776` cognitive-complexity threshold of 15. No observable behavior changes.

| File | Function | Before | After (est.) |
|------|----------|-------:|-------------:|
| `onnx-rt/src/model_loader/safetensors.rs` | `parse_header` (L128) | 31 | ~4 |
| `onnx-rt/src/model_loader/safetensors.rs` | `JsonParser::parse_string` (L454) | 20 | ~5 |
| `onnx-rt/src/model_loader/graph_builder.rs` | `GraphBuilder::build` (L401) | 30 | ~4 |
| `onnx-rt/src/model_loader/config.rs` | `ConfigJsonParser::parse_string` (L532) | 20 | ~5 |
| `onnx-rt/src/model_loader/config.rs` | `ConfigJsonParser::parse_number` (L599) | 21 | ~4 |
| `onnx-rt/src/metal_dispatch.rs` | `cpu_sdpa` (test helper, L1929) | 26 | ~3 |
| `net/src/dhcp.rs` | `iter_dhcp_options` closure (L446) | 16 | ~4 |

Key refactor moves:
- **safetensors header**: split into `split_header_region`, `build_tensor_entry`, and per-field decoders (`decode_entry_dtype`, `decode_entry_shape`, `decode_entry_offsets`, `resolve_absolute_offsets`).
- **graph build**: extracted `resolve_node_dependencies`, `compute_node_deps`, `is_externally_provided`, `register_node_outputs`, `validate_declared_outputs`, `run_topo_sort`.
- **JSON string/number parsers**: pulled escape and unicode handling into `consume_escape` / `consume_unicode_escape`; number parsing into `consume_optional_sign` / `consume_digits` / `consume_fraction_part` / `consume_exponent_part`; shared `hex_digit_value` helper.
- **`cpu_sdpa`** (Metal test helper): split into `cpu_sdpa_query`, `cpu_sdpa_scores`, `softmax_with_sum`, `cpu_sdpa_weighted_values`.
- **DHCP options iterator**: pulled the per-step decision into `next_dhcp_option` + `decode_tlv_option` returning a small `DhcpOptionStep` enum.

## Test plan

- [x] `cargo fmt -- --check` (clean)
- [x] `cargo clippy -p smallaios-onnx-rt --all-targets -- -D warnings` (clean)
- [x] `cargo clippy -p smallaios-onnx-rt --features metal --all-targets -- -D warnings` (clean on macOS)
- [x] `cargo clippy -p smallaios-net --all-targets -- -D warnings` (clean)
- [x] `cargo test -p smallaios-onnx-rt` — 891 + 19 + 39 + 9 + 5 + 3 + 9 tests pass; 14 ignored (CUDA / hardware-gated)
- [x] `cargo test -p smallaios-net` — 490 tests pass

Pre-existing develop failures (unrelated, not introduced here):
- `mgmt/tests/toml_oracle.rs` E0282 type inference errors surface during a workspace-wide `just clippy`.
- `onnx-rt/tests/test_cuda.rs` `Mutex.borrow` issue (CUDA host-test path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)