### PR TITLE
refactor(bus): reduce code duplication across {arinc664,ccsds,dds,spacewire,mil1553} adapters

### DIFF
--- a/bus/src/arinc429/adapter.rs
+++ b/bus/src/arinc429/adapter.rs
@@ -13,7 +13,7 @@ use alloc::format;
 use alloc::string::String;
 
 use super::word::{Arinc429Word, Label};
-use crate::transport::{BusSample, ZenohTransport};
+use crate::transport::{pack_sample, BusSample, ZenohTransport};
 use crate::BusError;
 
 /// Maximum number of queued receive words.
@@ -109,25 +109,9 @@ impl ZenohTransport for Arinc429ZenohAdapter {
     }
 
     fn receive<'a>(&mut self, buf: &'a mut [u8]) -> Result<Option<BusSample<'a>>, BusError> {
-        if let Some((key, word_bytes)) = self.rx_queue.pop_front() {
-            let key_bytes = key.as_bytes();
-            let total = key_bytes.len() + 1 + 4;
-            if buf.len() < total {
-                return Err(BusError::BufferTooSmall);
-            }
-            buf[..key_bytes.len()].copy_from_slice(key_bytes);
-            buf[key_bytes.len()] = 0;
-            let payload_start = key_bytes.len() + 1;
-            buf[payload_start..payload_start + 4].copy_from_slice(&word_bytes);
-
-            Ok(Some(BusSample {
-                key_expr: core::str::from_utf8(&buf[..key_bytes.len()])
-                    .map_err(|_| BusError::InvalidHeader)?,
-                payload: &buf[payload_start..payload_start + 4],
-                timestamp_us: 0,
-            }))
-        } else {
-            Ok(None)
+        match self.rx_queue.pop_front() {
+            Some((key, word_bytes)) => pack_sample(buf, &key, &word_bytes).map(Some),
+            None => Ok(None),
         }
     }
 }

--- a/bus/src/arinc664/adapter.rs
+++ b/bus/src/arinc664/adapter.rs
@@ -13,7 +13,7 @@ use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-use crate::transport::{BusSample, ZenohTransport};
+use crate::transport::{pack_sample, BusSample, ZenohTransport};
 use crate::BusError;
 
 /// Maximum number of queued receive frames.
@@ -82,25 +82,9 @@ impl ZenohTransport for AfdxZenohAdapter {
     }
 
     fn receive<'a>(&mut self, buf: &'a mut [u8]) -> Result<Option<BusSample<'a>>, BusError> {
-        if let Some((key, data)) = self.rx_queue.pop_front() {
-            let key_bytes = key.as_bytes();
-            let total = key_bytes.len() + 1 + data.len();
-            if buf.len() < total {
-                return Err(BusError::BufferTooSmall);
-            }
-            buf[..key_bytes.len()].copy_from_slice(key_bytes);
-            buf[key_bytes.len()] = 0;
-            let payload_start = key_bytes.len() + 1;
-            buf[payload_start..payload_start + data.len()].copy_from_slice(&data);
-
-            Ok(Some(BusSample {
-                key_expr: core::str::from_utf8(&buf[..key_bytes.len()])
-                    .map_err(|_| BusError::InvalidHeader)?,
-                payload: &buf[payload_start..payload_start + data.len()],
-                timestamp_us: 0,
-            }))
-        } else {
-            Ok(None)
+        match self.rx_queue.pop_front() {
+            Some((key, data)) => pack_sample(buf, &key, &data).map(Some),
+            None => Ok(None),
         }
     }
 }

--- a/bus/src/can/adapter.rs
+++ b/bus/src/can/adapter.rs
@@ -16,7 +16,7 @@ use alloc::vec::Vec;
 
 use super::controller::CanController;
 use super::frame::CanFrame;
-use crate::transport::{BusSample, ZenohTransport};
+use crate::transport::{pack_sample, BusSample, ZenohTransport};
 use crate::BusError;
 
 /// Maximum number of queued receive frames.
@@ -142,25 +142,9 @@ impl<C: CanController> ZenohTransport for CanZenohAdapter<C> {
         // Try polling the controller first.
         let _ = self.poll_rx();
 
-        if let Some((key, data)) = self.rx_queue.pop_front() {
-            if buf.len() < key.len() + 1 + data.len() {
-                return Err(BusError::BufferTooSmall);
-            }
-            // Pack key + null + data into buffer.
-            let key_bytes = key.as_bytes();
-            buf[..key_bytes.len()].copy_from_slice(key_bytes);
-            buf[key_bytes.len()] = 0; // null separator
-            let payload_start = key_bytes.len() + 1;
-            buf[payload_start..payload_start + data.len()].copy_from_slice(&data);
-
-            Ok(Some(BusSample {
-                key_expr: core::str::from_utf8(&buf[..key_bytes.len()])
-                    .map_err(|_| BusError::InvalidHeader)?,
-                payload: &buf[payload_start..payload_start + data.len()],
-                timestamp_us: 0,
-            }))
-        } else {
-            Ok(None)
+        match self.rx_queue.pop_front() {
+            Some((key, data)) => pack_sample(buf, &key, &data).map(Some),
+            None => Ok(None),
         }
     }
 }

--- a/bus/src/ccsds/adapter.rs
+++ b/bus/src/ccsds/adapter.rs
@@ -14,7 +14,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use super::packet::{SpacePacket, MAX_APID};
-use crate::transport::{BusSample, ZenohTransport};
+use crate::transport::{pack_sample, BusSample, ZenohTransport};
 use crate::BusError;
 
 /// Maximum number of queued receive packets.
@@ -104,25 +104,9 @@ impl ZenohTransport for CcsdsZenohAdapter {
     }
 
     fn receive<'a>(&mut self, buf: &'a mut [u8]) -> Result<Option<BusSample<'a>>, BusError> {
-        if let Some((key, data)) = self.rx_queue.pop_front() {
-            let key_bytes = key.as_bytes();
-            let total = key_bytes.len() + 1 + data.len();
-            if buf.len() < total {
-                return Err(BusError::BufferTooSmall);
-            }
-            buf[..key_bytes.len()].copy_from_slice(key_bytes);
-            buf[key_bytes.len()] = 0;
-            let payload_start = key_bytes.len() + 1;
-            buf[payload_start..payload_start + data.len()].copy_from_slice(&data);
-
-            Ok(Some(BusSample {
-                key_expr: core::str::from_utf8(&buf[..key_bytes.len()])
-                    .map_err(|_| BusError::InvalidHeader)?,
-                payload: &buf[payload_start..payload_start + data.len()],
-                timestamp_us: 0,
-            }))
-        } else {
-            Ok(None)
+        match self.rx_queue.pop_front() {
+            Some((key, data)) => pack_sample(buf, &key, &data).map(Some),
+            None => Ok(None),
         }
     }
 }

--- a/bus/src/dds/adapter.rs
+++ b/bus/src/dds/adapter.rs
@@ -20,7 +20,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use super::types::MAX_DOMAIN_ID;
-use crate::transport::{BusSample, ZenohTransport};
+use crate::transport::{pack_sample, BusSample, ZenohTransport};
 use crate::BusError;
 
 /// Maximum number of queued receive samples.
@@ -150,25 +150,9 @@ impl ZenohTransport for DdsZenohAdapter {
     }
 
     fn receive<'a>(&mut self, buf: &'a mut [u8]) -> Result<Option<BusSample<'a>>, BusError> {
-        if let Some((key, data)) = self.rx_queue.pop_front() {
-            let key_bytes = key.as_bytes();
-            let total = key_bytes.len() + 1 + data.len();
-            if buf.len() < total {
-                return Err(BusError::BufferTooSmall);
-            }
-            buf[..key_bytes.len()].copy_from_slice(key_bytes);
-            buf[key_bytes.len()] = 0;
-            let payload_start = key_bytes.len() + 1;
-            buf[payload_start..payload_start + data.len()].copy_from_slice(&data);
-
-            Ok(Some(BusSample {
-                key_expr: core::str::from_utf8(&buf[..key_bytes.len()])
-                    .map_err(|_| BusError::InvalidHeader)?,
-                payload: &buf[payload_start..payload_start + data.len()],
-                timestamp_us: 0,
-            }))
-        } else {
-            Ok(None)
+        match self.rx_queue.pop_front() {
+            Some((key, data)) => pack_sample(buf, &key, &data).map(Some),
+            None => Ok(None),
         }
     }
 }

--- a/bus/src/mil1553/word.rs
+++ b/bus/src/mil1553/word.rs
@@ -28,6 +28,46 @@ pub enum SyncType {
     Data,
 }
 
+/// 3-bit sync pattern that identifies a command word.
+const SYNC_COMMAND: u32 = 0b111;
+
+/// 3-bit sync pattern that identifies a status or data word.
+const SYNC_DATA: u32 = 0b110;
+
+/// Assemble a 20-bit MIL-STD-1553B word: `sync(3) | bits(16) | parity(1)`.
+///
+/// MIL-STD-1553B uses odd parity, so the parity bit is set to make the count
+/// of `1` bits across the 16-bit content plus the parity bit itself odd.
+#[inline]
+fn assemble_word(sync: u32, bits: u16) -> u32 {
+    let parity: u32 = if bits.count_ones().is_multiple_of(2) {
+        1
+    } else {
+        0
+    };
+    (sync << 17) | ((bits as u32) << 1) | parity
+}
+
+/// Validate sync + odd parity and extract the 16-bit content of a 1553 word.
+///
+/// Returns [`BusError::InvalidHeader`] if the sync field does not match
+/// `expected_sync`, or [`BusError::ParityError`] if the odd parity check fails.
+#[inline]
+fn parse_word(word: u32, expected_sync: u32) -> Result<u16, BusError> {
+    let sync = (word >> 17) & 0x7;
+    if sync != expected_sync {
+        return Err(BusError::InvalidHeader);
+    }
+    let bits = ((word >> 1) & 0xFFFF) as u16;
+    let parity_bit = (word & 1) as u16;
+    // Odd parity: count of ones in content + parity bit must be odd.
+    let ones = bits.count_ones() + parity_bit as u32;
+    if ones.is_multiple_of(2) {
+        return Err(BusError::ParityError);
+    }
+    Ok(bits)
+}
+
 /// MIL-STD-1553B Command Word.
 ///
 /// Layout (MSB first within the 16-bit content):
@@ -96,37 +136,17 @@ impl CommandWord {
         bits |= if self.transmit { 1 << 10 } else { 0 };
         bits |= (self.subaddress as u16 & 0x1F) << 5;
         bits |= self.word_count as u16 & 0x1F;
-        let parity = if !bits.count_ones().is_multiple_of(2) {
-            0u32
-        } else {
-            1
-        };
-        // Sync: command sync = 0b111 (we use 3-bit field [19:17])
-        (0b111u32 << 17) | ((bits as u32) << 1) | parity
+        assemble_word(SYNC_COMMAND, bits)
     }
 
     /// Decode from a 20-bit value.
     pub fn decode(word: u32) -> Result<Self, BusError> {
-        let sync = (word >> 17) & 0x7;
-        if sync != 0b111 {
-            return Err(BusError::InvalidHeader);
-        }
-        let bits = ((word >> 1) & 0xFFFF) as u16;
-        let parity_bit = (word & 1) as u16;
-        // Odd parity: count of 1s in bits + parity_bit should be odd
-        let ones = bits.count_ones() + parity_bit as u32;
-        if ones.is_multiple_of(2) {
-            return Err(BusError::ParityError);
-        }
-        let rt_address = ((bits >> 11) & 0x1F) as u8;
-        let transmit = (bits >> 10) & 1 == 1;
-        let subaddress = ((bits >> 5) & 0x1F) as u8;
-        let word_count = (bits & 0x1F) as u8;
+        let bits = parse_word(word, SYNC_COMMAND)?;
         Ok(Self {
-            rt_address,
-            transmit,
-            subaddress,
-            word_count,
+            rt_address: ((bits >> 11) & 0x1F) as u8,
+            transmit: (bits >> 10) & 1 == 1,
+            subaddress: ((bits >> 5) & 0x1F) as u8,
+            word_count: (bits & 0x1F) as u8,
         })
     }
 }
@@ -214,27 +234,12 @@ impl StatusWord {
         if self.terminal_flag {
             bits |= 1;
         }
-        let parity = if !bits.count_ones().is_multiple_of(2) {
-            0u32
-        } else {
-            1
-        };
-        // Data sync = 0b110
-        (0b110u32 << 17) | ((bits as u32) << 1) | parity
+        assemble_word(SYNC_DATA, bits)
     }
 
     /// Decode from a 20-bit value.
     pub fn decode(word: u32) -> Result<Self, BusError> {
-        let sync = (word >> 17) & 0x7;
-        if sync != 0b110 {
-            return Err(BusError::InvalidHeader);
-        }
-        let bits = ((word >> 1) & 0xFFFF) as u16;
-        let parity_bit = (word & 1) as u16;
-        let ones = bits.count_ones() + parity_bit as u32;
-        if ones.is_multiple_of(2) {
-            return Err(BusError::ParityError);
-        }
+        let bits = parse_word(word, SYNC_DATA)?;
         Ok(Self {
             rt_address: ((bits >> 11) & 0x1F) as u8,
             message_error: (bits >> 10) & 1 == 1,
@@ -271,28 +276,12 @@ impl DataWord {
 
     /// Encode to a 20-bit value (data sync + 16-bit data + parity).
     pub fn encode(&self) -> u32 {
-        let bits = self.data;
-        let parity = if !bits.count_ones().is_multiple_of(2) {
-            0u32
-        } else {
-            1
-        };
-        // Data sync = 0b110
-        (0b110u32 << 17) | ((bits as u32) << 1) | parity
+        assemble_word(SYNC_DATA, self.data)
     }
 
     /// Decode from a 20-bit value.
     pub fn decode(word: u32) -> Result<Self, BusError> {
-        let sync = (word >> 17) & 0x7;
-        if sync != 0b110 {
-            return Err(BusError::InvalidHeader);
-        }
-        let bits = ((word >> 1) & 0xFFFF) as u16;
-        let parity_bit = (word & 1) as u16;
-        let ones = bits.count_ones() + parity_bit as u32;
-        if ones.is_multiple_of(2) {
-            return Err(BusError::ParityError);
-        }
+        let bits = parse_word(word, SYNC_DATA)?;
         Ok(Self { data: bits })
     }
 }
@@ -533,6 +522,48 @@ mod tests {
             let dec = DataWord::decode(enc).unwrap();
             assert_eq!(dec.data, words[i]);
         }
+    }
+
+    // === Internal helper tests (assemble_word / parse_word) ===
+
+    #[test]
+    fn test_assemble_word_parity_odd_ones() {
+        // 0x0001 has one '1' bit (odd) -> parity bit must be 0 for total odd.
+        let word = assemble_word(SYNC_DATA, 0x0001);
+        assert_eq!((word >> 17) & 0x7, SYNC_DATA);
+        assert_eq!(word & 1, 0);
+    }
+
+    #[test]
+    fn test_assemble_word_parity_even_ones() {
+        // 0x0003 has two '1' bits (even) -> parity bit must be 1 for total odd.
+        let word = assemble_word(SYNC_DATA, 0x0003);
+        assert_eq!(word & 1, 1);
+    }
+
+    #[test]
+    fn test_parse_word_round_trip() {
+        let bits: u16 = 0xABCD;
+        let word = assemble_word(SYNC_COMMAND, bits);
+        assert_eq!(parse_word(word, SYNC_COMMAND).unwrap(), bits);
+    }
+
+    #[test]
+    fn test_parse_word_wrong_sync_rejected() {
+        let word = assemble_word(SYNC_COMMAND, 0x1234);
+        assert_eq!(
+            parse_word(word, SYNC_DATA).err(),
+            Some(BusError::InvalidHeader)
+        );
+    }
+
+    #[test]
+    fn test_parse_word_parity_flip_rejected() {
+        let word = assemble_word(SYNC_DATA, 0x5555) ^ 1;
+        assert_eq!(
+            parse_word(word, SYNC_DATA).err(),
+            Some(BusError::ParityError)
+        );
     }
 
     #[test]

--- a/bus/src/spacewire/adapter.rs
+++ b/bus/src/spacewire/adapter.rs
@@ -15,7 +15,7 @@ use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-use crate::transport::{BusSample, ZenohTransport};
+use crate::transport::{pack_sample, BusSample, ZenohTransport};
 use crate::BusError;
 
 /// Maximum number of queued receive packets.
@@ -92,25 +92,9 @@ impl ZenohTransport for SpwZenohAdapter {
     }
 
     fn receive<'a>(&mut self, buf: &'a mut [u8]) -> Result<Option<BusSample<'a>>, BusError> {
-        if let Some((key, data)) = self.rx_queue.pop_front() {
-            let key_bytes = key.as_bytes();
-            let total = key_bytes.len() + 1 + data.len();
-            if buf.len() < total {
-                return Err(BusError::BufferTooSmall);
-            }
-            buf[..key_bytes.len()].copy_from_slice(key_bytes);
-            buf[key_bytes.len()] = 0;
-            let payload_start = key_bytes.len() + 1;
-            buf[payload_start..payload_start + data.len()].copy_from_slice(&data);
-
-            Ok(Some(BusSample {
-                key_expr: core::str::from_utf8(&buf[..key_bytes.len()])
-                    .map_err(|_| BusError::InvalidHeader)?,
-                payload: &buf[payload_start..payload_start + data.len()],
-                timestamp_us: 0,
-            }))
-        } else {
-            Ok(None)
+        match self.rx_queue.pop_front() {
+            Some((key, data)) => pack_sample(buf, &key, &data).map(Some),
+            None => Ok(None),
         }
     }
 }

--- a/bus/src/transport.rs
+++ b/bus/src/transport.rs
@@ -49,6 +49,47 @@ pub trait ZenohTransport {
     fn receive<'a>(&mut self, buf: &'a mut [u8]) -> Result<Option<BusSample<'a>>, BusError>;
 }
 
+/// Pack a key expression and payload into the caller-supplied scratch buffer
+/// and return a borrowed [`BusSample`].
+///
+/// This is the shared layout used by every Zenoh adapter:
+/// `[key bytes][NUL separator][payload bytes]`. Centralising the layout keeps
+/// the `receive` implementations identical across protocols and avoids the
+/// `rust:S4144` duplicated-block findings flagged by SonarCloud.
+///
+/// # Errors
+///
+/// - [`BusError::BufferTooSmall`] if `buf` cannot hold `key.len() + 1 + data.len()` bytes.
+/// - [`BusError::InvalidHeader`] if the freshly copied key bytes do not round-trip as UTF-8
+///   (only possible if `key` itself was not valid UTF-8, which Rust `&str` guarantees against).
+pub fn pack_sample<'a>(
+    buf: &'a mut [u8],
+    key: &str,
+    data: &[u8],
+) -> Result<BusSample<'a>, BusError> {
+    let key_bytes = key.as_bytes();
+    let key_len = key_bytes.len();
+    let total = key_len + 1 + data.len();
+    if buf.len() < total {
+        return Err(BusError::BufferTooSmall);
+    }
+    buf[..key_len].copy_from_slice(key_bytes);
+    buf[key_len] = 0;
+    let payload_start = key_len + 1;
+    let payload_end = payload_start + data.len();
+    buf[payload_start..payload_end].copy_from_slice(data);
+
+    let (key_slice, rest) = buf.split_at(key_len);
+    let key_expr = core::str::from_utf8(key_slice).map_err(|_| BusError::InvalidHeader)?;
+    let payload = &rest[1..1 + data.len()];
+
+    Ok(BusSample {
+        key_expr,
+        payload,
+        timestamp_us: 0,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -64,5 +105,40 @@ mod tests {
         assert_eq!(sample.key_expr, "can/0/0x1A3");
         assert_eq!(sample.payload, &[0x01, 0x02, 0x03]);
         assert_eq!(sample.timestamp_us, 12345);
+    }
+
+    #[test]
+    fn test_pack_sample_basic() {
+        let mut buf = [0u8; 64];
+        let sample = pack_sample(&mut buf, "afdx/100", &[0xAA, 0xBB]).unwrap();
+        assert_eq!(sample.key_expr, "afdx/100");
+        assert_eq!(sample.payload, &[0xAA, 0xBB]);
+        assert_eq!(sample.timestamp_us, 0);
+    }
+
+    #[test]
+    fn test_pack_sample_empty_payload() {
+        let mut buf = [0u8; 16];
+        let sample = pack_sample(&mut buf, "ccsds/7", &[]).unwrap();
+        assert_eq!(sample.key_expr, "ccsds/7");
+        assert!(sample.payload.is_empty());
+    }
+
+    #[test]
+    fn test_pack_sample_buffer_too_small() {
+        let mut buf = [0u8; 4];
+        assert_eq!(
+            pack_sample(&mut buf, "afdx/100", &[0xAA, 0xBB]).err(),
+            Some(BusError::BufferTooSmall)
+        );
+    }
+
+    #[test]
+    fn test_pack_sample_exact_size() {
+        // key (8) + nul (1) + payload (2) == 11
+        let mut buf = [0u8; 11];
+        let sample = pack_sample(&mut buf, "afdx/100", &[0xAA, 0xBB]).unwrap();
+        assert_eq!(sample.key_expr, "afdx/100");
+        assert_eq!(sample.payload, &[0xAA, 0xBB]);
     }
 }


### PR DESCRIPTION
## Summary

Addresses SonarCloud `rust:S4144` (duplicated code blocks) findings in the `bus` crate. Two small helpers are introduced and the duplicated bodies are replaced with delegation calls. No public APIs change.

**Extractions:**

1. **`transport::pack_sample(buf, key, data) -> Result<BusSample, BusError>`** — centralises the `[key bytes][NUL separator][payload bytes]` scratch-buffer layout that was duplicated byte-for-byte across six `ZenohTransport::receive` implementations (arinc429, arinc664, can, ccsds, dds, spacewire). Each `receive` body shrinks from ~20 lines to a 2-line `match`/delegate.
2. **`mil1553::word::assemble_word(sync, bits)` + `parse_word(word, sync)`** — centralise the 20-bit MIL-STD-1553B `sync(3) | content(16) | odd_parity(1)` encode/decode framing that was duplicated across `CommandWord`, `StatusWord`, and `DataWord`. The per-field bit-packing remains in each `encode`/`decode` (preserving spec traceability) but the parity calculation, sync check, and 20-bit word assembly are now one-liners.

The four `adapter.rs` files SonarCloud flagged share *exactly* the same receive body. Two more adapters (`can/adapter.rs` and `arinc429/adapter.rs`) that share the same pattern but were below SonarCloud's reporting threshold are also refactored opportunistically so the helper is reused consistently across the whole `ZenohTransport` family.

## Files touched

- `bus/src/transport.rs` — added `pack_sample` + 4 new unit tests
- `bus/src/arinc664/adapter.rs` — `receive` body replaced with `pack_sample` delegation
- `bus/src/spacewire/adapter.rs` — same
- `bus/src/ccsds/adapter.rs` — same
- `bus/src/dds/adapter.rs` — same
- `bus/src/can/adapter.rs` — same (kept the existing `poll_rx()` call before delegating)
- `bus/src/arinc429/adapter.rs` — same
- `bus/src/mil1553/word.rs` — added `SYNC_COMMAND` + `SYNC_DATA` constants and `assemble_word`/`parse_word` helpers; rewired three `encode` and three `decode` methods; added 5 new unit tests

## Duplication impact (estimate)

| Location | Before | After |
|---|---:|---:|
| `arinc664/adapter.rs` receive | 22 lines | 4 lines |
| `spacewire/adapter.rs` receive | 22 lines | 4 lines |
| `ccsds/adapter.rs` receive | 22 lines | 4 lines |
| `dds/adapter.rs` receive | 22 lines | 4 lines |
| `can/adapter.rs` receive | 24 lines | 7 lines |
| `arinc429/adapter.rs` receive | 22 lines | 4 lines |
| `mil1553/word.rs` encode/decode bodies | 3x ~15 + 3x ~18 lines | 3x ~9 + 3x ~6 lines |

Equivalent duplicate-line counts SonarCloud was flagging should drop substantially:

- `arinc664/adapter.rs`: 31 dup lines / 4 blocks (16.8%) → expected near 0 / 0
- `spacewire/adapter.rs`: 30 / 4 (15.3%) → near 0 / 0
- `ccsds/adapter.rs`: 29 / 3 (11.5%) → near 0 / 0
- `dds/adapter.rs`: 31 / 4 (9.1%) → near 0 / 0
- `mil1553/word.rs`: 64 / 3 (11.7%) → expected to drop sharply (each encode/decode now diverges only in the field-specific bit packing)

Adapter `receive` bodies are now identical-by-construction (single call into the shared helper), so the duplicate-code detector cannot flag them.

## Test plan

- [x] `cargo test -p smallaios-bus` — **1137 passing** (was 1128 baseline; +4 `pack_sample` tests, +5 mil1553 helper tests, 0 regressions)
- [x] `cargo clippy -p smallaios-bus --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Workspace-wide `just clippy` fails on `mgmt/tests/toml_oracle.rs` due to **pre-existing** type-inference errors on `origin/develop` unrelated to this change (verified by stashing the patch and re-running on a clean tree).

## Notes

The duplication is *not* intentional for spec traceability — each protocol's per-field bit packing remains in its own module (so DO-178C MC/DC paths still trace cleanly to the spec). Only the protocol-agnostic scaffolding (buffer-layout packing, 1553 word framing) is shared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)