### PR TITLE
docs(openspec): propose scale-out + datacenter roadmap (numa, persistent-memory, gpu-mig, tsn)

### DIFF
--- a/openspec/changes/gpu-mig-partitioning-v1/design.md
+++ b/openspec/changes/gpu-mig-partitioning-v1/design.md
@@ -1,0 +1,156 @@
+# Design — gpu-mig-partitioning-v1
+
+## Goal
+
+Let a SmallAIOS unikernel instance run on a single NVIDIA MIG (Multi-Instance GPU) slice of an A100 / H100 / H200 / B100-class datacenter GPU, with hardware-isolation guarantees, MIG-aware resource budgeting, and MIG-aware telemetry — without adding any code path to the Jetson Orin production build.
+
+Success: (a) on an H100 host configured with MIG and at least two 1g.20gb slices, two SmallAIOS instances each pinned to a different slice run inference workloads concurrently with no observable performance interference; (b) the unikernel correctly reports the slice's DRAM partition size, compute pipeline count, and per-slice utilization in telemetry; (c) building `--features mig` on a Jetson Orin target either fails at compile-time (preferred) or fails fast at runtime with a clear error message; (d) building without `--features mig` on a non-MIG host or with the full GPU continues to work exactly as today.
+
+## Alternatives considered
+
+### A1. Treat MIG as transparent — let CUDA handle it, do nothing in SmallAIOS
+
+**Rejected as incomplete.** The CUDA runtime does honor MIG transparently — `cudaMalloc` will succeed up to the slice's partition limit, `cudaGetDeviceProperties` reports the slice's SM count. So functionally, SmallAIOS works today on a MIG slice with no code changes (the existing Jetson container path likely runs fine on an A100 MIG slice with no modification). The reasons we still want explicit MIG support:
+
+1. **Resource budgeting.** Without explicit MIG knowledge, the inference scheduler heuristics (batch size, stream count, KV cache size) target the full-GPU profile and over-commit on a MIG slice — leading to allocation failures or thrashing. Explicit MIG awareness lets the scheduler tune to the slice profile.
+2. **Telemetry.** The `gpu-profile` path reports memory and compute usage as if the slice were a full GPU, hiding the fact that the unikernel only has 1/7th of the silicon. Operators monitoring a multi-tenant cluster need per-slice metrics.
+3. **Fail-fast guarantees.** Today a misconfigured deployment (asking for MIG but getting a full GPU, or asking for full GPU but getting MIG) just silently produces wrong-shaped resource budgets. A clear error early is better than degraded behavior late.
+
+So A1 is rejected — explicit MIG awareness adds value beyond what CUDA's transparency provides.
+
+### A2. Make MIG always-on (no Cargo feature)
+
+**Rejected.** The detection code adds non-trivial CUDA-attribute queries to the boot path. On the Jetson production target where MIG is not supported, those queries are wasted work and may return error values that complicate error handling. A Cargo feature lets us compile-out the entire MIG path on Jetson builds, keeping the Jetson critical path minimal.
+
+### A3. Build "vGPU" / time-slicing support alongside MIG
+
+**Rejected for v1.** vGPU (NVIDIA GRID) is a separate licensed product with its own driver stack and is orthogonal to MIG. Time-slicing via MPS is software-only and has weaker isolation. Both are valid follow-up topics but mixing them into a single change inflates the scope without commensurate benefit.
+
+### A4. Support multi-MIG-slice within one unikernel instance
+
+**Rejected.** The whole point of MIG is hardware isolation — one slice per tenant. Spanning two slices from one process re-introduces the cross-tenant interference MIG was designed to prevent (the SmallAIOS process would be a single noisy neighbor across multiple slices). If a tenant needs more compute, the right answer is a larger slice profile, not multiple slices.
+
+## MIG slice detection
+
+NVIDIA exposes MIG slices via two mechanisms:
+
+1. **Device UUID prefix.** A full GPU has a UUID like `GPU-12345678-1234-1234-1234-1234567890ab`. A MIG slice has a UUID like `MIG-GPU-12345678-...` with additional slice identifier suffix. The UUID is returned by `cuDeviceGetUuid` and `nvmlDeviceGetUUID`.
+2. **CUDA device attribute.** `cuDeviceGetAttribute(CU_DEVICE_ATTRIBUTE_MIG_MODE)` returns `1` on a MIG slice of a MIG-enabled GPU, `0` otherwise.
+
+Detection sequence at CUDA context init:
+
+```
+1. Enumerate CUDA devices (cuDeviceGetCount + cuDeviceGet for each).
+2. For each device, query UUID and MIG_MODE attribute.
+3. If UUID starts with "MIG-" or MIG_MODE == 1:
+     classify as MIG slice; record slice profile via NVML
+     (nvmlDeviceGetMigDeviceHandleByIndex chain + nvmlDeviceGetAttributes)
+4. Else:
+     classify as full GPU; existing code path
+```
+
+The NVML calls require the NVIDIA Management Library to be available. On the container path (CDI runtime), NVML is part of the standard image. On the bare-metal / unikernel path (future), NVML is not available — instead we use the CUDA driver API attributes directly, which carry enough information for resource budgeting (SM count, memory size) even without NVML.
+
+## Slice-aware resource budgeting
+
+The unikernel maintains a `NvidiaDevice` descriptor per device. On a MIG slice, the descriptor populates:
+
+| Field | Source | Used by |
+|-------|--------|---------|
+| `compute_capability` | `cuDeviceGetAttribute(CC_MAJOR/MINOR)` | Kernel selection (cuBLAS / cuDNN dispatch) |
+| `sm_count` | `cuDeviceGetAttribute(MULTIPROCESSOR_COUNT)` | Scheduler stream count and batch-size heuristic |
+| `dram_bytes` | `cuDeviceTotalMem` | Tensor pool DRAM ceiling |
+| `l2_cache_bytes` | `cuDeviceGetAttribute(L2_CACHE_SIZE)` | Tile-size heuristic in GEMM |
+| `mig_profile` | NVML or attribute parse | Telemetry |
+| `mig_gpu_instance_id` | NVML | Telemetry |
+| `mig_compute_instance_id` | NVML | Telemetry |
+| `is_mig_slice` | Detection result | Branch points in budgeting code |
+
+The tensor pool's GPU side is unchanged in structure — it already honors `dram_bytes` as a hard ceiling. The change is that `dram_bytes` now reports the slice partition (e.g., 10 GB for a 1g.10gb slice on A100 80GB) rather than the full GPU's memory.
+
+## Telemetry extension
+
+The existing `gpu-profile` feature (per-op timing + memcpy byte counters dumped at `CudaRuntime::drop`) extends with:
+
+- `device.uuid` (string)
+- `device.is_mig` (bool)
+- `device.mig.profile` (string, e.g., `"1g.10gb"`)
+- `device.mig.gpu_instance_id` (u32)
+- `device.mig.compute_instance_id` (u32)
+- `device.mig.dram_partition_bytes` (u64)
+- `device.mig.peak_memory_used_bytes` (u64, sampled at unikernel exit)
+- `device.mig.peak_sm_utilization_pct` (f32, sampled from NVML if available, else 0)
+
+These fields appear alongside the existing per-op profile data in the dump. On non-MIG devices, the `mig.*` fields are absent.
+
+## Fail-fast paths
+
+### Compile-time
+
+The `mig` feature is mutually exclusive with the `tegra-orin` userspace CUDA feature on `smallaios-arch-nvidia`. The `Cargo.toml` declares this:
+
+```toml
+[features]
+mig = []
+tegra-orin = []
+# Other features omitted.
+
+# Mutual-exclusion enforced at build time via a compile_error! in lib.rs:
+# #[cfg(all(feature = "mig", feature = "tegra-orin"))]
+# compile_error!("The 'mig' feature is for datacenter GPUs (A100/H100/H200/B100); 'tegra-orin' is for Jetson Orin (Ampere GA10B) which does not support MIG. Enable one or the other, not both.");
+```
+
+This catches the misconfiguration "Jetson user enables --features mig" at build time with a clear pointer to the support matrix.
+
+### Runtime
+
+When `--features mig` is built but the assigned device at boot is NOT a MIG slice (full GPU, non-MIG GPU like L4, or no GPU), the unikernel emits a structured error and refuses to start:
+
+```
+[error] arch-nvidia: built with --features mig but assigned device is not a MIG slice
+  device: GPU-12345678-... (NVIDIA L4)
+  hint:   either rebuild without --features mig, or assign a MIG slice
+          (set NVIDIA_VISIBLE_DEVICES=MIG-GPU-..., or use --gpus '"device=0:1"' for the container path)
+  matrix: see docs/gpu-mig.md for supported GPUs and MIG profiles
+```
+
+When `--features mig` is NOT built but the assigned device IS a MIG slice, the unikernel runs but logs a warning at boot:
+
+```
+[warn] arch-nvidia: assigned device is a MIG slice but --features mig was not enabled at build time
+       MIG-specific telemetry will be unavailable. Rebuild with --features mig for full integration.
+```
+
+## Container-path integration
+
+The container path passes the GPU device via the NVIDIA CDI runtime. The operator's `docker run` (or Kubernetes pod spec) selects a MIG slice via:
+
+```bash
+docker run --gpus '"device=0:1"' ...  # GPU 0, MIG instance 1
+# or equivalently
+docker run -e NVIDIA_VISIBLE_DEVICES=MIG-GPU-12345678-... ...
+```
+
+SmallAIOS-side, the existing CUDA initialization code picks up the assigned device. The MIG-detection code path runs unconditionally when `--features mig` is on; no Docker-side changes are required beyond using a MIG-aware deployment manifest.
+
+## Documentation
+
+`docs/gpu-mig.md` covers:
+
+1. Support matrix (replicates the table in `proposal.md`).
+2. Host-side MIG configuration with `nvidia-smi mig`.
+3. Container-side deployment with MIG device assignment.
+4. SmallAIOS-side build with `--features mig`.
+5. Telemetry / observability — how to read the `mig.*` fields.
+6. Troubleshooting — common error messages and their fixes.
+7. **Jetson out-of-scope callout** — bold and unmissable, with a link back to `Dockerfile.jetson` for the supported Jetson workflow.
+
+## What this change explicitly does NOT do
+
+- Does not implement MIG configuration from inside the unikernel (host admin task).
+- Does not add MIG support to the Jetson code path.
+- Does not span multiple MIG slices from a single unikernel instance.
+- Does not implement vGPU, MPS, or any other software time-slicing approach.
+- Does not implement AMD MxGPU or Intel Flex partitioning analogs (separate future changes).
+- Does not implement dynamic MIG reshape at runtime (reshape requires unikernel restart).
+- Does not change the existing full-GPU code path when `--features mig` is off.

--- a/openspec/changes/gpu-mig-partitioning-v1/proposal.md
+++ b/openspec/changes/gpu-mig-partitioning-v1/proposal.md
@@ -1,0 +1,73 @@
+# gpu-mig-partitioning-v1
+
+## Summary
+
+NVIDIA A100 (Ampere, GA100), H100 (Hopper, GH100), and H200 (Hopper-refresh, GH100) datacenter GPUs support **Multi-Instance GPU (MIG)**: a single physical GPU is hardware-partitioned into up to 7 fully isolated GPU instances, each with dedicated SMs, L2 cache slices, DRAM partition, and memory-bandwidth quota. For multi-tenant datacenter inference, this is the foundational primitive that lets multiple small models share a single H100 without interference. This change adds a `arch-nvidia-mig` capability to SmallAIOS that lets a unikernel instance run on a **single MIG partition** rather than the full GPU, gated behind a new Cargo feature on `smallaios-arch-nvidia`.
+
+**Jetson Orin (Ampere GA10B / cc 8.7) does NOT support MIG.** This is explicitly out of scope on the Jetson production target. The MIG capability is purely a datacenter scale-out feature for A100 / H100 / H200 / B100-class hardware. The proposal documents the per-SKU support matrix and adds a runtime check that fails fast with a clear error message when MIG is requested on a non-MIG-capable GPU.
+
+## Why
+
+- **Multi-tenant inference is the datacenter inference shape.** A single H100 80GB has more compute and memory than most inference workloads need. In a datacenter, that GPU is shared — either via time-slicing (MPS), via SR-IOV-style virtualization (vGPU), or via MIG. MIG is the only one of these that provides **hardware-level isolation** — DRAM, L2 cache, and memory bandwidth are physically partitioned, so a misbehaving tenant cannot starve another. For inference serving with strict SLO requirements, MIG is the option.
+- **SmallAIOS isolation maps cleanly to MIG.** Each SmallAIOS unikernel instance owns its address space, its tensor pool, its scheduler. Pinning a unikernel instance to a MIG slice gives end-to-end hardware-and-software isolation in a way that a Linux container on a shared GPU cannot. This is the strongest possible isolation story for a multi-tenant inference platform and aligns with the DO-178C / safety-critical positioning of the project.
+- **Jetson does not need this.** Jetson Orin's Ampere GA10B is a single-tenant edge accelerator. There is no MIG support in the silicon (NVIDIA explicitly documents this), and a Jetson is rarely deployed multi-tenant. The Jetson container and unikernel paths use the full GPU directly. Adding MIG support to the Jetson code path would be wasted work.
+- **The work is bounded and feature-gated.** MIG configuration is done by the system administrator outside SmallAIOS (via `nvidia-smi mig -cgi` on the host before the unikernel runs); SmallAIOS only needs to (a) detect that it has been given a MIG slice rather than a full device, (b) honor the slice's resource limits, (c) report MIG-specific telemetry. The CUDA runtime already transparently respects MIG when given a MIG device UUID. The new code is mostly detection + telemetry + documentation.
+
+## Hardware prerequisites — MIG support matrix
+
+| GPU | Architecture | MIG support | Max instances | Notes |
+|-----|--------------|-------------|---------------|-------|
+| NVIDIA A100 40GB / 80GB | Ampere GA100 (cc 8.0) | YES | 7 | Original MIG silicon; canonical reference |
+| NVIDIA A30 24GB | Ampere GA100 (cc 8.0) | YES | 4 | Same silicon family, half the partitions |
+| NVIDIA H100 80GB SXM5 / PCIe | Hopper GH100 (cc 9.0) | YES | 7 | Enhanced MIG (per-instance compute pipelines, isolated NVDEC/NVJPG) |
+| NVIDIA H100 NVL (94GB) | Hopper GH100 (cc 9.0) | YES | 7 | Same as H100 |
+| NVIDIA H200 141GB | Hopper-refresh GH100 (cc 9.0) | YES | 7 | Same MIG capability as H100 |
+| NVIDIA B100 / B200 | Blackwell GB100 (cc 10.0) | YES | 7 (expected) | Pre-production; confirm at silicon release |
+| NVIDIA L4 24GB | Ada Lovelace AD104 (cc 8.9) | NO | — | Edge / inference card; no MIG |
+| NVIDIA L40 / L40S 48GB | Ada Lovelace AD102 (cc 8.9) | NO | — | Datacenter Ada; no MIG (despite the L-prefix) |
+| NVIDIA RTX 6000 Ada | Ada Lovelace AD102 (cc 8.9) | NO | — | Workstation card |
+| NVIDIA Jetson Orin (Nano / NX / AGX) | Ampere GA10B (cc 8.7) | **NO** | — | **Out of scope for this change** |
+| NVIDIA Jetson Thor | Blackwell GB10B (cc 10.0) | NO (expected) | — | Edge Blackwell; same single-tenant shape as Orin |
+| NVIDIA Tesla T4, V100, P-series | Pre-Ampere | NO | — | Pre-MIG silicon |
+| NVIDIA GeForce RTX consumer | Various | NO | — | Consumer cards; no MIG firmware path |
+
+**Datacenter Linux prerequisites:**
+- NVIDIA driver R450+ for A100, R470+ for A30, R535+ for H100, R550+ for H200.
+- `nvidia-smi mig -cgi` (create GPU instance) + `-cci` (create compute instance) configured **before** the SmallAIOS container or VM starts.
+- For container deployments: NVIDIA CDI runtime configured to pass a specific MIG device UUID (`MIG-GPU-...`) rather than the full GPU.
+
+## What changes
+
+- **New capability `arch-nvidia-mig`.** Owned by the `smallaios-arch-nvidia` crate, gated behind the new `mig` Cargo feature. When the feature is off (the Jetson default), the MIG code path does not compile in — zero footprint.
+- **Runtime detection.** On CUDA context initialization, query `cuDeviceGetAttribute(CU_DEVICE_ATTRIBUTE_MIG_MODE)` and `cuDeviceGetUuid` against the device assigned to the unikernel. If the UUID prefix is `MIG-`, classify the device as a MIG slice and store the slice profile (compute capability, SM count, DRAM partition size, L2 size) in the `NvidiaDevice` descriptor.
+- **Slice-aware resource budgeting.** The tensor pool's GPU-side allocator honors the slice's DRAM partition size as the hard ceiling. The scheduler's batch-size heuristic respects the slice's SM count. The hybrid CPU-GPU executor's stream count is bounded by the slice's per-instance compute pipeline count (1 for A100 slices, more for H100).
+- **MIG-aware telemetry.** The existing `gpu-profile` telemetry path adds `mig.profile`, `mig.gpu_instance_id`, `mig.compute_instance_id`, and `mig.dram_partition_bytes` fields. Per-MIG resource utilization is reported in addition to per-process.
+- **Fail-fast on misconfiguration.** If the operator builds with `--features mig` but the assigned device is a non-MIG-capable GPU (Jetson, L4, L40), the unikernel SHALL refuse to start with a clear error pointing at the MIG support matrix. If the operator builds without `--features mig` but the assigned device is a MIG slice, the unikernel runs but logs a warning that it is not making use of MIG-specific telemetry.
+- **Documentation** `docs/gpu-mig.md`: support matrix, host-side configuration steps (`nvidia-smi mig` workflow), container-side env-var requirements, troubleshooting, Jetson-explicit-out-of-scope callout.
+
+## Out of scope
+
+- **Multi-MIG-slice within one unikernel instance.** A unikernel instance is bound to a single MIG slice. Spanning multiple slices is not supported — that defeats the isolation purpose of MIG. If a tenant needs more compute than a single MIG slice provides, they should use a larger slice profile (e.g., MIG 4g.40gb instead of 1g.10gb), or the full GPU.
+- **Configuring MIG from inside the unikernel.** MIG instance creation requires host root privileges and the NVIDIA driver. SmallAIOS does not invoke `nvidia-smi mig` itself; the operator does, before the unikernel starts. Documenting the workflow is in scope; automating it inside the kernel is not.
+- **MPS (Multi-Process Service).** MPS is a software time-slicing approach with weaker isolation. It is orthogonal to MIG and is its own deferred topic (`gpu-mps-coexistence-v1` if/when needed).
+- **vGPU (NVIDIA GRID virtualization).** A licensed virtualization product with its own driver stack. Not applicable to the bare-metal / container deployment shapes SmallAIOS targets.
+- **Jetson MIG support.** The Jetson silicon does not support MIG. This proposal makes Jetson out-of-scope explicit and adds a runtime check to fail fast if someone enables `--features mig` on a Jetson build.
+- **AMD MxGPU / Intel Flex partitioning.** AMD and Intel have analogous partitioning concepts (SR-IOV-based on AMD, "Flex" tiles on Intel data-center GPUs). These would be separate capabilities (`arch-amd-mxgpu-v1`, `arch-intel-flex-v1`) under their respective architecture crates. The MIG capability covers only NVIDIA datacenter GPUs.
+- **Dynamic MIG reconfiguration at runtime.** MIG profiles can be reshaped without rebooting on H100+ silicon. SmallAIOS treats the MIG slice as static at boot — reshape requires unikernel restart. Dynamic reshape is a future concern.
+
+## When this becomes important
+
+- **Now (deferred):** Jetson Orin sweet spot — no MIG silicon. Treat as roadmap documentation; do not allocate engineering capacity.
+- **Trigger event:** First SmallAIOS deployment on a multi-tenant H100 or A100 cluster where two or more SmallAIOS instances should share a single physical GPU with hardware-level isolation. This is the canonical datacenter scale-out shape; if SmallAIOS sees adoption in datacenter inference services, this becomes an early request.
+- **Likely horizon:** 6-18 months out, depending on datacenter scale-out demand. If only single-tenant Jetson and full-GPU x86 deployments materialize, this change can be archived without implementation.
+
+## Effort estimate
+
+| Sub-phase | Scope | Estimate |
+|-----------|-------|----------|
+| 1 | `mig` feature flag + runtime detection (UUID-prefix + attribute query) | ~0.5 week |
+| 2 | Slice-aware resource budgeting (tensor pool DRAM ceiling, scheduler SM count) | ~1 week |
+| 3 | MIG-aware telemetry + per-instance utilization metrics | ~1 week |
+| 4 | Fail-fast error paths + comprehensive unit tests against a mocked MIG topology | ~0.5 week |
+| 5 | Integration test on real A100 or H100 hardware (loaner / cloud rental) + docs | ~1-2 weeks |
+| **Total** | | **~4-5 weeks** |

--- a/openspec/changes/gpu-mig-partitioning-v1/specs/arch-nvidia-mig/spec.md
+++ b/openspec/changes/gpu-mig-partitioning-v1/specs/arch-nvidia-mig/spec.md
@@ -1,0 +1,109 @@
+## ADDED Requirements
+
+### Requirement: MIG slice detection at CUDA context init
+
+When the `smallaios-arch-nvidia` crate is built with the `mig` Cargo feature, the kernel SHALL detect whether the CUDA device assigned to the unikernel is a MIG slice or a full GPU, using the CUDA driver API.
+
+#### Scenario: Detect a MIG slice via UUID prefix and MIG_MODE attribute
+
+- **GIVEN** the unikernel is built with `--features mig`
+- **GIVEN** the assigned CUDA device is a MIG slice on an A100, H100, H200, or B100-class GPU
+- **WHEN** the kernel initializes the CUDA context
+- **THEN** the kernel SHALL call `cuDeviceGetUuid` and observe the UUID begins with the prefix `MIG-`
+- **AND** the kernel SHALL call `cuDeviceGetAttribute(CU_DEVICE_ATTRIBUTE_MIG_MODE)` and observe the result is `1`
+- **AND** the kernel SHALL classify the device as a MIG slice in the `NvidiaDevice` descriptor (`is_mig_slice = true`)
+- **AND** boot logs SHALL include `arch-nvidia: detected MIG slice <uuid> profile=<profile>` at info level
+
+#### Scenario: Detect a full GPU on a MIG-capable host where MIG is not configured
+
+- **GIVEN** the unikernel is built with `--features mig`
+- **GIVEN** the assigned CUDA device is a full A100 / H100 / H200 GPU (MIG either disabled or not configured)
+- **WHEN** the kernel initializes the CUDA context
+- **THEN** the kernel SHALL observe the UUID begins with `GPU-` (not `MIG-`)
+- **AND** the kernel SHALL classify the device as a full GPU (`is_mig_slice = false`)
+- **AND** the kernel SHALL emit a runtime error and refuse to start, with a message pointing the operator to either rebuild without `--features mig` or assign a MIG slice
+- **AND** the error message SHALL reference `docs/gpu-mig.md` for the support matrix
+
+### Requirement: Slice-aware resource budgeting honors hardware partition limits
+
+When running on a MIG slice, the kernel SHALL respect the slice's hardware partition limits (DRAM, SM count, L2 cache) when sizing GPU resources.
+
+#### Scenario: GPU tensor pool honors the slice's DRAM partition
+
+- **GIVEN** a unikernel running on a 1g.10gb MIG slice (10 GB DRAM partition) of an A100 80GB
+- **WHEN** the GPU tensor pool is initialized
+- **THEN** the pool's DRAM ceiling SHALL be the slice's partition size (10 GB), not the full GPU's memory (80 GB)
+- **WHEN** an allocation request exceeds 10 GB
+- **THEN** the call SHALL return `Err(MemError::OutOfDeviceMemory)` BEFORE invoking `cudaMalloc`
+- **AND** the error message SHALL include the slice's profile and partition size
+
+#### Scenario: Scheduler stream count bounded by the slice's SM count
+
+- **GIVEN** a unikernel running on a 1g.10gb MIG slice (14 SMs on A100) or a 1g.10gb-equivalent slice
+- **WHEN** the inference scheduler initializes its CUDA stream pool
+- **THEN** the stream count SHALL be bounded by the slice's compute pipeline count (1 for A100 slices, more for H100)
+- **AND** the scheduler SHALL NOT launch more concurrent streams than the slice's hardware can isolate
+
+### Requirement: MIG-aware telemetry
+
+When running on a MIG slice, the kernel SHALL extend the `gpu-profile` telemetry path with MIG-specific fields.
+
+#### Scenario: Telemetry includes slice identity and profile
+
+- **GIVEN** a unikernel built with `--features mig` and `--features gpu-profile`
+- **GIVEN** the unikernel is running on a MIG slice
+- **WHEN** the unikernel exits and the `CudaRuntime::drop` dump is captured
+- **THEN** the dump SHALL include `device.uuid`, `device.is_mig = true`, `device.mig.profile`, `device.mig.gpu_instance_id`, `device.mig.compute_instance_id`, `device.mig.dram_partition_bytes`
+- **AND** the dump SHALL include `device.mig.peak_memory_used_bytes` sampled at exit
+- **AND** the dump SHALL include `device.mig.peak_sm_utilization_pct` (sampled from NVML where available; 0 otherwise)
+
+#### Scenario: Non-MIG telemetry is unchanged
+
+- **GIVEN** a unikernel built with `--features mig` and `--features gpu-profile`
+- **GIVEN** the unikernel is running on a full GPU (not in this requirement's MIG path — but the build flag is on)
+- **WHEN** the existing fail-fast check ensures the run does not start, the telemetry dump SHALL NOT be produced (by construction); separately, when the unikernel is built WITHOUT `--features mig` and runs on any device, telemetry SHALL be identical to develop (no `mig.*` fields).
+
+### Requirement: Fail-fast on mismatched feature flag and device
+
+The kernel SHALL detect and surface misconfigurations where the `mig` feature flag does not match the assigned device's MIG status.
+
+#### Scenario: Build with --features mig, assigned a non-MIG device
+
+- **GIVEN** the unikernel is built with `--features mig`
+- **GIVEN** the assigned device is NOT a MIG slice (full GPU, non-MIG GPU like L4 or L40, Jetson, or no GPU)
+- **WHEN** the kernel initializes the CUDA context
+- **THEN** the kernel SHALL emit a structured error to the boot log and SHALL refuse to enter the main inference loop
+- **AND** the error SHALL identify the assigned device (UUID + product name)
+- **AND** the error SHALL provide a hint for resolution (rebuild without `--features mig`, or assign a MIG slice via `NVIDIA_VISIBLE_DEVICES=MIG-GPU-...`)
+- **AND** the error SHALL reference `docs/gpu-mig.md` for the support matrix
+
+#### Scenario: Build without --features mig, assigned a MIG slice
+
+- **GIVEN** the unikernel is built WITHOUT `--features mig`
+- **GIVEN** the assigned device IS a MIG slice
+- **WHEN** the kernel initializes the CUDA context
+- **THEN** the kernel SHALL detect the MIG-prefixed UUID (best-effort, no NVML required) and SHALL log a warning at boot indicating MIG-specific telemetry will be unavailable
+- **AND** the unikernel SHALL continue to run normally on the slice (the CUDA runtime transparently honors the slice's resource limits)
+
+#### Scenario: Build-time exclusion of mig + tegra-orin
+
+- **GIVEN** a build invocation that enables both `--features mig` AND `--features tegra-orin`
+- **WHEN** `cargo build` runs
+- **THEN** the build SHALL fail with a `compile_error!` message stating that `mig` is for datacenter GPUs (A100/H100/H200/B100), `tegra-orin` is for Jetson Orin (Ampere GA10B) which does not support MIG, and that the operator must enable one or the other but not both
+- **AND** the error message SHALL reference `docs/gpu-mig.md` for the support matrix
+
+### Requirement: Jetson Orin is explicitly out of scope for MIG
+
+The kernel SHALL NOT advertise MIG support on Jetson Orin (any SKU) and SHALL document the absence prominently.
+
+#### Scenario: Jetson Orin documentation callout
+
+- **GIVEN** a user reading `docs/gpu-mig.md` or the README hardware matrix
+- **WHEN** the user looks for Jetson MIG support
+- **THEN** the documentation SHALL include a prominent callout stating that Jetson Orin (Nano, NX, AGX) silicon does NOT support MIG and SHALL refer the user to the existing Jetson container path (`Dockerfile.jetson`) for Jetson workflows
+
+#### Scenario: Jetson build path is unaffected by the MIG feature
+
+- **GIVEN** the existing `just build-container-arm` / `just docker-build-jetson` workflows
+- **WHEN** those workflows are run without `--features mig`
+- **THEN** the produced artifacts SHALL be identical to develop (no MIG code paths compiled in, no behavior change)

--- a/openspec/changes/gpu-mig-partitioning-v1/tasks.md
+++ b/openspec/changes/gpu-mig-partitioning-v1/tasks.md
@@ -1,0 +1,61 @@
+# Tasks — gpu-mig-partitioning-v1
+
+> **Status: Future-facing.** No work has started. This change is a roadmap document for multi-tenant datacenter inference on NVIDIA A100 / H100 / H200 / B100-class GPUs. **Jetson Orin does not support MIG and is explicitly out of scope.**
+
+## 0. Trigger conditions (review before starting)
+
+- [ ] 0.1 Confirm at least one production / customer target uses MIG-capable hardware (A100, A30, H100, H100 NVL, H200, or pre-production Blackwell). If only Jetson or single-tenant full-GPU deployments exist, defer this change.
+- [ ] 0.2 Secure access to an A100 or H100 host for integration testing (loaner hardware, cloud rental, or partner lab). Without this, the implementation cannot be validated.
+- [ ] 0.3 Capture NVML query outputs from a MIG-configured reference host for unit-test fixtures (UUIDs, MIG profile metadata, attribute dumps).
+
+## 1. Phase 1 — Feature flag + detection
+
+- [ ] 1.1 Add `mig` Cargo feature to `arch/nvidia/Cargo.toml` with a clear doc-comment describing the support matrix and the Jetson out-of-scope callout.
+- [ ] 1.2 Declare `mig` and `tegra-orin` mutually exclusive via a `compile_error!` in `arch/nvidia/src/lib.rs` (`#[cfg(all(feature = "mig", feature = "tegra-orin"))]`). The error message SHALL point at the support matrix in `docs/gpu-mig.md`.
+- [ ] 1.3 Add `is_mig_slice()` detection in `arch/nvidia/src/mig.rs` that combines `cuDeviceGetUuid` UUID-prefix check with `cuDeviceGetAttribute(CU_DEVICE_ATTRIBUTE_MIG_MODE)`.
+- [ ] 1.4 Extend the `NvidiaDevice` descriptor with the MIG fields (`mig_profile`, `mig_gpu_instance_id`, `mig_compute_instance_id`, `is_mig_slice`).
+- [ ] 1.5 On a CXL-less, MIG-less reference machine (Jetson Orin or x86 with a non-MIG GPU like L4), confirm building **without** `--features mig` is unchanged from develop.
+
+## 2. Phase 2 — Slice-aware resource budgeting
+
+- [ ] 2.1 Update the GPU tensor pool's DRAM ceiling to use `device.dram_bytes` (slice partition size on MIG, full GPU memory otherwise). On MIG, attempt to allocate beyond the partition SHALL return `Err(MemError::OutOfDeviceMemory)` not a CUDA error from deep inside the allocator.
+- [ ] 2.2 Update the scheduler's stream count heuristic to bound on `device.sm_count`. On a 1g.10gb A100 slice (14 SMs), stream count SHALL NOT exceed the slice's compute pipeline count.
+- [ ] 2.3 Update the GEMM tile-size heuristic to honor `device.l2_cache_bytes` (slice's L2 partition).
+- [ ] 2.4 Add unit tests against a mocked MIG topology (simulated `NvidiaDevice` with MIG fields) covering: alloc within budget, alloc exceeds budget, scheduler stream count caps.
+
+## 3. Phase 3 — Telemetry
+
+- [ ] 3.1 Extend the `gpu-profile` telemetry path with the `device.uuid`, `device.is_mig`, `device.mig.*` fields described in `design.md`.
+- [ ] 3.2 Sample peak memory and peak SM utilization at unikernel exit (NVML where available; CUDA driver attribute where not).
+- [ ] 3.3 Document the telemetry schema in `docs/gpu-mig.md` alongside the existing `gpu-profile` documentation.
+
+## 4. Phase 4 — Fail-fast paths
+
+- [ ] 4.1 Implement the runtime check: built with `--features mig` AND assigned device is NOT a MIG slice → refuse to start with the structured error from `design.md`.
+- [ ] 4.2 Implement the runtime warning: built WITHOUT `--features mig` AND assigned device IS a MIG slice → log a warning at boot.
+- [ ] 4.3 Test the runtime check on a Jetson Orin: rebuild with `--features mig` (after temporarily removing the compile-time exclusion to exercise the runtime path) and confirm the runtime check fires correctly with the documented error message.
+
+## 5. Phase 5 — Integration test on real hardware
+
+- [ ] 5.1 Provision an A100 or H100 host with at least two MIG slices (e.g., `7x 1g.10gb` on A100, or `2x 3g.40gb` on H100 80GB).
+- [ ] 5.2 Deploy two SmallAIOS container instances, each pinned to a separate MIG slice via `NVIDIA_VISIBLE_DEVICES=MIG-GPU-...`.
+- [ ] 5.3 Run a benchmark workload concurrently on both instances. Confirm: (a) both instances report their slice profile correctly in telemetry; (b) p99 inference latency on instance A is unaffected by load on instance B (the hardware-isolation claim); (c) the sum of per-slice memory utilization equals the GPU's total allocated memory.
+- [ ] 5.4 Capture the benchmark results and paste in the PR description as the acceptance evidence.
+
+## 6. Phase 6 — Documentation
+
+- [ ] 6.1 Create `docs/gpu-mig.md` covering: support matrix, host-side `nvidia-smi mig` configuration, container deployment, build instructions, telemetry, troubleshooting, **Jetson out-of-scope callout in bold**.
+- [ ] 6.2 Add a row to the README hardware matrix for "Datacenter MIG-capable GPUs" with a link to `docs/gpu-mig.md`.
+- [ ] 6.3 Update `Dockerfile` (or add `Dockerfile.mig` if needed) to be MIG-compatible — verify CDI runtime configuration works when a MIG device UUID is passed.
+
+## 7. Phase 7 — CI
+
+- [ ] 7.1 Add a build matrix entry that compiles `--features mig` (host-build only; CI runners don't have MIG hardware). Validates compile-time correctness.
+- [ ] 7.2 Add a scheduled integration job `mig-h100-smoke` that runs against a self-hosted H100 runner (when available) with a MIG profile configured. Advisory initially.
+- [ ] 7.3 Promote `mig-h100-smoke` to `change-gates` when self-hosted MIG runner availability is reliable (separate change).
+
+## 8. Close-out
+
+- [ ] 8.1 PR title: `feat(arch/nvidia): gpu-mig-partitioning-v1 — datacenter MIG slice support for A100/H100/H200`.
+- [ ] 8.2 Reviewer sign-off + green CI + real-MIG-hardware integration test evidence in the PR description.
+- [ ] 8.3 Update CLAUDE.md "Current state" to mention MIG slice support for A100/H100/H200, and that Jetson Orin is explicitly out of scope for MIG.

--- a/openspec/changes/numa-aware-tensor-alloc-v1/design.md
+++ b/openspec/changes/numa-aware-tensor-alloc-v1/design.md
@@ -1,0 +1,103 @@
+# Design — numa-aware-tensor-alloc-v1
+
+## Goal
+
+Make the `kernel/src/mem/tensor.rs` allocator NUMA-aware on multi-socket x86-64 and multi-die ARM64 servers, while keeping the Jetson Orin single-domain path a zero-cost fall-through. Success is measured as: (a) NUMA topology is correctly discovered and reported on at least one 2P EPYC and one Ampere Altra Max reference host; (b) under a synthetic two-node tensor-allocation workload, ≥90% of allocations land on the requesting thread's home node; (c) the existing Orin single-node benchmark suite shows no regression (within ±2% of the v0 baseline).
+
+## Alternatives considered
+
+### A1. Do nothing — let Linux-style userspace NUMA libraries handle it
+
+**Rejected.** SmallAIOS is a unikernel; there is no userspace `libnuma` to fall back to. The tensor pool is the only allocator on the inference fast path. If the pool ignores NUMA, every inference op pays the cross-socket tax.
+
+### A2. Implement first-touch placement only (default Linux behavior)
+
+**Considered, partially adopted as fallback.** First-touch (memory is allocated on the node where it is first written) is the cheapest NUMA-aware policy and matches Linux's default. We adopt first-touch as the **fallback when no hint is supplied**, but we add the explicit `numa_hint` API because the inference scheduler knows the consumer node up front — it can give a better placement decision than first-touch's lazy heuristic. First-touch alone leaves performance on the table when the producing thread (e.g., a model-loader) writes the weight tensor on node 0 but a different node's inference thread is going to consume it.
+
+### A3. Build a richer "NUMA policy" object (MPOL_BIND, MPOL_PREFERRED, MPOL_INTERLEAVE)
+
+**Rejected for v1.** Linux's `mbind` policy framework is general but adds API surface and code paths we cannot validate against the Jetson Orin target. We ship the minimal `Option<NumaNodeId>` hint (which maps to "preferred" semantics — try the hinted node, fall back to any node under pressure). If interleave or strict-bind becomes necessary, extend the API in a follow-up change.
+
+### A4. Make NUMA awareness a compile-time feature (`--features numa`)
+
+**Rejected.** Single-socket builds would have to know which feature flags are appropriate; multi-socket production builds would have to recompile. The runtime cost of a `Option<NumaNodeId>` check that resolves to "always node 0 because single-node topology" is one branch on a path that already dispatches on size class — well below the noise floor. Runtime detection with single-node fallback is the right shape.
+
+## Topology discovery
+
+### x86-64 — ACPI SRAT
+
+The System Resource Affinity Table (SRAT) is the canonical NUMA topology source on x86-64. SmallAIOS already parses the RSDP / RSDT at boot for early hardware enumeration; SRAT parsing adds:
+
+- **Memory Affinity structures** (type 1): map physical address ranges to proximity domains.
+- **Processor Local APIC/SAPIC Affinity structures** (type 0): map APIC IDs to proximity domains.
+
+The proximity domain → `NumaNodeId` mapping is a `BTreeMap` populated at boot. ~150 LOC of new code in `kernel/src/acpi/srat.rs`. We do not parse SLIT (System Locality Information Table) in v1 — the distance matrix is interesting but not required for the "prefer my home node" policy.
+
+### ARM64 — Device Tree
+
+The Linux device-tree binding `numa-node-id` on `cpu@N` and `memory@N` nodes is the standard ARM64 NUMA source. Ampere Altra and Grace both expose this when configured for multi-node operation. We walk the DTB once at boot, populate the same `NumaNodeId` mapping. ~80 LOC in `kernel/src/dt/numa.rs`.
+
+### Single-node fallback
+
+When neither path yields useful data (the Jetson Orin case — no SRAT, no `numa-node-id` properties), the allocator constructs `NumaTopology::single_node()` containing one node spanning all RAM, all CPUs. Every `numa_hint` resolves trivially to node 0. This is the **default** path and the only path exercised by the existing CI matrix.
+
+## Tensor pool extension
+
+```rust
+// Existing API (kept verbatim, calls through to alloc_with_hint(.., None))
+pub fn alloc(size: usize, dtype: DType) -> Result<TensorBuf, MemError>;
+
+// New API
+pub fn alloc_with_hint(
+    size: usize,
+    dtype: DType,
+    numa_hint: Option<NumaNodeId>,
+) -> Result<TensorBuf, MemError>;
+
+// Topology accessor
+pub fn topology() -> &'static NumaTopology;
+```
+
+Internally, the pool's free-list becomes `[FreeList; MAX_NUMA_NODES]` where `MAX_NUMA_NODES` is a `const` chosen at workspace level (`16` for v1 — covers every system in the hardware-prerequisite table). Allocation flow:
+
+1. If `numa_hint = Some(n)`, try `nodes[n].free_list` first.
+2. On miss, try any node with free capacity in this size class.
+3. On total miss, fall back to the underlying page allocator (existing path).
+
+The page allocator itself is **not** modified in v1. We accept that newly-allocated pages may not be on the hinted node — they are allocated wherever the kernel's page allocator finds free memory, and the NUMA hint affects only the free-list bucket choice. This is a known limitation; a future change can extend the page allocator with a per-node freelist if profiling shows the limitation matters.
+
+### Per-node accounting
+
+The pool exports atomic counters per node:
+
+- `numa.node[i].alloc_local` — alloc on hinted node, hit in local free-list.
+- `numa.node[i].alloc_remote` — alloc on hinted node, satisfied from a different node's free-list.
+- `numa.node[i].alloc_unhinted` — alloc with no hint.
+
+These feed the same kernel telemetry path that exports cooperative-scheduler stats today.
+
+## Scheduler integration
+
+The cooperative scheduler runs inference ops on cores 1..N. Each core is statically assigned to a NUMA node at boot via the topology discovery shim. The scheduler exposes a per-thread `home_node: NumaNodeId` and passes it as the hint on every tensor allocation made on behalf of that thread.
+
+Core 0 (System/IPC) is bound to node 0 by convention. Cores assigned to a non-zero node use that node's id; on single-node systems every core gets node 0.
+
+## Observability
+
+A new file `/proc/smallaios/numa` (or the unikernel-equivalent telemetry endpoint) reports:
+
+```
+nodes: 2
+node 0: cpus=0,1,2,3 mem=64GB alloc_local=12345 alloc_remote=42 alloc_unhinted=8
+node 1: cpus=4,5,6,7 mem=64GB alloc_local=11987 alloc_remote=35 alloc_unhinted=4
+```
+
+Local/remote ratio is the headline metric for tuning.
+
+## What this change explicitly does NOT do
+
+- Does not modify the page allocator (only the tensor free-list layer).
+- Does not add NUMA awareness to the `net` crate's packet pool, the `ipc` crate's ring buffers, or the cooperative scheduler's task queue. Those are separate follow-ups if profiling shows them mattering.
+- Does not implement page migration, interleave, or strict-bind policies.
+- Does not change behavior on single-node systems beyond the addition of zero-cost dispatch through `Option::None`.
+- Does not require new CI hardware. The single-node CI path continues to validate the default; multi-socket validation is a manual / scheduled-runner concern.

--- a/openspec/changes/numa-aware-tensor-alloc-v1/proposal.md
+++ b/openspec/changes/numa-aware-tensor-alloc-v1/proposal.md
@@ -1,0 +1,63 @@
+# numa-aware-tensor-alloc-v1
+
+## Summary
+
+SmallAIOS today assumes a single memory domain. The Jetson Orin sweet spot (Orin NX 16 GB, single-die Tegra234, single LPDDR5 controller) is a uniform memory machine and the existing tensor pool at `kernel/src/mem/tensor.rs` correctly ignores NUMA topology. This change introduces NUMA-aware tensor allocation as a Tier 3 scale-out feature for **multi-socket x86-64** (dual/quad EPYC Genoa, dual Xeon Sapphire Rapids) and **multi-die ARM64 server** (Ampere Altra Max, NVIDIA Grace, Grace-Hopper Superchip) deployments running models that exceed a single NUMA node's local DRAM (>100 GB working set is the canonical case). Tensor allocations SHOULD prefer the NUMA node whose CPU cores or PCIe root complex consume them; cross-socket DRAM traffic measurably costs latency (UPI / Infinity Fabric / NVLink-C2C round-trip) and energy.
+
+The kernel-side change is bounded: extend the tensor pool API with an optional `numa_hint: Option<NumaNodeId>` parameter, surface a per-node free-list, add a topology-discovery shim that reads ACPI SRAT / `nodeX/cpulist` on x86-64 and `numa-node-id` device-tree properties on ARM64, and wire a thread-locality bias into the inference scheduler. No ABI break — existing callers pass `None` and get the current behavior. Capability `kernel-mem` is extended (not replaced).
+
+## Why
+
+- **Today's target is uniform.** Tegra Orin is a single-socket SoC; there is no NUMA topology to honor. Adding NUMA awareness to the tensor pool while the production target is a single-die system pays development cost with zero observable benefit on the production hardware. This proposal explicitly defers the kernel work until a multi-socket runner enters the test matrix.
+- **Scale-out demand is the gate.** When SmallAIOS is deployed as a unikernel on a dual-socket EPYC server hosting a 70B-parameter LLM split across both NUMA nodes' DRAM, cross-socket KV-cache traffic dominates the latency budget — measured on Linux at 1.5-3x local-DRAM latency for naive allocations. At that point, NUMA awareness is no longer cosmetic; it is the difference between fitting in a service-level objective and missing it. Until that deployment shape appears in the roadmap, this is a future-facing investment.
+- **The change is bounded, not architectural.** The tensor pool already separates allocation from consumption (the cooperative scheduler picks ops, then asks the pool for buffers). Adding a node-affinity hint is a parameter addition, not a redesign. The existing single-domain code path remains the default; the new path is opt-in via a hint argument.
+- **It unlocks future GPU-aware work.** Multi-GPU systems (8x H100 in a single chassis) already have an analogous problem: each GPU's PCIe root complex lives on one socket, and CPU-side memory used for staging that GPU's batches SHOULD be on the matching node. The `numa_hint` API generalizes to this case — a "preferred socket for this GPU's host buffers" is just another NUMA hint. The MIG change (`gpu-mig-partitioning-v1`) and this change compose cleanly without coupling.
+
+## Hardware prerequisites
+
+| Class | Examples | NUMA topology |
+|-------|----------|----------------|
+| Multi-socket x86-64 | 2P AMD EPYC Genoa/Bergamo, 2P/4P Intel Xeon Sapphire Rapids / Emerald Rapids | 1 node per socket (or per CCD for "NPS4" mode on EPYC) |
+| Multi-die ARM64 | Ampere Altra Max (128c, 1-2 sockets), NVIDIA Grace (72c, single CPU but with multi-die LPDDR5X memory controllers), Grace-Hopper GH200 | 1-2 nodes per socket; Grace exposes UMA externally but micro-architecturally has internal NUMA |
+| Single-socket x86-64 / single-die ARM64 | Jetson Orin, Apple M-series, Ryzen 7000, Xeon Bronze single-socket | 1 node — NUMA hint is a no-op |
+
+The Jetson Orin production target falls in the last row. NUMA is observable but not exploitable on it.
+
+## What changes
+
+- **Capability `kernel-mem`** extends with NUMA-aware allocation:
+  - `TensorPool::alloc_with_hint(size, dtype, numa_hint: Option<NumaNodeId>)` — new API; `numa_hint = None` matches today's behavior.
+  - `TensorPool::topology() -> &NumaTopology` — accessor for discovered topology (read-only).
+  - Per-node free-lists inside the pool; cross-node steal allowed under memory pressure.
+- **Topology discovery shim** lives in `kernel/src/mem/numa.rs`:
+  - x86-64: parse ACPI SRAT (System Resource Affinity Table) at boot.
+  - ARM64: walk the device tree for `numa-node-id` properties on memory and CPU nodes.
+  - Single-node fallback: synthesize `NumaTopology::single_node()` when neither path yields useful data (this is the Jetson Orin path).
+- **Scheduler integration**:
+  - Inference threads gain a "home node" — Core 0 (System/IPC) on node 0; data-parallel cores 1..N bound to their physical node.
+  - The cooperative scheduler passes the current thread's home node as a hint into the tensor pool on every allocation.
+- **Documentation**: `docs/numa-tensor-alloc.md` covering the topology, when to opt in, and observability (per-node hit/miss counters in `/proc/smallaios/numa` analog).
+
+## Out of scope
+
+- **Memory migration / page migration on demand.** Linux's `numa_balance` migrates pages between nodes based on access patterns. SmallAIOS will not implement this — we believe explicit hints are sufficient for the data-parallel inference workload (ops have known input/output shapes; we know up front where they should land). Revisit if profiling shows hot-page mis-placement after this lands.
+- **Interleave policy.** Linux's `MPOL_INTERLEAVE` round-robins pages across nodes for bandwidth-bound workloads. Out of scope for the v1; if interleave benefits emerge for specific GEMM sizes, add it as a future change.
+- **CPU pinning APIs.** Thread-to-core binding is already handled by the AMP scheduler; this change only adds the home-node bias, not a full `sched_setaffinity` equivalent.
+- **NUMA across the QUIC stack.** The networking crate's buffer pool ignores NUMA. Adding NIC-RX-queue → home-node affinity is a sensible follow-up but is its own change (`net-numa-affinity-v1` if/when it lands).
+- **HMM / heterogeneous memory.** Tier-aware allocation across DRAM and PMem is covered by the sibling `persistent-memory-v1` change. The two compose: PMem appears as additional NUMA nodes with a "slow tier" attribute.
+
+## When this becomes important
+
+- **Now (deferred):** Jetson Orin single-socket — zero benefit. Document the API surface and reference design so the implementation is ready when needed; do not allocate engineering capacity.
+- **Trigger event:** First scale-out customer / internal deployment that uses a 2P EPYC / Xeon SP server with a model >50 GB. At that point, schedule the implementation: ~3-4 weeks for the kernel work, plus a benchmark harness to quantify the cross-socket latency reduction.
+- **Likely horizon:** 12-18 months out, contingent on SmallAIOS adoption on multi-socket hosts. If only Jetson + single-socket cloud (e.g., Graviton, c7g) deployments materialize, this change can be archived without implementation and reopened later.
+
+## Effort estimate
+
+| Sub-phase | Scope | Estimate |
+|-----------|-------|----------|
+| 1 | Topology discovery shim (x86 SRAT + ARM DT walk + single-node fallback) | ~1 week |
+| 2 | Tensor pool API extension + per-node free-lists | ~1 week |
+| 3 | Scheduler home-node bias + observability counters | ~1 week |
+| 4 | Multi-socket benchmark + docs + CI matrix expansion | ~0.5-1 week |
+| **Total** | | **~3-4 weeks** |

--- a/openspec/changes/numa-aware-tensor-alloc-v1/specs/kernel-mem/spec.md
+++ b/openspec/changes/numa-aware-tensor-alloc-v1/specs/kernel-mem/spec.md
@@ -1,0 +1,104 @@
+## ADDED Requirements
+
+### Requirement: NUMA topology discovery at boot
+
+The kernel SHALL discover the host's NUMA topology at boot and expose it via a read-only `TensorPool::topology()` accessor. The topology SHALL include, for each NUMA node, the set of CPU IDs local to that node and the set of physical memory ranges owned by that node.
+
+#### Scenario: x86-64 SRAT discovery
+
+- **GIVEN** a multi-socket x86-64 host (e.g., 2P AMD EPYC Genoa, 2P Intel Xeon Sapphire Rapids) that publishes an ACPI SRAT
+- **WHEN** the kernel boots
+- **THEN** the kernel SHALL parse SRAT Memory Affinity (type 1) structures to map physical address ranges to proximity domains
+- **AND** the kernel SHALL parse SRAT Processor Local APIC/SAPIC Affinity (type 0) structures to map APIC IDs to proximity domains
+- **AND** the resulting `NumaTopology` SHALL report at least one node per proximity domain
+- **AND** boot logs SHALL include a line like `numa: discovered N nodes via SRAT` at info level
+
+#### Scenario: ARM64 device-tree discovery
+
+- **GIVEN** a multi-die ARM64 server (e.g., Ampere Altra Max, NVIDIA Grace) whose device tree publishes `numa-node-id` properties on `cpu@*` and `memory@*` nodes
+- **WHEN** the kernel boots
+- **THEN** the kernel SHALL walk the device tree and read every `numa-node-id` property on CPU and memory nodes
+- **AND** the resulting `NumaTopology` SHALL group CPUs and memory ranges by node id
+- **AND** boot logs SHALL include `numa: discovered N nodes via device-tree` at info level
+
+#### Scenario: Single-node fallback (Jetson Orin and other UMA hosts)
+
+- **GIVEN** a host that publishes neither SRAT NUMA data nor `numa-node-id` device-tree properties (e.g., Jetson Orin NX, single-socket x86-64 desktop, Apple silicon)
+- **WHEN** the kernel boots
+- **THEN** the kernel SHALL synthesize a `NumaTopology::single_node()` containing exactly one node spanning all RAM and all CPUs
+- **AND** boot logs SHALL include `numa: single-node fallback` at info level
+- **AND** subsequent calls to `alloc_with_hint(.., Some(0))` and `alloc_with_hint(.., None)` SHALL behave identically
+
+### Requirement: NUMA-aware tensor allocation hint
+
+The `TensorPool` SHALL accept an optional NUMA node hint on allocation and SHALL prefer the hinted node's per-node free-list when satisfying the allocation.
+
+#### Scenario: Hinted allocation on a multi-node host hits the local free-list
+
+- **GIVEN** a multi-socket host with discovered topology `N >= 2`
+- **GIVEN** the per-node free-list for node 1 has at least one buffer of the requested size class
+- **WHEN** a caller invokes `TensorPool::alloc_with_hint(size, dtype, Some(1))`
+- **THEN** the returned `TensorBuf` SHALL be drawn from node 1's free-list
+- **AND** the `numa.node[1].alloc_local` counter SHALL increment by one
+- **AND** the `numa.node[1].alloc_remote` counter SHALL NOT increment
+
+#### Scenario: Hinted allocation falls back to another node under pressure
+
+- **GIVEN** the per-node free-list for the hinted node has no buffers in the requested size class
+- **GIVEN** another node's free-list has a buffer in that size class
+- **WHEN** a caller invokes `TensorPool::alloc_with_hint(size, dtype, Some(hinted))`
+- **THEN** the pool SHALL satisfy the allocation from any other node's free-list
+- **AND** the `numa.node[hinted].alloc_remote` counter SHALL increment by one
+- **AND** the allocation SHALL NOT fail solely because the hinted node is empty
+
+#### Scenario: Unhinted allocation works on every system
+
+- **GIVEN** any topology (single-node or multi-node)
+- **WHEN** a caller invokes `TensorPool::alloc_with_hint(size, dtype, None)` or the legacy `TensorPool::alloc(size, dtype)`
+- **THEN** the pool SHALL satisfy the allocation from any available node's free-list
+- **AND** the corresponding node's `alloc_unhinted` counter SHALL increment by one
+- **AND** the call SHALL NOT panic, error, or behave differently from the v0 (pre-NUMA) implementation on a single-node host
+
+### Requirement: Cooperative scheduler propagates home-node hint
+
+The AMP cooperative scheduler SHALL associate each thread with a `home_node: NumaNodeId` and SHALL pass that node id as the NUMA hint on every tensor-pool allocation made on behalf of that thread.
+
+#### Scenario: Data-parallel inference threads run on their physical node
+
+- **GIVEN** a multi-socket host with the inference scheduler running data-parallel ops on cores 1..N
+- **GIVEN** core K is physically located on NUMA node M (per `NumaTopology`)
+- **WHEN** the scheduler dispatches an inference op to core K
+- **AND** the op's kernel allocates a tensor via the scheduler-provided allocator handle
+- **THEN** the allocation SHALL be issued as `alloc_with_hint(.., Some(M))`
+- **AND** on a 2P EPYC host, the steady-state ratio `alloc_local / (alloc_local + alloc_remote)` SHALL be ≥ 0.90 under a synthetic two-node benchmark
+
+#### Scenario: Core 0 (System/IPC) is bound to node 0 by convention
+
+- **GIVEN** any host topology
+- **WHEN** the scheduler dispatches System/IPC work on core 0
+- **THEN** core 0's `home_node` SHALL be 0
+- **AND** allocations made by core 0 SHALL be hinted to node 0
+
+### Requirement: Single-node hosts pay zero NUMA overhead
+
+On single-node hosts (the Jetson Orin production target), the NUMA-aware allocation path SHALL impose no measurable performance regression on the existing tensor-pool benchmark suite.
+
+#### Scenario: Jetson Orin regression guard
+
+- **GIVEN** the existing tensor-pool alloc/free benchmark suite captured on the Jetson Orin NX 16 GB baseline
+- **WHEN** the benchmark is re-run on this change's branch on the same Jetson Orin host
+- **THEN** the median and p99 alloc latency SHALL be within ±2% of the v0 baseline
+- **AND** the per-op tensor throughput SHALL be within ±2% of the v0 baseline
+- **AND** the boot log SHALL show `numa: single-node fallback`, confirming the no-cost path is taken
+
+### Requirement: Per-node allocation counters are exposed via telemetry
+
+The kernel SHALL expose per-node tensor-allocation counters via the existing telemetry endpoint, suitable for observability and tuning.
+
+#### Scenario: Counters reflect alloc paths
+
+- **GIVEN** the telemetry endpoint `/proc/smallaios/numa` (or the unikernel-equivalent path under the OTel exporter)
+- **WHEN** the operator reads the endpoint
+- **THEN** the endpoint SHALL list every discovered node with: cpu set, memory size, `alloc_local`, `alloc_remote`, `alloc_unhinted`
+- **AND** the sum of all three counters across all nodes SHALL equal the total number of `TensorPool` allocations since boot
+- **AND** the endpoint SHALL be read-only and SHALL NOT modify allocator state

--- a/openspec/changes/numa-aware-tensor-alloc-v1/tasks.md
+++ b/openspec/changes/numa-aware-tensor-alloc-v1/tasks.md
@@ -1,0 +1,66 @@
+# Tasks — numa-aware-tensor-alloc-v1
+
+> **Status: Future-facing.** No work has started. This change is a roadmap document for scale-out / multi-socket deployments; the Jetson Orin production target does not exercise NUMA. Tasks are sequenced for when scale-out demand triggers implementation.
+
+## 0. Trigger conditions (review before starting)
+
+- [ ] 0.1 Confirm at least one production / customer deployment target is multi-socket (2P+ x86-64 or multi-die ARM64 server). If only single-socket targets exist, defer this change indefinitely.
+- [ ] 0.2 Confirm CI matrix can be extended with at least one multi-socket runner (self-hosted; GitHub-hosted runners are single-socket).
+- [ ] 0.3 Capture a baseline on the Jetson Orin single-node benchmark (current tensor-pool alloc/free latency + per-op tensor throughput). This is the regression guard for the implementation phase.
+
+## 1. Phase 1 — Topology discovery shim
+
+### 1a. x86-64 SRAT parser
+
+- [ ] 1.1 Add `kernel/src/acpi/srat.rs` parsing SRAT memory-affinity (type 1) and processor local APIC/SAPIC affinity (type 0) structures. Use the existing ACPI table-walker.
+- [ ] 1.2 Construct a `NumaTopology` containing `nodes: [NumaNode; N]` where each node holds `cpu_ids: BitSet<256>`, `mem_ranges: Vec<PhysAddrRange>`.
+- [ ] 1.3 Unit-test the parser against captured SRAT blobs from 2P EPYC Genoa and 2P Xeon Sapphire Rapids (committed under `kernel/src/acpi/test-data/`).
+
+### 1b. ARM64 device-tree walk
+
+- [ ] 1.4 Add `kernel/src/dt/numa.rs` walking the device tree for `numa-node-id` properties on `cpu@*` and `memory@*` nodes.
+- [ ] 1.5 Unit-test against captured DTBs from Ampere Altra Max and NVIDIA Grace (committed under `kernel/src/dt/test-data/`).
+
+### 1c. Fallback
+
+- [ ] 1.6 Implement `NumaTopology::single_node()` synthesizer for the no-NUMA case. Verify against the Jetson Orin DTB — single node, all RAM, all cores.
+- [ ] 1.7 Boot sequence: try SRAT (x86), then DT (ARM), then fall back to single-node. Log the chosen path at info level.
+
+## 2. Phase 2 — Tensor pool API extension
+
+- [ ] 2.1 Add `alloc_with_hint(size, dtype, numa_hint: Option<NumaNodeId>)` to `kernel/src/mem/tensor.rs`. Keep the existing `alloc(size, dtype)` as `alloc_with_hint(size, dtype, None)`.
+- [ ] 2.2 Restructure the pool's free-list from `FreeList` to `[FreeList; MAX_NUMA_NODES]` (const `MAX_NUMA_NODES = 16`).
+- [ ] 2.3 Implement the three-tier allocation flow: try hinted node → try any node → fall back to page allocator.
+- [ ] 2.4 Add atomic per-node counters (`alloc_local`, `alloc_remote`, `alloc_unhinted`).
+- [ ] 2.5 Expose `TensorPool::topology()` accessor returning `&'static NumaTopology`.
+
+## 3. Phase 3 — Scheduler home-node bias
+
+- [ ] 3.1 Extend the AMP scheduler with a `home_node: NumaNodeId` per thread, populated from the topology at thread creation.
+- [ ] 3.2 Inference ops invoked via the scheduler pick up the current thread's `home_node` and pass it as the hint into tensor allocation.
+- [ ] 3.3 Document the rule: Core 0 (System/IPC) is always `home_node = 0`; data-parallel cores 1..N use their physical node.
+
+## 4. Phase 4 — Observability and benchmarks
+
+- [ ] 4.1 Add a `/proc/smallaios/numa`-equivalent telemetry endpoint (or extend the existing telemetry-otel-export path) reporting per-node counters + topology.
+- [ ] 4.2 Write a synthetic two-node tensor-allocation benchmark in `bench/`: spawn N threads, each pinned to its own node, allocate / free tensors in a loop, report `alloc_local / (alloc_local + alloc_remote)` ratio.
+- [ ] 4.3 Run the benchmark on a 2P EPYC Genoa host (loaner / customer hardware) and capture: (a) ratio ≥90%; (b) p99 alloc latency vs single-socket Jetson baseline.
+- [ ] 4.4 Run the existing Jetson Orin tensor-pool benchmark on develop and on this branch; confirm ≤2% regression on the single-node path.
+
+## 5. Phase 5 — Documentation
+
+- [ ] 5.1 Create `docs/numa-tensor-alloc.md` covering: when NUMA matters, how to read the topology endpoint, how to interpret the local/remote ratio, troubleshooting (zero local hits = scheduler not setting home_node correctly).
+- [ ] 5.2 Update `docs/architecture.md` to note the per-node free-list and the topology discovery layer.
+- [ ] 5.3 Add a row to the README hardware matrix for "multi-socket x86-64" and "multi-die ARM64" with a link to the NUMA doc.
+
+## 6. Phase 6 — CI matrix expansion
+
+- [ ] 6.1 Add a scheduled job `numa-multi-socket-smoke` that runs the benchmark on a self-hosted 2P EPYC runner. Advisory initially.
+- [ ] 6.2 Confirm the existing single-socket gate jobs continue to pass (no regression).
+- [ ] 6.3 Promote `numa-multi-socket-smoke` to `change-gates` when self-hosted runner availability is reliable (separate change).
+
+## 7. Close-out
+
+- [ ] 7.1 PR title: `feat(kernel): numa-aware-tensor-alloc-v1 — multi-socket NUMA topology + per-node tensor free-lists`.
+- [ ] 7.2 Reviewer sign-off + green CI + manual 2P EPYC benchmark evidence pasted in the PR description.
+- [ ] 7.3 Update CLAUDE.md "Current state" to mention NUMA-aware tensor allocation on multi-socket hosts.

--- a/openspec/changes/persistent-memory-v1/design.md
+++ b/openspec/changes/persistent-memory-v1/design.md
@@ -1,0 +1,145 @@
+# Design — persistent-memory-v1
+
+## Goal
+
+Add a memory-tier abstraction on top of the existing tensor pool so that **CXL.mem** (host-attached memory expanders, CXL 1.1+) and **CXL 3.0 pooled / shared memory** can back large model weights and warm caches, while preserving zero overhead on the Jetson Orin single-tier production target.
+
+Success: (a) on a CXL.mem-equipped reference host (e.g., Sapphire Rapids + Astera Leo, or EPYC Genoa + Samsung CMM-D), the kernel discovers the warm-tier node via HMAT/CDAT and the inference scheduler places weight tensors on the warm tier and KV caches on the hot tier; (b) on a CXL 3.0 fabric reference host (when silicon is available), two SmallAIOS instances on the same fabric map the same `SharedRegion` for weights read-only; (c) on Jetson Orin (no CXL), the same code path falls through to single-tier behavior with zero measurable regression on the existing tensor-pool benchmarks.
+
+## Alternatives considered
+
+### A1. Treat persistent memory as a block device, not as memory
+
+**Rejected.** The pmem-as-block-device path (with a filesystem on top, e.g., ext4-DAX or XFS-DAX) is a Linux legacy from the Optane era. CXL.mem is presented to the OS as system RAM, not as a block device — the controller emits `EFI_MEMORY_SP` (Special-Purpose Memory) attributes that tell the OS "this is memory, but a different tier". Block-device emulation throws away the memory-mapped programming model that CXL.mem is designed around, and the inference fast path is already memory-mapped tensor access — exposing it via `read()` / `write()` would defeat the purpose.
+
+### A2. Use Linux's `memhotplug` / `kmem` driver model
+
+**Not applicable.** SmallAIOS is a unikernel. There is no Linux `kmem` driver or hotplug subsystem. We must own the discovery and integration ourselves. The Linux model does, however, validate the design point: tiered memory appears as additional NUMA nodes with a `target` attribute. We follow the same shape in the kernel-side `NumaTopology`.
+
+### A3. Implement persistent / crash-consistent semantics now
+
+**Rejected.** Crash consistency in the SNIA NVM Programming Model sense (`pmem_persist`, `pmem_flush`, transactional allocators à la libpmemobj) is a deep rabbit hole that adds significant complexity to the allocator and assumes a use case (in-memory databases) we are not targeting. SmallAIOS uses CXL.mem as **slow DRAM, not as durable store**. If a crash-consistent state is needed, it goes in NVMe storage via the existing filesystem path. This decision is reversible: if a future workload demands persistence, we can layer a transactional allocator on top of the tier API; the API itself does not preclude it.
+
+### A4. Build a single, unified "any memory" allocator with no tier concept
+
+**Rejected.** Without tiering, the allocator has two options: (a) treat all memory the same (puts model weights in DRAM, defeats the purpose of CXL.mem); (b) auto-migrate based on access patterns (Linux's `numa_balance` — adds non-trivial complexity, requires page-fault-driven migration which the unikernel does not have today). Explicit tier hints are cheaper and more predictable. The inference scheduler already knows which tensors are weights (read-only after load, large, reuse-heavy) and which are activations / KV cache (read-write, small per-op, latency-sensitive) — passing that signal to the allocator is a 1-line change at each call site.
+
+### A5. CXL 3.0 shared memory as a transparent shared-page-table feature
+
+**Rejected.** CXL 3.0 leaves coherence semantics implementation-defined; some fabrics expose hardware-coherent shared regions, others require software-managed coherence. SmallAIOS cannot assume the strong model. We expose `SharedRegion` as **explicit, advisory** — read-only model-weight sharing is the only blessed use case; writable shared state requires application-level coordination (which is out of scope for this change).
+
+## Discovery shim
+
+### x86-64 — ACPI HMAT
+
+The Heterogeneous Memory Attribute Table (ACPI 6.3+) is the canonical CXL.mem discovery source on x86-64. Key sub-structures:
+
+- **Memory Proximity Domain Attributes** (type 0): flags indicate whether a proximity domain is "memory side cache" or "memory only", plus reservation hints.
+- **System Locality Latency and Bandwidth Information** (type 1): per-(initiator, target) latency / bandwidth matrix. Higher latency + lower bandwidth = warm tier.
+- **Memory Side Cache Information** (type 2): not directly relevant for tier classification but useful for future hardware acceleration.
+
+Classification rule for v1: a memory proximity domain is **Warm tier** if its access latency from any local CPU exceeds 2x the lowest-latency domain's reciprocal access latency. This is the same heuristic Linux uses for `tier_higher_rank` ordering in `mm/memory-tiers.c`. ~200 LOC of new code in `kernel/src/acpi/hmat.rs`.
+
+### CXL CDAT (both x86-64 and ARM64)
+
+The Coherent Device Attribute Table is published by each CXL device via the DOE (Data Object Exchange) mailbox. For CXL.mem devices, CDAT carries:
+
+- **Device Scoped Memory Affinity Structure (DSMAS):** range + proximity domain.
+- **Device Scoped Latency and Bandwidth Information Structure (DSLBIS):** per-range latency / bandwidth.
+
+We walk the PCI / CXL bus at boot, query CDAT via DOE, and merge the data with HMAT (on x86-64) or use CDAT alone (on ARM64 where HMAT may be absent). ~250 LOC in `kernel/src/cxl/cdat.rs`. The CXL bus walker reuses the existing PCIe enumeration code in the `bus` crate.
+
+### Single-tier fallback
+
+When neither HMAT nor CDAT yields any tier data — Jetson Orin, single-socket x86-64 desktop without CXL, ARM64 servers without `numa-node-id` for CXL devices — the discovery shim synthesizes a single-tier topology where every node reports `MemTier::Hot`. The tier API becomes a no-op; `Preferred(Warm)` resolves to "any node" since no warm node exists.
+
+## Allocation API
+
+```rust
+pub enum MemTier {
+    Hot,    // Local DRAM
+    Warm,   // CXL.mem / persistent memory
+    Cold,   // NVMe-mapped (future)
+}
+
+pub enum MemTierPolicy {
+    Required(MemTier),  // Fail if no node of that tier has capacity
+    Preferred(MemTier), // Try that tier; fall back to any tier
+    Any,                // Default; identical to v0 behavior
+}
+
+// New API
+pub fn alloc_with_tier(
+    size: usize,
+    dtype: DType,
+    tier_policy: MemTierPolicy,
+) -> Result<TensorBuf, MemError>;
+
+// Compose with NUMA hint from numa-aware-tensor-alloc-v1
+pub fn alloc_full(
+    size: usize,
+    dtype: DType,
+    numa_hint: Option<NumaNodeId>,
+    tier_policy: MemTierPolicy,
+) -> Result<TensorBuf, MemError>;
+```
+
+The two-knob API (NUMA hint + tier policy) is the composition of this change with `numa-aware-tensor-alloc-v1`. The NUMA hint says "which node"; the tier policy says "which tier of node". They are orthogonal: a `Preferred(Warm) + Some(node=3)` allocation tries node 3 first if it is a warm tier, otherwise tries any warm node, otherwise any node.
+
+## Scheduler integration
+
+The inference scheduler knows the lifetime and access pattern of each tensor at op-dispatch time. Default placement policy:
+
+- **Model weights** (loaded once at boot, read-only thereafter): `Preferred(Warm)`. Large, reuse-heavy, latency-tolerant because compute time hides the access cost.
+- **KV cache** (read-write per token, latency-critical): `Required(Hot)`. Falls back to alloc failure if hot tier is exhausted; do not silently put KV cache in CXL.mem.
+- **Activations / intermediates** (short-lived, latency-critical): `Required(Hot)`.
+- **Diagnostic buffers, logs, telemetry**: `Preferred(Warm)`. Same rationale as weights — large, read-mostly.
+
+These defaults are documented and configurable via `SMALLAIOS_TIER_POLICY` environment variable or a kernel boot argument.
+
+## CXL 3.0 SharedRegion (Phase 2)
+
+```rust
+pub struct SharedRegion {
+    fabric_id: CxlFabricId,
+    region_id: u64,
+    base: PhysAddr,
+    len: usize,
+    access: AccessMode,  // ReadOnly or ReadWrite (with caveats)
+}
+
+impl SharedRegion {
+    pub fn map_read_only(spec: SharedRegionSpec) -> Result<Self, CxlError>;
+    // No map_writable in v1; writable shared regions require
+    // application-level coordination protocols out of scope here.
+}
+```
+
+The model-loading code looks up a shared-region spec from a pre-provisioned config (CXL fabric manager publishes region ids; the SmallAIOS instance reads the id from its env / config). On `map_read_only`, the kernel verifies (a) the region exists on the fabric, (b) the local node has read permission, (c) the region size matches the expected model size, and maps it into the tensor-pool address space tagged `MemTier::Warm` + `shared = true`. Reads from this region behave like reads from any warm-tier address.
+
+Cache coherence across hosts is **explicitly not assumed**. A v1 read-only region is safe because no host writes after the model-load epoch. Future writable shared regions will need application-managed coherence (e.g., epoch-based reload signaling).
+
+## Observability
+
+Telemetry endpoint extends `/proc/smallaios/numa` (from `numa-aware-tensor-alloc-v1`) with a `tier` column per node and per-tier counters:
+
+```
+tiers: hot warm
+tier hot:  total=64GB used=42GB alloc_required=12345 alloc_preferred=89
+tier warm: total=512GB used=380GB alloc_required=0 alloc_preferred=7654
+
+node 0: tier=hot cpus=0,1,2,3 mem=32GB alloc_local=8000 alloc_remote=12
+node 1: tier=hot cpus=4,5,6,7 mem=32GB alloc_local=7800 alloc_remote=15
+node 2: tier=warm cxl_dev=cxl0 mem=256GB alloc_local=3800
+node 3: tier=warm cxl_dev=cxl1 mem=256GB alloc_local=3854
+```
+
+## What this change explicitly does NOT do
+
+- Does not implement persistent / crash-consistent semantics.
+- Does not target Optane DC PMEM (discontinued hardware).
+- Does not implement page migration between tiers.
+- Does not assume CXL 3.0 hardware coherence for writable shared regions.
+- Does not enable hot-add / hot-remove of CXL devices (static topology at boot for v1).
+- Does not modify the existing single-tier path's behavior on Jetson Orin or other CXL-less hosts.
+- Does not extend the `net` crate, the `ipc` crate, or any non-`kernel-mem` capability with tier awareness in this change.

--- a/openspec/changes/persistent-memory-v1/proposal.md
+++ b/openspec/changes/persistent-memory-v1/proposal.md
@@ -1,0 +1,68 @@
+# persistent-memory-v1
+
+## Summary
+
+Add a memory-tier abstraction to the SmallAIOS tensor pool so that large model weights, KV caches, and warm inference state can be backed by **persistent memory** — concretely, **CXL.mem** devices and **CXL 3.0 pooled / shared memory fabrics** — in addition to the existing DRAM-only path. The pool gains a tier concept (`Hot = DRAM`, `Warm = CXL.mem` / persistent memory, `Cold = NVMe-mapped`), allocation gains an optional `MemTier` preference, and the kernel grows a discovery shim that enumerates persistent-memory regions via ACPI HMAT (Heterogeneous Memory Attribute Table) on x86-64 and via CXL CDAT (Coherent Device Attribute Table) walk on both x86-64 and ARM64. Datacenter scale-out deployments running models that exceed local DRAM, or sharing weight tensors across multiple SmallAIOS instances on a CXL 3.0 fabric, become possible without rebuilding the whole memory subsystem.
+
+This is a Tier 3 scale-out feature. The Jetson Orin production target has no CXL.mem and no persistent-memory devices; the tiering API is a no-op fallback there.
+
+## Why
+
+- **Intel Optane is dead; CXL.mem is the successor.** Intel ended Optane DC Persistent Memory production in 2022. The 2024-2026 industry direction is **CXL.mem** (CXL 1.1/2.0 type-3 devices — memory expanders) and **CXL 3.0** (pooled / shared memory fabrics across multiple hosts). All near-term persistent-memory designs ride the CXL bus, share PCIe physical layer, and present as `system-ram` to the OS with NUMA-distance-style affinity attributes. SmallAIOS skipping Optane entirely and going directly to CXL.mem is the right design call.
+- **Large-model deployments need tiered memory.** A 405B-parameter LLM in INT8 is ~400 GB. A 2P server can ship with 1-2 TB of DRAM, but DRAM is expensive ($/GB) and power-hungry (W/GB). CXL.mem expanders deliver 1-4 TB at half the $/GB and a fraction of the power, with latency 1.5-3x local-DRAM (similar to remote-socket access on a 2P system). For inference where the working set is reuse-heavy (model weights stream through compute, KV cache is read-mostly), the latency penalty is hidden by compute time and the cost/density win is large.
+- **CXL 3.0 pooled memory enables multi-instance weight sharing.** When two or more SmallAIOS unikernel instances on a single CXL 3.0 fabric share access to a pooled memory region, they can map the same model weights once into pooled CXL and reference them read-only from every instance. This is the industry-standard datacenter scale-out story for inference: weight tensors are amortized across N replicas, KV cache and activations are per-instance and stay in local DRAM. SmallAIOS as a unikernel is uniquely well-positioned for this — no Linux page-cache layer, no userspace mmap dance, just a kernel-level tiered allocator.
+- **Tier 3 — not urgent for Jetson.** Jetson Orin has no CXL controller and never will (Tegra234 fixed-function memory controller). Adding tiering to the production critical path while the production target is Orin pays cost with zero benefit. This proposal exists so the design is captured, the spec is reviewed, and the implementation is ready when a CXL-equipped target enters the roadmap.
+
+## Hardware prerequisites
+
+| Hardware class | Examples | What we get |
+|----------------|----------|-------------|
+| **CXL 1.1 type-3 (host attached memory expander)** | Samsung CMM-D, SK hynix CXL Memory Module, Micron CZ120 | DDR5-class memory at PCIe-bus-attached latencies; presented as a separate NUMA node with a "slow tier" attribute via HMAT/CDAT |
+| **CXL 2.0 type-3 (switch attached, single host)** | Astera Labs Leo controller, MemVerge solutions | Same as 1.1, plus hot-add/remove and richer telemetry |
+| **CXL 3.0 type-3 (pooled / shared)** | Pre-production silicon (Astera Aries, Marvell Structera) targeting 2025-2027 datacenter rollout | Multi-host shared memory; SmallAIOS instances on the same fabric can map the same region |
+| **Host CPU support** | Intel Xeon Sapphire Rapids / Emerald Rapids / Granite Rapids (CXL 1.1/2.0), Intel Xeon Granite Rapids-AP (CXL 3.0), AMD EPYC Genoa / Bergamo (CXL 1.1/2.0), AMD EPYC Turin (CXL 2.0/3.0), Ampere AmpereOne (CXL 1.1+), NVIDIA Grace (CXL 1.1) | Required — CXL controller must be present in the host root complex |
+| **Discontinued / out of scope** | Intel Optane DC PMEM (discontinued 2022), NVDIMM-N | We do not target legacy persistent memory; CXL.mem is the forward-looking design |
+
+**Not supported:** Jetson Orin (Tegra234 — no CXL controller), Apple Silicon (proprietary memory architecture, no CXL public path), Raspberry Pi-class SBCs.
+
+## What changes
+
+- **Capability `kernel-mem-tiering` (new):**
+  - `MemTier` enum — `Hot`, `Warm`, `Cold`.
+  - `MemTierPolicy` — per-allocation: `Required(tier)`, `Preferred(tier)`, `Any` (default).
+  - `TensorPool::alloc_with_tier(size, dtype, tier_policy)` — new API. Existing `alloc()` defaults to `Any`.
+- **Discovery shim** `kernel/src/mem/tier.rs`:
+  - x86-64: ACPI HMAT — System Locality Latency / Bandwidth tables identify persistent-memory devices.
+  - CXL CDAT — common path on both x86-64 and ARM64; walks CXL device CDAT structures for memory attribute info.
+  - Single-tier fallback: when no HMAT / CDAT is present, every node reports `MemTier::Hot` and the API is a no-op (Jetson Orin path).
+- **Tier integration with NUMA:** Tiered memory regions appear as additional NUMA nodes with a tier tag. The pool's free-list becomes `[FreeList; MAX_NUMA_NODES]` indexed by node, with each node carrying its `tier` attribute. The two changes (`numa-aware-tensor-alloc-v1` and this one) compose: NUMA hint says "which node"; tier policy says "which tier of node".
+- **CXL 3.0 shared-region support (Phase 2 deliverable):** A `SharedRegion` abstraction representing pooled CXL memory accessible to multiple hosts. Read-only mapping for model weights; explicit coordination protocol for any writable region (no implicit cache coherence assumptions across hosts — CXL 3.0 spec leaves coherence semantics implementation-defined).
+- **Documentation**: `docs/persistent-memory.md` covering the tier model, the discovery path, CXL.mem provisioning on a host, and the CXL 3.0 shared-region usage pattern.
+
+## Out of scope
+
+- **Persistence semantics (crash consistency).** Despite the name "persistent memory", we treat the warm tier as a **slow DRAM**, not as a crash-consistent store. We do not implement durable-write barriers, persistence-aware allocator transactions, or anything from the SNIA NVM Programming Model. If a SmallAIOS instance crashes, the warm-tier contents are abandoned just like DRAM. Crash-consistent persistent state belongs in storage (NVMe), not tiered memory.
+- **Optane DC PMEM support.** Intel discontinued Optane in 2022. No engineering will be invested in App Direct Mode, Memory Mode, or `pmem` namespace management. The forward-looking design is CXL.mem.
+- **Page migration between tiers.** Linux's `damon` / `numa_balancing` migrates hot pages from slow tiers to fast tiers based on access patterns. Out of scope for v1 — we use explicit `tier_policy` hints from the inference scheduler (which knows weight tensors are read-heavy and belong in warm tier; KV cache is read-write and belongs in hot tier). Revisit if profiling shows mis-placement.
+- **CXL.cache and CXL.io.** CXL has three protocols on the same wire: `.io` (PCIe-equivalent), `.cache` (accelerator caches host memory), `.mem` (host accesses device memory). Only `.mem` is in scope for this change. `.cache` belongs in a future GPU-accelerator change if/when an accelerator vendor ships CXL-attached silicon.
+- **DCD (Dynamic Capacity Device) provisioning.** CXL 3.0 DCD lets the fabric dynamically add/remove memory regions to a host. We treat the topology as static at boot. Hot-add of a tier-1 device is a v2 concern.
+
+## When this becomes important
+
+- **Now (deferred):** Jetson Orin — no CXL, no benefit. Treat as roadmap documentation only.
+- **Trigger event 1:** SmallAIOS deployment on a single-host CXL.mem-equipped server running a model whose total weights exceed local DRAM (canonical example: 400B-class LLM, 1 TB DRAM + 2 TB CXL.mem). This unlocks Phase 1 (single-host tiered allocation).
+- **Trigger event 2:** SmallAIOS deployment on a CXL 3.0 fabric with multiple unikernel instances sharing weights. This unlocks Phase 2 (`SharedRegion` API). Likely 24-36 months out given CXL 3.0 production silicon timing.
+- **Likely horizon for Phase 1:** 12-24 months out, contingent on CXL.mem-equipped server availability in our deployment matrix.
+
+## Effort estimate
+
+| Sub-phase | Scope | Estimate |
+|-----------|-------|----------|
+| 1 | HMAT + CDAT discovery shim, MemTier types | ~1 week |
+| 2 | TensorPool tier-aware alloc API + per-tier counters | ~1 week |
+| 3 | Scheduler integration (weight tensors → Warm; KV cache → Hot) | ~1 week |
+| 4 | Single-host CXL.mem benchmark + docs | ~1 week |
+| 5 | CXL 3.0 `SharedRegion` API + cross-host coordination protocol | ~2 weeks |
+| **Total** | | **~5-6 weeks** (Phase 1 alone: ~3-4 weeks) |
+
+Phase 5 only proceeds when CXL 3.0 silicon and a test harness exist.

--- a/openspec/changes/persistent-memory-v1/specs/kernel-mem-tiering/spec.md
+++ b/openspec/changes/persistent-memory-v1/specs/kernel-mem-tiering/spec.md
@@ -1,0 +1,136 @@
+## ADDED Requirements
+
+### Requirement: Memory tier discovery at boot
+
+The kernel SHALL discover the host's memory-tier topology at boot and SHALL classify each memory region as `Hot`, `Warm`, or `Cold` tier based on standard ACPI / CXL attribute tables.
+
+#### Scenario: x86-64 HMAT discovery on a CXL.mem-equipped host
+
+- **GIVEN** a Sapphire Rapids / Granite Rapids / EPYC Genoa host with a CXL 1.1+ type-3 memory expander attached, publishing ACPI HMAT
+- **WHEN** the kernel boots
+- **THEN** the kernel SHALL parse HMAT Memory Proximity Domain Attributes (type 0) to enumerate memory proximity domains
+- **AND** the kernel SHALL parse HMAT System Locality Latency and Bandwidth Information (type 1) to derive per-(initiator, target) access latencies
+- **AND** the kernel SHALL classify a proximity domain as `MemTier::Warm` when its access latency from any local CPU exceeds 2x the lowest-latency domain's access latency
+- **AND** boot logs SHALL include `mem-tier: discovered N tiers via HMAT` at info level
+
+#### Scenario: CDAT discovery on any architecture with CXL devices
+
+- **GIVEN** a host with CXL type-3 devices on the PCI bus, each publishing CDAT via DOE
+- **WHEN** the kernel boots
+- **THEN** the kernel SHALL walk the PCI / CXL bus and query each CXL device's CDAT via the DOE mailbox
+- **AND** the kernel SHALL parse Device Scoped Memory Affinity (DSMAS) and Device Scoped Latency and Bandwidth (DSLBIS) structures
+- **AND** the resulting tier classification SHALL merge cleanly with HMAT on x86-64 hosts
+- **AND** on ARM64 hosts without HMAT, CDAT alone SHALL drive tier classification
+- **AND** boot logs SHALL include `mem-tier: discovered N CXL devices via CDAT` at info level
+
+#### Scenario: Single-tier fallback on Jetson Orin and other CXL-less hosts
+
+- **GIVEN** a host that publishes neither HMAT nor CXL CDAT (e.g., Jetson Orin NX, single-socket x86-64 desktop without CXL, Apple silicon)
+- **WHEN** the kernel boots
+- **THEN** the kernel SHALL synthesize a single-tier topology where every memory node reports `MemTier::Hot`
+- **AND** boot logs SHALL include `mem-tier: single-tier fallback` at info level
+- **AND** subsequent calls to `alloc_with_tier(.., MemTierPolicy::Preferred(MemTier::Warm))` SHALL transparently fall back to `Hot` (the only tier present)
+
+### Requirement: Tier-aware tensor allocation API
+
+The `TensorPool` SHALL accept an optional `MemTierPolicy` argument controlling whether allocations are restricted to a tier, prefer a tier, or accept any tier.
+
+#### Scenario: Required(Hot) succeeds when hot tier has capacity
+
+- **GIVEN** a CXL.mem-equipped host with discovered tiers `Hot` and `Warm`
+- **GIVEN** the hot tier has free buffers in the requested size class
+- **WHEN** a caller invokes `TensorPool::alloc_with_tier(size, dtype, MemTierPolicy::Required(MemTier::Hot))`
+- **THEN** the returned `TensorBuf` SHALL be drawn from a hot-tier node's free-list
+- **AND** the `alloc_required` counter on the hot tier SHALL increment by one
+- **AND** the buffer SHALL NOT be drawn from any warm-tier or cold-tier node
+
+#### Scenario: Required(Hot) fails when hot tier is exhausted
+
+- **GIVEN** the hot tier has no free buffers in the requested size class and the page allocator cannot grow it
+- **WHEN** a caller invokes `TensorPool::alloc_with_tier(size, dtype, MemTierPolicy::Required(MemTier::Hot))`
+- **THEN** the call SHALL return `Err(MemError::TierExhausted(MemTier::Hot))`
+- **AND** the pool SHALL NOT silently satisfy the allocation from a warm-tier node
+- **AND** the failure SHALL propagate to the calling op (e.g., KV-cache allocation failure aborts the inference step rather than placing KV cache in CXL.mem)
+
+#### Scenario: Preferred(Warm) prefers warm but falls back
+
+- **GIVEN** a CXL.mem-equipped host where the warm tier has free buffers
+- **WHEN** a caller invokes `TensorPool::alloc_with_tier(size, dtype, MemTierPolicy::Preferred(MemTier::Warm))`
+- **THEN** the returned `TensorBuf` SHALL be drawn from a warm-tier node
+- **AND** the warm tier's `alloc_preferred` counter SHALL increment by one
+- **GIVEN** the warm tier is exhausted
+- **WHEN** the same call is made
+- **THEN** the allocation SHALL succeed against a hot-tier node
+- **AND** the warm tier's `alloc_fallback` counter SHALL increment by one
+
+#### Scenario: Any policy is the v0-compatible default
+
+- **GIVEN** any host topology
+- **WHEN** a caller invokes `TensorPool::alloc_with_tier(size, dtype, MemTierPolicy::Any)` or the legacy `TensorPool::alloc(size, dtype)`
+- **THEN** the pool SHALL satisfy the allocation from any tier with capacity
+- **AND** the call SHALL NOT panic or behave differently from the v0 (pre-tiering) implementation on a single-tier host
+
+### Requirement: Inference scheduler applies default tier policies
+
+The inference scheduler SHALL classify each tensor allocation by role and SHALL apply tier policies aligned with that role.
+
+#### Scenario: Model weights prefer the warm tier
+
+- **GIVEN** a CXL.mem-equipped host
+- **WHEN** the model loader allocates a buffer for a model-weight tensor
+- **THEN** the allocation SHALL use `MemTierPolicy::Preferred(MemTier::Warm)`
+- **AND** the `alloc_preferred` counter on the warm tier SHALL increment
+
+#### Scenario: KV cache requires the hot tier
+
+- **GIVEN** any host
+- **WHEN** the inference scheduler allocates a buffer for KV cache state
+- **THEN** the allocation SHALL use `MemTierPolicy::Required(MemTier::Hot)`
+- **AND** if hot-tier capacity is unavailable, the inference step SHALL fail with a `TierExhausted` error rather than degrading silently
+
+#### Scenario: Policy override via environment / boot argument
+
+- **GIVEN** the operator sets `SMALLAIOS_TIER_POLICY=weights:any,kv:hot` (container path) or the equivalent kernel boot argument
+- **WHEN** the inference scheduler dispatches an op
+- **THEN** the scheduler SHALL honor the override, using `MemTierPolicy::Any` for weight allocations instead of the `Preferred(Warm)` default
+- **AND** the chosen policy SHALL be logged at info level on first use
+
+### Requirement: CXL 3.0 shared regions support read-only weight sharing across instances
+
+When CXL 3.0 pooled / shared memory is available, the kernel SHALL provide a `SharedRegion` abstraction allowing multiple SmallAIOS instances on the same CXL fabric to map the same physical memory region read-only.
+
+#### Scenario: Read-only mapping of a pre-provisioned shared region
+
+- **GIVEN** a CXL 3.0 fabric with a pre-provisioned pooled memory region containing a model's weight tensors
+- **GIVEN** the SmallAIOS instance has been granted read access to the region by the fabric manager
+- **WHEN** the model loader invokes `SharedRegion::map_read_only(spec)`
+- **THEN** the kernel SHALL verify the region exists, verify size and permissions match the spec, and map the region into the tensor-pool address space
+- **AND** the mapped region SHALL be tagged with `MemTier::Warm` and the `shared = true` flag
+- **AND** subsequent tensor allocations SHALL be able to reference the shared region as backing storage for read-only weight buffers
+
+#### Scenario: Two SmallAIOS instances share weights without duplication
+
+- **GIVEN** two SmallAIOS unikernel instances on the same CXL 3.0 fabric
+- **GIVEN** both instances have read access to a pre-provisioned shared region containing model weights
+- **WHEN** both instances start and load the same model
+- **THEN** both instances SHALL map the same `SharedRegion` read-only
+- **AND** the total fabric memory consumed by weight tensors SHALL be the size of one copy (not two)
+- **AND** each instance SHALL produce identical inference outputs for the same input
+
+#### Scenario: Writable shared regions are explicitly unsupported in v1
+
+- **GIVEN** a caller attempting to use a writable shared region in v1
+- **WHEN** the caller invokes a writable shared-region API
+- **THEN** no such API SHALL exist; only `map_read_only` is provided
+- **AND** documentation SHALL note that writable shared regions require application-level coherence coordination that is out of scope for v1
+
+### Requirement: Single-tier hosts pay zero tiering overhead
+
+On hosts with a single memory tier (the Jetson Orin production target), the tier-aware allocation path SHALL impose no measurable performance regression on the existing tensor-pool benchmark suite.
+
+#### Scenario: Jetson Orin regression guard
+
+- **GIVEN** the existing tensor-pool alloc/free benchmark suite captured on the Jetson Orin NX 16 GB baseline
+- **WHEN** the benchmark is re-run on this change's branch on the same Jetson Orin host
+- **THEN** the median and p99 alloc latency SHALL be within ±2% of the v0 baseline
+- **AND** the boot log SHALL show `mem-tier: single-tier fallback`, confirming the no-cost path is taken

--- a/openspec/changes/persistent-memory-v1/tasks.md
+++ b/openspec/changes/persistent-memory-v1/tasks.md
@@ -1,0 +1,81 @@
+# Tasks — persistent-memory-v1
+
+> **Status: Future-facing.** No work has started. This change is a roadmap document for CXL.mem / CXL 3.0 datacenter deployments. The Jetson Orin production target has no CXL controller. Phase 5 (CXL 3.0 shared regions) is contingent on CXL 3.0 production silicon availability (likely 2026-2028).
+
+## 0. Trigger conditions (review before starting)
+
+- [ ] 0.1 Confirm at least one production / customer target ships with CXL.mem-equipped hardware (Sapphire Rapids+ / Granite Rapids / EPYC Genoa+ / Ampere AmpereOne / Grace) and a CXL type-3 memory expander.
+- [ ] 0.2 Capture HMAT and CDAT blobs from a reference CXL.mem host for unit-test fixtures. Without this, the discovery shim is unverifiable.
+- [ ] 0.3 Establish a CXL.mem-equipped scheduled CI runner (self-hosted; no GitHub-hosted runner has CXL.mem).
+- [ ] 0.4 (Phase 5 gate) Confirm CXL 3.0 pooled-memory silicon and fabric manager are available before starting `SharedRegion` work.
+
+## 1. Phase 1 — Discovery shim
+
+### 1a. HMAT parser
+
+- [ ] 1.1 Add `kernel/src/acpi/hmat.rs` parsing Memory Proximity Domain Attributes (type 0), System Locality Latency and Bandwidth (type 1), and Memory Side Cache Information (type 2).
+- [ ] 1.2 Classify each proximity domain as `MemTier::Hot` or `MemTier::Warm` based on the >2x access-latency heuristic (consistent with Linux `mm/memory-tiers.c` ordering).
+- [ ] 1.3 Unit-test the parser against captured HMAT blobs from Sapphire Rapids + Astera Leo and EPYC Genoa + Samsung CMM-D fixtures (committed under `kernel/src/acpi/test-data/`).
+
+### 1b. CDAT walker
+
+- [ ] 1.4 Add `kernel/src/cxl/cdat.rs` walking CXL devices on the PCI bus, querying CDAT via DOE mailbox.
+- [ ] 1.5 Parse Device Scoped Memory Affinity (DSMAS) and Device Scoped Latency/Bandwidth (DSLBIS) structures.
+- [ ] 1.6 Merge CDAT data with HMAT (x86-64) or use standalone (ARM64).
+- [ ] 1.7 Unit-test the walker against captured DOE / CDAT byte streams (committed under `kernel/src/cxl/test-data/`).
+
+### 1c. Single-tier fallback
+
+- [ ] 1.8 Implement `MemTopology::single_tier()` synthesizer for hosts without HMAT or CDAT. Verify against Jetson Orin DTB — all nodes report `MemTier::Hot`.
+- [ ] 1.9 Boot sequence: try HMAT → CDAT → single-tier fallback. Log the chosen path at info level.
+
+## 2. Phase 2 — TensorPool tier-aware API
+
+- [ ] 2.1 Add `MemTier` enum and `MemTierPolicy` types to `kernel/src/mem/tier.rs`.
+- [ ] 2.2 Add `TensorPool::alloc_with_tier(size, dtype, tier_policy)` to `kernel/src/mem/tensor.rs`. Keep `alloc()` as a thin wrapper passing `MemTierPolicy::Any`.
+- [ ] 2.3 Compose with NUMA hint from `numa-aware-tensor-alloc-v1` via `alloc_full(size, dtype, numa_hint, tier_policy)`.
+- [ ] 2.4 Implement allocation flow:
+  - `Required(tier)`: scan only nodes of that tier; fail if none have capacity.
+  - `Preferred(tier)`: scan that tier first; fall back to any tier.
+  - `Any`: existing v0 behavior.
+- [ ] 2.5 Add per-tier and per-(node,tier) counters: `alloc_required`, `alloc_preferred`, `alloc_fallback`, `alloc_any`.
+
+## 3. Phase 3 — Scheduler integration
+
+- [ ] 3.1 Define default tier policies for the inference scheduler:
+  - Model weights → `Preferred(Warm)`.
+  - KV cache → `Required(Hot)`.
+  - Activations / intermediates → `Required(Hot)`.
+  - Diagnostics / logs → `Preferred(Warm)`.
+- [ ] 3.2 Allow override via `SMALLAIOS_TIER_POLICY` env var (container path) and kernel boot argument (unikernel path).
+- [ ] 3.3 Document the failure mode: if `Required(Hot)` allocation fails because hot tier is exhausted, the op fails (we do not silently promote KV cache to warm tier).
+
+## 4. Phase 4 — Single-host CXL.mem benchmark + docs
+
+- [ ] 4.1 Write a benchmark in `bench/` that loads a 100-GB-class weight tensor with `Preferred(Warm)` and measures effective end-to-end inference latency vs an all-DRAM baseline.
+- [ ] 4.2 Run the benchmark on a CXL.mem-equipped reference host (Sapphire Rapids + Astera Leo or equivalent). Capture: (a) `alloc_preferred` hits on warm tier, (b) inference p50 / p99 vs DRAM baseline, (c) cost-per-token estimate using nominal $/GB DRAM vs $/GB CXL.mem.
+- [ ] 4.3 Run the existing Jetson Orin benchmark on this branch vs develop. Confirm ≤2% regression on the single-tier fallback path.
+- [ ] 4.4 Create `docs/persistent-memory.md` covering: when tiering matters, hardware prerequisites, how to provision CXL.mem on a host, the default tier policies, the telemetry endpoint, troubleshooting.
+- [ ] 4.5 Add a row to the README hardware matrix for "CXL.mem-equipped server".
+
+## 5. Phase 5 — CXL 3.0 SharedRegion API
+
+> **Phase 5 gate:** CXL 3.0 production silicon, fabric manager software, and at least two SmallAIOS instances on the same fabric are prerequisites. If unavailable, defer Phase 5 indefinitely; Phase 1-4 are independently valuable on single-host CXL.mem.
+
+- [ ] 5.1 Add `SharedRegion` and `SharedRegionSpec` types to `kernel/src/cxl/shared.rs`.
+- [ ] 5.2 Implement `map_read_only(spec)` — verify region exists on fabric, verify size and permissions match spec, map into tensor-pool address space tagged `MemTier::Warm` + `shared = true`.
+- [ ] 5.3 Document the coherence model: writable shared regions are out of scope for v1; v1 supports read-only weight sharing only.
+- [ ] 5.4 Add a multi-instance test scenario: two SmallAIOS unikernels on the same CXL 3.0 fabric, both map the same weight region read-only, run inference, confirm matching outputs.
+- [ ] 5.5 Update `docs/persistent-memory.md` with a CXL 3.0 shared-region section + provisioning workflow.
+
+## 6. Phase 6 — CI integration
+
+- [ ] 6.1 Add a scheduled job `cxl-mem-smoke` running the Phase 4 benchmark on a self-hosted CXL.mem runner. Advisory initially.
+- [ ] 6.2 Confirm the existing single-tier gate jobs continue to pass on the Jetson Orin path.
+- [ ] 6.3 Promote `cxl-mem-smoke` to `change-gates` when self-hosted runner availability is reliable (separate change).
+
+## 7. Close-out
+
+- [ ] 7.1 PR title: `feat(kernel): persistent-memory-v1 — CXL.mem tiered tensor allocation + CXL 3.0 shared regions`.
+- [ ] 7.2 Reviewer sign-off + green CI + CXL.mem benchmark evidence pasted in the PR description.
+- [ ] 7.3 Update CLAUDE.md "Current state" to mention tiered memory allocation for CXL-equipped hosts.

--- a/openspec/changes/tsn-integration-v1/design.md
+++ b/openspec/changes/tsn-integration-v1/design.md
@@ -1,0 +1,145 @@
+# Design — tsn-integration-v1
+
+## Goal
+
+Make SmallAIOS a viable Time-Sensitive Networking (TSN) endpoint for industrial automation, in-vehicle networks, and similar deterministic control-loop deployments. Concretely: gPTP-synchronized to sub-microsecond accuracy with the TSN domain grandmaster; able to advertise its supported scheduled-traffic windows to upstream configurators; cooperative scheduler hooks that consume the schedule and meet deadlines at op-boundary granularity; explicit out-of-scope-on-Jetson positioning.
+
+Success: (a) on an Intel i210-equipped industrial PC paired with a Hirschmann or Cisco TSN-capable switch, the unikernel synchronizes its clock to the grandmaster with mean offset <500 ns over a 10-minute window; (b) a configured 1 ms scheduled-traffic window opens predictably with NIC-enforced gate semantics; (c) an inference op tagged with that window's deadline either completes before the gate closes or the scheduler emits a structured warning + configured-action; (d) on the Jetson Orin production target without `--features tsn`, behavior is identical to develop.
+
+## Alternatives considered
+
+### A1. Treat TSN as a userspace concern (run `linuxptp` next to SmallAIOS)
+
+**Not applicable.** SmallAIOS is a unikernel; there is no userspace partition where `linuxptp` could run, no shared `ethtool -T` plumbing. The gPTP daemon must live inside the kernel (or in the same address space — same thing in a unikernel). Furthermore, the scheduler integration requires kernel-side awareness of the TSN clock; deferring it to a userspace daemon would lose the deadline-propagation benefit.
+
+### A2. Use 802.1Qav (credit-based shaping) instead of 802.1Qbv
+
+**Considered, partially overlapping.** Qav is per-class credit-based shaping; Qbv is time-aware gate-based scheduling. Qav guarantees bounded latency per class but not a specific time window; Qbv guarantees specific time windows. For the **AI inference deadline** use case, Qbv is the better fit — we have a deadline aligned to a network schedule, not a bandwidth allocation. We may add Qav support in a follow-up if a use case (e.g., audio-style traffic class) demands it; v1 focuses on Qbv.
+
+### A3. Implement TSN as a generic `bus` crate extension (alongside AFDX/ARINC664)
+
+**Rejected.** TSN is fundamentally an Ethernet (802.1) standard suite, not a bus protocol. Its natural home is the `net` crate (where Ethernet, IPv4, IPv6, TCP, UDP live). The `bus` crate's AFDX support is also Ethernet-based, but it implements ARINC664 Part 7 virtual links — a specific avionics profile that, while conceptually similar, has its own conformance test suite and protocol semantics. Mixing them confuses the conformance story for both standards. They share the underlying Ethernet packet path but diverge at the upper layers.
+
+### A4. Use a vendor-specific TSN library (e.g., Intel TSN Linux SDK port)
+
+**Rejected.** The Intel TSN Linux SDK is GPL-licensed and Linux-kernel-specific (relies on `taprio` qdisc, `cbs` qdisc, ethtool TSN extensions). Porting it to a `#![no_std]` Rust unikernel is not feasible. We re-implement the standards-conformant pieces from the IEEE specs.
+
+### A5. Implement gPTP without hardware timestamping (software-only)
+
+**Considered as fallback.** Software-only PTP achieves ~100 µs accuracy at best on a busy system — well above the 1 µs target for TSN. We support software-only as a fallback for testing / development on NICs without PHC support, with a loud warning that sub-microsecond accuracy is unattainable. Production deployments must use a NIC with hardware timestamping (every NIC in the supported set has it; the issue arises only on QEMU virtio-net or on Jetson where Qbv enforcement is missing anyway).
+
+## gPTP (802.1AS)
+
+The 802.1AS profile of PTPv2 differs from base PTP in several ways important for the implementation:
+
+- **Layer 2 multicast only** (destination MAC `01:80:C2:00:00:0E`) — no UDP. Simpler datapath than general PTP.
+- **No best-master-clock-algorithm (BMCA) negotiation** by default — the grandmaster is configured / pinned, not elected.
+- **Path delay measured via peer-delay mechanism** (PDelay_Req / PDelay_Resp / PDelay_Resp_Follow_Up between adjacent peers, not end-to-end Delay_Req as in base PTP).
+- **Domain number** = 0 for the default 802.1AS profile; other domains are non-standard.
+
+The daemon's state machine:
+
+1. Send periodic `PDelay_Req` to the upstream peer. Capture TX timestamp.
+2. Receive `PDelay_Resp` with peer's RX timestamp. Receive `PDelay_Resp_Follow_Up` with peer's TX timestamp. Compute mean propagation delay.
+3. Receive `Sync` + `Follow_Up` from the grandmaster (forwarded by the upstream peer with residence-time correction). Compute clock offset.
+4. Apply offset to local PHC (Precision Hardware Clock) via a NIC-driver-specific call.
+
+Implementation: ~600 LOC in `net/src/tsn/gptp.rs`. Hardware-timestamp hooks abstracted via a `PhcDriver` trait that each supported NIC implements.
+
+## 802.1Qbv Gate Control List
+
+A Gate Control List is a cyclic schedule of `(gate_states, duration_ns)` tuples. `gate_states` is a bitmask of which traffic-class queues are open during that interval. The NIC enforces the schedule at the precise gPTP-synchronized boundary.
+
+SmallAIOS-side responsibilities:
+
+1. Read the schedule from `SMALLAIOS_TSN_SCHEDULE` (TOML).
+2. Translate to the NIC's GCL register format.
+3. Program the GCL via the `TsnNicDriver::set_gcl` trait method.
+4. Acknowledge schedule activation (next-cycle vs immediate; vendor-specific).
+
+The Gate Control List is **static** in v1 — we set it once at boot, and changes require a reboot or an explicit reconfiguration call. Dynamic schedules (e.g., schedule changes orchestrated by an upstream YANG-based configurator) are a follow-up.
+
+NIC-specific notes:
+
+- **Intel i210**: GCL programmed via `IGC_BASE_TIME` and `IGC_LAUNCHTIME` registers; up to 16 GCL entries; 1 µs gate-granularity. Documented in Intel's i210 datasheet section 7.4.
+- **Intel i225/i226**: GCL up to 256 entries; ns-precision via Time Aware Scheduler hardware. Section 7.5 of the i225 datasheet.
+- **Intel E810**: Datacenter-grade TSN; GCL up to 1024 entries.
+
+Initial NIC support is i210 only; i225/i226/E810 are added in follow-up changes (each ~0.5-1 week).
+
+## Scheduler deadline propagation
+
+The cooperative scheduler today yields at op boundaries. We extend the op-boundary check with a deadline check:
+
+```rust
+pub struct OpDeadline {
+    tsn_window_id: TsnWindowId,
+    close_at_gptp_ns: u64,
+    on_miss: DeadlineMissAction,  // Warn, Abort, or Continue
+}
+
+// Existing op boundary becomes:
+fn yield_or_continue(&mut self) -> SchedulerAction {
+    if let Some(deadline) = self.current_op_deadline() {
+        let now_gptp = self.gptp_clock().now_ns();
+        if now_gptp + self.estimated_next_op_cost_ns() > deadline.close_at_gptp_ns {
+            return SchedulerAction::DeadlineMiss(deadline.on_miss);
+        }
+    }
+    // ... existing logic
+}
+```
+
+`estimated_next_op_cost_ns` is a heuristic based on op type + tensor sizes. We do not need it to be exact — we need it to be a useful warning signal so the operator can tune their schedule.
+
+`DeadlineMissAction` is configurable per-window:
+
+- `Warn`: log + emit a metric; continue executing. Suitable for soft-real-time use cases.
+- `Abort`: abandon the op chain, emit a metric, await the next window. Suitable for hard-real-time where stale output is worse than no output.
+- `Continue`: do nothing (most permissive — for early development).
+
+## Schedule TOML format
+
+```toml
+[gptp]
+domain = 0
+grandmaster_priority1 = 128  # we are not the grandmaster
+
+[qbv]
+cycle_time_ns = 5_000_000  # 5 ms total cycle
+nic = "i210"
+interface = "eth0"
+
+[[qbv.gate_control_list]]
+duration_ns = 1_000_000  # 1 ms scheduled-traffic window
+gates = ["TC7", "TC6"]
+window_id = "inference-result"
+
+[[qbv.gate_control_list]]
+duration_ns = 4_000_000  # 4 ms best-effort window
+gates = ["TC0", "TC1", "TC2", "TC3"]
+window_id = "best-effort"
+
+[[ops.deadline]]
+op_pattern = "model:vision-inspect.onnx"
+window_id = "inference-result"
+on_miss = "warn"
+```
+
+## Observability
+
+Extends the existing telemetry path with:
+
+- `tsn.gptp.offset_ns_p50`, `tsn.gptp.offset_ns_p99`, `tsn.gptp.path_delay_ns`
+- `tsn.qbv.cycles_completed`, `tsn.qbv.gate_open_late_count`
+- `tsn.deadline.met_count{window_id=...}`, `tsn.deadline.miss_count{window_id=...}`
+
+## What this change explicitly does NOT do
+
+- Does not modify the Jetson Orin Ethernet code path (Tegra234 EQOS does not enforce Qbv anyway).
+- Does not become a gPTP grandmaster.
+- Does not implement 802.1Qci, 802.1CB, or 802.1Qbu in v1.
+- Does not implement YANG-based dynamic configuration in v1 (TOML only).
+- Does not modify the existing AFDX / ARINC664 path in the `bus` crate.
+- Does not target TSN-over-wireless (802.11be, 5G URLLC).
+- Does not change the existing `net` crate behavior when `--features tsn` is off.

--- a/openspec/changes/tsn-integration-v1/proposal.md
+++ b/openspec/changes/tsn-integration-v1/proposal.md
@@ -1,0 +1,92 @@
+# tsn-integration-v1
+
+## Summary
+
+Integrate **Time-Sensitive Networking (TSN)** support into the SmallAIOS networking stack and cooperative scheduler so that the unikernel can participate as a deadline-driven node in industrial-automation control loops where the network schedule and the inference schedule must align. TSN is a set of IEEE 802.1 standards that turn ordinary Ethernet into a deterministic-latency fabric — the canonical scale-out shape for factory floors, robotic cells, automotive in-vehicle networks, and time-sensitive measurement systems. This change adds:
+
+- **IEEE 802.1AS (generalized Precision Time Protocol / gPTP)** clock synchronization to sub-microsecond accuracy across TSN domain peers. The existing `bus` crate already touches similar concepts via ARINC664 / AFDX, but the 802.1AS profile is the standard industrial / automotive shape.
+- **IEEE 802.1Qbv (time-aware scheduled traffic gates)** so that scheduled traffic on a TSN-enabled NIC is gated open / closed at the gPTP-synchronized clock boundaries. SmallAIOS-side bookkeeping for the schedule; the NIC enforces the gate.
+- **Cooperative scheduler hooks** that consume the TSN schedule and emit inference deadlines aligned with the scheduled-traffic windows. Inference op N must complete before window K closes; the scheduler honors the deadline as a soft preemption point at op boundaries.
+
+This is a Tier 3 industrial-automation feature. The Jetson Orin AI-inference sweet spot (a Jetson NX running an ONNX model behind an HTTP endpoint over best-effort Ethernet) does not need TSN. The proposal documents the integration shape for when SmallAIOS is deployed as a factory-floor controller or in-vehicle inference node.
+
+## Why
+
+- **Industrial AI inference is increasingly TSN-orchestrated.** The 2024-2026 industrial-automation shift is from PROFINET / EtherCAT (deterministic but proprietary or limited-interop fieldbuses) to TSN over standard Ethernet (deterministic *and* interoperable). Major industrial-controls vendors (Siemens, Beckhoff, Rockwell, B&R) are converging on TSN. AI vision inspection, predictive-maintenance inference, robotic-control regression — all of these are increasingly TSN endpoints. SmallAIOS as an inference engine on a factory floor needs to speak the same time-aware protocol as the PLCs around it.
+- **The unikernel is the right shape for TSN.** A cooperative scheduler with deterministic op boundaries is closer to a TSN endpoint's natural shape than a Linux real-time-patched kernel. SmallAIOS doesn't need to fight scheduler jitter, page-fault latency, or interrupt threads competing for CPU — the boundaries are explicit. This is the same reason RTOSes (FreeRTOS, Zephyr, VxWorks) have TSN integrations: deterministic schedulers compose cleanly with deterministic networks.
+- **Bus crate is partway there.** The existing `bus` crate's AFDX / ARINC664 path implements bounded-latency virtual link concepts that share DNA with TSN's time-aware shaping. The cooperative scheduler already has the notion of an op boundary as a yield point. The new code is **(a)** gPTP daemon (clock sync over the network), **(b)** NIC-driver hooks for 802.1Qbv schedule programming, **(c)** scheduler-side deadline propagation. Each piece is bounded.
+- **Jetson does not need this for typical AI use cases.** Jetson Orin running a customer-facing inference endpoint over best-effort TCP/IP has zero TSN requirements; the latency budget is dominated by GPU compute time, not network jitter. The TSN path adds value only when SmallAIOS is the slow link in a 1 ms control loop — that's a factory-floor or automotive workload, not the Jetson sweet spot.
+
+## Hardware prerequisites
+
+### TSN-capable NICs
+
+| NIC family | TSN features supported | Notes |
+|------------|------------------------|-------|
+| **Intel i210** | 802.1AS, 802.1Qbv, 802.1Qav | Common entry-level TSN NIC. Single-port 1 GbE; well-documented. |
+| **Intel i225 / i226 (Foxville)** | 802.1AS, 802.1Qbv, 802.1Qav, 802.1Qbu (Frame Preemption) | 2.5 GbE; common on industrial PCs (e.g., Siemens IPC227G) |
+| **Intel I350** | 802.1AS, 802.1Qbv (limited) | Older but widely deployed |
+| **Intel E810** | Full TSN: 802.1AS / Qbv / Qav / Qbu / Qci | Datacenter / industrial; 10-100 GbE |
+| **Marvell Prestera DX / Falcon** | 802.1AS / Qbv / Qav | Industrial / automotive switch SoCs |
+| **NXP S32G with built-in TSN switch** | 802.1AS / Qbv / Qav | Automotive central compute |
+| **Microchip LAN9662 / LAN9668** | 802.1AS / Qbv / Qav | Industrial Ethernet switches |
+
+### TSN-incapable NICs (out of scope)
+
+| NIC | Reason |
+|-----|--------|
+| **Tegra234 EQOS Ethernet (Jetson Orin)** | No 802.1Qbv gate enforcement in hardware; only 802.1AS PHC support |
+| **Realtek RTL8111 / RTL8125** | Consumer; no TSN features |
+| **Most cloud-VM virtio-net adapters** | Paravirtualized; no TSN guarantees |
+| **Apple silicon Ethernet** | No public TSN feature support |
+
+Note: the Jetson Orin's NIC supports gPTP hardware timestamping (so 802.1AS can run), but it does not enforce 802.1Qbv gates. A Jetson can be a gPTP **time slave** in a TSN domain but cannot be a scheduled-traffic endpoint with strong guarantees. This is one of the reasons TSN is out of scope for the typical Jetson workload.
+
+### Domain partners
+
+A TSN deployment requires at minimum:
+
+- One gPTP grandmaster (often a TSN switch like Cisco IE-3400, Hirschmann RSPE, or Beckhoff CU2208).
+- TSN-aware Ethernet switches between endpoints (or a single switch).
+- Network configuration via the IEEE 802.1Qcc Network Configuration model (typically a YANG-based netconf flow or a vendor-specific tool like TTTech's Slate XNS).
+
+SmallAIOS interoperates with this topology as an **endpoint**, not as a switch or grandmaster.
+
+## What changes
+
+- **Capability `net-tsn` (new):** owned by the `net` crate, gated behind a new `tsn` Cargo feature.
+- **gPTP daemon** (`net/src/tsn/gptp.rs`): IEEE 802.1AS profile of PTPv2. Hardware-timestamping aware (uses NIC PHC where available, falls back to software timestamping otherwise — with a loud warning that sub-microsecond accuracy is unattainable in software-only mode).
+- **802.1Qbv schedule programming** (`net/src/tsn/qbv.rs`): Gate Control List (GCL) construction; NIC-driver shim that writes the GCL to the hardware (vendor-specific, abstracted behind a trait). Initial NIC support: Intel i210 (canonical reference for "minimum viable TSN NIC"). Subsequent NICs added in follow-up changes.
+- **Scheduler hooks** (`kernel/src/sched/tsn.rs`): the cooperative scheduler exposes a `Deadline { tsn_window_id, close_at_gptp_time }` type. Inference ops associated with a TSN window are dispatched with the deadline; the scheduler tracks remaining time at each op-boundary yield and emits a warning (or aborts the chain, configurable) if a deadline is at risk of being missed.
+- **Configuration**: a TOML schedule file (`SMALLAIOS_TSN_SCHEDULE`) describes the Gate Control List, the gPTP domain, and the mapping from inference ops to windows.
+- **Documentation**: `docs/tsn-integration.md` covering the standards landscape, the SmallAIOS configuration model, hardware compatibility, and an end-to-end example (industrial vision inspection with a 1 ms inference budget aligned to a 5 ms TSN cycle).
+
+## Out of scope
+
+- **Becoming a gPTP grandmaster.** SmallAIOS is a TSN endpoint, not a clock source. Grandmaster duties belong on a dedicated TSN switch or appliance.
+- **802.1Qci (Per-Stream Filtering and Policing).** Adds ingress traffic-policing per-stream; useful for switch nodes but less so for endpoints. Defer.
+- **802.1CB (Frame Replication and Elimination for Reliability).** Frame replication / duplicate elimination across redundant paths; targeted at high-reliability industrial / automotive deployments. Defer to a follow-up change once basic TSN endpoint capability is in.
+- **802.1Qbu (Frame Preemption).** Allows large best-effort frames to be preempted by an urgent express frame mid-transmission. Hardware-dependent; defer until at least one NIC with Qbu enforcement is in the supported set and a use case demands it.
+- **TSN over wireless (802.11be Wi-Fi 7 with TSN, 5G URLLC).** Wired-Ethernet TSN only for v1.
+- **Building a TSN configuration GUI / YANG client.** Configuration is via static TOML in v1; YANG-based dynamic configuration is a follow-up.
+- **Modifying the Jetson Orin Ethernet path.** Tegra234 EQOS does not enforce 802.1Qbv. The unikernel will run gPTP-only mode on Jetson (clock sync, no scheduled traffic) — useful in some research scenarios but not the production target for this change.
+- **AFDX / ARINC664 changes.** The bus crate's existing avionics-bus paths are not modified by this change. TSN and AFDX share concepts but are distinct standards stacks. TSN-ization of the bus crate is a future concern.
+
+## When this becomes important
+
+- **Now (deferred):** Jetson Orin AI inference behind an HTTP endpoint — zero TSN requirement. Treat as roadmap documentation.
+- **Trigger event 1:** SmallAIOS deployment as an industrial vision-inspection node, predictive-maintenance inference engine, or robotic-control coprocessor where the upstream PLC enforces a TSN cycle.
+- **Trigger event 2:** SmallAIOS deployment in an automotive central-compute platform (e.g., NXP S32G-based zonal controller) where TSN is the in-vehicle backbone.
+- **Likely horizon:** 12-24 months out, contingent on industrial-automation or automotive design wins. If those segments don't materialize, this change can be archived.
+
+## Effort estimate
+
+| Sub-phase | Scope | Estimate |
+|-----------|-------|----------|
+| 1 | gPTP daemon (802.1AS profile, hardware-timestamping shim) | ~1.5 weeks |
+| 2 | 802.1Qbv GCL construction + Intel i210 driver shim | ~1 week |
+| 3 | Scheduler deadline hooks + op-boundary deadline tracking | ~0.5 week |
+| 4 | TOML schedule format + bench harness + docs | ~0.5-1 week |
+| **Total** | | **~3-4 weeks** |
+
+Each additional supported NIC adds ~0.5-1 week (mostly vendor-specific register programming for the gate control list).

--- a/openspec/changes/tsn-integration-v1/specs/net-tsn/spec.md
+++ b/openspec/changes/tsn-integration-v1/specs/net-tsn/spec.md
@@ -1,0 +1,128 @@
+## ADDED Requirements
+
+### Requirement: IEEE 802.1AS gPTP clock synchronization
+
+When the `net` crate is built with the `tsn` Cargo feature and the host has a TSN-capable NIC with hardware timestamping, the kernel SHALL implement an IEEE 802.1AS (gPTP) profile of PTPv2 and SHALL synchronize the local hardware clock to a TSN-domain grandmaster with sub-microsecond mean offset.
+
+#### Scenario: Hardware-timestamped gPTP slave to an upstream grandmaster
+
+- **GIVEN** the unikernel is built with `--features tsn`
+- **GIVEN** the host has an Intel i210 (or equivalent supported NIC) with hardware timestamping enabled
+- **GIVEN** the host is connected to a TSN-capable switch acting as a gPTP grandmaster (or forwarding from one)
+- **WHEN** the unikernel boots and the gPTP daemon initializes
+- **THEN** the daemon SHALL exchange `PDelay_Req` / `PDelay_Resp` / `PDelay_Resp_Follow_Up` messages with the upstream peer to measure mean path delay
+- **AND** the daemon SHALL consume `Sync` + `Follow_Up` from the grandmaster and adjust the local Precision Hardware Clock (PHC) accordingly
+- **AND** within 60 seconds of boot, the running mean of `tsn.gptp.offset_ns` over a 10-minute window SHALL be < 500 ns
+- **AND** `tsn.gptp.path_delay_ns` SHALL be reported and SHALL be stable to within ±100 ns on a quiet network
+
+#### Scenario: Software-timestamp fallback warns loudly
+
+- **GIVEN** the unikernel is built with `--features tsn`
+- **GIVEN** the host's NIC does not support hardware timestamping (e.g., a development virtio-net adapter)
+- **WHEN** the gPTP daemon initializes
+- **THEN** the daemon SHALL fall back to software timestamping
+- **AND** the daemon SHALL emit a `warn!` log at boot stating that software-only mode cannot achieve sub-microsecond accuracy and is suitable for development / testing only
+- **AND** production deployments SHALL be expected to use a NIC from the supported set (Intel i210 / i225 / i226 / E810, or equivalents documented in `docs/tsn-integration.md`)
+
+### Requirement: IEEE 802.1Qbv scheduled-traffic gate enforcement
+
+When the `tsn` feature is enabled and the host's NIC supports 802.1Qbv hardware gates, the kernel SHALL program a Gate Control List on the NIC from the configured schedule and SHALL rely on the NIC to enforce gate-open / gate-close boundaries at gPTP-synchronized times.
+
+#### Scenario: GCL programmed at boot from TOML configuration
+
+- **GIVEN** the operator provides a TOML schedule via `SMALLAIOS_TSN_SCHEDULE` (container path) or boot argument (unikernel path) describing a `cycle_time_ns`, a sequence of `gate_control_list` entries, and an interface binding
+- **GIVEN** the bound NIC supports 802.1Qbv (e.g., Intel i210)
+- **WHEN** the unikernel boots and the TSN subsystem initializes
+- **THEN** the kernel SHALL parse and validate the TOML schedule (total entry duration matches `cycle_time_ns`; all gate-state bitmasks well-formed)
+- **AND** the kernel SHALL translate the GCL into the NIC's vendor-specific register format
+- **AND** the kernel SHALL program the NIC via the `TsnNicDriver::set_gcl` trait method
+- **AND** the first cycle SHALL start at a gPTP-aligned base time after the gPTP daemon has reached steady-state synchronization
+
+#### Scenario: Wire-line enforcement of gate windows
+
+- **GIVEN** a configured 5 ms cycle with a 1 ms `inference-result` window (gates TC7 / TC6 open) followed by a 4 ms `best-effort` window (gates TC0-TC3 open)
+- **GIVEN** the unikernel is generating traffic on both TC7 and TC0 traffic classes
+- **WHEN** an external TAP captures wire-line traffic
+- **THEN** TC7 frames SHALL appear on the wire exclusively within the 1 ms scheduled window of each cycle
+- **AND** TC0 frames SHALL appear exclusively within the 4 ms best-effort window
+- **AND** the `tsn.qbv.gate_open_late_count` counter SHALL be 0 under nominal operation; non-zero indicates a clock-sync issue or schedule misconfiguration
+
+### Requirement: Cooperative scheduler honors TSN-derived deadlines
+
+The cooperative inference scheduler SHALL accept per-op deadlines tied to TSN scheduled-traffic windows and SHALL evaluate the deadline at each op-boundary yield point.
+
+#### Scenario: Op completes before deadline
+
+- **GIVEN** an inference op chain associated with the `inference-result` TSN window (deadline = end of the 1 ms window)
+- **GIVEN** the chain's actual execution cost is well within 1 ms
+- **WHEN** the scheduler dispatches the chain
+- **THEN** each op-boundary yield SHALL re-evaluate `remaining_time = deadline - gptp_now`
+- **AND** the chain SHALL complete before the deadline
+- **AND** the `tsn.deadline.met_count{window_id="inference-result"}` counter SHALL increment by one
+
+#### Scenario: Deadline miss with Warn action
+
+- **GIVEN** an op chain with `on_miss = "warn"` configured for its window
+- **GIVEN** the chain's actual execution exceeds the deadline
+- **WHEN** the scheduler detects, at an op-boundary yield, that `gptp_now + estimated_next_op_cost > deadline`
+- **THEN** the scheduler SHALL log a structured warning naming the window, the deadline, and the projected overshoot
+- **AND** the scheduler SHALL continue executing the chain (Warn = best effort)
+- **AND** the `tsn.deadline.miss_count{window_id=...}` counter SHALL increment by one
+
+#### Scenario: Deadline miss with Abort action
+
+- **GIVEN** an op chain with `on_miss = "abort"` configured for its window (hard-real-time profile)
+- **GIVEN** the chain's actual execution would exceed the deadline
+- **WHEN** the scheduler detects the projected overshoot
+- **THEN** the scheduler SHALL abandon the remaining ops in the chain
+- **AND** the scheduler SHALL emit a structured warning naming the window and the abandoned op
+- **AND** the scheduler SHALL await the next cycle's window for the next chain
+- **AND** the `tsn.deadline.miss_count{window_id=...}` counter SHALL increment by one
+
+### Requirement: NIC driver shim is abstracted for future NIC support
+
+The `TsnNicDriver` trait SHALL abstract NIC-specific TSN feature programming so that new NICs (Intel i225/i226, Intel E810, Marvell Prestera, NXP S32G built-in switch) can be added without changes to the gPTP daemon, scheduler, or configuration parser.
+
+#### Scenario: Adding a new NIC requires only implementing the trait
+
+- **GIVEN** a future change adding Intel i225 support
+- **WHEN** the change implements the `TsnNicDriver` trait for the i225 register layout
+- **THEN** no changes SHALL be required to `net/src/tsn/gptp.rs`, `net/src/tsn/qbv.rs`, `kernel/src/sched/tsn.rs`, or the TOML parser
+- **AND** the existing TOML schedule format SHALL transparently support the new NIC by setting `nic = "i225"` in the configuration
+
+### Requirement: Jetson Orin is explicitly out of scope for Qbv enforcement
+
+The kernel SHALL NOT advertise full TSN endpoint capability on Jetson Orin and SHALL document the limitation prominently.
+
+#### Scenario: Jetson Orin can run gPTP-slave only
+
+- **GIVEN** a Jetson Orin NX or AGX host with the Tegra234 EQOS Ethernet controller
+- **WHEN** the unikernel is built with `--features tsn` (research / experimental case)
+- **THEN** the gPTP daemon SHALL function (Tegra234 EQOS supports gPTP hardware timestamping)
+- **AND** the Qbv subsystem SHALL detect at boot that the EQOS controller does NOT support 802.1Qbv gate enforcement and SHALL emit a clear error
+- **AND** the error message SHALL state that Jetson can be a gPTP slave but cannot be a scheduled-traffic endpoint, and point at `docs/tsn-integration.md` for the supported NIC matrix
+
+#### Scenario: Production Jetson AI workflows are unaffected
+
+- **GIVEN** the existing `just build-container-arm` / `just docker-build-jetson` workflows without `--features tsn`
+- **WHEN** those workflows are run
+- **THEN** the produced artifacts SHALL be identical to develop (no TSN code paths compiled in, no behavior change)
+
+### Requirement: Single-NIC initial support, extensible
+
+The v1 implementation SHALL ship with Intel i210 support as the canonical reference NIC; additional NICs SHALL be added in follow-up changes.
+
+#### Scenario: Intel i210 is the v1 reference
+
+- **GIVEN** the v1 implementation
+- **WHEN** a deployment uses an Intel i210
+- **THEN** gPTP synchronization SHALL meet the < 500 ns mean offset target
+- **AND** Qbv GCL programming SHALL succeed with up to 16 GCL entries
+- **AND** the i210-specific gate-granularity (1 µs rounding) SHALL be documented in `docs/tsn-integration.md`
+
+#### Scenario: Other NICs report unsupported in v1
+
+- **GIVEN** a host with a non-i210 TSN-capable NIC (e.g., i225, E810) in v1
+- **WHEN** the unikernel boots with `--features tsn` and the TOML schedule references that NIC
+- **THEN** the kernel SHALL emit a clear error stating the NIC is not supported in v1 and pointing at the supported-NIC matrix
+- **AND** the error SHALL include a link to the GitHub issue tracker for requesting / contributing additional NIC support

--- a/openspec/changes/tsn-integration-v1/tasks.md
+++ b/openspec/changes/tsn-integration-v1/tasks.md
@@ -1,0 +1,85 @@
+# Tasks — tsn-integration-v1
+
+> **Status: Future-facing.** No work has started. This change is a roadmap document for industrial-automation / in-vehicle TSN deployments. The Jetson Orin AI-inference sweet spot does not need TSN.
+
+## 0. Trigger conditions (review before starting)
+
+- [ ] 0.1 Confirm at least one production / customer target uses a TSN-orchestrated network (industrial PLC + TSN switch + SmallAIOS inference node, or in-vehicle central-compute + TSN switch).
+- [ ] 0.2 Procure / borrow at least one TSN-capable NIC (Intel i210 minimum) and one TSN-capable Ethernet switch (Hirschmann, Cisco IE-3400, Beckhoff, or equivalent) for integration testing.
+- [ ] 0.3 Identify a reference industrial workload to anchor the implementation (e.g., vision-inspection inference aligned to a 5 ms TSN cycle, 1 ms scheduled-traffic window).
+
+## 1. Phase 1 — gPTP daemon (802.1AS)
+
+### 1a. Cargo feature + module scaffolding
+
+- [ ] 1.1 Add `tsn` Cargo feature to `net/Cargo.toml` with doc-comment describing the scope (industrial / in-vehicle TSN endpoints; Jetson out-of-scope for Qbv enforcement).
+- [ ] 1.2 Create `net/src/tsn/mod.rs` exposing the public API (`Gptp`, `Qbv`, `TsnNicDriver` trait).
+- [ ] 1.3 Add `PhcDriver` trait abstracting NIC hardware timestamping.
+
+### 1b. PTPv2 packet handling
+
+- [ ] 1.4 Implement PTPv2 message types: `Sync`, `Follow_Up`, `PDelay_Req`, `PDelay_Resp`, `PDelay_Resp_Follow_Up`. Layer 2 framing with destination MAC `01:80:C2:00:00:0E` and ethertype `0x88F7`.
+- [ ] 1.5 Implement the 802.1AS state machine in `net/src/tsn/gptp.rs` — peer-delay measurement, offset computation, clock adjustment.
+- [ ] 1.6 Hook the daemon into the existing `net` packet path with priority over best-effort traffic (gPTP is the foundation everything else depends on).
+
+### 1c. Hardware-timestamp shim
+
+- [ ] 1.7 Define `PhcDriver` methods: `get_phc_time()`, `adjust_phc_freq(ppb)`, `step_phc(offset_ns)`, `rx_timestamp(packet)`, `tx_timestamp(packet)`.
+- [ ] 1.8 Implement `PhcDriver` for Intel i210 (canonical reference NIC). Reads / writes `IGC_SYSTIM`, `IGC_RXSTMPL`, `IGC_TXSTMPL` registers per datasheet section 7.4.
+- [ ] 1.9 Implement software-timestamp fallback with a loud `warn!` at boot indicating sub-microsecond accuracy is unattainable in this mode.
+
+### 1d. gPTP unit + integration tests
+
+- [ ] 1.10 Unit tests for PTPv2 packet parsing / serialization (captured wire-format fixtures committed under `net/src/tsn/test-data/`).
+- [ ] 1.11 Integration test against a real i210 + TSN switch: mean offset over 10 minutes SHALL be <500 ns.
+
+## 2. Phase 2 — 802.1Qbv scheduled traffic
+
+### 2a. Gate Control List
+
+- [ ] 2.1 Define `GateControlList` and `GateInterval` types in `net/src/tsn/qbv.rs`.
+- [ ] 2.2 Parse the GCL from TOML configuration (`SMALLAIOS_TSN_SCHEDULE`).
+- [ ] 2.3 Validate the GCL: total cycle time matches `cycle_time_ns`, all gate-state bitmasks are well-formed.
+
+### 2b. NIC-driver shim
+
+- [ ] 2.4 Define `TsnNicDriver::set_gcl(gcl, base_time)` trait method.
+- [ ] 2.5 Implement for Intel i210 — translate the GCL into i210's `IGC_BASE_TIME` / `IGC_LAUNCHTIME` register layout, up to 16 entries.
+- [ ] 2.6 Document the per-NIC quirks (i210 gate-granularity is 1 µs; ns-precision GCL must round; etc.).
+
+### 2c. Qbv tests
+
+- [ ] 2.7 Unit tests for GCL parsing + translation to NIC registers.
+- [ ] 2.8 Integration test: program a 5 ms cycle with a 1 ms inference window + 4 ms best-effort window; capture wire-line timing via an external TAP + Wireshark / `tcpdump`; confirm the inference-window frames are transmitted exclusively within the 1 ms gate-open interval.
+
+## 3. Phase 3 — Scheduler deadline propagation
+
+- [ ] 3.1 Add `OpDeadline` and `DeadlineMissAction` types to `kernel/src/sched/tsn.rs`.
+- [ ] 3.2 Modify the cooperative-scheduler op-boundary yield to check the active deadline and emit `SchedulerAction::DeadlineMiss(action)` when the next op's estimated cost would exceed the deadline.
+- [ ] 3.3 Implement the three `DeadlineMissAction` variants: `Warn`, `Abort`, `Continue`.
+- [ ] 3.4 Add `estimated_op_cost_ns()` heuristic — table-driven, indexed by op type + tensor shape. Initial estimates can be conservative; refinement is a follow-up.
+
+## 4. Phase 4 — Configuration + observability
+
+- [ ] 4.1 Define the TOML schedule format (see `design.md`) and add parser + validator.
+- [ ] 4.2 Wire `SMALLAIOS_TSN_SCHEDULE` env var (container path) and equivalent kernel boot argument.
+- [ ] 4.3 Extend telemetry with `tsn.gptp.offset_ns_p50/p99`, `tsn.gptp.path_delay_ns`, `tsn.qbv.cycles_completed`, `tsn.qbv.gate_open_late_count`, `tsn.deadline.met_count{window_id}`, `tsn.deadline.miss_count{window_id}`.
+- [ ] 4.4 Add a TSN-aware example to `examples/` and a TOML snippet to the docs.
+
+## 5. Phase 5 — Documentation
+
+- [ ] 5.1 Create `docs/tsn-integration.md` covering: standards (802.1AS, 802.1Qbv), hardware compatibility matrix, TOML schedule format, deadline-miss handling, troubleshooting (clock not syncing, gates not enforcing, deadlines missed).
+- [ ] 5.2 Add a clear **Jetson out-of-scope** callout: Tegra234 EQOS supports gPTP hardware timestamping (so software gPTP works) but does NOT enforce 802.1Qbv gates. Jetson SmallAIOS can be a gPTP slave but not a scheduled-traffic endpoint with strong guarantees.
+- [ ] 5.3 Add a row to the README hardware matrix for "TSN-capable industrial deployments" linking to `docs/tsn-integration.md`.
+
+## 6. Phase 6 — CI
+
+- [ ] 6.1 Add a host-build CI job that compiles `--features tsn` (no TSN hardware on GitHub-hosted runners; validates compile-time correctness).
+- [ ] 6.2 Add a scheduled job `tsn-i210-smoke` that runs gPTP + Qbv against a self-hosted i210 + TSN switch (when available). Advisory initially.
+- [ ] 6.3 Promote `tsn-i210-smoke` to `change-gates` when the self-hosted runner availability is reliable (separate change).
+
+## 7. Close-out
+
+- [ ] 7.1 PR title: `feat(net): tsn-integration-v1 — 802.1AS gPTP + 802.1Qbv scheduled traffic + deadline-aware scheduler`.
+- [ ] 7.2 Reviewer sign-off + green CI + i210 + TSN switch integration evidence (clock offset histogram + Qbv wire-capture) in the PR description.
+- [ ] 7.3 Update CLAUDE.md "Current state" to mention TSN endpoint capability with the explicit Jetson-out-of-scope note.


### PR DESCRIPTION
## Summary

Drafts four Tier 3 OpenSpec proposals covering scale-out, datacenter, and industrial deployment targets that sit **outside** the current Jetson Orin sweet spot. All four are documentation-only — no Rust code is touched. Each proposal includes an explicit "When this becomes important" section so the priority is clear: none of these is urgent for the current SmallAIOS Jetson Orin target.

## Changes (4)

- **`numa-aware-tensor-alloc-v1`** (~3-4 weeks) — multi-socket x86-64 + multi-die ARM64 NUMA-aware tensor pool. Extends `kernel-mem` with `Option<NumaNodeId>` hint; single-node fallback keeps Jetson Orin zero-cost. ([proposal](openspec/changes/numa-aware-tensor-alloc-v1/proposal.md))
- **`persistent-memory-v1`** (~5-6 weeks) — CXL.mem + CXL 3.0 pooled memory tiering. New `kernel-mem-tiering` capability with `Hot`/`Warm`/`Cold` tiers and `SharedRegion` for read-only weight sharing across instances. Targets CXL.mem (Optane discontinued; not a target). ([proposal](openspec/changes/persistent-memory-v1/proposal.md))
- **`gpu-mig-partitioning-v1`** (~4-5 weeks) — NVIDIA A100/H100/H200 MIG slice support. New `arch-nvidia-mig` capability. Jetson Orin (Ampere GA10B) does NOT support MIG and is explicitly out of scope; enforced by build-time mutex with the `tegra-orin` feature. ([proposal](openspec/changes/gpu-mig-partitioning-v1/proposal.md))
- **`tsn-integration-v1`** (~3-4 weeks) — IEEE 802.1AS gPTP + 802.1Qbv scheduled traffic for industrial automation. New `net-tsn` capability with cooperative-scheduler deadline hooks. Initial NIC: Intel i210 reference. Jetson EQOS supports gPTP slave but not Qbv enforcement — documented as out of scope for full TSN endpoint capability. ([proposal](openspec/changes/tsn-integration-v1/proposal.md))

## Sequencing

**None of these are urgent.** They are roadmap documents for when scale-out / datacenter / industrial demand materializes:

| Change | Trigger | Likely horizon |
|--------|---------|----------------|
| `numa-aware-tensor-alloc-v1` | First 2P+ x86-64 / multi-die ARM64 deployment with >50 GB model | 12-18 months |
| `persistent-memory-v1` (Phase 1) | First CXL.mem-equipped server deployment | 12-24 months |
| `persistent-memory-v1` (Phase 5 — CXL 3.0) | CXL 3.0 production silicon + multi-host fabric | 24-36 months |
| `gpu-mig-partitioning-v1` | First multi-tenant H100 / A100 datacenter deployment | 6-18 months |
| `tsn-integration-v1` | Industrial automation / automotive central-compute design win | 12-24 months |

If only Jetson + single-socket-cloud (Graviton, c7g) deployments materialize, each of these can be archived without implementation.

## Hardware prerequisites are documented concretely

Each proposal includes a hardware support / non-support matrix:
- NUMA: 2P EPYC Genoa, 2P Xeon SPR, Ampere Altra Max, NVIDIA Grace (in-scope); Jetson, single-socket desktops (no-op fallback).
- Persistent memory: Sapphire Rapids+ / EPYC Genoa+ / AmpereOne / Grace with CXL 1.1+ memory expanders (in-scope); Optane discontinued (out of scope); Jetson (no CXL controller, no-op fallback).
- MIG: A100 / A30 / H100 / H100 NVL / H200 / B100 (in-scope); L4 / L40 / RTX 6000 Ada / Jetson Orin / consumer GPUs (explicit out-of-scope with fail-fast).
- TSN: Intel i210 / i225 / i226 / E810, Marvell Prestera, NXP S32G, Microchip LAN9662 (in-scope); Jetson Tegra234 EQOS (gPTP slave only, no Qbv enforcement); Realtek / virtio-net (out of scope).

## Test plan

- [x] `openspec validate numa-aware-tensor-alloc-v1` passes
- [x] `openspec validate persistent-memory-v1` passes
- [x] `openspec validate gpu-mig-partitioning-v1` passes
- [x] `openspec validate tsn-integration-v1` passes
- [x] `openspec list` shows all four new changes
- [x] No Rust source files modified — documentation only
- [x] Each proposal includes proposal.md (3-6 KB scale), design.md (alternatives + decisions), tasks.md (phased `[ ]`-checkbox breakdown), and a spec.md with ## ADDED Requirements
- [x] Each proposal explicitly addresses why Jetson Orin does not need this feature now

Reviewers should focus on:
1. Are the trigger conditions well-defined?
2. Are the hardware support matrices accurate?
3. Are the capability names (`kernel-mem` extend, `kernel-mem-tiering` new, `arch-nvidia-mig` new, `net-tsn` new) the right shape?
4. Are the out-of-scope sections drawn correctly (no scope creep into adjacent changes)?

This PR is intentionally a **draft** — no implementation work is scheduled for any of these changes; they exist as roadmap documents.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>