### PR TITLE
docs(openspec): propose deterministic scheduling + watchdog/lockstep safety roadmap

### DIFF
--- a/openspec/changes/deterministic-scheduling-v1/design.md
+++ b/openspec/changes/deterministic-scheduling-v1/design.md
@@ -1,0 +1,127 @@
+# Design — deterministic-scheduling-v1
+
+## Goal
+
+A single opt-in mode (`SessionConfig::deterministic = true`; container env-var `SMALLAIOS_DETERMINISTIC=1`; kernel CLI `--deterministic`) that makes `(model, input)` → `output` a *function* in the mathematical sense, on a given hardware + driver combination, regardless of host scheduling, multi-stream timing, or wall-clock-derived state.
+
+The deliverable is the contract, not the magic: every nondeterminism source is either removed, replaced with a deterministic counterpart, or explicitly documented as out-of-scope for v1.
+
+Success = `just test-determinism` runs an inference twice and produces byte-identical outputs across at least four representative models (one CPU-only, one CUDA-CPU-hybrid, one CUDA-pure, one with explicit RNG ops like a small generative LLM head).
+
+## Nondeterminism sources we are removing
+
+| Source | Where it lives today | Deterministic-mode replacement |
+|--------|----------------------|--------------------------------|
+| Sibling-task dispatch order in `RunQueue` (timer-derived FIFO/LIFO tiebreaker on the per-core queue) | `kernel/src/sched/executor.rs` | Strict `(priority, task_id, spawn_seq)` ordering — no host-time input |
+| Inference work-stealing across cores | `kernel/src/sched/executor.rs::steal_task` | Work-stealing disabled in deterministic mode; Inference queue pinned to its AMP-assigned core |
+| Multi-stream CUDA execution order | `onnx-rt/src/cuda/streams.rs`, `onnx-rt/src/cuda/gpu_executor.rs`, configured via `SessionConfig::stream_config` | Force `StreamConfig::SingleStream` + op-boundary `cudaStreamSynchronize` |
+| CUDA Graphs replay (capture order depends on initial issue order) | `onnx-rt/src/cuda/graph.rs`, `onnx-rt/src/cuda/graph_cache.rs` | Bypass graph capture entirely in deterministic mode (v1); honor capture in v2 once it is keyed on the deterministic sequence number |
+| Per-op xorshift32 PRNG seeded from `seed` attribute but called by the operator without a session-level salt | `onnx-rt/src/ops/generative.rs` | Per-session `DeterministicRng` keyed on `(session_seed, op_index, draw_index)`; the operator-level seed becomes a hash input, not the whole seed |
+| Wall-clock-derived sampling temperatures and Multinomial seed paths | `onnx-rt/src/ops/generative.rs` Multinomial / Bernoulli implementations | Read from `DeterministicRng`; "wall clock" in deterministic mode means the per-session monotonic counter, not host time |
+| `enable_profiling` measurement feedback (measured op time → budget enforcement decision → potential abort) | `onnx-rt/src/profile.rs`, executor budget check | Decision left enabled (we still want the abort behavior), but the *decision branch* must be enforced after the op's outputs are computed, not before — so a Heisenbug from "this op was fast on this run" can't change subsequent op behavior. Already mostly true; we audit and lock in. |
+
+## Alternatives considered
+
+### Alternative A — Make the default mode deterministic, deprecate multi-stream
+
+**Rejected.** Multi-stream delivers 1.3-1.5× on serving workloads and is the right default for the production container path (Jetson Orin AI server, GPU-accelerated inference at scale). Forcing every deployment to pay the determinism cost when most deployments don't need certification claims would be a major performance regression. The opt-in flag is the right user contract.
+
+### Alternative B — Two scheduler binaries (build-time switch)
+
+Build-time selection of `Default` vs `Deterministic` schedulers (analogous to `kernel` vs `container` Cargo features). **Rejected** because: (a) we want a single CI artifact that can verify both modes, (b) the runtime flip is cheap (one branch in `RunQueue::dequeue`, one branch in `ensure_stream_pool`), (c) DO-178C does *not* require build-time exclusion — it requires verifiable mode setting, which a runtime flag with a one-way init satisfies, and (d) supporting both modes from one binary keeps the existing test matrix from doubling.
+
+### Alternative C — Per-task determinism (some tasks deterministic, some not)
+
+**Rejected.** Determinism is a session-level property; mixing modes inside a session means the deterministic ops can be perturbed by the non-deterministic ones (cache contention, queue jostling). The DO-178C surface is "this inference session is deterministic" or "this inference session is not"; we cleanly model the same.
+
+### Alternative D — DRBG instead of xorshift32 for the per-session RNG
+
+**Deferred to a follow-up.** xorshift32 is the existing operator-level kernel and it has known cryptographic weaknesses, but cryptographic strength is not a determinism requirement — we just need a long-period reproducible stream. If a future change wants ChaCha20-DRBG (NIST SP 800-90A) for FIPS alignment, it can replace `XorShift32` under the existing `DeterministicRng` facade without breaking the determinism contract. The seam is intentional.
+
+### Alternative E — Hardware-RNG fallback for non-RNG operators
+
+Some hardware-accelerated kernels (e.g. cuRAND) bypass our PRNG entirely. **Rejected for v1** — we do not currently use cuRAND on the hybrid executor path (the int8 quantize/dequantize ops don't need RNG, and our `Multinomial`/`Bernoulli` implementations run on the CPU side of the hybrid split). When a future change moves these ops to GPU we will need a deterministic-mode branch that either disables the GPU implementation or routes through cuRAND-pseudo-host mode; tracked but not in scope here.
+
+## Scheduler ordering — the deterministic tiebreaker
+
+Current `RunQueue::dequeue` in `kernel/src/sched/executor.rs` returns the highest-priority task from the per-core queue. Within a priority class, the existing implementation uses queue insertion order (FIFO), which is deterministic *within* a single execution but depends on which core scheduled the task spawn first — a function of host timing on multi-core systems.
+
+New deterministic ordering:
+
+```text
+sort_key(task) = (priority_class, task_id, spawn_sequence_number)
+```
+
+- `priority_class` — existing (`System < Ipc < Inference`).
+- `task_id` — existing; assigned at task creation. Stable across runs because task creation order is itself determined by deterministic scheduling once at-rest.
+- `spawn_sequence_number` — new; a per-scheduler atomic counter incremented at task spawn. Stable across runs because deterministic mode makes spawn order itself deterministic (chicken-and-egg resolved by initializing the counter at zero before the boot path starts).
+
+The key insight: in default mode, two tasks of equal priority can run in either order depending on which core polled the queue first. In deterministic mode, the queue itself is sorted on `(priority, task_id, spawn_sequence_number)` so the ordering is a *function* of the queue contents, not of the polling pattern. Work-stealing is disabled in deterministic mode to maintain this invariant.
+
+## CUDA — single stream + op boundary sync
+
+`SessionConfig::deterministic = true` forces `StreamConfig::SingleStream` regardless of any explicit `stream_config` value. Explicitly: in `onnx-rt/src/session.rs::Session::ensure_stream_pool`, the existing dispatch on `stream_config` gains a wrapper that resolves `(deterministic, stream_config) -> effective_stream_config` as:
+
+```text
+(true, _)                  -> SingleStream  // determinism overrides
+(false, x)                 -> x             // default plumbing unchanged
+```
+
+If a user sets both `deterministic = true` and `stream_config = Overlap { ... }`, the session emits a one-line warning to syslog at construction time and proceeds in single-stream mode. The warning is suppressible via a `SessionConfig::deterministic_silent: bool` if it becomes noisy in container deployments (probably not needed; we will see).
+
+The op-boundary `cudaStreamSynchronize` is added to the hybrid executor's run loop (`onnx-rt/src/cuda/gpu_executor.rs`) as the last action of each operator's GPU-side work, before the executor returns control to the cooperative scheduler. Cost on the single-stream path is at most one CUDA driver round-trip per operator — typically sub-millisecond on Orin Ampere — and it serves as the lockstep voter's checkpoint.
+
+CUDA Graphs (`onnx-rt/src/cuda/graph.rs` capture/replay path) is bypassed in deterministic mode. The reasoning: a captured graph's behavior is a function of the host-side issue order at capture time; replaying it later in deterministic mode would leak the capture-time nondeterminism into the deterministic run. Bypassing capture costs roughly 5-10% of throughput on the Jetson Orin path (per the `cuda-graphs-v1` archived measurements); this is documented as part of the deterministic-mode throughput cost.
+
+## RNG — the `DeterministicRng` contract
+
+A new type lives in `onnx-rt/src/determinism.rs` (or as a sub-module of `profile.rs`):
+
+```text
+struct DeterministicRng {
+    session_seed: u64,         // From SessionConfig::deterministic_seed, default 0
+    op_index: u32,             // Operator's position in the graph, assigned at load time
+    draw_counter: AtomicU32,   // Bumped on each draw, reset per-session
+}
+```
+
+Per draw:
+
+```text
+state = hash_combine(session_seed, op_index, draw_counter.fetch_add(1))
+xorshift32 = XorShift32::new(state as u32)
+return xorshift32.next()
+```
+
+Two draws on the same op produce different values; two runs of the same `(session_seed, model)` produce the same draws. `hash_combine` is a public deterministic mixing function (e.g. SplitMix or FxHash-derived) — pick the simplest one that produces low-bias 32-bit outputs.
+
+The existing `XorShift32` in `onnx-rt/src/ops/generative.rs` stays as the kernel. Operators that currently call `XorShift32::new(op_attribute_seed)` change to call `DeterministicRng::draw(op_attribute_seed)` which folds the attribute seed in as an additional hash input.
+
+For Multinomial and Bernoulli (the two ops that draw a *sample* per run, not just a fixed PRNG state), the wall-clock-derived sampling currently uses host time as a fallback when `seed = 0`. Deterministic mode rewrites the fallback to use `(session_seed, op_index, draw_counter)`, never host time.
+
+## Failure modes and abort behavior
+
+- **A new operator that requires nondeterminism is added** (e.g. a future op that reads `cuda_get_device_count` at runtime). Deterministic-mode session construction must reject the model with a typed error. Implementation: maintain a registry of "is this op deterministic-safe?" — defaults to `true`, ops that opt out (currently none, this is forward-compat) set `false`.
+- **The user sets `deterministic_seed = 0` and runs twice expecting different outputs.** Document clearly: same seed → same output is the contract. If the user wants different outputs across runs in deterministic mode they must vary the seed themselves (e.g. via a session-level counter persisted to disk).
+- **`cudaStreamSynchronize` fails.** Existing error path applies (fatal session error). Deterministic mode does not change error semantics.
+
+## CI verification surface
+
+- New `just test-determinism` recipe runs an inference twice in deterministic mode, diffs the outputs.
+- New CI job `determinism-reproducibility` (advisory initially, gate after a release of stability) runs the same recipe in PR CI against a small set of fixture models stored under `tests/fixtures/determinism/`.
+- Existing tests keep their existing assertions; deterministic mode is additive.
+- Coverage gate (`cargo-llvm-cov --fail-under-lines 80`) still applies; new code paths must meet the existing 93% coverage ratchet.
+
+## Throughput cost budget
+
+We accept up to 35% throughput regression in deterministic mode vs. default mode on the hybrid-executor workload, measured on `bench/llm-inference-bench` on the Jetson Orin Industrial reference platform (cc 8.7, JetPack 6 base). Above 35%, the design is wrong and we should reopen the proposal. Below 35%, ship it.
+
+Measurement methodology, baseline targets, and acceptance numbers are captured in `tasks.md` section 5 (Benchmarks).
+
+## What this change explicitly does NOT do
+
+- Does not change the default mode. Every existing deployment keeps the multi-stream / work-stealing behavior bit-for-bit.
+- Does not change the `OperatorBudget` enforcement semantics. Budget checks still run; budget violations still abort.
+- Does not change `onnx-rt`'s public API surface in a breaking way. `SessionConfig::deterministic` is a new field with a backward-compatible default.
+- Does not add a new syscall. The kernel-mode flag is plumbed through existing init paths.
+- Does not introduce SMP scheduling. AMP topology is preserved; deterministic mode only affects ordering *within* the existing AMP partitioning.

--- a/openspec/changes/deterministic-scheduling-v1/proposal.md
+++ b/openspec/changes/deterministic-scheduling-v1/proposal.md
@@ -1,0 +1,71 @@
+# deterministic-scheduling-v1
+
+## Summary
+
+SmallAIOS already ships a cooperative scheduler that yields at ONNX operator boundaries (`kernel/src/sched/executor.rs`, design captured in `docs/scheduling-model.md`) and a hybrid CUDA executor that overlaps host/device transfers across multiple streams (`onnx-rt/src/cuda/streams.rs`, archived as `2026-05-03-async-multistream-v1`). The cooperative model gives us *bounded* execution windows — every operator runs to completion before the next preempt opportunity — but the actual *order* in which sibling tasks run, the operator-to-stream binding chosen by the hybrid executor, and the values produced by RNG-driven operators (`Multinomial`, `Bernoulli`, `Dropout`, `RandomUniform`, `RandomNormal` — see `onnx-rt/src/ops/generative.rs`) all depend on host wall-clock timing today. That means **the same `(model, input)` pair can produce different outputs on the same hardware on different runs.** For sampling-style generative inference this is sometimes intentional; for DO-178C DAL A certification it is fatal — input-output traceability is a hard objective and cannot be claimed without bit-identical reproducibility, and automotive Diagnostic Coverage credit under ISO 26262 likewise requires a deterministic baseline against which redundant-channel votes can be compared.
+
+This change adds a single new runtime mode — `--deterministic` (kernel) and `SessionConfig::deterministic = true` (host/container) — that forces the cooperative scheduler to dispatch sibling tasks in a stable, hash-defined order, collapses the multi-stream CUDA executor back onto a single synchronous stream at op boundaries, and replaces every wall-clock-dependent RNG source with a seeded counter-based DRBG that is driven by a deterministic per-session sequence number rather than host time. Same input → same output, on the same hardware, regardless of how many other processes the host is running or how many cores are warm. The default mode (multi-stream, free-running ordering, current behavior) is preserved bit-for-bit; deterministic mode is opt-in and pays a measurable throughput cost (we estimate 20-35% on hybrid-executor workloads where multi-stream overlap is the dominant speedup) in exchange for the certification claim.
+
+Three deliveries: (1) extend the existing `kernel-core` cooperative-scheduler spec with a `Deterministic` ordering mode; (2) add a new `onnx-rt-determinism` capability spec covering the CUDA-stream collapse and the seeded-DRBG contract; (3) wire enough config plumbing through `SessionConfig`, the `Justfile`, and the container env-var layer that a developer can flip the mode with a single flag and verify reproducibility via a new `just test-determinism` recipe that runs an inference twice and diffs the outputs byte-for-byte.
+
+## Why
+
+- **DO-178C DAL A input-output traceability is unclaimable without deterministic mode.** Table A-3 objective 1 ("software requirements comply with system requirements") and Table A-7 objective 8 ("verification of verification activities") both require that every verification run against a given input produce the same observable output as the version that was reviewed and certified. Today's multi-stream executor breaks this: stream scheduling order is decided by the CUDA driver, which is not part of our certifiable boundary. The `formal-proving-and-redteam-v1` change (also in flight) needs this same property to make claims about formal proofs covering executable behavior — a formal proof over a non-deterministic implementation only covers the relation, not the function. Deterministic mode is the precondition for both.
+- **Automotive Diagnostic Coverage credit needs a reproducible reference channel.** When `watchdog-lockstep-v1` (the sibling change in this batch) wires up dual-core lockstep on Cortex-A78AE, the lockstep voter compares two replicas of the same inference. If the replicas are running in non-deterministic mode they can legitimately produce different outputs — same model, same input, same hardware, but different timer-derived RNG draws and different multi-stream scheduling. The voter has no signal. Deterministic mode is what makes lockstep voting meaningful: a divergence between replicas in deterministic mode is *always* a soft fault (the whole point of the redundancy), never a benign timing artifact.
+- **The RNG path already wants to be deterministic — the design just isn't enforced.** `onnx-rt/src/ops/generative.rs` lines 16-20 already document: *"Random operators use a deterministic xorshift32 PRNG seeded from the `seed` attribute (float) and `shape` attribute (ints) so repeated calls with the same seed produce reproducible results. This is critical for DO-178C DAL A certification — 'random' is a misnomer; every draw must be deterministically replayable from (seed, call-site)."* The `XorShift32` type in that file is wired correctly per-operator, but the *whole-session* state (which operator runs first when two are eligible, when the multi-stream executor decides to flush, how token-sampling temperature interacts with the per-op seed) is not yet under that same discipline. This change finishes the work the operator path started.
+- **Cost is bounded and measurable.** Multi-stream gives ~1.3-1.5× on serving workloads (per the `2026-05-03-async-multistream-v1` archive). Deterministic mode forfeits that overlap by definition — but we already documented and shipped the single-stream path as the default, so the deterministic mode is implementable by *reusing the existing `StreamConfig::SingleStream` plumbing*, not by writing new code. The op-boundary `cudaStreamSynchronize` is a one-line addition.
+
+## What changes
+
+### Kernel scheduling — extend `kernel-core`
+
+- Add a `SchedulerMode` enum to `kernel/src/sched/executor.rs`: `Default` (current behavior — multi-stream-friendly, work-stealing on the Inference queue) and `Deterministic` (stable dispatch order, work-stealing disabled, all multi-core work serialized through a deterministic round-robin over the configured `CpuAffinity` set). The mode is set once at scheduler init and is immutable for the lifetime of the boot.
+- Replace the LIFO-on-tie ordering currently used in `RunQueue::dequeue` with a deterministic tiebreaker keyed on `(priority, task_id, deterministic_sequence_number)`. The sequence number is a per-scheduler monotonic counter incremented at task spawn — it produces a stable order across runs without requiring host time.
+- Disable Inference-queue work-stealing (`steal_task()` in `kernel/src/sched/executor.rs`) when in `Deterministic` mode. Work-stealing makes per-core run order depend on which core happened to be idle first, which is the definition of nondeterminism we are trying to remove. Single-core inference is the cost; for AMP topologies the Inference queue collapses to its assigned core only.
+
+### CUDA execution — collapse multi-stream overlap
+
+- Honor `SessionConfig::deterministic = true` by forcing `StreamConfig::SingleStream` regardless of any explicit `Overlap { transfer_streams }` setting (with a runtime warning if the user passed both). The plumbing already exists; this change is one branch in `onnx-rt/src/session.rs::Session::ensure_stream_pool`.
+- Add an op-boundary `cudaStreamSynchronize` to the hybrid executor's run loop (`onnx-rt/src/cuda/gpu_executor.rs`) when `deterministic = true`. Under `SingleStream` mode the synchronize is technically redundant for correctness (everything is already on one stream), but it converts the implicit per-stream FIFO ordering into a checkpoint that the lockstep voter (and the formal-verification surface) can hang assertions on. Cheap insurance.
+- Bypass the CUDA Graphs capture path entirely in deterministic mode for v1. Graph capture amortizes launch overhead by recording a stream's sequence of work, but the capture itself is a function of *when* operators were issued, so reusing a captured graph across runs that were captured in non-deterministic mode would leak nondeterminism into the deterministic run. A future revision can teach graph capture to also key on the deterministic sequence number; out of scope for v1.
+
+### RNG — single per-session deterministic DRBG
+
+- Add a `DeterministicRng` type to `onnx-rt/src/profile.rs` (or a new `onnx-rt/src/determinism.rs`) keyed on `(session_seed: u64, op_index: u32, draw_index: u32)`. The existing `XorShift32` in `onnx-rt/src/ops/generative.rs` is the right starting kernel; the new type wraps it so that every RNG-consuming operator threads the same `(session_seed, op_index)` pair and gets a fresh `draw_index` per call. Same operator, same position in the graph, same model, same input → same draws.
+- Replace any call to `cudaDeviceGetTimerValue` / wall-clock-derived sampling temperatures (currently used in `multinomial` and `Bernoulli` paths) with reads from the per-session `DeterministicRng`. Document the contract: in deterministic mode, "wall clock" is the per-session counter, not host time.
+- Reject `SessionConfig::deterministic = true` if the loaded model contains an operator that demonstrably cannot be made deterministic (none today; this is a forward-compatibility check). Return a typed error at session creation, not at first inference.
+
+### Config + verification surfaces
+
+- New `SessionConfig::deterministic: bool` (default `false`). Feeds the four behaviors above.
+- New container env-var `SMALLAIOS_DETERMINISTIC=1` that sets the same flag on the container path.
+- New `just test-determinism` recipe that builds, runs an inference twice with `deterministic=true`, byte-diffs the outputs, fails on diff. Wired into CI as an advisory check initially, gate after one release of stability.
+- New `docs/determinism.md` documenting the deterministic-mode guarantees, the throughput cost, and the certification claims it unlocks.
+
+## Relation to prior work
+
+This change **extends** the cooperative scheduling design captured in `docs/scheduling-model.md` and the operator-level RNG contract documented in `onnx-rt/src/ops/generative.rs` (which itself was reviewed as part of `2026-04-21-generative-llm-v1`, archived). It does not contradict any archived design. It **conflicts with** `2026-05-03-async-multistream-v1` only in the narrow sense that it disables that path's overlap mode under one specific flag — the default mode is preserved bit-for-bit, so no existing deployment regresses.
+
+The hard precondition is the `timer-hal-wcet-v1` work (archived `2026-04-10-timer-hal-wcet-v1`) which already replaced wall-clock dependency in `sys_time()` with the architecture timer; deterministic mode builds on that by also gating the per-operator measurement away from any flow that influences scheduling decisions. (Measurement still happens — it just doesn't feed back into ordering.)
+
+## Out of scope
+
+- **GPU kernel determinism within a single op.** cuDNN's GEMM and convolution kernels are not bit-deterministic across CUDA driver versions (the reduction-tree shape depends on tile counts and warp-scheduling). v1 of deterministic mode is "deterministic across runs *on the same driver + hardware*". A future change can layer cuBLAS-deterministic-mode (`CUBLAS_PEDANTIC_MATH`) and cuDNN-deterministic-algorithm-selection to extend the guarantee across driver versions, with a measurable additional throughput cost.
+- **Multi-process determinism.** This change covers a single SmallAIOS instance. If two instances run inference on shared hardware, the host kernel's GPU scheduling between them is not under our control.
+- **Distributed determinism (across nodes).** Out of scope by deliberate choice — would require a deterministic network transport, which is a separate (very large) change.
+- **Bit-identical floating-point across architectures.** AArch64 and x86-64 NEON/AVX paths in some CPU operators use slightly different reduction orders. Determinism is defined per-architecture in v1.
+
+## Sequencing
+
+This change should land **before** `watchdog-lockstep-v1` so the lockstep voter has a deterministic reference channel to compare against. It is **independent** of the Tegra234 BSP from `unikernel-orin-bringup-v1` — deterministic mode is a host-architecture-agnostic property of the kernel + ONNX runtime, and can be developed and tested entirely on x86-64 hardware. The Orin path picks it up "for free" once the BSP merges.
+
+## Effort estimate
+
+| Sub-area | Scope | Estimate |
+|----------|-------|----------|
+| Scheduler mode + deterministic tiebreaker | `kernel/src/sched/executor.rs` + `RunQueue` changes | ~1 week |
+| CUDA stream collapse + op-boundary sync | `onnx-rt/src/cuda/{gpu_executor,streams}.rs` + `SessionConfig` plumb | ~1 week |
+| `DeterministicRng` + operator wiring | `onnx-rt/src/ops/generative.rs` + new `determinism.rs` | ~1 week |
+| `just test-determinism` recipe + CI advisory job + docs | `Justfile`, `.github/workflows/ci.yml`, `docs/determinism.md` | ~1 week |
+| Reproducibility golden tests across 3-4 representative models | New `tests/` modules | ~1 week |
+| **Total** | | **~4-5 weeks** |

--- a/openspec/changes/deterministic-scheduling-v1/specs/kernel-scheduling/spec.md
+++ b/openspec/changes/deterministic-scheduling-v1/specs/kernel-scheduling/spec.md
@@ -1,0 +1,96 @@
+# Capability: kernel-scheduling — Deterministic mode (delta)
+
+## ADDED Requirements
+
+### Requirement: Deterministic scheduler mode
+
+The kernel SHALL provide a one-shot init-time scheduler mode setting (`SchedulerMode::Default` or `SchedulerMode::Deterministic`) such that, when `Deterministic` is selected, the dispatch order of tasks within a priority class is a pure function of `(priority_class, task_id, spawn_sequence_number)` and is independent of host wall-clock timing, of which core polled the run queue first, and of any work-stealing behavior.
+
+#### Scenario: Deterministic mode is selectable at boot
+
+- **GIVEN** a SmallAIOS kernel boot
+- **WHEN** the kernel is started with the `--deterministic` boot argument (kernel mode) or with `SMALLAIOS_DETERMINISTIC=1` (container mode)
+- **THEN** the scheduler SHALL initialize in `SchedulerMode::Deterministic` before the first task spawn
+- **AND** subsequent attempts to change the mode after task spawning has begun SHALL return a typed error
+- **AND** the mode setting SHALL be queryable via `Scheduler::mode()` so other subsystems (the CUDA executor, the `DeterministicRng`) can read the mode without a per-call host-time branch
+
+#### Scenario: Deterministic dispatch order within a priority class
+
+- **GIVEN** a scheduler running in `Deterministic` mode
+- **AND** three tasks of equal `SchedulingClass::Inference` priority queued from two different cores in some host-timing-dependent order
+- **WHEN** the run queue is dequeued
+- **THEN** the dequeue order SHALL be the lexicographic order of `(task_id, spawn_sequence_number)` across the three tasks
+- **AND** two identical kernel boots with the same input load SHALL produce the same dispatch sequence
+- **AND** the dispatch order SHALL be independent of which core happened to spawn each task
+
+#### Scenario: Work-stealing disabled in deterministic mode
+
+- **GIVEN** a scheduler running in `Deterministic` mode with multiple cores
+- **WHEN** an idle core checks the global executor for a steal candidate via `RunQueue::steal_task`
+- **THEN** `steal_task` SHALL return `None` regardless of whether other cores have queued Inference tasks
+- **AND** Inference tasks SHALL execute only on their AMP-assigned core
+- **AND** the resulting per-core data-parallel decomposition SHALL be documented in `docs/scheduling-model.md` so contributors understand the determinism / throughput trade-off
+
+#### Scenario: Default mode behavior preserved bit-for-bit
+
+- **GIVEN** a scheduler initialized in `SchedulerMode::Default` (the default)
+- **WHEN** the same workload runs as before this change
+- **THEN** the dispatch order, work-stealing behavior, and throughput SHALL be bit-for-bit identical to the pre-`deterministic-scheduling-v1` implementation
+- **AND** the regression-pinning unit tests in `kernel/src/sched/executor.rs` SHALL assert this property
+
+### Requirement: Spawn-sequence numbering
+
+The `Task` type SHALL carry a `spawn_sequence_number: u64` field assigned atomically at task spawn from a per-scheduler monotonic counter, and the dispatch tiebreaker in deterministic mode SHALL consume this field.
+
+#### Scenario: Spawn-sequence is monotonic and unique
+
+- **GIVEN** a sequence of `N` task spawns on a scheduler
+- **WHEN** each spawn is inspected
+- **THEN** each task SHALL have a unique `spawn_sequence_number`
+- **AND** the sequence numbers SHALL be strictly monotonically increasing across spawns within the lifetime of the boot
+
+#### Scenario: Spawn-sequence is stable across deterministic-mode runs
+
+- **GIVEN** two identical kernel boots in deterministic mode with the same workload
+- **WHEN** the spawn sequence of all tasks is captured in each boot
+- **THEN** the captured sequence numbers SHALL be identical across the two boots for corresponding tasks
+- **AND** this property SHALL be verifiable by a reproducibility integration test
+
+### Requirement: Cooperative-yield semantics unchanged in deterministic mode
+
+Deterministic mode SHALL NOT change the cooperative-yield contract documented in `docs/scheduling-model.md` (yield at ONNX operator boundaries, no mid-operator preemption, `OperatorBudget` enforcement preserved, priority preemption at yield points only).
+
+#### Scenario: Operator-boundary yield still fires
+
+- **GIVEN** a scheduler running in `Deterministic` mode
+- **AND** an inference task running with a registered `yield_fn` callback
+- **WHEN** the task completes an ONNX operator
+- **THEN** the `yield_fn` SHALL be invoked exactly as in `Default` mode
+- **AND** the scheduler SHALL check for pending SYSTEM and IPC tasks before resuming the inference
+
+#### Scenario: `OperatorBudget` enforcement preserved
+
+- **GIVEN** a scheduler running in `Deterministic` mode
+- **AND** an operator whose measured wall-clock time exceeds its `hard_limit_multiplier * budget_ns`
+- **WHEN** the operator completes
+- **THEN** the scheduler SHALL abort the inference session with the same `SessionError::ExecutionFailed` it would have raised in `Default` mode
+- **AND** the abort decision SHALL be made *after* the operator's outputs are computed, so the decision branch cannot leak host-timing state into subsequent operator behavior
+
+#### Scenario: Priority preemption at yield points
+
+- **GIVEN** an inference task running in deterministic mode
+- **AND** a SYSTEM-class task (e.g. watchdog) becoming runnable
+- **WHEN** the inference task reaches the next operator-boundary yield
+- **THEN** the scheduler SHALL preempt the inference and run the SYSTEM task
+- **AND** the order in which SYSTEM tasks are dispatched (if multiple are ready) SHALL follow the deterministic tiebreaker
+
+### Requirement: Documentation of deterministic mode
+
+`docs/scheduling-model.md` SHALL gain a "Deterministic mode" section that documents the ordering rule, the work-stealing disablement, the throughput cost, the certification claims unlocked, and the cross-link to `docs/determinism.md`.
+
+#### Scenario: Contributor can discover deterministic-mode rules
+
+- **GIVEN** a new contributor reading `docs/scheduling-model.md`
+- **WHEN** they search for "deterministic"
+- **THEN** they SHALL find an explicit section explaining (a) when to enable deterministic mode, (b) what changes about scheduling behavior, (c) what changes about throughput, and (d) what DO-178C / ISO 26262 claims the mode unlocks
+- **AND** they SHALL find a cross-link to `docs/determinism.md` for the full contract

--- a/openspec/changes/deterministic-scheduling-v1/specs/onnx-rt-determinism/spec.md
+++ b/openspec/changes/deterministic-scheduling-v1/specs/onnx-rt-determinism/spec.md
@@ -1,0 +1,136 @@
+# Capability: onnx-rt-determinism
+
+## ADDED Requirements
+
+### Requirement: SessionConfig deterministic flag
+
+`SessionConfig` SHALL expose a `deterministic: bool` field (default `false`) and a `deterministic_seed: u64` field (default `0`), and the runtime SHALL honor them by collapsing all sources of host-timing-derived nondeterminism into a single reproducible execution path.
+
+#### Scenario: Deterministic flag plumbs to the session
+
+- **GIVEN** a developer constructing a `Session` with `SessionConfig { deterministic: true, deterministic_seed: 42, ..Default::default() }`
+- **WHEN** the session is constructed
+- **THEN** the session SHALL initialize all internal RNG state from `deterministic_seed`
+- **AND** the session SHALL force `StreamConfig::SingleStream` regardless of any explicit `stream_config` value
+- **AND** the session SHALL bypass CUDA Graphs capture and replay paths
+- **AND** the resulting session SHALL be marked deterministic for the purpose of downstream queries (e.g. `Session::is_deterministic()`)
+
+#### Scenario: Conflicting stream config emits a warning, not an error
+
+- **GIVEN** a developer constructing a `Session` with both `deterministic: true` and `stream_config: StreamConfig::Overlap { transfer_streams: 2 }`
+- **WHEN** the session is constructed
+- **THEN** the session SHALL succeed
+- **AND** the session SHALL emit a one-line warning to syslog explaining that determinism overrides the overlap configuration
+- **AND** the resulting session SHALL behave as if `stream_config = SingleStream`
+
+#### Scenario: Default config is unchanged
+
+- **GIVEN** a developer constructing a `Session` with `SessionConfig::default()`
+- **WHEN** the session is constructed
+- **THEN** the `deterministic` field SHALL be `false`
+- **AND** the session SHALL behave bit-for-bit identically to the pre-`deterministic-scheduling-v1` default
+- **AND** existing throughput benchmarks SHALL be unchanged
+
+### Requirement: Deterministic CUDA stream collapse
+
+When `Session::is_deterministic()` is `true`, the CUDA executor SHALL run all GPU work on a single stream and SHALL issue a `cudaStreamSynchronize` at every operator boundary.
+
+#### Scenario: Single stream is used in deterministic mode
+
+- **GIVEN** a deterministic session executing a GPU-accelerated ONNX model
+- **WHEN** the executor processes the first operator
+- **THEN** the operator's GPU work SHALL be issued on the session's single compute stream
+- **AND** no transfer streams SHALL be allocated
+- **AND** the `StreamPool::is_single_stream()` invariant SHALL hold for the session lifetime
+
+#### Scenario: Op-boundary synchronize is issued
+
+- **GIVEN** a deterministic session executing a GPU operator
+- **WHEN** the operator's GPU work completes
+- **THEN** the executor SHALL issue `cudaStreamSynchronize` on the compute stream before returning control to the cooperative scheduler
+- **AND** the synchronize SHALL block until all preceding GPU work on the stream has completed
+- **AND** a failed synchronize SHALL surface as a fatal session error using the existing error path
+
+#### Scenario: CUDA Graphs capture is bypassed
+
+- **GIVEN** a deterministic session executing an ONNX model that the default-mode runtime would normally capture via CUDA Graphs
+- **WHEN** the session runs an inference
+- **THEN** the runtime SHALL NOT call `cudaGraphCapture` / `cudaGraphInstantiate` / `cudaGraphLaunch`
+- **AND** the operators SHALL execute via the uncaptured op-by-op path
+- **AND** the documented throughput cost (5-10% on the Jetson Orin path) SHALL be acknowledged in `docs/determinism.md`
+
+### Requirement: Per-session deterministic RNG
+
+The runtime SHALL provide a `DeterministicRng` type keyed on `(session_seed, op_index, draw_counter)` and SHALL route every RNG-consuming operator through it when the session is in deterministic mode.
+
+#### Scenario: Same seed produces same draws
+
+- **GIVEN** two deterministic sessions constructed with `deterministic_seed = S` for the same model
+- **WHEN** each session runs an inference with the same input
+- **THEN** every RNG draw on every operator SHALL produce the same value across the two sessions
+- **AND** the output tensors SHALL be byte-identical
+
+#### Scenario: Different seed produces different draws
+
+- **GIVEN** two deterministic sessions constructed with `deterministic_seed = S1` and `deterministic_seed = S2` where `S1 ≠ S2`, for the same model
+- **WHEN** each session runs an inference with the same input
+- **THEN** the per-operator RNG draws SHALL differ between the two sessions (with overwhelmingly high probability for any reasonable hash mixing)
+- **AND** the output tensors SHALL differ for any operator whose output depends on RNG draws
+
+#### Scenario: No wall-clock fallback
+
+- **GIVEN** a deterministic session running an operator that previously used host wall-clock time as a "random" seed (e.g. `Multinomial` or `Bernoulli` with `seed = 0`)
+- **WHEN** the operator draws a sample
+- **THEN** the draw SHALL come from `DeterministicRng` keyed on the session seed and operator index
+- **AND** the runtime SHALL NOT call `std::time::Instant::now`, `clock_gettime`, or `cudaDeviceGetTimerValue` on the inference hot path
+
+#### Scenario: RNG draws are stable across session restarts
+
+- **GIVEN** a deterministic session constructed with `deterministic_seed = S` for model `M` with input `I`
+- **AND** the session being destroyed and reconstructed with the same `(S, M, I)`
+- **WHEN** the second session runs an inference
+- **THEN** the output tensors SHALL be byte-identical to the first session's output
+
+### Requirement: Deterministic-safe operator registry
+
+The runtime SHALL maintain a registry of which ONNX operators are deterministic-safe and SHALL reject session construction with `deterministic = true` if the loaded model contains an operator that is not deterministic-safe.
+
+#### Scenario: All current operators are deterministic-safe
+
+- **GIVEN** the v1 implementation of `deterministic-scheduling-v1`
+- **WHEN** the operator registry is initialized
+- **THEN** every operator currently implemented in `onnx-rt/src/ops/` SHALL be marked deterministic-safe (this is a v1 invariant — no operator currently introduces nondeterminism that we cannot remove)
+- **AND** a future operator that legitimately requires nondeterminism SHALL set its registry entry to `false` and document the reason
+
+#### Scenario: Unsafe operator rejects deterministic session
+
+- **GIVEN** a future ONNX operator marked deterministic-unsafe in the registry
+- **WHEN** a developer attempts to construct a session with `deterministic = true` on a model containing that operator
+- **THEN** session construction SHALL return a typed error naming the offending operator
+- **AND** the error message SHALL include a pointer to `docs/determinism.md` for further reading
+
+### Requirement: Reproducibility test surface
+
+The repository SHALL provide a `just test-determinism` recipe and a `determinism-reproducibility` advisory CI job that together verify the bit-identical reproducibility contract on at least four representative models.
+
+#### Scenario: `just test-determinism` runs locally
+
+- **GIVEN** a developer with the workspace built and the CUDA toolchain available (or skipping CUDA fixtures)
+- **WHEN** they run `just test-determinism`
+- **THEN** the recipe SHALL invoke `scripts/test-determinism.sh`, which runs each fixture model twice in deterministic mode and byte-diffs the outputs
+- **AND** the recipe SHALL exit 0 if all fixture outputs match, 30 if a model failed to run, 40 if any output diverged (with a hex dump of the first divergent bytes printed to stderr)
+
+#### Scenario: CI advisory job runs on every PR
+
+- **GIVEN** a PR that touches `onnx-rt/`, `kernel/src/sched/`, or `onnx-rt/src/cuda/`
+- **WHEN** the PR pipeline runs
+- **THEN** the `determinism-reproducibility` advisory CI job SHALL execute `just test-determinism` against the CPU-only and RNG-op fixture models
+- **AND** the job SHALL be marked `continue-on-error: true` until promoted to a gate
+- **AND** a comment in the workflow YAML SHALL document the promote-to-gate criterion
+
+#### Scenario: Throughput regression budget enforced
+
+- **GIVEN** the `bench/llm-inference-bench` benchmark extended with a deterministic-mode comparison
+- **WHEN** the benchmark runs on the Jetson Orin Industrial reference platform or x86-64 CUDA
+- **THEN** deterministic-mode throughput SHALL be at least 65% of default-mode throughput (i.e. at most 35% regression)
+- **AND** a regression below 65% SHALL fail the benchmark and require proposal revision before re-merge

--- a/openspec/changes/deterministic-scheduling-v1/tasks.md
+++ b/openspec/changes/deterministic-scheduling-v1/tasks.md
@@ -1,0 +1,102 @@
+# Tasks — deterministic-scheduling-v1
+
+## 0. Pre-flight — pin the determinism baseline
+
+- [ ] 0.1 Document the current bit-level determinism status of each representative model: capture three runs of `bench/llm-inference-bench` and the four `tests/fixtures/` model paths and record where outputs diverge today (CPU vs GPU vs hybrid). The list is the design's "before" state; we ratchet against it.
+- [ ] 0.2 Capture the baseline throughput of `bench/llm-inference-bench` in default mode on the Jetson Orin Industrial reference platform and on x86-64 CUDA. These numbers anchor the "max 35% regression" budget in deterministic mode.
+- [ ] 0.3 Identify (search `onnx-rt/src/` for `Instant::now`, `clock_gettime`, `time(0)`, `cudaDeviceGetTimerValue`) every wall-clock call on the inference hot path. Each one must either: (a) be removed in deterministic mode, (b) be replaced with a `DeterministicRng` draw, or (c) be documented as deterministic-safe (e.g. profiling-only, no feedback into scheduling). Produce the list as `notes/0.3-wall-clock-call-sites.md`.
+
+## 1. Scheduler — extend `kernel-core`
+
+### 1a. `SchedulerMode` enum + init
+
+- [ ] 1.1 Add `SchedulerMode` enum (`Default`, `Deterministic`) to `kernel/src/sched/executor.rs`. Default to `Default`. Setter is a one-shot init function callable only before the first task spawn; subsequent calls return an error.
+- [ ] 1.2 Plumb the mode through `kernel::init`: read from boot args (`--deterministic` flag) or from a static set at compile time in container mode (driven by `SMALLAIOS_DETERMINISTIC` env var). Document the boot-arg parse in `docs/scheduling-model.md`.
+- [ ] 1.3 Expose `Scheduler::mode()` getter so other subsystems (the CUDA executor in particular) can read it without taking a runtime branch on every call.
+
+### 1b. Deterministic tiebreaker
+
+- [ ] 1.4 Add `spawn_sequence_number: u64` to `Task` in `kernel/src/sched/task.rs`. Assigned atomically at task spawn from a per-scheduler `AtomicU64` counter.
+- [ ] 1.5 Modify `RunQueue::dequeue` in `kernel/src/sched/executor.rs`: in `Deterministic` mode, sort the dequeue candidates on `(priority_class, task_id, spawn_sequence_number)` and return the smallest. In `Default` mode, current FIFO/LIFO behavior is preserved bit-for-bit (use a feature branch or runtime branch — measure cost; if branch cost is non-trivial, gate on a `cfg(feature = "deterministic")` or use a function pointer set at scheduler init).
+- [ ] 1.6 Disable `RunQueue::steal_task` in `Deterministic` mode: return `None` immediately. Document in `docs/scheduling-model.md` that this collapses Inference-queue parallelism to one core per Inference task in deterministic mode.
+
+### 1c. Tests + verification
+
+- [ ] 1.7 Unit tests in `kernel/src/sched/executor.rs`: spawn N tasks with deliberately-shuffled `task_id`s, verify deterministic-mode dequeue order is sorted regardless of spawn-call ordering on the test thread.
+- [ ] 1.8 Unit tests: verify `Default` mode dequeue behavior is bit-identical to the pre-change implementation (regression-pinning the current contract).
+- [ ] 1.9 Update `docs/scheduling-model.md` with a new "Deterministic mode" section documenting the ordering rule, the work-stealing disable, and the cost.
+
+## 2. CUDA — collapse multi-stream
+
+### 2a. Stream-config override
+
+- [ ] 2.1 Add `deterministic: bool` field to `SessionConfig` in `onnx-rt/src/session.rs`, default `false`. Add `deterministic_seed: u64`, default `0`. Document the field meaning in the struct doc-comment.
+- [ ] 2.2 Modify `Session::ensure_stream_pool` to compute the *effective* stream config: `(deterministic, stream_config) -> effective_stream_config` where `deterministic = true` collapses any `Overlap { ... }` to `SingleStream`. Emit a one-line warning to syslog if the user passed both.
+- [ ] 2.3 Add a runtime branch in `onnx-rt/src/cuda/gpu_executor.rs` that calls `cudaStreamSynchronize` at the end of each operator's GPU work when the session is in deterministic mode. Plumb the deterministic flag from `Session` into the executor.
+
+### 2b. Bypass graph capture in deterministic mode
+
+- [ ] 2.4 In `onnx-rt/src/cuda/graph.rs` / `onnx-rt/src/cuda/graph_cache.rs`, add a guard: if the session is deterministic, skip capture and skip replay — fall through to the uncaptured op-by-op path. Document the cost (5-10% throughput regression on the Orin path) in `docs/determinism.md`.
+- [ ] 2.5 Add a unit test that runs the same model twice with `deterministic = true` and asserts identical output tensors. Use a small CUDA model from `tests/fixtures/`.
+
+## 3. RNG — `DeterministicRng`
+
+### 3a. The type
+
+- [ ] 3.1 Create `onnx-rt/src/determinism.rs` (or sub-module of `profile.rs`) housing `DeterministicRng`. Public API: `new(session_seed, op_index)`, `draw_u32(&self) -> u32`, `draw_f32(&self) -> f32`, `draw_into(&self, buf: &mut [u32])`.
+- [ ] 3.2 Internal: use `XorShift32` from `onnx-rt/src/ops/generative.rs` as the kernel; pre-mix the per-draw state via `hash_combine(session_seed, op_index, draw_counter)` so each draw produces an independent state. Match the existing operator-level seeding contract documented in lines 16-20 of `generative.rs`.
+
+### 3b. Operator integration
+
+- [ ] 3.3 Modify `RandomNormal`, `RandomNormalLike`, `RandomUniform`, `RandomUniformLike`, `Bernoulli`, `Dropout`, `Multinomial`, `EyeLike` in `onnx-rt/src/ops/generative.rs` to draw from `DeterministicRng` when the session is in deterministic mode. Keep the existing per-op `seed` attribute as one of the hash inputs.
+- [ ] 3.4 Identify and remove any wall-clock fallback when `seed = 0` (currently used to derive a "random" seed). In deterministic mode, `seed = 0` is a valid seed (it folds with `session_seed` and `op_index` so the result is non-trivial).
+- [ ] 3.5 Add a registry of "is this op deterministic-safe?" defaults — populate with all current ops marked safe. Reject session construction if a future op marks itself unsafe and `deterministic = true`.
+
+### 3c. RNG tests
+
+- [ ] 3.6 Unit tests: same `(session_seed, op_index, draw_count)` produces same output across two runs.
+- [ ] 3.7 Unit tests: different `session_seed` produces different output (sanity check on the hash mixing).
+- [ ] 3.8 Unit tests: `XorShift32` invariants preserved (no zero collapse, period ≥ 2^32 - 1).
+
+## 4. Config + verification surfaces
+
+### 4a. `just test-determinism` recipe
+
+- [ ] 4.1 Add `just test-determinism [MODEL]` recipe that runs the named model twice in deterministic mode, byte-diffs the outputs, exits 0 on match. Default model is a small CPU-only fixture so the recipe runs without CUDA. Two failure exit codes: 30 = inference failed, 40 = outputs diverged (with hex dump of the first divergent bytes).
+- [ ] 4.2 Add `scripts/test-determinism.sh` as the underlying wrapper (so CI can use the same code path).
+
+### 4b. CI advisory job
+
+- [ ] 4.3 Add a `determinism-reproducibility` advisory CI job to `.github/workflows/ci.yml` that runs `just test-determinism` for each of three fixture models: one CPU-only, one with explicit RNG ops, one with CUDA-CPU hybrid (kept advisory until we have a self-hosted runner for the CUDA case).
+- [ ] 4.4 Document the promote-to-gate criterion in the workflow YAML.
+
+### 4c. Docs
+
+- [ ] 4.5 Create `docs/determinism.md` covering: the contract (same `(model, input, seed, hardware, driver)` → same output), the throughput cost, the certification claims (DO-178C input-output traceability, ISO 26262 Diagnostic Coverage as the channel for lockstep voting), the deterministic-mode CLI/env-var flags, the user-side responsibility (don't reuse seed if you want different draws), and the operator-level deterministic-safe registry.
+- [ ] 4.6 Update `docs/scheduling-model.md` "POSIX Scheduling Alignment" section with a deterministic-mode subsection (linking to `docs/determinism.md`).
+- [ ] 4.7 Update `CLAUDE.md` "Crate Feature Flags" section to list the new `SessionConfig::deterministic` field (no new feature flag — runtime config).
+- [ ] 4.8 Update `README.md` deployment matrix or feature table to surface that deterministic mode is available; one line + link to `docs/determinism.md`.
+
+## 5. Benchmarks
+
+- [ ] 5.1 Extend `bench/llm-inference-bench` with a deterministic-mode comparison. Print throughput (default mode) and throughput (deterministic mode) side-by-side. Assert deterministic-mode throughput ≥ 65% of default-mode (the 35% regression budget).
+- [ ] 5.2 Capture benchmark numbers in `notes/5.1-deterministic-throughput-baseline.md` for the next reviewer.
+- [ ] 5.3 If deterministic-mode throughput falls below 65%, escalate before merging — the design's cost model is wrong and the proposal needs revision.
+
+## 6. Reproducibility golden tests
+
+- [ ] 6.1 Add a `tests/determinism/` directory with fixture inputs and expected outputs (byte-identical) for at least four models: one CPU-only small classifier, one CUDA-pure ResNet-ish path, one CUDA-CPU hybrid (e.g. ONNX with int8 quantize on CPU + GEMM on GPU), one with explicit RNG-op coverage (Dropout + Multinomial).
+- [ ] 6.2 Wire `tests/determinism/` into `cargo test` so it runs in PR CI. Skip the CUDA fixtures when CUDA is not available (existing `#[cfg(feature = "cuda")]` pattern).
+- [ ] 6.3 Document in `docs/determinism.md` how to regenerate the golden outputs when the underlying model intentionally changes.
+
+## 7. Verify + close-out
+
+- [ ] 7.1 Run `openspec validate deterministic-scheduling-v1 --strict`.
+- [ ] 7.2 PR title: `feat(kernel,onnx-rt): deterministic-scheduling-v1 — opt-in reproducibility mode`. Target `develop`.
+- [ ] 7.3 PR description includes: (a) before/after benchmarks from 5.2, (b) reproducibility evidence (output of `just test-determinism` against each fixture), (c) the certification claim text (deterministic-mode unlocks DO-178C input-output traceability and ISO 26262 Diagnostic Coverage on the lockstep voter).
+- [ ] 7.4 Reviewer sign-off + squash-merge.
+
+## 8. Archive (after `watchdog-lockstep-v1` lands)
+
+- [ ] 8.1 Run `openspec validate deterministic-scheduling-v1 --strict` post-merge.
+- [ ] 8.2 Move to `openspec/changes/archive/YYYY-MM-DD-deterministic-scheduling-v1` and sync the spec deltas to `openspec/specs/kernel-core/` and `openspec/specs/onnx-rt-determinism/`.

--- a/openspec/changes/watchdog-lockstep-v1/design.md
+++ b/openspec/changes/watchdog-lockstep-v1/design.md
@@ -1,0 +1,196 @@
+# Design — watchdog-lockstep-v1
+
+## Goal
+
+Add the two missing safety-critical primitives for AI inference on a single SoC: a software watchdog (catches liveness faults; the inference is stuck or has crashed) and dual-core hardware lockstep voting (catches correctness faults; the inference completed but produced a wrong answer due to a soft error). Both are required to unlock DO-178C DAL A "fault detection coverage" credit and ISO 26262 ASIL-D Diagnostic Coverage credit on the certifiable inference path.
+
+The deliverables are spec'd separately because they have different hardware prerequisites (watchdog: none; lockstep: Orin Industrial A78AE-AS silicon) but they live behind a single `kernel-safety` capability boundary because they share a fault-handling surface — the watchdog is what fires when the lockstep replay-and-revote sequence escalates.
+
+## Phase 1 — software watchdog
+
+### Why a software watchdog when the syscall surface implies hardware
+
+`sys_watchdog_pet` (0x55) and `sys_watchdog_remaining` (0x56) are documented in `kernel/src/syscall/system.rs` as "service the hardware watchdog timer" and "query remaining watchdog time (in milliseconds)". The current implementations are stubs (`TODO: Write to hardware watchdog service register`) and the second unconditionally returns 30000ms.
+
+A real hardware watchdog on Tegra234 lives in two places: (a) the Tegra WDT (`/soc/watchdog@2380000` in the JetPack DTB), accessible from EL2 with the appropriate firmware-side configuration, and (b) the secure WDT accessed via TF-A in EL3. Either one requires Tegra-specific bring-up that's gated on the `unikernel-orin-bringup-v1` Phase 2 BSP. Today we don't have it.
+
+What we *do* have is the cooperative scheduler's `kernel/src/sched/timer.rs` tick infrastructure (`TICK_COUNT` atomic, monotonic). We can build a *software* watchdog on top of the tick counter that catches every inference-task liveness fault — task stuck in an infinite loop, task crashed silently, task waiting on a never-completing future — and the only thing we miss is "the entire kernel deadlocked or hung". For the AI inference workload that's a meaningful safety improvement; the remaining gap (kernel-level hang) is what the eventual hardware WDT is for.
+
+The software watchdog is also testable on every supported platform (x86-64 host, AArch64 QEMU, Jetson dev kit, Orin Industrial) — it does not need Tegra-specific firmware. We get DO-178C "process-level liveness detection" credit on every deployment.
+
+### Watchdog mechanics
+
+A `Watchdog` task is spawned at `kernel::init` with `TaskType::Watchdog` and `SchedulingClass::System`. It runs once every `T_check = 100ms` (configurable via boot arg `--watchdog-check-ms`). On each invocation:
+
+1. Walks the list of registered inference tasks (a new structure in `kernel/src/sched/executor.rs` — a `RegisteredInferenceTasks` slab).
+2. For each task, computes `(current_tick - task.last_pet_tick)` against `task.watchdog_deadline_ms`.
+3. If any task is over its deadline, triggers the configured `WatchdogPolicy`.
+
+`sys_watchdog_pet`:
+- Stamps the calling task's `last_pet_tick` with `TICK_COUNT.load(Ordering::Acquire)`.
+- Returns `0` on success.
+- Returns `-EINVAL` if the calling task is not a registered inference task.
+
+`sys_watchdog_remaining`:
+- Reads the calling task's `last_pet_tick` and `watchdog_deadline_ms`.
+- Returns `max(0, deadline_ticks - (current_tick - last_pet_tick))` converted to milliseconds.
+
+The inference task pets the watchdog at every operator-boundary yield (the same yield that the cooperative scheduler uses for preemption — see `docs/scheduling-model.md`). Adding the pet to the yield path is one new line in the `yield_fn` callback.
+
+### `WatchdogPolicy` enum
+
+```text
+enum WatchdogPolicy {
+    PanicReboot,    // Existing kernel::state::shutdown() with reason = WatchdogFired
+    FallbackModel,  // Activate the pre-registered fallback session, continue serving
+}
+```
+
+Default is `PanicReboot` (the conservative DO-178C-aligned default). `FallbackModel` requires the application to have called `Session::register_fallback(fallback_session)` on the primary session at startup; without a registered fallback, the policy degrades to `PanicReboot` and a warning is logged.
+
+The `FallbackModel` path:
+
+1. On watchdog fire, the primary session is marked `Aborted`.
+2. The pre-registered fallback session is activated; subsequent inference requests are routed to it.
+3. A `FallbackEngaged` metric counter is incremented in `onnx-rt/src/profile.rs`.
+4. Optionally (configurable), the primary session is rebuilt asynchronously in the background after a cool-down. If the rebuild succeeds, the fallback is deactivated and the primary resumes service. If the rebuild fails twice, the policy escalates to `PanicReboot`.
+
+Recovery semantics are deliberately conservative — DO-178C DAL A prefers "fail-fast" to "fail-soft" because fail-soft can mask repeated faults. Operators who want fail-soft must opt in explicitly via `FallbackModel`, and the system must log the engagement loudly.
+
+### Alternatives considered for the watchdog
+
+**Per-operator deadline (not per-inference).** Rejected — operators vary by 5+ orders of magnitude in cost (a Relu is microseconds; a self-attention layer over 4096 tokens is hundreds of milliseconds). Per-operator deadlines would either fire on legitimate large ops or be loose enough not to catch real hangs. The per-inference deadline at 1s default plus the existing `OperatorBudget` hard-limit at 10× soft budget (already wired in `timer-hal-wcet-v1`) together cover both timescales.
+
+**One watchdog task vs. per-core watchdogs.** Rejected per-core. A single watchdog on Core 0 (the AMP System/IPC core per `docs/scheduling-model.md`) sees all registered inference tasks via the shared registry. Per-core watchdogs would add coordination overhead with no detection-quality gain.
+
+**Pet on syscall entry instead of yield.** Rejected. Pet on yield is more frequent (every op boundary) than pet on syscall entry (only when the user calls a syscall, which an inference loop might not do for hundreds of operators). Yield-pet catches "operators are running but the inference is in an infinite operator-replay loop" — which a syscall-pet would miss.
+
+## Phase 2 — dual-core lockstep
+
+### Why dual lockstep, not TMR
+
+TMR (Triple Modular Redundancy) is the canonical fault-tolerance pattern: three replicas vote, majority wins, single faulty replica is masked. It requires three execution units plus a separate voter. For a SmallAIOS workload on Orin, the available pattern is *dual* lockstep — Arm A78AE supports it in hardware; A78 (non-AE) does not. Building TMR on a SoC that only ships dual lockstep means we'd be doing it in software across three logical replicas, which loses the hardware-comparator credit. Worse, the third core would have to come from somewhere — on Orin Industrial the A78AE complex is 8 cores in 4 paired clusters, so dedicating 3 to TMR leaves only 5 for everything else and breaks the AMP topology.
+
+Dual lockstep with replay-on-divergence is the right pattern here: a single fault is *detected* (not masked), and the system either re-runs the operator and re-votes (catches transient single faults — recoverable) or escalates to the watchdog (catches persistent faults — fail-fast). This matches the standard ISO 26262 "1oo2 with diagnostics" architecture for ASIL-D.
+
+### Hardware vs software comparator
+
+Two modes, selected at runtime based on platform detection:
+
+| Mode | When used | Detection of soft fault | Detection of design bug |
+|------|-----------|-------------------------|-------------------------|
+| Hardware comparator | A78AE silicon in lock mode, lockstep-strap pins asserted | Yes (cycle-level) | No |
+| Software comparator | Dev kit, CI runner, QEMU, A78-non-AE silicon | No (no AE compare unit) | Yes (catches runtime bugs that cause replica divergence) |
+
+The software comparator runs *two* sessions in the same address space, on different cores (different AMP-assigned Inference cores), with `deterministic = true`. At every operator boundary, the voter bit-compares the two sessions' output tensors. The cost is approximately 2× core occupancy and 2× memory for activations. The benefit on dev kits is catching runtime bugs where the deterministic-mode contract is violated (e.g. an operator that accidentally reads host time and produces different output across the replicas). On Orin Industrial in hardware-comparator mode, the software comparator can be left enabled as a redundant check.
+
+For CI verification, the software comparator is the primary surface. QEMU does not model the A78AE compare unit, so the hardware-comparator path can only be exercised on physical Orin Industrial hardware. We accept that gap and gate the hardware-comparator's end-to-end verification on hardware-access milestones.
+
+### A78AE lock-mode boot configuration
+
+The A78AE TRM (Arm DDI 0626) section 4.5.1 documents the "Split/lock mode" configuration. The relevant register is `CLUSTERECTLR_EL1` (cluster-level), and the configuration must be applied *before* the secondary cores are released from reset.
+
+On Tegra234, the strap pins that enable lock-mode on the AE-AS variants are set at chip manufacturing time — they are not firmware-switchable. The kernel's job is to (a) check via a feature register that lock-mode is enabled, (b) configure the cluster registers consistent with lock-mode operation, and (c) configure the GICv3 distributor so that interrupts intended for the lockstep pair are delivered to the leader core only.
+
+The boot sequence in `arch/aarch64/src/boot.rs` (for the `aarch64-unknown-none` path) or `arch/aarch64/src/boot_uefi.rs` (for the UEFI path) gains a new step *before* GICv3 init:
+
+1. Read `CLUSTERIDR_EL1` and `CLUSTERREVIDR_EL1` to confirm A78AE silicon.
+2. Read the implementation-defined lockstep status bit (TRM section 4.5.1 documents which bit; we wire it).
+3. If lockstep is hardware-enabled, write the cluster-control registers to gate the comparator behavior we want.
+4. Continue with GICv3 init, ensuring the redistributor for the follower core is configured as a passive observer.
+
+If lockstep is *not* hardware-enabled but the `lockstep` Cargo feature is on, the kernel logs a clear diagnostic and falls back to software-comparator mode on two non-locked cores. This is the dev-kit deployment path — Cargo feature is enabled for CI, but the silicon does not back it.
+
+### Fault detection and replay
+
+When the A78AE compare unit detects a divergence between the lockstep pair, it raises an asynchronous error (`SError`) on the leader core. The existing `arch/aarch64/src/interrupts.rs` SError path gains a new fault decoder that inspects the syndrome register (`ESR_EL1`) for the implementation-defined lockstep-fault EC + ISS pattern (TRM section 11 documents the exact bit layout).
+
+On detected lockstep fault:
+
+1. The `arch::aarch64::lockstep` module captures the fault context (which operator was running, the input pointers, the output buffer state).
+2. Control returns to the executor's voting hook.
+3. The executor consults the `LockstepVoter`'s state: "this is the first divergence for this operator → replay".
+4. The operator is re-run from the saved inputs. The comparator hardware re-engages. If the replay succeeds (no divergence), the inference continues normally and a `LockstepTransient` metric is incremented.
+5. If the replay also diverges, the `LockstepVoter` returns `Permanent`, the inference is aborted, and the watchdog policy is invoked. For DAL A this is typically `PanicReboot`; for less critical workloads it can fall through to `FallbackModel`.
+
+The software-comparator path does the same dance without the hardware fault; the voter explicitly bit-compares the two replicas' outputs at each operator boundary and triggers the same replay-or-escalate sequence on divergence.
+
+### Composition with deterministic mode
+
+Lockstep voting is meaningless without deterministic mode (a vote between two non-deterministic replicas can legitimately disagree from RNG draws and multi-stream timing). The `lockstep` runtime flag forces `deterministic = true` on the underlying `Session`s, with a warning if the user explicitly disabled determinism elsewhere. The hard precondition is checked at session construction; a non-deterministic lockstep session is rejected with a typed error.
+
+### Alternatives considered for lockstep
+
+**Software-only redundancy without AE silicon.** We considered building a pure-software dual-channel mode that runs on any AArch64 SoC. Rejected as the primary path: without the AE compare unit, software comparison adds 2× core cost for *less* detection coverage (we can detect software bugs that violate determinism but cannot detect a hardware soft error that happened to corrupt both replicas identically). Software comparator stays as a *fallback* and *CI* path, not as the primary safety claim.
+
+**Run lockstep on three cores (1oo3).** Rejected per the dual-lockstep-vs-TMR analysis above.
+
+**GPU-side lockstep.** The GA10B GPU on Orin does not have hardware lockstep at the SM level. Software comparison of two GPU sessions on different SMs would catch SM-level transient faults but not detect them at the cycle level. Out of scope for v1; tracked for future work as a separate change.
+
+**Lockstep on Core 0.** Rejected — Core 0 is the System/IPC core per AMP topology. Lockstep should run on the Inference cores. We assign cores 1 and 2 (the first paired AE cluster after Core 0) to the lockstep pair on Industrial silicon; the AMP topology shifts to "Core 0 = System/IPC, Cores 1-2 = lockstep Inference, Cores 3-7 = additional Inference partitions".
+
+## Watchdog + lockstep — shared fault surface
+
+The two phases share the fault-handling code path. Lockstep escalation feeds the watchdog policy (the same `WatchdogPolicy` enum determines whether a permanent lockstep divergence triggers reboot or fallback). The watchdog can fire from a slow operator independently of lockstep; the metrics distinguish the two causes.
+
+```text
+                +---------------------+
+                |  Inference task     |
+                |  (op-boundary yield)|
+                +------+--------------+
+                       |
+              ---------+---------
+              |                 |
+              v                 v
+    +---------------+   +-------------------+
+    | Pet watchdog  |   | LockstepVoter     |
+    | (if deadline  |   | compare outputs   |
+    | OK)           |   +---+----+----------+
+    +---+-----------+       |    |
+        | over deadline     |    | divergence
+        |                   |    v
+        |          +--------+----+-----+
+        |          | Replay operator   |
+        |          | (1 retry)         |
+        |          +--------+----------+
+        |                   |
+        |                   v
+        |          +--------+----------+
+        |          | Re-vote outputs   |
+        |          +--------+----+-----+
+        |                   |    | persistent
+        v                   v    v
+   +--------------+    +----+----+---------+
+   | WatchdogFired|    | LockstepPermanent |
+   +-------+------+    +---+----+----------+
+           |               |
+           +---+----+------+
+               v    v
+       +-------+----+------+
+       | WatchdogPolicy    |
+       | PanicReboot OR    |
+       | FallbackModel     |
+       +-------------------+
+```
+
+## Cost model
+
+| Mode | Core occupancy | Memory overhead | Detection coverage |
+|------|----------------|------------------|---------------------|
+| No watchdog, no lockstep (status quo) | 1× | 1× | None |
+| Watchdog only | 1× + epsilon (1 System-class task at 100ms tick) | 1× + small registry | Liveness only |
+| Watchdog + software comparator | 2× | 2× activations | Liveness + determinism-violation detection |
+| Watchdog + hardware comparator (Orin Industrial) | 2× (cores in lock mode) | 1× activations (single execution path, hardware doubles it) | Liveness + hardware soft-error detection |
+| Watchdog + hardware comparator + software comparator (defense-in-depth) | 2× | 2× activations | All of the above |
+
+For DO-178C DAL A the recommended mode is "Watchdog + hardware comparator on Industrial silicon". For dev-kit deployments the practical mode is "Watchdog + software comparator", giving most of the credit (liveness coverage + determinism enforcement) without the hardware prerequisite.
+
+## What this change explicitly does NOT do
+
+- Does not touch hardware-watchdog register access (Tegra WDT, secure WDT). Tracked as a follow-up gated on the `unikernel-orin-bringup-v1` BSP and on EL3 firmware access from TF-A.
+- Does not change the default boot path on any platform. Lockstep is triple-opt-in (Cargo feature + runtime flag + detected silicon).
+- Does not change the cooperative scheduler's yield contract. The voter hooks into the existing op-boundary yield; it does not introduce new preemption points.
+- Does not implement TMR. Dual lockstep + replay is the v1 ceiling.
+- Does not implement asymmetric replicas (CPU vs GPU; different runtimes). Replicas are byte-identical sessions in v1.
+- Does not implement network-attached redundancy. Both replicas are local to the same SoC.
+- Does not modify the `safety-critical` capability spec's DO-178C process requirements. This change adds *implementation* of fault-detection mechanics; the process spec is unchanged.

--- a/openspec/changes/watchdog-lockstep-v1/proposal.md
+++ b/openspec/changes/watchdog-lockstep-v1/proposal.md
@@ -1,0 +1,98 @@
+# watchdog-lockstep-v1
+
+## Summary
+
+Two related safety primitives that together provide the "fault detection" surface DO-178C DAL A and ISO 26262 ASIL-D require for an AI inference workload running on a single SoC:
+
+- **Phase 1 — Software watchdog (Tier 3a, ~2-3 weeks).** A kernel timer-driven watchdog task running in `SchedulingClass::System` that fires if the inference task doesn't check in within a configurable deadline. Two recovery actions are supported: (a) panic + reboot via the existing `kernel::state` shutdown path, or (b) fall through to an alternate model (a smaller, faster, certified-baseline model) and continue serving. The watchdog plumbing already has stub syscall entry points (`sys_watchdog_pet` and `sys_watchdog_remaining` in `kernel/src/syscall/system.rs`) — this change wires them to real per-task deadlines, integrates with the cooperative scheduler's tick infrastructure (`kernel/src/sched/timer.rs`), and adds the alternate-model fallback escape hatch on the ONNX runtime side. Independent of any specific Tegra hardware — runs on every supported platform.
+- **Phase 2 — Dual-core lockstep (Tier 3b, ~4-5 weeks).** For Tegra Orin Industrial / Automotive SKUs that ship A78AE cores with hardware split/lock support, the kernel SHALL configure two cores into hardware lockstep and execute the same inference path on both replicas, voting outputs at operator boundaries. The Cortex-A78AE's *AE* designator specifically denotes Arm's Automotive Enhanced core with native split/lock mode — when the two cores are in lock mode, they execute the same instruction stream and Arm's lockstep comparator hardware automatically detects mismatches (soft errors caused by radiation, transient faults, single-event upsets). The unikernel observes this as either "everything is fine and the inference completes" or "the lockstep comparator raised a fault" — handled by a new abort path. Voting at op boundaries means a soft fault is contained to a single operator: replay the operator, re-vote, escalate if it diverges a second time. **Crucial hardware prerequisite:** the J4012 Orin NX dev kit's silicon does NOT ship in the Industrial/Automotive AE-locked SKU — this work is gated on access to an Orin Industrial reference platform (P3737-derived module on a carrier that exposes the lockstep-mode strap pins). The dev-kit-only deployment path falls back to the software-watchdog-only mode in Phase 1.
+
+Both phases compose with `deterministic-scheduling-v1` (the sibling change in this batch). Watchdog runs in all modes; lockstep is meaningless without determinism (a lockstep vote between two non-deterministic replicas can legitimately disagree from timing alone, so the vote is unsound). The hard dependency is documented as a precondition in this proposal's "Sequencing" section.
+
+## Why
+
+- **DO-178C DAL A "fault detection coverage" credit needs both layers.** DAL A requires the system to detect and respond to faults that affect safety-critical outputs. A software watchdog catches *liveness* faults (the inference is stuck or has crashed silently) and unlocks credit for the "the system cannot remain in a faulted state for more than `T_deadline`" certification claim. Hardware lockstep voting catches *correctness* faults (the inference completed but produced the wrong answer due to a soft error) and unlocks credit for the "single-bit transient faults are detected and recovered" claim. Without both, the DAL A claim is incomplete.
+- **ISO 26262 Diagnostic Coverage for ASIL-D inference paths.** Automotive deployments on Orin Industrial demand ASIL-D coverage. The single-channel inference path on a single A78AE core gives at most ASIL-B coverage; dual-channel lockstep with voting is the standard route to ASIL-D. The lockstep comparator hardware in the A78AE is *specifically* there for this purpose — Arm sells the AE variant into automotive precisely for the safety credit.
+- **The watchdog plumbing is half-built and stubs are misleading.** `kernel/src/syscall/system.rs` already exposes `sys_watchdog_pet` (syscall 0x55) and `sys_watchdog_remaining` (syscall 0x56), but both currently `TODO: Write to hardware watchdog service register` and the latter unconditionally returns `30000`. The scheduler's `TaskType::Watchdog` exists with `SchedulingClass::System` priority and the `kernel/src/sched/timer.rs` module documents `Watchdog tick integration` as a goal — but no actual watchdog task is spawned at boot, and no real deadline is checked. This change finishes that wiring with real semantics, then adds the lockstep layer on top.
+- **The alternate-model fallback is what makes the watchdog useful in production.** A bare "panic + reboot" watchdog is correct but unfriendly: the inference service goes dark for the boot duration. The alternate-model fallback path lets the system continue serving with a degraded (smaller, faster, pre-certified) model while the primary path is re-initialized or escalated to a higher-level recovery. This is the standard ARINC-653-style "alternative-mode" pattern, applied to inference workloads.
+- **A78AE split/lock is documented but unused.** The Tegra234 BSP work in `unikernel-orin-bringup-v1` (Phase 2) lands the GICv3 + UART foundation but does not touch the A78AE-specific safety features. This change adds a `arch-aarch64-lockstep` capability covering the boot-time configuration of the cluster into lock mode (via the `CPUACTLR_EL1` / `CLUSTERACTLR_EL1` / `RVBAR` / `EDPRCR` setup the A78AE TRM documents) and the runtime handling of lockstep-comparator faults (via the existing AArch64 SError / synchronous-exception path with new diagnostic decoding).
+
+## Phase 1 — Software watchdog (independent, ships first)
+
+### What changes
+
+- A `Watchdog` task is spawned at `kernel::init` time with `SchedulingClass::System` and `TaskType::Watchdog`. The task runs once every `T_check = 100ms` (configurable via boot arg) and inspects all registered inference tasks for their `last_pet_tick` field.
+- `sys_watchdog_pet` writes the current scheduler tick (from `kernel/src/sched/timer.rs::TICK_COUNT`) into the calling task's `last_pet_tick`. The existing syscall surface stays unchanged; the implementation moves from `TODO` to real plumbing.
+- `sys_watchdog_remaining` returns `(deadline_ticks - (current_tick - last_pet_tick))` clamped to non-negative.
+- When the watchdog task observes `(current_tick - last_pet_tick) > T_deadline` for any inference task, it triggers the configured fault response: `WatchdogPolicy::PanicReboot` (default) or `WatchdogPolicy::FallbackModel`.
+- `WatchdogPolicy::FallbackModel` requires the application to have pre-registered a fallback `Session` via a new `Session::register_fallback(primary)` API. On watchdog fire, the runtime swaps the primary session out, brings up the fallback session, and continues serving with a `FallbackEngaged` metric incremented in `onnx-rt/src/profile.rs`.
+- The cooperative scheduler's existing `should_continue_inference` check (per `docs/scheduling-model.md` design rule 4) is extended to also consult the watchdog state — if the watchdog has fired, the next op-boundary yield aborts the inference rather than returning to it.
+- Default deadline values are documented in `docs/watchdog.md` (new): 100ms for inference tasks, 1s wall-clock cap for the whole inference, configurable per-task via a new `SessionConfig::watchdog_deadline_ms` field.
+
+### What does not change
+
+- The two existing watchdog syscall numbers (0x55, 0x56) and their POSIX-ish ABI stay the same. The implementations are filled in; the contract is unchanged.
+- The hardware watchdog register (Tegra234 WDT, Cortex-A78AE secure-watchdog) is *not* touched by Phase 1 — that's still a TODO in `sys_watchdog_pet`. The software watchdog is sufficient for inference-task liveness; hardware-watchdog integration is a separate concern tracked for a follow-up.
+
+## Phase 2 — Dual-core lockstep (gated on Industrial hardware)
+
+### What changes
+
+- A new `arch-aarch64-lockstep` capability is added to `arch/aarch64/src/lib.rs` (gated on a new `lockstep` Cargo feature on `smallaios-arch-aarch64`, which is itself gated on `tegra234-industrial` — see "Hardware prerequisites" below).
+- At boot (in `boot.rs` for `aarch64-unknown-none` or `boot_uefi.rs` for the UEFI path), if `lockstep` is enabled, the kernel writes the A78AE `CLUSTERECTLR_EL1` / `CLUSTERACTLR_EL1` "split/lock mode" bits to put cores 0 and 1 into hardware lock mode *before* the GICv3 initialization. The Arm Cortex-A78AE TRM (DDI 0626) section 4.5.1 "Split/lock mode" is the reference; the BSP-specific Tegra234 documentation for which strap pins to assert is the second reference (NVIDIA-confidential; we cite the documented procedure without reproducing it).
+- The lockstep-comparator fault, raised by the A78AE's compare unit when the two cores' outputs diverge, surfaces as an `SError` or synchronous abort to the leader core. A new `arch::aarch64::lockstep` module decodes the EC + ISS bits to identify a lockstep fault distinctly from a normal page fault, alignment fault, or other AArch64 exception cause. On lockstep fault: the kernel logs the diagnostic, marks the current operator as "needs replay", and returns control to the executor's voting path.
+- A new `LockstepVoter` type in `onnx-rt/src/lockstep.rs` runs alongside the executor. At every operator boundary (the same boundary where the cooperative scheduler yields per `docs/scheduling-model.md`), the voter compares the operator's output tensor with the replica's output tensor. Two strategies:
+  - **Hardware-comparator mode** (preferred, A78AE lock mode): the comparator hardware does the bit-compare automatically and raises a fault on mismatch. The voter consumes the fault event.
+  - **Software-comparator mode** (fallback, for testing on non-AE hardware): the voter explicitly bit-compares the two output tensors. Used for CI verification on QEMU (which does not model the AE comparator) and on dev-kit Orin (where the silicon does not support lock mode).
+- A divergence triggers operator replay (re-run the operator with the same inputs, re-vote). A second divergence escalates to the watchdog's fault policy (typically `PanicReboot`).
+- The voter's compare strategy is selected at runtime based on the detected platform: hardware-comparator on Orin Industrial, software-comparator on dev kits and CI runners. Both are spec'd; tests cover both.
+
+### Hardware prerequisites — important
+
+- **The Seeed reComputer J4012 (Jetson Orin NX 16 GB dev kit) does NOT support A78AE lockstep mode.** Arm and NVIDIA segment the A78AE silicon: the AE-AS (Automotive Specific) variants ship the lock-mode strap pins; the consumer-grade Orin Nano, Orin NX, AGX Orin dev kit variants do not. This is a hardware-level distinction baked into the Tegra234 silicon, not a Cargo-feature or firmware-switchable knob. The Orin Industrial (Drive Orin AGX Industrial / Hyperion Industrial reference platforms) and the automotive Drive Orin variants are the SKUs that ship lockstep-capable silicon.
+- **Implication for verification:** Phase 2 development can proceed on dev-kit hardware using `software-comparator` mode (which exercises the voting logic, the replay-on-divergence path, and the escalation to the watchdog) but the *hardware-comparator* mode can only be verified end-to-end on an Industrial reference platform. This is called out in `tasks.md` as a "platform verification gate" — Phase 2 ships software-comparator-tested only; hardware-comparator is gated on hardware access and lands as a follow-up sub-PR once we have access.
+- **The `software-comparator` mode is itself a useful safety primitive** even on dev kits: two sessions running the same model on the same input should produce bit-identical outputs in deterministic mode (per `deterministic-scheduling-v1`), so a divergence in software-comparator mode catches Heisenbugs in the runtime regardless of whether the underlying hardware is AE-locked. We ship it as a first-class mode, not just a test stub.
+
+### What does not change
+
+- The default boot path. Lockstep is opt-in via the `lockstep` Cargo feature *and* the `--lockstep` runtime flag *and* the presence of detected Industrial silicon. Three layers of opt-in so that nobody accidentally turns lockstep on and pays the 2× core cost for nothing.
+- The cooperative scheduler's yield-at-op-boundary contract. The voter hooks into the same boundary the scheduler uses; it does not introduce a new preemption point.
+- The single-stream CUDA path enforced by deterministic mode. Lockstep voting compares CPU-side output tensors after each operator; GPU-side execution remains single-threaded per replica.
+
+## Relation to prior work
+
+- **Depends on `deterministic-scheduling-v1`.** Lockstep voting between two replicas requires that both replicas produce identical outputs in the absence of a fault. Non-deterministic mode permits legitimate divergence (different RNG draws, different multi-stream order), which makes voting unsound. The watchdog half of this proposal does not depend on determinism and can ship first if needed.
+- **Depends on `unikernel-orin-bringup-v1` Phase 2 (Tegra234 BSP).** The lockstep boot-time configuration writes to A78AE cluster registers that are only accessible once the Tegra234 BSP has reached the early-boot phase where the cluster topology is known. Phase 1 of *this* change (software watchdog) is platform-agnostic and can ship before the BSP.
+- **Composes with `timer-hal-wcet-v1` (archived).** The watchdog uses the same `Timestamp::now()` primitive that `timer-hal-wcet-v1` wired up. No new timer infrastructure is needed.
+- **Extends the existing `safety-critical` capability spec** (`openspec/specs/safety-critical/spec.md`) which today covers DO-178C process compliance. We add the *implementation* surface — the watchdog task, the lockstep voter — that the process spec already implies should exist.
+
+## Out of scope
+
+- **Hardware watchdog register integration.** The Tegra234 WDT (`/soc/watchdog@...`) and the secure-watchdog accessed via TF-A are reachable but require firmware-side configuration (the WDT can only be poked in EL3 by default). A future change can wire `sys_watchdog_pet` to the hardware WDT in addition to the software deadline check; v1 of this change covers software-watchdog only.
+- **Triple Modular Redundancy.** True TMR needs three cores plus a majority voter and recovers from a single faulty replica. The A78AE only supports dual lockstep; TMR would require a separate voter implementation outside the AE silicon or a different platform entirely. Tracked as a "future safety" stretch; explicitly out of scope here.
+- **Asymmetric replicas (different runtimes voting).** Voting between a CPU-only and a GPU-accelerated replica is interesting (catches numerical bugs in either path) but compounds with quantization, kernel-selection differences, and floating-point reduction-order differences. Out of scope; v1 votes between two byte-identical sessions only.
+- **Network-attached redundancy.** Voting across a network link (one replica on the inference node, one on a paired safety node) is a higher-tier safety concept and needs network determinism that we don't have. Out of scope.
+- **Failover between primary and fallback models triggered by anything other than watchdog timeout.** E.g. failover on accuracy drop, on temperature throttling, on power-cap. Each of these is its own change.
+
+## Sequencing
+
+| Order | What | Why this order |
+|-------|------|----------------|
+| 1 | `deterministic-scheduling-v1` lands first | Required so lockstep replicas can produce bit-identical outputs |
+| 2 | `unikernel-orin-bringup-v1` Phase 2 lands the Tegra234 BSP | Required so lockstep boot-time config can write to A78AE cluster registers |
+| 3 | This change Phase 1 (software watchdog) lands | Independent of (2); can land in parallel with `deterministic-scheduling-v1` |
+| 4 | This change Phase 2 software-comparator mode lands | Requires (1) and (3); does not require (2) for development, only for end-to-end |
+| 5 | This change Phase 2 hardware-comparator mode lands | Requires (2) and access to Orin Industrial reference platform |
+
+Phases 1 and 2 of this change can be split into separate PRs to keep review tractable; the proposal narrates both because they share a capability boundary (`kernel-safety`) and share a verification surface (the same fault-handling test suite covers both, with the voter as the new piece).
+
+## Effort estimate
+
+| Sub-area | Scope | Estimate |
+|----------|-------|----------|
+| Phase 1 — software watchdog + alternate-model fallback | `kernel/src/sched/`, `onnx-rt/src/session.rs` | ~2-3 weeks |
+| Phase 2 — `LockstepVoter` software-comparator mode | `onnx-rt/src/lockstep.rs`, executor hooks | ~1-2 weeks |
+| Phase 2 — A78AE lock-mode boot configuration | `arch/aarch64/src/lockstep.rs`, `boot.rs` plumbing | ~2-3 weeks (gated on Industrial hardware access) |
+| Phase 2 — fault decoder + replay path | `arch/aarch64/src/interrupts.rs` extension, executor replay | ~1 week |
+| Docs + CI + tests | `docs/watchdog.md`, `docs/lockstep.md`, CI advisory jobs | ~1 week |
+| **Total** | | **~6-8 weeks** |

--- a/openspec/changes/watchdog-lockstep-v1/specs/arch-aarch64-lockstep/spec.md
+++ b/openspec/changes/watchdog-lockstep-v1/specs/arch-aarch64-lockstep/spec.md
@@ -1,0 +1,144 @@
+# Capability: arch-aarch64-lockstep
+
+## ADDED Requirements
+
+### Requirement: A78AE silicon detection at boot
+
+The AArch64 boot path SHALL detect whether the running silicon is a Cortex-A78AE variant with hardware lockstep support and SHALL configure the kernel's lockstep mode (`HardwareComparator` vs `SoftwareComparator`) based on the detection result.
+
+#### Scenario: Detect A78AE-AS silicon on Orin Industrial
+
+- **GIVEN** a SmallAIOS kernel booting on Tegra Orin Industrial / Drive Orin AGX Industrial hardware (the SKUs that ship Arm Cortex-A78AE Automotive Specific silicon)
+- **AND** the `lockstep` Cargo feature is enabled at build time
+- **WHEN** the kernel reaches the early-boot lockstep configuration step (before GICv3 init)
+- **THEN** the kernel SHALL read `CLUSTERIDR_EL1` and `CLUSTERREVIDR_EL1` to confirm A78AE silicon
+- **AND** the kernel SHALL read the Arm-implementation-defined lockstep status bit per the Cortex-A78AE TRM (Arm DDI 0626) section 4.5.1
+- **AND** if lockstep is hardware-enabled, the kernel SHALL log "A78AE lockstep silicon detected" via the early UART
+- **AND** the kernel SHALL select `LockstepMode::HardwareComparator` as the runtime mode
+
+#### Scenario: Fall back to software comparator on dev-kit silicon
+
+- **GIVEN** a SmallAIOS kernel booting on Jetson Orin NX dev kit silicon (P3767-0000 module, the consumer-grade variant that does NOT ship A78AE-AS lockstep silicon)
+- **AND** the `lockstep` Cargo feature is enabled at build time
+- **WHEN** the kernel reaches the early-boot lockstep configuration step
+- **THEN** the kernel SHALL detect that lockstep is NOT hardware-enabled
+- **AND** the kernel SHALL log "lockstep feature enabled but silicon does not support hardware lockstep — falling back to software-comparator mode"
+- **AND** the kernel SHALL select `LockstepMode::SoftwareComparator` as the runtime mode
+- **AND** the boot SHALL continue normally; software comparator is a first-class supported mode, not an error
+
+#### Scenario: Lockstep feature off, no detection
+
+- **GIVEN** a SmallAIOS kernel built without the `lockstep` Cargo feature
+- **WHEN** the kernel boots
+- **THEN** the lockstep detection SHALL be skipped entirely
+- **AND** the kernel SHALL NOT write to A78AE cluster control registers
+- **AND** the boot path SHALL be bit-for-bit identical to the pre-`watchdog-lockstep-v1` AArch64 boot
+
+### Requirement: A78AE cluster configuration for hardware lockstep
+
+When hardware lockstep is detected and selected, the AArch64 boot path SHALL configure the A78AE cluster registers per the Cortex-A78AE TRM to gate the cluster into lock mode before any secondary cores are released from reset.
+
+#### Scenario: Cluster registers are configured before secondary core release
+
+- **GIVEN** a boot path that has selected `LockstepMode::HardwareComparator`
+- **WHEN** the kernel configures the A78AE cluster registers per Cortex-A78AE TRM (Arm DDI 0626) section 4.5.1
+- **THEN** the configuration SHALL complete before any secondary core is released from reset
+- **AND** the kernel SHALL read back the relevant cluster status register after writing to confirm the cluster is operating in lock mode
+- **AND** a failed readback SHALL be a fatal boot error (the system cannot continue in a partial-lockstep state)
+
+#### Scenario: GICv3 redistributor configured for follower-as-passive
+
+- **GIVEN** a boot path that has configured the A78AE cluster for lock mode
+- **WHEN** the kernel initializes the GICv3 redistributor for each lockstep-paired core
+- **THEN** the redistributor for the follower core SHALL be configured as a passive observer
+- **AND** interrupts targeted at the lockstep pair SHALL be delivered to the leader's redistributor only
+- **AND** the follower SHALL NOT receive direct interrupt routing (the AE compare unit handles synchronization)
+
+### Requirement: Lockstep fault decoding and replay routing
+
+The AArch64 exception handlers SHALL distinguish lockstep-comparator faults from other AArch64 exception causes and SHALL route them to the `LockstepVoter`'s replay path.
+
+#### Scenario: Lockstep fault is identifiable in ESR_EL1
+
+- **GIVEN** a hardware-comparator lockstep configuration
+- **AND** the A78AE compare unit raises an `SError` on a detected divergence between the lockstep pair
+- **WHEN** the AArch64 SError handler reads `ESR_EL1`
+- **THEN** the handler SHALL decode the implementation-defined `EC` + `ISS` bits per the Cortex-A78AE TRM (Arm DDI 0626) section 11
+- **AND** the handler SHALL distinguish the lockstep-fault pattern from page-fault, alignment-fault, and other exception causes
+- **AND** a lockstep fault SHALL be routed to `arch::aarch64::lockstep::handle_fault`; other faults SHALL continue to follow the existing exception path
+
+#### Scenario: Fault context capture preserves replay inputs
+
+- **GIVEN** a lockstep fault raised mid-operator
+- **WHEN** `arch::aarch64::lockstep::handle_fault` runs
+- **THEN** the handler SHALL capture the executor's current-operator context: the saved input pointers, the output buffer state, the operator identity and graph index
+- **AND** the handler SHALL return control to the executor's voting hook, which consults the `LockstepVoter` to decide replay-or-escalate
+- **AND** the captured context SHALL be sufficient to re-run the operator from its inputs without re-running any preceding operator
+
+#### Scenario: Non-lockstep exceptions are unaffected
+
+- **GIVEN** a lockstep-configured system
+- **WHEN** a non-lockstep exception occurs (e.g. a page fault from a non-replicated execution path)
+- **THEN** the existing exception handler SHALL handle it via the pre-`watchdog-lockstep-v1` path
+- **AND** the lockstep-fault decoder SHALL not interfere with normal exception handling
+
+### Requirement: AMP topology adjustment for lockstep mode
+
+When lockstep is active, the AMP core assignment SHALL allocate the lockstep replica pair to the first available Inference cores (Cores 1 and 2 by default) and SHALL document the resulting topology in `docs/scheduling-model.md`.
+
+#### Scenario: Default AMP topology with lockstep
+
+- **GIVEN** a SmallAIOS kernel booted with `lockstep` enabled on an 8-core Orin Industrial system
+- **WHEN** the AMP topology is established
+- **THEN** Core 0 SHALL be the System/IPC core (unchanged)
+- **AND** Cores 1 and 2 SHALL form the lockstep replica pair (Inference partition A)
+- **AND** Cores 3-7 SHALL be additional Inference partitions (B, C, ...) running non-replicated workloads if any
+- **AND** the topology SHALL be documented in `docs/scheduling-model.md`
+
+#### Scenario: Lockstep is incompatible with work-stealing
+
+- **GIVEN** a lockstep-active system
+- **AND** the deterministic-scheduling-v1 contract (work-stealing disabled in deterministic mode)
+- **WHEN** the scheduler considers whether to steal tasks
+- **THEN** work-stealing SHALL remain disabled
+- **AND** the lockstep replica pair SHALL not have tasks stolen from or to them — they execute only their replicated workload
+- **AND** if the scheduler observes a configuration that violates this invariant (lockstep on with work-stealing on), it SHALL refuse to boot and log a clear diagnostic
+
+### Requirement: Hardware-comparator mode is opt-in via three layers
+
+Hardware-comparator lockstep mode SHALL require all three of: (a) the `lockstep` Cargo feature enabled at build time, (b) the `--lockstep` runtime flag set at boot, and (c) detected A78AE-AS silicon with hardware lockstep enabled.
+
+#### Scenario: Triple opt-in prevents accidental enablement
+
+- **GIVEN** any one of: (a) `lockstep` Cargo feature off, (b) `--lockstep` runtime flag absent, (c) detected silicon without hardware lockstep
+- **WHEN** the kernel boots
+- **THEN** the hardware-comparator mode SHALL NOT be engaged
+- **AND** the system SHALL boot in the highest applicable fallback mode (software-comparator if (c) only, no-lockstep otherwise)
+
+#### Scenario: All three layers present enables hardware comparator
+
+- **GIVEN** all three of: (a) `lockstep` Cargo feature on, (b) `--lockstep` runtime flag set, (c) detected A78AE-AS silicon with lockstep enabled
+- **WHEN** the kernel boots
+- **THEN** `LockstepMode::HardwareComparator` SHALL be engaged
+- **AND** the cluster configuration SHALL be performed per the requirements above
+- **AND** the AE compare unit SHALL be active for the lockstep replica pair
+
+### Requirement: Lockstep verification surface
+
+The repository SHALL provide unit tests that exercise the lockstep-fault decoder logic against synthetic ESR_EL1 values and SHALL document the hardware-access requirement for end-to-end hardware-comparator verification.
+
+#### Scenario: Fault decoder is testable on the host
+
+- **GIVEN** a host-mode test build of `arch/aarch64/src/lockstep.rs`
+- **WHEN** the unit tests run
+- **THEN** the tests SHALL feed synthetic `ESR_EL1` values matching documented lockstep-fault and non-lockstep-fault patterns
+- **AND** the decoder SHALL correctly classify each value
+- **AND** the tests SHALL not require physical A78AE hardware
+
+#### Scenario: End-to-end hardware verification is gated on hardware access
+
+- **GIVEN** a draft PR landing the hardware-comparator code path
+- **WHEN** the PR is reviewed
+- **THEN** the PR description SHALL document that end-to-end verification requires access to an Orin Industrial / Drive Orin AGX Industrial reference platform
+- **AND** the PR SHALL remain draft until on-Industrial-hardware fault-injection evidence (e.g. deliberate register-state corruption captured by the comparator) is captured and pasted into the PR description
+- **AND** the software-comparator unit tests SHALL be the gate for PR-CI passes; hardware-comparator end-to-end is a release-gate, not a PR-gate

--- a/openspec/changes/watchdog-lockstep-v1/specs/kernel-safety/spec.md
+++ b/openspec/changes/watchdog-lockstep-v1/specs/kernel-safety/spec.md
@@ -1,0 +1,142 @@
+# Capability: kernel-safety
+
+## ADDED Requirements
+
+### Requirement: Software watchdog for inference tasks
+
+The kernel SHALL implement a software watchdog task running in `SchedulingClass::System` that detects when registered inference tasks fail to check in within a configurable deadline and triggers a configured fault-response policy on violation.
+
+#### Scenario: Watchdog task is spawned at boot
+
+- **GIVEN** a SmallAIOS kernel boot
+- **WHEN** `kernel::init` completes
+- **THEN** a `Watchdog` task SHALL be spawned with `TaskType::Watchdog` and `SchedulingClass::System`
+- **AND** the task SHALL run at a configurable check interval (`--watchdog-check-ms` boot argument, default 100ms)
+- **AND** each invocation of the watchdog task SHALL complete in less than 1 ms (the System-class hard-RT constraint per `docs/scheduling-model.md`)
+
+#### Scenario: Inference task pets the watchdog at every operator-boundary yield
+
+- **GIVEN** an inference task running in cooperative-yield mode
+- **WHEN** the task reaches an operator boundary and the `yield_fn` callback fires
+- **THEN** the runtime SHALL invoke `sys_watchdog_pet` (syscall 0x55) to stamp the task's `last_pet_tick` with the current scheduler tick
+- **AND** the syscall SHALL return `0` on success
+- **AND** the syscall SHALL return `-EINVAL` if the calling task is not in the registered inference tasks set
+
+#### Scenario: Watchdog detects a stuck inference task
+
+- **GIVEN** an inference task that has not petted the watchdog within its configured `watchdog_deadline_ms`
+- **WHEN** the watchdog task runs its next check interval
+- **THEN** the watchdog SHALL detect the violation
+- **AND** the watchdog SHALL invoke the configured `WatchdogPolicy`
+- **AND** the watchdog SHALL log a diagnostic identifying the violating task
+
+#### Scenario: Remaining-time query is accurate
+
+- **GIVEN** an inference task that petted the watchdog `T_elapsed` ticks ago with a deadline of `D` ticks
+- **WHEN** the task invokes `sys_watchdog_remaining` (syscall 0x56)
+- **THEN** the syscall SHALL return `max(0, D - T_elapsed)` converted to milliseconds
+- **AND** the syscall SHALL NOT return a hardcoded constant
+- **AND** the syscall SHALL return 0 when the deadline has elapsed
+
+### Requirement: Watchdog fault-response policy
+
+The kernel SHALL support at least two fault-response policies for a watchdog violation: `PanicReboot` (default) and `FallbackModel` (alternate-model swap-and-continue).
+
+#### Scenario: PanicReboot policy invokes orderly shutdown
+
+- **GIVEN** a watchdog configured with `WatchdogPolicy::PanicReboot`
+- **AND** an inference task that has exceeded its deadline
+- **WHEN** the watchdog detects the violation
+- **THEN** the watchdog SHALL invoke `kernel::state::shutdown` with the reason `WatchdogFired`
+- **AND** the kernel SHALL log the shutdown reason and the violating task identity to syslog before halting
+
+#### Scenario: FallbackModel policy activates the registered fallback session
+
+- **GIVEN** a primary session that has called `Session::register_fallback(fallback_session)`
+- **AND** the primary's watchdog is configured with `WatchdogPolicy::FallbackModel`
+- **AND** the primary has exceeded its deadline
+- **WHEN** the watchdog detects the violation
+- **THEN** the primary session SHALL be marked `Aborted`
+- **AND** subsequent inference requests SHALL be routed to the fallback session
+- **AND** a `FallbackEngaged` metric counter SHALL be incremented in `onnx-rt/src/profile.rs`
+- **AND** the system SHALL log the fallback engagement loudly so operators can observe the degraded mode
+
+#### Scenario: FallbackModel without a registered fallback degrades to PanicReboot
+
+- **GIVEN** a primary session with `WatchdogPolicy::FallbackModel` but no fallback registered
+- **WHEN** the watchdog fires
+- **THEN** the policy SHALL degrade to `PanicReboot`
+- **AND** the system SHALL log a warning naming the absent fallback and the policy-degradation behavior
+
+#### Scenario: Background primary-rebuild after fallback engagement
+
+- **GIVEN** a fallback engaged via `WatchdogPolicy::FallbackModel`
+- **WHEN** the configurable cool-down expires (default 30s)
+- **THEN** the runtime SHALL attempt to rebuild the primary session asynchronously
+- **AND** two consecutive successful rebuilds SHALL deactivate the fallback and resume primary service
+- **AND** two consecutive failed rebuilds SHALL escalate the policy to `PanicReboot`
+
+### Requirement: Watchdog configurable per session
+
+`SessionConfig` SHALL expose a `watchdog_deadline_ms: Option<u32>` field that overrides the kernel-default watchdog deadline for the session's inference task.
+
+#### Scenario: Per-session deadline overrides the kernel default
+
+- **GIVEN** a kernel booted with the default 1000ms watchdog deadline
+- **AND** a session constructed with `SessionConfig { watchdog_deadline_ms: Some(250), .. }`
+- **WHEN** the session's inference task is registered with the watchdog
+- **THEN** the task's `watchdog_deadline_ms` SHALL be 250 (not 1000)
+- **AND** the watchdog SHALL fire on the per-session deadline, not the kernel default
+
+#### Scenario: Default deadline is used when not overridden
+
+- **GIVEN** a session constructed with `SessionConfig { watchdog_deadline_ms: None, .. }`
+- **WHEN** the session's inference task is registered with the watchdog
+- **THEN** the task's `watchdog_deadline_ms` SHALL be the kernel-default value
+- **AND** the kernel default SHALL be 1000ms unless overridden by the `--watchdog-deadline-ms` boot argument
+
+### Requirement: Lockstep voting integration with watchdog
+
+The kernel SHALL surface a `LockstepVoter` capability that detects divergences between two lockstep replica sessions at operator boundaries and uses the watchdog's `WatchdogPolicy` enum to determine the fault-response action on persistent divergence.
+
+#### Scenario: Voter detects a transient divergence and replays
+
+- **GIVEN** two lockstep replicas executing the same model on the same input in deterministic mode
+- **AND** a first-time divergence detected at an operator boundary
+- **WHEN** the voter consults its replay state
+- **THEN** the voter SHALL roll both replicas back to the operator's saved inputs
+- **AND** the voter SHALL re-run the operator and re-compare outputs
+- **AND** the voter SHALL increment a `LockstepTransient` metric counter
+- **AND** the inference SHALL continue normally if the replay matches
+
+#### Scenario: Voter escalates a persistent divergence
+
+- **GIVEN** a lockstep replay that itself diverges (second consecutive divergence at the same operator)
+- **WHEN** the voter consults its replay state
+- **THEN** the voter SHALL increment a `LockstepPermanent` metric counter
+- **AND** the voter SHALL invoke the configured `WatchdogPolicy` (`PanicReboot` or `FallbackModel`)
+- **AND** the persistent-divergence event SHALL be logged with the operator name, the first-divergence and second-divergence byte offsets, and the replica identifiers
+
+#### Scenario: Lockstep without deterministic mode is rejected
+
+- **GIVEN** a `SessionConfig` with `lockstep = Some(_)` and `deterministic = false`
+- **WHEN** the session is constructed
+- **THEN** session construction SHALL return a typed error explaining that lockstep voting requires deterministic mode
+- **AND** the error message SHALL reference `docs/lockstep.md` for further reading
+
+### Requirement: Watchdog documentation and observability
+
+The repository SHALL provide a `docs/watchdog.md` document covering the software-watchdog contract, the syscall ABI, the configurable parameters, the `WatchdogPolicy` semantics, and the alternate-model fallback workflow.
+
+#### Scenario: Documentation is discoverable and complete
+
+- **GIVEN** a new contributor or operator
+- **WHEN** they read `docs/watchdog.md`
+- **THEN** they SHALL find: (a) the syscall ABI (0x55 pet, 0x56 remaining) including return-code semantics, (b) the configurable parameters (`--watchdog-check-ms`, `--watchdog-deadline-ms`, `SessionConfig::watchdog_deadline_ms`), (c) the `WatchdogPolicy` enum and its degradation rules, (d) the alternate-model fallback workflow including the cool-down + rebuild semantics, (e) the DO-178C DAL A liveness-detection claim the watchdog unlocks, and (f) the future hardware-WDT integration roadmap
+
+#### Scenario: Lockstep documentation is separated
+
+- **GIVEN** a `docs/lockstep.md` document
+- **THEN** it SHALL be distinct from `docs/watchdog.md` because lockstep is a higher tier of safety credit and a different operator audience
+- **AND** it SHALL cross-link to `docs/watchdog.md` for the shared fault-response policy semantics
+- **AND** it SHALL cover both software-comparator and hardware-comparator modes

--- a/openspec/changes/watchdog-lockstep-v1/tasks.md
+++ b/openspec/changes/watchdog-lockstep-v1/tasks.md
@@ -1,0 +1,132 @@
+# Tasks — watchdog-lockstep-v1
+
+## 0. Preconditions and platform survey
+
+- [ ] 0.1 Confirm `deterministic-scheduling-v1` has landed on `develop` before starting Phase 2 work — lockstep voting is meaningless without deterministic mode. Phase 1 (software watchdog) has no dependency on determinism and can start any time.
+- [ ] 0.2 Capture the Tegra234 platform survey for lockstep-capable silicon. On a Jetson Orin NX dev kit (P3767-0000 / P3768-0000 / J4012), confirm via the Arm Cortex-A78AE TRM-documented feature register that **lockstep is NOT hardware-enabled** — record this in `notes/0.2-orin-dev-kit-lockstep-survey.md` so future contributors don't assume the dev kit supports it. On Orin Industrial reference platforms (if hardware access is available), confirm lockstep IS enabled and record the feature-register values.
+- [ ] 0.3 Inventory every existing `sys_watchdog_*` reference: search `kernel/src/syscall/system.rs`, `posix/`, `container/`, `bench/`. Confirm no production code currently relies on the stub behavior (returning 30000ms from `sys_watchdog_remaining`). Document findings in `notes/0.3-existing-watchdog-callers.md`.
+
+## 1. Phase 1 — Software watchdog
+
+### 1a. Watchdog task scaffolding
+
+- [ ] 1.1 Add `last_pet_tick: AtomicU64` and `watchdog_deadline_ms: u32` fields to `Task` in `kernel/src/sched/task.rs`. Initialize `last_pet_tick = 0`, `watchdog_deadline_ms = 1000` (1 second default).
+- [ ] 1.2 Create `kernel/src/sched/watchdog.rs` housing the `Watchdog` task implementation, the `WatchdogPolicy` enum (`PanicReboot`, `FallbackModel`), and the `RegisteredInferenceTasks` slab.
+- [ ] 1.3 Spawn the `Watchdog` task at `kernel::init` with `TaskType::Watchdog` and `SchedulingClass::System`. Configurable check interval via `--watchdog-check-ms=N` boot arg, default 100ms.
+- [ ] 1.4 The watchdog task body walks the registry, computes elapsed ticks since `last_pet_tick`, compares against `watchdog_deadline_ms`, and on violation invokes the policy. Each iteration must complete in < 1 ms per the System-class constraint.
+
+### 1b. Syscall implementation
+
+- [ ] 1.5 Replace the `TODO` stub in `sys_watchdog_pet` (`kernel/src/syscall/system.rs`) with: stamp the calling task's `last_pet_tick` from `TICK_COUNT.load(Acquire)`. Return `0` on success, `-EINVAL` if the calling task is not in the registered-inference-tasks set.
+- [ ] 1.6 Replace the `TODO` stub in `sys_watchdog_remaining` with: read `last_pet_tick` and `watchdog_deadline_ms`, return `max(0, deadline_ticks - elapsed_ticks)` converted to milliseconds. Remove the hardcoded `return 30000`.
+- [ ] 1.7 Update the unit tests in `kernel/src/syscall/system.rs` (`test_sys_watchdog_pet_returns_success`, `test_sys_watchdog_remaining_returns_value`) to assert the new behavior — pet stamps the tick, remaining returns the actual deadline minus elapsed.
+- [ ] 1.8 Add a new unit test verifying that `sys_watchdog_remaining` returns 0 when the deadline has elapsed.
+
+### 1c. Cooperative-scheduler integration
+
+- [ ] 1.9 In the existing `yield_fn` callback path (`onnx-rt/src/executor.rs`), add a call to `sys_watchdog_pet` at every operator-boundary yield. This is one line; document the change in `docs/scheduling-model.md`.
+- [ ] 1.10 Update `docs/scheduling-model.md` "Design Guidelines for Contributors" with rule 9: "Inference tasks must pet the software watchdog at every operator-boundary yield. The `yield_fn` callback does this automatically; custom executors must do it manually."
+
+### 1d. Alternate-model fallback
+
+- [ ] 1.11 Add `Session::register_fallback(fallback: Session)` to `onnx-rt/src/session.rs` that links a fallback session to a primary. The primary holds a pointer to the fallback; the fallback is constructed lazily so its model load cost is only paid if needed.
+- [ ] 1.12 Add `SessionConfig::watchdog_deadline_ms: Option<u32>` (default `None` = use kernel default). Plumb it through to the task's `watchdog_deadline_ms` field.
+- [ ] 1.13 On watchdog fire with `WatchdogPolicy::FallbackModel`, mark the primary session `Aborted`, activate the fallback, route subsequent requests to the fallback, increment a `FallbackEngaged` metric in `onnx-rt/src/profile.rs`.
+- [ ] 1.14 Add background-rebuild logic: after a configurable cool-down (default 30s), attempt to rebuild the primary session. If successful twice in a row, deactivate the fallback. If failed twice, escalate the policy to `PanicReboot`.
+
+### 1e. Watchdog tests
+
+- [ ] 1.15 Unit test: spawn a watchdog task with `T_check = 10ms` and a fake inference task with `deadline = 50ms`. Verify the watchdog fires within 60ms of the last pet.
+- [ ] 1.16 Unit test: verify `WatchdogPolicy::PanicReboot` invokes `kernel::state::shutdown(WatchdogFired)`.
+- [ ] 1.17 Unit test: verify `WatchdogPolicy::FallbackModel` activates the registered fallback session and increments `FallbackEngaged`.
+- [ ] 1.18 Integration test (using the existing host-mode test runner): run a deliberately-slow ONNX inference under deterministic mode + watchdog enabled, verify the watchdog catches the hang within the deadline.
+- [ ] 1.19 Negative test: `FallbackModel` policy with no registered fallback degrades to `PanicReboot` with a logged warning.
+
+### 1f. Watchdog docs + close-out
+
+- [ ] 1.20 Create `docs/watchdog.md` covering: the software-watchdog contract, the syscall ABI (0x55 pet, 0x56 remaining), the configurable parameters (`--watchdog-check-ms`, `SessionConfig::watchdog_deadline_ms`), the `WatchdogPolicy` enum semantics, the alternate-model fallback workflow, the DO-178C DAL A liveness-detection claim it unlocks, and the future hardware-WDT integration roadmap.
+- [ ] 1.21 Update `CLAUDE.md` "Current state" to note that the software watchdog is wired end-to-end.
+- [ ] 1.22 PR title: `feat(kernel,onnx-rt): watchdog-lockstep-v1 phase 1 — software watchdog + fallback`. Target `develop`.
+- [ ] 1.23 PR green + reviewer sign-off + squash-merge.
+
+## 2. Phase 2 — Lockstep voting (software comparator)
+
+### 2a. Voter scaffolding
+
+- [ ] 2.1 Create `onnx-rt/src/lockstep.rs` housing `LockstepVoter` (tracks two replica sessions and their per-op output tensors), `LockstepMode` enum (`HardwareComparator`, `SoftwareComparator`), and `LockstepResult` enum (`Match`, `Transient`, `Permanent`).
+- [ ] 2.2 Add `SessionConfig::lockstep: Option<LockstepMode>` field (default `None`). When `Some`, force `deterministic = true` and reject the session if the user explicitly set `deterministic = false`.
+- [ ] 2.3 Lockstep mode requires two underlying `Session`s with identical configs. The `LockstepVoter` constructs both and owns them.
+
+### 2b. Voter integration with the executor
+
+- [ ] 2.4 At each operator-boundary yield in `onnx-rt/src/executor.rs`, if lockstep is active, the voter bit-compares the two replicas' output tensors for the just-completed operator. The compare uses a fast SIMD-friendly memcmp on the contiguous tensor bytes.
+- [ ] 2.5 On `Match`: continue normally.
+- [ ] 2.6 On first divergence (`Transient`): roll both replicas back to the operator's saved inputs, re-run the operator, re-vote. Increment a `LockstepTransient` metric.
+- [ ] 2.7 On second divergence (`Permanent`): increment `LockstepPermanent` metric, invoke the configured `WatchdogPolicy` (the lockstep voter consumes the same policy enum as the watchdog).
+
+### 2c. AMP topology adjustment
+
+- [ ] 2.8 When lockstep is enabled, the AMP topology shifts: Core 0 stays System/IPC, Cores 1 and 2 become the lockstep replica pair (Inference partition A), Cores 3-N remain Inference (additional partitions). Document this in `docs/scheduling-model.md`.
+- [ ] 2.9 Add a `CpuAffinity::LockstepPair { leader: u8, follower: u8 }` variant. The leader publishes outputs to the voter; the follower runs the replica computation and publishes its outputs for comparison.
+
+### 2d. Software-comparator tests
+
+- [ ] 2.10 Unit test: two replicas running the same model on the same input in `SoftwareComparator` mode produce `Match` at every op boundary.
+- [ ] 2.11 Unit test: injecting a deliberate divergence in one replica (e.g. corrupting the output tensor between operators) triggers `Transient` → replay → `Match`.
+- [ ] 2.12 Unit test: injecting a persistent divergence (corrupt every operator output) triggers `Permanent` and invokes the configured policy.
+- [ ] 2.13 Negative test: constructing a `LockstepVoter` with `deterministic = false` returns a typed error.
+
+### 2e. Software-comparator close-out
+
+- [ ] 2.14 Run `just test-determinism` with `--lockstep` enabled against the existing reproducibility fixtures; confirm `LockstepTransient` and `LockstepPermanent` counters stay at 0 across 100 runs.
+- [ ] 2.15 Document the software-comparator mode in a new `docs/lockstep.md` — separate from `docs/watchdog.md` because the audience is different (lockstep is a higher tier of safety credit and only relevant to ASIL-D / DAL A deployments).
+- [ ] 2.16 PR title: `feat(onnx-rt,kernel): watchdog-lockstep-v1 phase 2a — software-comparator lockstep`. Target `develop`.
+- [ ] 2.17 PR green + reviewer sign-off + squash-merge.
+
+## 3. Phase 2 — Lockstep (hardware comparator, A78AE)
+
+### 3a. A78AE detection
+
+- [ ] 3.1 Add `arch/aarch64/src/lockstep.rs` housing the A78AE detection + configuration code. Gated by a new `lockstep` Cargo feature on `smallaios-arch-aarch64`, itself gated on `tegra234`.
+- [ ] 3.2 At boot (in `arch/aarch64/src/boot.rs` or `boot_uefi.rs` depending on target), read `CLUSTERIDR_EL1` and `CLUSTERREVIDR_EL1` to confirm A78AE silicon. Read the implementation-defined lockstep status bit. If lockstep is hardware-enabled, log "A78AE lockstep silicon detected, configuring for lock mode" via the early UART.
+- [ ] 3.3 If `lockstep` Cargo feature is on but silicon detection returns "no lockstep" (the dev-kit case), log "lockstep feature enabled but silicon does not support hardware lockstep — falling back to software-comparator mode" and continue.
+
+### 3b. Cluster register configuration
+
+- [ ] 3.4 Write the A78AE cluster-control registers per the Arm Cortex-A78AE TRM (Arm DDI 0626) section 4.5.1 to gate the cluster into lock mode. Reference the implementation-defined `CLUSTERECTLR_EL1` writes; this work requires close reading of the TRM and is gated on hardware access for verification.
+- [ ] 3.5 Configure the GICv3 redistributor for the follower core as a passive observer — interrupts targeted at the lockstep pair are delivered to the leader's redistributor only.
+- [ ] 3.6 Confirm via a post-boot diagnostic that the cluster is operating in lock mode (read the same status register from EL2 after the configuration and confirm the expected value).
+
+### 3c. Hardware-fault decoder
+
+- [ ] 3.7 Extend `arch/aarch64/src/interrupts.rs` SError handling: decode `ESR_EL1` for the implementation-defined lockstep-fault EC + ISS pattern per the A78AE TRM section 11. On match, route to the new `arch::aarch64::lockstep::handle_fault` function.
+- [ ] 3.8 The fault handler captures the fault context (saved-input pointers from the executor's current-operator state) and returns control to the voter's replay path.
+- [ ] 3.9 Distinguish lockstep faults from other AArch64 exception causes (page fault, alignment, etc.) — only lockstep faults should engage the replay path.
+
+### 3d. Hardware-comparator tests
+
+- [ ] 3.10 The hardware-comparator path can only be end-to-end verified on Orin Industrial silicon. Document the hardware-access requirement in the PR description and tag the change blocked on hardware availability.
+- [ ] 3.11 In the meantime, add a unit test that mocks the SError + ISS bits and confirms the fault decoder routes correctly. The decoder logic is platform-independent and testable on the host.
+- [ ] 3.12 When hardware access is available: run a deliberate-fault-injection test (e.g. a kernel patch that corrupts one replica's register state mid-operator) and confirm the comparator catches it. Record the test evidence in the PR description.
+
+### 3e. Hardware-comparator close-out
+
+- [ ] 3.13 Update `docs/lockstep.md` with a "Hardware comparator mode" section covering: silicon detection, cluster configuration, fault decoding, AMP topology in lockstep mode, the DO-178C / ISO 26262 credit claim, and the hardware-access prerequisite.
+- [ ] 3.14 PR title: `feat(arch/aarch64,onnx-rt): watchdog-lockstep-v1 phase 2b — A78AE hardware lockstep`. Target `develop`. Mark as draft until Orin Industrial hardware verification is captured.
+- [ ] 3.15 PR green + on-Industrial-hardware fault-injection evidence + reviewer sign-off + squash-merge.
+
+## 4. CI advisory jobs
+
+- [ ] 4.1 Add a `watchdog-fires-test` advisory CI job that runs the watchdog hang-detection integration test in QEMU; gates on Phase 1 landing.
+- [ ] 4.2 Add a `lockstep-software-comparator` advisory CI job that runs the software-comparator unit tests + a smoke `just test-determinism --lockstep` invocation; gates on Phase 2a landing.
+- [ ] 4.3 Document the promote-to-gate criterion in the workflow YAML for each job.
+
+## 5. Cross-phase verification + archive
+
+- [ ] 5.1 Run `openspec validate watchdog-lockstep-v1 --strict` after all sub-PRs land.
+- [ ] 5.2 Update the `safety-critical` capability spec's traceability section to reference the new `kernel-safety` and `arch-aarch64-lockstep` capabilities as the implementation surfaces backing the DO-178C "fault detection coverage" objective.
+- [ ] 5.3 Archive: move to `openspec/changes/archive/YYYY-MM-DD-watchdog-lockstep-v1` and sync the spec deltas to `openspec/specs/kernel-safety/` and `openspec/specs/arch-aarch64-lockstep/`.
+
+## 6. Phase split escape hatch
+
+- [ ] If Phase 2 (lockstep) work blocks on Orin Industrial hardware access for more than ~4 weeks after Phase 1 lands, split Phase 2 out as `lockstep-voting-v1` (a new change) and archive this change with only Phase 1 (software watchdog + fallback) implemented. Update `proposal.md` "Out of scope" to reference the new change name and the hardware-access prerequisite.


### PR DESCRIPTION
## Summary

Two new OpenSpec changes (documentation only — no Rust code) that pencil in the next two tiers of certifiable-AI-inference work: a reproducibility mode that unlocks DO-178C input-output traceability, and a fault-detection layer (software watchdog + dual-core lockstep on A78AE) that unlocks DAL A fault-detection coverage and ISO 26262 ASIL-D Diagnostic Coverage on Orin Industrial silicon.

## Changes

- [\`openspec/changes/deterministic-scheduling-v1/\`](openspec/changes/deterministic-scheduling-v1/proposal.md) — Tier 1, ~4-5 weeks. Opt-in \`--deterministic\` / \`SessionConfig::deterministic = true\` / \`SMALLAIOS_DETERMINISTIC=1\` mode. Extends \`kernel-core\` cooperative-scheduler spec with deterministic-tiebreaker ordering; adds new \`onnx-rt-determinism\` capability spec covering single-stream CUDA collapse, op-boundary \`cudaStreamSynchronize\`, \`DeterministicRng\` keyed on \`(session_seed, op_index, draw_counter)\`, and the bit-identical-reproducibility verification surface (\`just test-determinism\`). Default mode preserved bit-for-bit; throughput cost budgeted at ≤ 35% regression.

- [\`openspec/changes/watchdog-lockstep-v1/\`](openspec/changes/watchdog-lockstep-v1/proposal.md) — Tier 3, ~6-8 weeks, multi-phase. Phase 1 wires the existing \`sys_watchdog_pet\` / \`sys_watchdog_remaining\` syscall stubs to real per-task deadlines via the scheduler tick, with \`PanicReboot\` and \`FallbackModel\` policies. Phase 2 adds dual-core lockstep voting on Cortex-A78AE silicon: software-comparator mode runs on dev kits + CI (catches determinism-contract violations); hardware-comparator mode runs only on Tegra Orin Industrial / Drive Orin AGX Industrial silicon (the AE-AS variants — explicitly NOT the J4012 / Orin NX dev kit, which does not ship lockstep silicon). Adds two new capability specs (\`kernel-safety\`, \`arch-aarch64-lockstep\`).

## Sequencing

\`\`\`
deterministic-scheduling-v1  ──┐
                                ├──> watchdog-lockstep-v1 Phase 2 (lockstep)
unikernel-orin-bringup-v1 P2 ──┘    (Phase 1 watchdog is independent)
\`\`\`

- \`deterministic-scheduling-v1\` lands first. Lockstep voting between two non-deterministic replicas is unsound, so the voter spec hard-requires deterministic mode at session construction.
- The software-watchdog half of \`watchdog-lockstep-v1\` (Phase 1) is independent of both \`deterministic-scheduling-v1\` and the Tegra234 BSP, and can ship in parallel with either.
- The hardware-comparator half of \`watchdog-lockstep-v1\` (Phase 2 hardware mode) depends on the Tegra234 BSP from \`unikernel-orin-bringup-v1\` Phase 2 (needs A78AE cluster-register access at boot) and on access to Orin Industrial reference hardware (documented as a \"platform verification gate\" in the change's \`tasks.md\`).

## Test plan

These are documentation-only proposals; no code lands here, so PR CI is the OpenSpec validation + the standard format/lint sweep over Markdown.

- [x] \`openspec validate deterministic-scheduling-v1 --strict\` — passes
- [x] \`openspec validate watchdog-lockstep-v1 --strict\` — passes
- [x] \`openspec list\` shows both new changes
- [ ] Reviewer pass on the sequencing / capability boundaries / hardware-prerequisite call-outs
- [ ] Once approved, the implementation PRs land in the order documented above, each verified against its own task list

🤖 Generated with [Claude Code](https://claude.com/claude-code)