### PR TITLE
refactor(kernel): reduce code duplication in mem + syscall::memory

### DIFF
--- a/kernel/src/mem/mod.rs
+++ b/kernel/src/mem/mod.rs
@@ -26,53 +26,76 @@ pub struct PhysAddr(pub usize);
 #[repr(transparent)]
 pub struct VirtAddr(pub usize);
 
+/// Internal const helper: round `addr` up to the next multiple of `align`.
+///
+/// `align` must be a power of two. Used by both `PhysAddr::align_up` and
+/// `VirtAddr::align_up` to share their alignment arithmetic without
+/// forcing the address newtypes through a (non-`const`) trait.
+#[inline]
+const fn align_up_usize(addr: usize, align: usize) -> usize {
+    (addr + align - 1) & !(align - 1)
+}
+
+/// Internal const helper: round `addr` down to the previous multiple of `align`.
+#[inline]
+const fn align_down_usize(addr: usize, align: usize) -> usize {
+    addr & !(align - 1)
+}
+
+/// Internal const helper: check that `addr` is a multiple of `align`.
+#[inline]
+const fn is_aligned_usize(addr: usize, align: usize) -> bool {
+    addr & (align - 1) == 0
+}
+
+/// Generates the shared `const fn` API (`new`, `as_usize`, `align_up`,
+/// `align_down`, `is_aligned`) on a `#[repr(transparent)]` address newtype.
+///
+/// `PhysAddr` and `VirtAddr` are intentionally distinct types (mixing them
+/// is a kernel-correctness bug), so we keep the strong typing but share
+/// the body via a macro instead of duplicating five identical methods per
+/// type. This preserves the existing public API byte-for-byte.
+macro_rules! impl_addr_newtype {
+    ($t:ty) => {
+        impl $t {
+            #[inline]
+            pub const fn new(addr: usize) -> Self {
+                Self(addr)
+            }
+
+            #[inline]
+            pub const fn as_usize(self) -> usize {
+                self.0
+            }
+
+            #[inline]
+            pub const fn align_up(self, align: usize) -> Self {
+                Self(align_up_usize(self.0, align))
+            }
+
+            #[inline]
+            pub const fn align_down(self, align: usize) -> Self {
+                Self(align_down_usize(self.0, align))
+            }
+
+            #[inline]
+            pub const fn is_aligned(self, align: usize) -> bool {
+                is_aligned_usize(self.0, align)
+            }
+        }
+    };
+}
+
+impl_addr_newtype!(PhysAddr);
+impl_addr_newtype!(VirtAddr);
+
 impl PhysAddr {
-    pub const fn new(addr: usize) -> Self {
-        Self(addr)
-    }
-
-    pub const fn as_usize(self) -> usize {
-        self.0
-    }
-
-    pub const fn align_up(self, align: usize) -> Self {
-        Self((self.0 + align - 1) & !(align - 1))
-    }
-
-    pub const fn align_down(self, align: usize) -> Self {
-        Self(self.0 & !(align - 1))
-    }
-
-    pub const fn is_aligned(self, align: usize) -> bool {
-        self.0 & (align - 1) == 0
-    }
-
     pub const fn offset(self, offset: usize) -> Self {
         Self(self.0 + offset)
     }
 }
 
 impl VirtAddr {
-    pub const fn new(addr: usize) -> Self {
-        Self(addr)
-    }
-
-    pub const fn as_usize(self) -> usize {
-        self.0
-    }
-
-    pub const fn align_up(self, align: usize) -> Self {
-        Self((self.0 + align - 1) & !(align - 1))
-    }
-
-    pub const fn align_down(self, align: usize) -> Self {
-        Self(self.0 & !(align - 1))
-    }
-
-    pub const fn is_aligned(self, align: usize) -> bool {
-        self.0 & (align - 1) == 0
-    }
-
     pub const fn as_ptr<T>(self) -> *const T {
         self.0 as *const T
     }
@@ -118,18 +141,32 @@ pub enum MemError {
 mod tests {
     use super::*;
 
-    #[test]
-    fn phys_addr_basic() {
-        let addr = PhysAddr::new(0x1000);
-        assert_eq!(addr.as_usize(), 0x1000);
+    /// Asserts that an address newtype's shared `new` / `as_usize` /
+    /// `align_up` / `align_down` / `is_aligned` API behaves correctly.
+    ///
+    /// Used by both the `PhysAddr` and `VirtAddr` test cases below to
+    /// avoid duplicating the same five assertions per type.
+    macro_rules! assert_addr_api {
+        ($t:ty, $base:expr) => {{
+            let base: usize = $base;
+            // new + as_usize round-trip.
+            assert_eq!(<$t>::new(base).as_usize(), base);
+            // align_up rounds an off-by-one address up to the next page.
+            assert_eq!(
+                <$t>::new(base | 0x1).align_up(0x1000).as_usize(),
+                base + 0x1000
+            );
+            // align_down strips the low bits.
+            assert_eq!(<$t>::new(base | 0xFFF).align_down(0x1000).as_usize(), base);
+            // is_aligned discriminates page-aligned vs unaligned.
+            assert!(<$t>::new(base).is_aligned(0x1000));
+            assert!(!<$t>::new(base | 0x1).is_aligned(0x1000));
+        }};
     }
 
     #[test]
-    fn phys_addr_align() {
-        assert_eq!(PhysAddr::new(0x1001).align_up(0x1000).as_usize(), 0x2000);
-        assert_eq!(PhysAddr::new(0x1FFF).align_down(0x1000).as_usize(), 0x1000);
-        assert!(PhysAddr::new(0x1000).is_aligned(0x1000));
-        assert!(!PhysAddr::new(0x1001).is_aligned(0x1000));
+    fn phys_addr_basic_and_align() {
+        assert_addr_api!(PhysAddr, 0x1000);
     }
 
     #[test]
@@ -138,17 +175,8 @@ mod tests {
     }
 
     #[test]
-    fn virt_addr_basic() {
-        let addr = VirtAddr::new(0x2000);
-        assert_eq!(addr.as_usize(), 0x2000);
-    }
-
-    #[test]
-    fn virt_addr_align() {
-        assert_eq!(VirtAddr::new(0x2001).align_up(0x1000).as_usize(), 0x3000);
-        assert_eq!(VirtAddr::new(0x2FFF).align_down(0x1000).as_usize(), 0x2000);
-        assert!(VirtAddr::new(0x2000).is_aligned(0x1000));
-        assert!(!VirtAddr::new(0x2001).is_aligned(0x1000));
+    fn virt_addr_basic_and_align() {
+        assert_addr_api!(VirtAddr, 0x2000);
     }
 
     #[test]

--- a/kernel/src/syscall/memory.rs
+++ b/kernel/src/syscall/memory.rs
@@ -99,6 +99,36 @@ fn size_to_order(size: usize) -> usize {
     (usize::BITS - (pages - 1).leading_zeros()) as usize
 }
 
+/// Look up the current task's capability for `(resource_type, instance)`
+/// with the requested permission bits.
+///
+/// Returns `Ok(())` when the capability is held, or `Err(syscall_error_code)`
+/// (a negative `i64`) ready to be returned directly from a syscall handler.
+///
+/// This shared helper collapses the previously-repeated four-line block
+/// `let resource = ResourceRef::new(...); if let Err(e) = state::check_capability(...) { return e; }`
+/// that appeared in every capability-checked memory syscall.
+#[inline]
+fn require_capability(
+    resource_type: ResourceType,
+    instance: u64,
+    perm: Permissions,
+) -> Result<(), i64> {
+    let resource = ResourceRef::new(resource_type, instance);
+    state::check_capability(current_task_id(), &resource, perm).map(|_| ())
+}
+
+/// Convert a `Result<(), MemError>` into a `0`-on-success syscall return
+/// (negative on error). Used by `sys_mem_free` / `sys_tensor_free` to
+/// share their identical match-on-result tail.
+#[inline]
+fn unit_mem_result(r: Result<(), crate::mem::MemError>) -> SyscallResult {
+    match r {
+        Ok(()) => SyscallError::Success.as_i64(),
+        Err(err) => state::mem_error_to_syscall(err),
+    }
+}
+
 /// Allocate kernel memory.
 ///
 /// Args: [size, align, flags, 0, 0, 0]
@@ -154,23 +184,15 @@ pub fn sys_mem_free(args: &SyscallArgs) -> SyscallResult {
         return SyscallError::InvalidArgument.as_i64();
     }
 
-    // Try slab first for small sizes, fall back to buddy
+    // Try slab first for small sizes, fall back to buddy.
     if size <= 2048 {
         // SAFETY: Syscall handlers run with interrupts masked.
-        let result = unsafe { state::with_slab(|slab| slab.free(ptr as *mut u8, size)) };
-        match result {
-            Ok(()) => SyscallError::Success.as_i64(),
-            Err(err) => state::mem_error_to_syscall(err),
-        }
+        unit_mem_result(unsafe { state::with_slab(|slab| slab.free(ptr as *mut u8, size)) })
     } else {
         let order = size_to_order(size);
         let addr = PhysAddr::new(ptr);
         // SAFETY: Syscall handlers run with interrupts masked.
-        let result = unsafe { state::with_buddy(|buddy| buddy.free(addr, order)) };
-        match result {
-            Ok(()) => SyscallError::Success.as_i64(),
-            Err(err) => state::mem_error_to_syscall(err),
-        }
+        unit_mem_result(unsafe { state::with_buddy(|buddy| buddy.free(addr, order)) })
     }
 }
 
@@ -188,8 +210,7 @@ pub fn sys_mem_map(args: &SyscallArgs) -> SyscallResult {
     }
 
     // MMIO mapping is a privileged operation — require Device:WRITE capability.
-    let resource = ResourceRef::new(ResourceType::Device, 0);
-    if let Err(e) = state::check_capability(current_task_id(), &resource, Permissions::WRITE) {
+    if let Err(e) = require_capability(ResourceType::Device, 0, Permissions::WRITE) {
         return e;
     }
 
@@ -212,8 +233,7 @@ pub fn sys_mem_protect(args: &SyscallArgs) -> SyscallResult {
     }
 
     // Memory protection changes are privileged — require Device:WRITE capability.
-    let resource = ResourceRef::new(ResourceType::Device, 0);
-    if let Err(e) = state::check_capability(current_task_id(), &resource, Permissions::WRITE) {
+    if let Err(e) = require_capability(ResourceType::Device, 0, Permissions::WRITE) {
         return e;
     }
 
@@ -243,8 +263,7 @@ pub fn sys_tensor_alloc(args: &SyscallArgs) -> SyscallResult {
     };
 
     // Tensor allocation requires TensorBuffer:WRITE capability.
-    let resource = ResourceRef::new(ResourceType::TensorBuffer, 0);
-    if let Err(e) = state::check_capability(current_task_id(), &resource, Permissions::WRITE) {
+    if let Err(e) = require_capability(ResourceType::TensorBuffer, 0, Permissions::WRITE) {
         return e;
     }
 
@@ -292,8 +311,11 @@ pub fn sys_tensor_free(args: &SyscallArgs) -> SyscallResult {
     }
 
     // Tensor free requires TensorBuffer:WRITE capability.
-    let resource = ResourceRef::new(ResourceType::TensorBuffer, handle_raw as u64);
-    if let Err(e) = state::check_capability(current_task_id(), &resource, Permissions::WRITE) {
+    if let Err(e) = require_capability(
+        ResourceType::TensorBuffer,
+        handle_raw as u64,
+        Permissions::WRITE,
+    ) {
         return e;
     }
 
@@ -301,11 +323,35 @@ pub fn sys_tensor_free(args: &SyscallArgs) -> SyscallResult {
     let handle = crate::mem::tensor::TensorHandle::from_index(handle_idx as u32);
 
     // SAFETY: Syscall handlers run with interrupts masked.
-    let result = unsafe { state::with_tensor_pool(|pool| pool.release(handle)) };
-    match result {
-        Ok(()) => SyscallError::Success.as_i64(),
-        Err(err) => state::mem_error_to_syscall(err),
+    unit_mem_result(unsafe { state::with_tensor_pool(|pool| pool.release(handle)) })
+}
+
+/// Shared front-end for `sys_tensor_map_gpu` / `sys_tensor_unmap_gpu`.
+///
+/// Validates the tensor handle and checks both capabilities required to
+/// map a tensor across the GPU boundary:
+///   * `TensorBuffer:WRITE` on the tensor handle
+///   * `GpuDevice:EXECUTE` on the target device
+///
+/// Returns `Ok(())` when the caller is authorized, or a negative syscall
+/// error code on the first failure. Mirrors the (formerly duplicated)
+/// validation logic that previously lived inline in both syscalls.
+#[inline]
+fn validate_tensor_gpu_request(handle: usize, device_id: usize) -> Result<(), i64> {
+    if handle == 0 {
+        return Err(SyscallError::InvalidHandle.as_i64());
     }
+    require_capability(
+        ResourceType::TensorBuffer,
+        handle as u64,
+        Permissions::WRITE,
+    )?;
+    require_capability(
+        ResourceType::GpuDevice,
+        device_id as u64,
+        Permissions::EXECUTE,
+    )?;
+    Ok(())
 }
 
 /// Map a tensor buffer for GPU access.
@@ -313,20 +359,7 @@ pub fn sys_tensor_free(args: &SyscallArgs) -> SyscallResult {
 /// Args: [handle, device_id, 0, 0, 0, 0]
 /// Returns: GPU pointer on success, negative error code on failure.
 pub fn sys_tensor_map_gpu(args: &SyscallArgs) -> SyscallResult {
-    let handle = args.args[0];
-    let device_id = args.args[1];
-
-    if handle == 0 {
-        return SyscallError::InvalidHandle.as_i64();
-    }
-
-    // Requires TensorBuffer:WRITE on the tensor and GpuDevice:EXECUTE on the device.
-    let tensor_res = ResourceRef::new(ResourceType::TensorBuffer, handle as u64);
-    if let Err(e) = state::check_capability(current_task_id(), &tensor_res, Permissions::WRITE) {
-        return e;
-    }
-    let gpu_res = ResourceRef::new(ResourceType::GpuDevice, device_id as u64);
-    if let Err(e) = state::check_capability(current_task_id(), &gpu_res, Permissions::EXECUTE) {
+    if let Err(e) = validate_tensor_gpu_request(args.args[0], args.args[1]) {
         return e;
     }
 
@@ -339,20 +372,7 @@ pub fn sys_tensor_map_gpu(args: &SyscallArgs) -> SyscallResult {
 /// Args: [handle, device_id, 0, 0, 0, 0]
 /// Returns: 0 on success, negative error code on failure.
 pub fn sys_tensor_unmap_gpu(args: &SyscallArgs) -> SyscallResult {
-    let handle = args.args[0];
-    let device_id = args.args[1];
-
-    if handle == 0 {
-        return SyscallError::InvalidHandle.as_i64();
-    }
-
-    // Requires TensorBuffer:WRITE on the tensor and GpuDevice:EXECUTE on the device.
-    let tensor_res = ResourceRef::new(ResourceType::TensorBuffer, handle as u64);
-    if let Err(e) = state::check_capability(current_task_id(), &tensor_res, Permissions::WRITE) {
-        return e;
-    }
-    let gpu_res = ResourceRef::new(ResourceType::GpuDevice, device_id as u64);
-    if let Err(e) = state::check_capability(current_task_id(), &gpu_res, Permissions::EXECUTE) {
+    if let Err(e) = validate_tensor_gpu_request(args.args[0], args.args[1]) {
         return e;
     }
 


### PR DESCRIPTION
## Summary

Reduces SonarCloud `rust:S4144` duplicated-code density in the kernel memory subsystem by extracting small repeated patterns into shared helpers. No public API change, no observable behavior change.

- **`kernel/src/mem/mod.rs`** (was 21.0% dup density / 38 dup lines / 2 blocks): `PhysAddr` and `VirtAddr` shared five line-identical `pub const fn`s (`new`, `as_usize`, `align_up`, `align_down`, `is_aligned`). They are now generated by a single private `impl_addr_newtype!` macro that delegates to three private `const fn` integer helpers. The duplicated address-test pairs are merged via an `assert_addr_api!` test macro. Newtypes stay distinct — kernel correctness boundary preserved.
- **`kernel/src/syscall/memory.rs`** (was 4.5% dup density / 40 dup lines / 2 blocks): six handlers repeated the four-line `ResourceRef::new + state::check_capability` block — now `require_capability(resource_type, instance, perm) -> Result<(), i64>`. Three handlers repeated the `Ok(()) => Success / Err => mem_error_to_syscall` tail — now `unit_mem_result`. `sys_tensor_map_gpu` and `sys_tensor_unmap_gpu` had byte-identical handle + capability validation — now front-ended by `validate_tensor_gpu_request`.

## Files touched

- `kernel/src/mem/mod.rs`
- `kernel/src/syscall/memory.rs`

## Duplication impact (estimate)

- `mem/mod.rs`: removed ~30 lines of duplicated method bodies + ~10 lines of duplicated test assertions. Density target: 21.0% -> ~0% in the address-newtype region (file grew slightly from added doc comments + macro definitions, but the duplicated tokens are gone). Net file size: 181 -> 208 lines (additional documentation more than offsets the dedup; SonarCloud measures duplicated *blocks*, not line count).
- `syscall/memory.rs`: removed ~25 lines of repeated cap-check + match-result boilerplate spread across 6 syscalls. The two duplicated blocks SonarCloud flagged (likely the cap-check pattern across `sys_mem_map`/`sys_mem_protect` and the GPU map/unmap pair) are unified through `require_capability` and `validate_tensor_gpu_request`. Expect S4144 to drop to 0 for this file.

All `pub` items keep their names, signatures, and `const`-ness — no API surface change.

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy -p smallaios-kernel --all-targets -- -D warnings` (clean)
- [x] `cargo test -p smallaios-kernel --lib` — 655 pass / 0 fail (baseline was 657; the two-test drop is the intentional consolidation of `phys_addr_basic`+`phys_addr_align` and `virt_addr_basic`+`virt_addr_align` into single tests with all original assertions preserved)
- [x] `cargo check -p smallaios-kernel --features large-memory`
- [x] `cargo check -p smallaios-kernel --features no-global-alloc`
- [ ] CI gates (clippy, fmt-check, unit tests, build x86/aarch64/riscv64, semver, supply chain) — pending CI run

## Notes for reviewers

- Why a macro instead of a trait for `PhysAddr`/`VirtAddr`? The methods are `pub const fn` and called from `const` contexts elsewhere in the kernel; const-trait fns are still unstable. A declarative macro emits identical code per type without touching the public API, while keeping the two types non-interchangeable.
- The `assert_addr_api!` test macro keeps both newtypes covered with the same assertions, so MC/DC and assertion count are preserved (slightly more coverage, in fact — each newtype now exercises `new`+`as_usize` round-trip *and* alignment in a single `#[test]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)