### PR TITLE
refactor(onnx-rt): reduce code duplication in cuda descriptors + kv_cache + kv_compression

### DIFF
--- a/onnx-rt/src/cuda/descriptors.rs
+++ b/onnx-rt/src/cuda/descriptors.rs
@@ -23,6 +23,55 @@ pub(crate) fn dnn_dtype(dt: DataType) -> Result<ffi::cudnnDataType_t, CudaError>
     }
 }
 
+/// Convert a cuDNN status code into a `CudaError::DnnError` when it is
+/// not `CUDNN_STATUS_SUCCESS`. Shared across the descriptor wrappers
+/// so each one doesn't hand-roll the same `if err != SUCCESS` check.
+#[inline]
+fn check_dnn(status: ffi::cudnnStatus_t, op: &'static str) -> Result<(), CudaError> {
+    if status == ffi::CUDNN_STATUS_SUCCESS {
+        Ok(())
+    } else {
+        Err(CudaError::DnnError { op, code: status })
+    }
+}
+
+/// Build a descriptor by:
+///   1. allocating a handle via `create_fn`,
+///   2. configuring it via `set_call` (a closure that returns the
+///      cuDNN status code from the `cudnnSet*Descriptor` call),
+///   3. destroying the handle via `destroy_fn` if step 2 fails.
+///
+/// This collapses the create-and-set boilerplate that every descriptor
+/// wrapper used to hand-roll.
+#[inline]
+fn build_desc<H>(
+    create_op: &'static str,
+    set_op: &'static str,
+    create_fn: unsafe extern "C" fn(*mut H) -> ffi::cudnnStatus_t,
+    set_call: impl FnOnce(H) -> ffi::cudnnStatus_t,
+    destroy_fn: unsafe extern "C" fn(H) -> ffi::cudnnStatus_t,
+) -> Result<H, CudaError>
+where
+    H: Copy,
+{
+    // SAFETY: we initialise `desc` to a null/zero handle before calling
+    // `create_fn`, which is documented to write a valid handle on
+    // success.
+    let mut desc: H = unsafe { core::mem::zeroed() };
+    // SAFETY: `create_fn` matches the descriptor type `H` and only
+    // writes through the `&mut H` we pass.
+    check_dnn(unsafe { create_fn(&mut desc) }, create_op)?;
+    if let Err(e) = check_dnn(set_call(desc), set_op) {
+        // SAFETY: `desc` was successfully created above; we must
+        // destroy it to avoid leaking the handle on the failure path.
+        unsafe {
+            let _ = destroy_fn(desc);
+        }
+        return Err(e);
+    }
+    Ok(desc)
+}
+
 pub(crate) struct TensorDesc {
     pub desc: ffi::cudnnTensorDescriptor_t,
 }
@@ -35,34 +84,23 @@ impl TensorDesc {
         w: i32,
         dtype: ffi::cudnnDataType_t,
     ) -> Result<Self, CudaError> {
-        let mut desc: ffi::cudnnTensorDescriptor_t = core::ptr::null_mut();
-        let err = unsafe { ffi::cudnnCreateTensorDescriptor(&mut desc) };
-        if err != ffi::CUDNN_STATUS_SUCCESS {
-            return Err(CudaError::DnnError {
-                op: "createTensorDesc",
-                code: err,
-            });
-        }
-        let err = unsafe {
-            ffi::cudnnSetTensor4dDescriptor(
-                desc,
-                ffi::cudnnTensorFormat_t::CUDNN_TENSOR_NCHW,
-                dtype,
-                n,
-                c,
-                h,
-                w,
-            )
-        };
-        if err != ffi::CUDNN_STATUS_SUCCESS {
-            unsafe {
-                ffi::cudnnDestroyTensorDescriptor(desc);
-            }
-            return Err(CudaError::DnnError {
-                op: "setTensor4dDesc",
-                code: err,
-            });
-        }
+        let desc = build_desc(
+            "createTensorDesc",
+            "setTensor4dDesc",
+            ffi::cudnnCreateTensorDescriptor,
+            |d| unsafe {
+                ffi::cudnnSetTensor4dDescriptor(
+                    d,
+                    ffi::cudnnTensorFormat_t::CUDNN_TENSOR_NCHW,
+                    dtype,
+                    n,
+                    c,
+                    h,
+                    w,
+                )
+            },
+            ffi::cudnnDestroyTensorDescriptor,
+        )?;
         Ok(Self { desc })
     }
 }
@@ -90,36 +128,25 @@ impl PoolDesc {
         stride_h: i32,
         stride_w: i32,
     ) -> Result<Self, CudaError> {
-        let mut desc: ffi::cudnnPoolingDescriptor_t = core::ptr::null_mut();
-        let err = unsafe { ffi::cudnnCreatePoolingDescriptor(&mut desc) };
-        if err != ffi::CUDNN_STATUS_SUCCESS {
-            return Err(CudaError::DnnError {
-                op: "createPoolingDesc",
-                code: err,
-            });
-        }
-        let err = unsafe {
-            ffi::cudnnSetPooling2dDescriptor(
-                desc,
-                mode,
-                ffi::cudnnNanPropagation_t::CUDNN_NOT_PROPAGATE_NAN,
-                kh,
-                kw,
-                pad_h,
-                pad_w,
-                stride_h,
-                stride_w,
-            )
-        };
-        if err != ffi::CUDNN_STATUS_SUCCESS {
-            unsafe {
-                ffi::cudnnDestroyPoolingDescriptor(desc);
-            }
-            return Err(CudaError::DnnError {
-                op: "setPooling2dDesc",
-                code: err,
-            });
-        }
+        let desc = build_desc(
+            "createPoolingDesc",
+            "setPooling2dDesc",
+            ffi::cudnnCreatePoolingDescriptor,
+            |d| unsafe {
+                ffi::cudnnSetPooling2dDescriptor(
+                    d,
+                    mode,
+                    ffi::cudnnNanPropagation_t::CUDNN_NOT_PROPAGATE_NAN,
+                    kh,
+                    kw,
+                    pad_h,
+                    pad_w,
+                    stride_h,
+                    stride_w,
+                )
+            },
+            ffi::cudnnDestroyPoolingDescriptor,
+        )?;
         Ok(Self { desc })
     }
 }
@@ -138,31 +165,20 @@ pub(crate) struct ActivationDesc {
 
 impl ActivationDesc {
     pub fn new(mode: ffi::cudnnActivationMode_t, coef: f64) -> Result<Self, CudaError> {
-        let mut desc: ffi::cudnnActivationDescriptor_t = core::ptr::null_mut();
-        let err = unsafe { ffi::cudnnCreateActivationDescriptor(&mut desc) };
-        if err != ffi::CUDNN_STATUS_SUCCESS {
-            return Err(CudaError::DnnError {
-                op: "createActivationDesc",
-                code: err,
-            });
-        }
-        let err = unsafe {
-            ffi::cudnnSetActivationDescriptor(
-                desc,
-                mode,
-                ffi::cudnnNanPropagation_t::CUDNN_NOT_PROPAGATE_NAN,
-                coef,
-            )
-        };
-        if err != ffi::CUDNN_STATUS_SUCCESS {
-            unsafe {
-                ffi::cudnnDestroyActivationDescriptor(desc);
-            }
-            return Err(CudaError::DnnError {
-                op: "setActivationDesc",
-                code: err,
-            });
-        }
+        let desc = build_desc(
+            "createActivationDesc",
+            "setActivationDesc",
+            ffi::cudnnCreateActivationDescriptor,
+            |d| unsafe {
+                ffi::cudnnSetActivationDescriptor(
+                    d,
+                    mode,
+                    ffi::cudnnNanPropagation_t::CUDNN_NOT_PROPAGATE_NAN,
+                    coef,
+                )
+            },
+            ffi::cudnnDestroyActivationDescriptor,
+        )?;
         Ok(Self { desc })
     }
 }
@@ -184,31 +200,20 @@ impl OpTensorDesc {
         op: ffi::cudnnOpTensorOp_t,
         comp_type: ffi::cudnnDataType_t,
     ) -> Result<Self, CudaError> {
-        let mut desc: ffi::cudnnOpTensorDescriptor_t = core::ptr::null_mut();
-        let err = unsafe { ffi::cudnnCreateOpTensorDescriptor(&mut desc) };
-        if err != ffi::CUDNN_STATUS_SUCCESS {
-            return Err(CudaError::DnnError {
-                op: "createOpTensorDesc",
-                code: err,
-            });
-        }
-        let err = unsafe {
-            ffi::cudnnSetOpTensorDescriptor(
-                desc,
-                op,
-                comp_type,
-                ffi::cudnnNanPropagation_t::CUDNN_NOT_PROPAGATE_NAN,
-            )
-        };
-        if err != ffi::CUDNN_STATUS_SUCCESS {
-            unsafe {
-                ffi::cudnnDestroyOpTensorDescriptor(desc);
-            }
-            return Err(CudaError::DnnError {
-                op: "setOpTensorDesc",
-                code: err,
-            });
-        }
+        let desc = build_desc(
+            "createOpTensorDesc",
+            "setOpTensorDesc",
+            ffi::cudnnCreateOpTensorDescriptor,
+            |d| unsafe {
+                ffi::cudnnSetOpTensorDescriptor(
+                    d,
+                    op,
+                    comp_type,
+                    ffi::cudnnNanPropagation_t::CUDNN_NOT_PROPAGATE_NAN,
+                )
+            },
+            ffi::cudnnDestroyOpTensorDescriptor,
+        )?;
         Ok(Self { desc })
     }
 }

--- a/onnx-rt/src/cuda/kv_cache.rs
+++ b/onnx-rt/src/cuda/kv_cache.rs
@@ -265,33 +265,12 @@ impl GpuKvCache {
         let layer = &self.layers[layer_idx];
         let offset = self.current_position * stride;
 
+        // SAFETY: `offset + stride <= layer.k.size()` by the
+        // `current_position < max_seq_len` and `stride` invariants
+        // enforced above. Same for V.
         unsafe {
-            let k_dst = (layer.k.as_mut_ptr() as *mut u8).add(offset) as *mut core::ffi::c_void;
-            let err = ffi::cudaMemcpy(
-                k_dst,
-                new_k.buffer.as_ptr(),
-                stride,
-                ffi::cudaMemcpyKind::cudaMemcpyDeviceToDevice,
-            );
-            if err != ffi::CUDA_SUCCESS {
-                return Err(CudaError::CopyFailed {
-                    msg: "kv_cache append K (D2D)",
-                    code: err,
-                });
-            }
-            let v_dst = (layer.v.as_mut_ptr() as *mut u8).add(offset) as *mut core::ffi::c_void;
-            let err = ffi::cudaMemcpy(
-                v_dst,
-                new_v.buffer.as_ptr(),
-                stride,
-                ffi::cudaMemcpyKind::cudaMemcpyDeviceToDevice,
-            );
-            if err != ffi::CUDA_SUCCESS {
-                return Err(CudaError::CopyFailed {
-                    msg: "kv_cache append V (D2D)",
-                    code: err,
-                });
-            }
+            append_token_to(layer.k.as_mut_ptr(), offset, new_k, stride, "K")?;
+            append_token_to(layer.v.as_mut_ptr(), offset, new_v, stride, "V")?;
         }
 
         Ok(())
@@ -321,40 +300,7 @@ impl GpuKvCache {
     ///
     /// Returns raw device pointers (see [`KvView`]). The view does NOT copy.
     pub fn view(&self, layer_idx: usize) -> Result<KvView, CudaError> {
-        if layer_idx >= self.layers.len() {
-            return Err(CudaError::RuntimeError {
-                op: "kv_cache_view:layer_idx",
-                code: -1,
-            });
-        }
-        let layer = &self.layers[layer_idx];
-        let stride = self.token_stride_bytes();
-
-        let (start, count) = match layer.sliding_window {
-            None => (0, self.current_position),
-            Some(w) => {
-                let count = core::cmp::min(w, self.current_position);
-                let start = self.current_position - count;
-                (start, count)
-            }
-        };
-
-        // Even when count == 0 we return pointers to the buffer base. The
-        // caller is expected to handle the empty-view case gracefully.
-        let k_base = layer.k.as_ptr() as *const u8;
-        let v_base = layer.v.as_ptr() as *const u8;
-        let k_ptr = unsafe { k_base.add(start * stride) } as *const core::ffi::c_void;
-        let v_ptr = unsafe { v_base.add(start * stride) } as *const core::ffi::c_void;
-
-        Ok(KvView {
-            k_ptr,
-            v_ptr,
-            token_count: count,
-            stride_bytes: stride,
-            num_kv_heads: self.num_kv_heads,
-            head_dim: self.head_dim,
-            dtype: self.dtype,
-        })
+        self.view_at(layer_idx, self.current_position, "kv_cache_view:layer_idx")
     }
 
     /// View that includes the most recently appended (but not yet
@@ -372,27 +318,51 @@ impl GpuKvCache {
     /// itself reflects the same window — `view_pending` is only needed
     /// during the in-flight append.
     pub fn view_pending(&self, layer_idx: usize) -> Result<KvView, CudaError> {
+        self.view_at(
+            layer_idx,
+            self.current_position + 1,
+            "kv_cache_view_pending:layer_idx",
+        )
+    }
+
+    /// Build a [`KvView`] for `layer_idx` covering tokens
+    /// `[max(0, end - window), end)` where `end` is `position` for
+    /// global-attention layers and `min(window, position)` defines the
+    /// length for sliding-window layers.
+    ///
+    /// Shared body for [`view`](Self::view) (uses
+    /// `current_position`) and [`view_pending`](Self::view_pending)
+    /// (uses `current_position + 1`).
+    fn view_at(
+        &self,
+        layer_idx: usize,
+        position: usize,
+        oob_op: &'static str,
+    ) -> Result<KvView, CudaError> {
         if layer_idx >= self.layers.len() {
             return Err(CudaError::RuntimeError {
-                op: "kv_cache_view_pending:layer_idx",
+                op: oob_op,
                 code: -1,
             });
         }
         let layer = &self.layers[layer_idx];
         let stride = self.token_stride_bytes();
-        let pending_position = self.current_position + 1;
 
         let (start, count) = match layer.sliding_window {
-            None => (0, pending_position),
+            None => (0, position),
             Some(w) => {
-                let count = core::cmp::min(w, pending_position);
-                let start = pending_position - count;
+                let count = core::cmp::min(w, position);
+                let start = position - count;
                 (start, count)
             }
         };
 
+        // Even when count == 0 we return pointers to the buffer base. The
+        // caller is expected to handle the empty-view case gracefully.
         let k_base = layer.k.as_ptr() as *const u8;
         let v_base = layer.v.as_ptr() as *const u8;
+        // SAFETY: `start * stride <= max_seq_len * stride <= layer
+        // buffer size` by construction of the cache.
         let k_ptr = unsafe { k_base.add(start * stride) } as *const core::ffi::c_void;
         let v_ptr = unsafe { v_base.add(start * stride) } as *const core::ffi::c_void;
 
@@ -419,6 +389,47 @@ impl GpuKvCache {
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────
+
+/// Copy one token's worth (`stride` bytes) of K *or* V from `src`
+/// into `dst_base + offset` on the device.
+///
+/// `which` is one of `"K"` / `"V"` and only appears in the error
+/// message (`"kv_cache append K (D2D)"` / `"kv_cache append V (D2D)"`),
+/// so that K and V failures remain distinguishable in logs.
+///
+/// # Safety
+///
+/// - `dst_base + offset` must point to at least `stride` writable
+///   device bytes inside the per-layer K/V buffer (the caller checks
+///   `current_position < max_seq_len` and that `stride` matches
+///   `token_stride_bytes`).
+/// - `src.buffer.as_ptr()` must point to at least `stride` readable
+///   device bytes (the caller checks `src.byte_size() == stride`).
+unsafe fn append_token_to(
+    dst_base: *mut core::ffi::c_void,
+    offset: usize,
+    src: &DeviceTensor,
+    stride: usize,
+    which: &'static str,
+) -> Result<(), CudaError> {
+    let dst = (dst_base as *mut u8).add(offset) as *mut core::ffi::c_void;
+    let err = ffi::cudaMemcpy(
+        dst,
+        src.buffer.as_ptr(),
+        stride,
+        ffi::cudaMemcpyKind::cudaMemcpyDeviceToDevice,
+    );
+    if err != ffi::CUDA_SUCCESS {
+        let msg: &'static str = match which {
+            "K" => "kv_cache append K (D2D)",
+            // any non-"K" tag (currently only "V") falls through to
+            // the V message; this keeps the helper monomorphic
+            _ => "kv_cache append V (D2D)",
+        };
+        return Err(CudaError::CopyFailed { msg, code: err });
+    }
+    Ok(())
+}
 
 /// Fill a [`DeviceBuffer`] with zero bytes via `cudaMemset`.
 fn zero_buffer(buf: &DeviceBuffer) -> Result<(), CudaError> {

--- a/onnx-rt/src/kv_compression.rs
+++ b/onnx-rt/src/kv_compression.rs
@@ -71,19 +71,16 @@ impl Xorshift64 {
 // Walsh-Hadamard Transform
 // ---------------------------------------------------------------------------
 
-/// In-place Walsh-Hadamard transform with random sign flips.
+/// In-place Walsh-Hadamard butterfly followed by `1/sqrt(n)`
+/// normalisation. `n = x.len()` must be a power of two.
 ///
-/// `x` must have power-of-two length equal to `signs.len()`.
-/// After the transform, `x` is scaled by `1/sqrt(n)`.
-fn wht_with_signs(x: &mut [f32], signs: &[i8]) {
+/// Shared by both `wht_with_signs` (which applies the signs *before*
+/// the butterfly) and `inverse_wht_with_signs` (which applies them
+/// *after*). The transform itself is identical in both directions.
+#[inline]
+fn wht_butterfly_normalize(x: &mut [f32]) {
     let n = x.len();
     debug_assert!(n.is_power_of_two());
-    debug_assert_eq!(n, signs.len());
-
-    // Apply sign flips
-    for i in 0..n {
-        x[i] *= signs[i] as f32;
-    }
 
     // Butterfly
     let mut h = 1;
@@ -108,41 +105,37 @@ fn wht_with_signs(x: &mut [f32], signs: &[i8]) {
     }
 }
 
+/// Multiply each element of `x` by the corresponding `signs[i]`
+/// (interpreted as `±1`). Used both before the forward WHT and after
+/// the inverse WHT, where `S^{-1} = S` because each sign is its own
+/// inverse.
+#[inline]
+fn apply_signs(x: &mut [f32], signs: &[i8]) {
+    debug_assert_eq!(x.len(), signs.len());
+    for i in 0..x.len() {
+        x[i] *= signs[i] as f32;
+    }
+}
+
+/// In-place Walsh-Hadamard transform with random sign flips.
+///
+/// `x` must have power-of-two length equal to `signs.len()`.
+/// After the transform, `x` is scaled by `1/sqrt(n)`.
+fn wht_with_signs(x: &mut [f32], signs: &[i8]) {
+    debug_assert_eq!(x.len(), signs.len());
+    apply_signs(x, signs);
+    wht_butterfly_normalize(x);
+}
+
 /// Inverse WHT: apply WHT again then undo sign flips.
 ///
 /// WHT is self-inverse up to scaling: H * H = n * I.
 /// With our `1/sqrt(n)` normalization, applying WHT twice is identity.
 fn inverse_wht_with_signs(x: &mut [f32], signs: &[i8]) {
-    let n = x.len();
-    debug_assert!(n.is_power_of_two());
-    debug_assert_eq!(n, signs.len());
-
-    // Butterfly (same as forward)
-    let mut h = 1;
-    while h < n {
-        let mut i = 0;
-        while i < n {
-            for j in i..i + h {
-                let a = x[j];
-                let b = x[j + h];
-                x[j] = a + b;
-                x[j + h] = a - b;
-            }
-            i += h * 2;
-        }
-        h *= 2;
-    }
-
-    // Normalize
-    let scale = 1.0 / sqrt_approx(n as f32);
-    for v in x.iter_mut() {
-        *v *= scale;
-    }
-
+    debug_assert_eq!(x.len(), signs.len());
+    wht_butterfly_normalize(x);
     // Undo sign flips (S^{-1} = S since each sign is its own inverse)
-    for i in 0..n {
-        x[i] *= signs[i] as f32;
-    }
+    apply_signs(x, signs);
 }
 
 // ---------------------------------------------------------------------------
@@ -889,13 +882,7 @@ impl CompressedKVCache {
         }
 
         // Fallback: dequantize from blocks
-        let quantizer = &self.quantizers[layer][head];
-        let mut result = Vec::with_capacity(len * self.head_dim);
-        for block in blocks.iter().take(end).skip(start) {
-            let decoded = quantizer.decode(block);
-            result.extend_from_slice(&decoded);
-        }
-        result
+        self.dequantize_blocks(blocks, layer, head, start, end, len)
     }
 
     /// Read dequantized V values for a given layer, head, starting position
@@ -908,6 +895,26 @@ impl CompressedKVCache {
         let end = start + len;
         assert!(end <= blocks.len());
 
+        self.dequantize_blocks(blocks, layer, head, start, end, len)
+    }
+
+    /// Dequantize the range `blocks[start..end]` (which has `len`
+    /// entries) using `self.quantizers[layer][head]` and concatenate
+    /// the decoded vectors into a single `Vec<f32>` of length
+    /// `len * head_dim`.
+    ///
+    /// Shared by [`read_k`](Self::read_k) (after its low-rank
+    /// fast-path miss) and [`read_v`](Self::read_v).
+    #[inline]
+    fn dequantize_blocks(
+        &self,
+        blocks: &[QuantizedBlock],
+        layer: usize,
+        head: usize,
+        start: usize,
+        end: usize,
+        len: usize,
+    ) -> Vec<f32> {
         let quantizer = &self.quantizers[layer][head];
         let mut result = Vec::with_capacity(len * self.head_dim);
         for block in blocks.iter().take(end).skip(start) {


### PR DESCRIPTION
## Summary

Targets the SonarCloud `rust:S4144` duplicated-code hotspots in three onnx-rt files that the recent cognitive-complexity refactors (#194, #197, #198) did not touch. No public-API or behavior changes. All 891 onnx-rt unit tests still pass.

The same approach as #197 and #198: extract small private helpers (no macros needed here) that absorb the repeated boilerplate while leaving the public API untouched.

### `onnx-rt/src/cuda/descriptors.rs` — was 20.2% dup density

All four cuDNN descriptor wrappers (`TensorDesc`, `PoolDesc`, `ActivationDesc`, `OpTensorDesc`) hand-rolled the same `cudnnCreate*Descriptor` → check → `cudnnSet*Descriptor` → check-with-cleanup sequence (~30 lines × 4 wrappers).

Now shared via two private helpers:
- `check_dnn(status, op) -> Result<(), CudaError>` — single place that folds the `if status != CUDNN_STATUS_SUCCESS` check.
- `build_desc(create_op, set_op, create_fn, set_call, destroy_fn) -> Result<H, CudaError>` — runs the create+set pair on a fresh handle and destroys the handle if the `set` call fails. Each wrapper's `new` constructor shrinks to ~10 lines (a closure over the type-specific `cudnnSet*Descriptor` plus its arguments).

### `onnx-rt/src/cuda/kv_cache.rs` — was 9.2% dup density

Two duplications:
- `GpuKvCache::append` copied K and then V with identical `cudaMemcpy` D2D + error-check blocks. Now both copies go through private `unsafe fn append_token_to(dst_base, offset, src, stride, which)`. Error messages (`"kv_cache append K (D2D)"` / `"kv_cache append V (D2D)"`) are preserved verbatim.
- `view` and `view_pending` differed only in whether they computed the window over `current_position` or `current_position + 1`. Both now delegate to private `view_at(layer_idx, position, oob_op)`.

### `onnx-rt/src/kv_compression.rs` — was 1.9% dup density (40 dup lines)

Two clear duplicate blocks:
- `wht_with_signs` (forward) and `inverse_wht_with_signs` shared identical Walsh-Hadamard butterfly + `1/sqrt(n)` normalize loops. Split into two private helpers `wht_butterfly_normalize(x)` and `apply_signs(x, signs)`. The public functions now read as their mathematical definitions: forward = sign-flip then butterfly; inverse = butterfly then sign-flip.
- `read_k`'s fallback path and the entire body of `read_v` ran the same `quantizer.decode` loop over `blocks[start..end]`. Extracted private `dequantize_blocks(blocks, layer, head, start, end, len)`.

## Files touched

- `onnx-rt/src/cuda/descriptors.rs`
- `onnx-rt/src/cuda/kv_cache.rs`
- `onnx-rt/src/kv_compression.rs`

(diff: +242 / -219, net +23 lines, mostly doc-comments on the new helpers)

## Duplication impact (estimate)

| File | Before density | After (expected) | Mechanism |
|---|---:|---:|---|
| `cuda/descriptors.rs` | 20.2% (~45 lines) | <2% | 4 wrappers now share `build_desc` + `check_dnn` |
| `cuda/kv_cache.rs` | 9.2% (~40 lines) | <2% | K/V copy + view/view_pending bodies de-duplicated |
| `kv_compression.rs` | 1.9% (~40 lines) | <0.5% | WHT butterfly + read_k/read_v fallback de-duplicated |

SonarCloud will report exact numbers after the next scan.

## Test plan

- [x] `just fmt-check` — clean
- [x] `cargo clippy -p smallaios-onnx-rt --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p smallaios-onnx-rt --features cuda --lib -- -D warnings` — clean (type-checks the cuDNN dispatch logic without requiring a CUDA toolkit)
- [x] `cargo test -p smallaios-onnx-rt --lib` — 891 passed, 0 failed (identical to baseline on `develop`)
- [ ] CI gates (clippy / fmt / tests / build matrix / supply-chain) pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor

* Consolidated internal CUDA descriptor creation and configuration logic to reduce code duplication and improve maintainability.
* Refactored KV cache management utilities to streamline internal device operations and improve code organization.
* Improved compression utility implementation by extracting shared helper functions and reducing duplicate logic across related operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SmallAIOS/SmallAIOS/pull/199)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->