### PR TITLE
docs(openspec): propose memory-safety + DMA-isolation roadmap (tegra-smmu, mte-pac, spec-exec, ecc, cheri)

### DIFF
--- a/openspec/changes/aarch64-mte-pac-hardening-v1/design.md
+++ b/openspec/changes/aarch64-mte-pac-hardening-v1/design.md
@@ -1,0 +1,130 @@
+# Design — aarch64-mte-pac-hardening-v1
+
+## Goal
+
+Two CPU-side hardware memory-safety features active on every `--features tegra234` build of the SmallAIOS kernel:
+
+1. **PAC** — return-address signing on every function entry/exit (catches ROP), signed indirect-call pointers in the ONNX op dispatch (catches JOP), and signed data pointers for capability handles (catches confused-deputy attacks on `ResourceType`).
+2. **MTE** — synchronous tag-check on every load/store, with allocator-side tag assignment from a hardware RNG, and a kernel-side fault handler that converts mismatches into structured panics (or watchdog notifications on safety-critical builds).
+
+Verification: on Orin NX hardware, a deliberately-injected use-after-free or stack-smash triggers a trapped fault before observable memory corruption, with a structured log line identifying the fault PC.
+
+## Design decisions
+
+### Decision 1: PAC algorithm choice — QARMA5 with all five keys
+
+ARMv8.5-A defines five PAC keys: `APIA` (instruction address A), `APIB` (instruction address B), `APDA` (data address A), `APDB` (data address B), `APGA` (generic). We enable and key all five rather than the bare-minimum `APIA` (return-address only):
+
+| Key | Use | Why enable |
+|-----|-----|------------|
+| **APIA** | `pacia` / `autia` — return addresses | Baseline ROP defense, free with compiler flag |
+| **APIB** | `pacib` / `autib` — alternate inst key | Used by Rust for non-return indirect branches |
+| **APDA** | `pacda` / `autda` — data pointers | We use for capability handle signing |
+| **APDB** | (unused initially) | Wired but not used; available for future signed-FFI cases |
+| **APGA** | `pacga` — generic 64-bit signing | We use for ONNX op dispatch indirect call signing |
+
+Cost of enabling all five: 5 × 128 bits = 80 bytes of EL1 system register state. Worth it because compilers may emit any of them and we don't want a "key not installed" trap on instruction execution.
+
+QARMA5 vs. QARMA3: silicon decides. Cortex-A78AE implements QARMA5 by default; we don't get to pick. We read `ID_AA64ISAR1_EL1.{APA, GPA}` to confirm at boot and refuse to enable PAC if the silicon reports unsupported.
+
+### Decision 2: PAC keys are per-boot, derived from hardware RNG
+
+Each boot derives all five keys from Orin's TRNG (`RNGSR_EL0` available on the security engine; falls back to `CNTPCT_EL0`-mixed PRNG on platforms without TRNG, with a boot-time warning). Keys never persist across reboots — an attacker who exfiltrates the key for one boot cannot use it after a reboot.
+
+A build-time `mte-pac-deterministic` Cargo feature lets development builds use a fixed key (printed at boot) so a debugger can decode signed pointers manually. Off by default. Production builds always use the TRNG path.
+
+### Decision 3: MTE in synchronous mode (sync TCF), not asynchronous
+
+| TCF mode | Latency on hit | Precision | Use case |
+|----------|---------------|-----------|----------|
+| **Sync (0b01)** | Traps immediately | Exact fault PC | Pick this — safety-critical needs precise diagnosis |
+| Async (0b10) | Trap on next exception entry | Approximate PC | Faster on workloads with many tag operations |
+| Asymmetric (0b11) | Sync on read, async on write | Mixed | Compromise — not picked |
+
+We pick sync for the primary build because (a) Cortex-A78AE's MTE implementation has very low sync overhead per Arm's published numbers, (b) async loses the offending PC on workloads with deep `unsafe` chains, which is exactly the workloads MTE is supposed to diagnose. We add an `mte-async` Cargo feature for non-safety-critical builds that prefer throughput.
+
+### Decision 4: 4-bit tags chosen by per-allocation RNG, granule = 16 bytes
+
+ARMv8.5-A fixes the tag width (4 bits = 16 values) and granule (16 bytes). We have no design freedom there. The choice is *how to assign tags*:
+
+- Random per-allocation: 1/16 chance two adjacent allocations collide, which is fine for catching most UAF/OOB.
+- Sequential (1, 2, 3, ..., 15, 1, 2, ...): better for spatial locality, slightly worse for entropy. Linux uses this on kernel allocations.
+
+We pick **random** because the kernel allocator (`kernel/src/mem/heap.rs`) is called rarely (most ONNX-runtime allocation goes through a slab allocator that we tag separately) and the entropy is worth more than the locality.
+
+Tag-zero is reserved for "untagged" memory regions (MMIO, stack, DTB). The allocator assigns from 1-15 only.
+
+### Decision 5: MTE fault handler converts to structured panic, not silent retry
+
+A sync MTE fault raises a Data Abort with `ESR_EL1.EC = 0x25` (data abort, current EL) and a specific FSC code (`0x11` for tag check fault). The handler in `interrupts.rs`:
+
+1. Decodes `ESR_EL1`, `FAR_EL1`, and `ELR_EL1` to capture the fault PC, fault address, and the expected vs. actual tag (from address bits 56-59 and the granule tag).
+2. Logs a structured fault line: `[mte-fault] pc=0x… addr=0x… tag_pointer=N tag_memory=M`.
+3. Panics — the kernel does not attempt to continue execution because tag mismatches always indicate a real safety bug. (Linux's user-space MTE allows recovery by re-tagging; the kernel case is "this should not happen".)
+4. On `mte-watchdog` Cargo feature builds, instead of panicking, signals the hardware watchdog and produces a coredump-shaped serial dump.
+
+### Decision 6: Capability handle PAC signing — APDA, not APGA
+
+The existing capability system in `kernel/src/cap.rs` stores `ResourceType` enums inside handles. A bug that lets a caller flip the `ResourceType` bits (via a confused `transmute` or a misused arg decoding) is a classic confused-deputy escalation. PAC signing fixes this: the kernel signs the handle with `pacda` using the resource-type-derived modifier; if anything in the handle flips, `autda` traps.
+
+We pick `APDA` (data address A) for this rather than `APGA` (generic) because:
+
+- `pacda` traps inside the kernel directly when `autda` fails — `pacga` only produces a 32-bit signature that the caller has to check explicitly with a compare-and-branch, which is more code and easier to forget.
+- `APDA` is unused by Rust's compiler-emitted PAC instructions, so we own that key for application-defined purposes.
+
+## Alternatives considered
+
+### Alt A: Software-only ASLR + stack canaries instead of PAC
+
+**Rejected.** Stack canaries are useful but they catch a narrower class of attacks (stack-buffer-overflow → return-address corruption only). PAC catches the same class plus indirect-call corruption plus heap-based ROP. ASLR is orthogonal — we don't ship ASLR today (the unikernel has a fixed kernel layout) and adding it costs more than just enabling PAC. PAC is the right primary defense.
+
+### Alt B: Use AddressSanitizer (ASAN) instead of MTE
+
+**Rejected.** ASAN-style red-zone instrumentation costs ~50% throughput and doubles memory use. MTE costs <2% throughput and ~3% memory (one tag byte per 16 bytes of allocation, packed in DRAM). ASAN is the right tool for development; MTE is the right tool for production safety-critical builds. We may opt-in ASAN for unit-test builds (`#[cfg(test)]`) as a follow-up.
+
+### Alt C: Enable PAC and MTE conditionally based on runtime feature detection
+
+**Rejected for the primary path.** SmallAIOS is `#![no_std]` and we know our target hardware at build time. The `mte-pac` Cargo feature is opt-in at build time (default-on for `tegra234`, off for other aarch64 targets). Runtime feature detection adds branch overhead and a "what if it's missing" code path we don't need. If we ever target a non-MTE aarch64 SoC, we build without the feature.
+
+### Alt D: Defer until DO-178C tooling story is more mature
+
+**Considered, rejected.** Waiting for full DO-178C tooling support before adding MTE/PAC means missing an entire generation of hardware mitigations. We document the features in the existing safety case structure and let the certification work catch up.
+
+## Risks
+
+### Risk 1: ONNX runtime perf regression from MTE allocator overhead
+
+The ONNX runtime allocates working buffers per operator. Tagged allocations cost a `stg` instruction per 16-byte granule on alloc and a check on every access. Mitigation: (a) benchmark on representative ONNX workloads (existing `bench/` crate) before/after MTE, gate merge on <5% steady-state regression; (b) for the slab allocator path (high-frequency same-size allocs), assign one tag per *slab* rather than per allocation — slab-level MTE catches inter-slab OOB but not intra-slab; (c) document the `mte-async` opt-out.
+
+### Risk 2: PAC key reuse across boots could weaken security
+
+Mitigation handled in Decision 2 — per-boot TRNG-derived keys. The `mte-pac-deterministic` dev feature is opt-in only.
+
+### Risk 3: MTE fault during early boot (before fault handler installed)
+
+If the allocator or any tagged-pointer operation runs before `interrupts.rs` has installed the Data Abort vector, a tag mismatch becomes an unrecoverable hardware fault. Mitigation: ordering — `mte::init()` is called *after* `interrupts::init()` in the boot sequence (`arch/aarch64/src/main.rs`). Before `mte::init`, the kernel runs untagged (TCF=0), so no tag mismatch can fire.
+
+### Risk 4: UEFI firmware leaves MTE/PAC state inconsistent
+
+JetPack 6's UEFI may have programmed `SCTLR_EL1` with its own PAC/MTE settings before `ExitBootServices`. Mitigation: at `kernel_main` entry, we explicitly disable both (`SCTLR_EL1.{TCF, EnIA, EnIB, EnDA, EnDB} = 0`), then install our own keys, then re-enable. Single-source-of-truth: the kernel owns the keys; UEFI's choices are clobbered.
+
+### Risk 5: Toolchain divergence — Rust nightly PAC support is moving
+
+The Rust 2026-02-01 toolchain pinned in `rust-toolchain.toml` supports `-C codegen-options=branch-protection=pac-ret` stably. The MTE-aware allocator hook (`-Z sanitizer=memtag`) is nightly-only and has changed shape across recent toolchains. Mitigation: pin the toolchain explicitly in the new CI job; document the codegen flags in `docs/aarch64-security.md` with the exact `cargo build` invocation.
+
+## Build/CI surface
+
+- New Cargo feature `mte-pac` on `smallaios-arch-aarch64`. Default-on for `tegra234`, default-off elsewhere.
+- New module `arch/aarch64/src/security/{mod.rs, pac.rs, mte.rs}` containing the boot-init code, key install, and fault decoder.
+- Modify `arch/aarch64/src/interrupts.rs` Data Abort handler to dispatch tag-check faults into `security::mte::handle_fault`.
+- Modify `arch/aarch64/src/main.rs` / `main_uefi.rs` boot sequence to call `security::init()` after `interrupts::init()` and before allocator init.
+- New `mte-pac-deterministic` (dev) and `mte-async` (perf) and `mte-watchdog` (safety) sub-features.
+- New CI advisory job `aarch64-mte-pac-build` — builds with the feature and runs the existing QEMU smoke (QEMU's `cortex-a78` model supports `+mte,+pauth` — we add `-cpu cortex-a78,mte=on,pauth=on` to the smoke recipe).
+- New `just mte-fault-test` recipe that runs a tag-mismatch-injecting test binary under QEMU and asserts the fault handler fires.
+
+## What this change explicitly does NOT do
+
+- Does not change syscall ABI — PAC/MTE are CPU-internal, invisible to syscall callers.
+- Does not modify any non-aarch64 architecture path. The `kernel-security` capability spec (separate from `arch-aarch64-security`) covers cross-arch mitigations under `spec-exec-mitigations-v1`.
+- Does not enable user-space MTE (there is no user space).
+- Does not change the existing PQC crypto stack — MTE/PAC are CPU memory protections, not cryptographic primitives.

--- a/openspec/changes/aarch64-mte-pac-hardening-v1/proposal.md
+++ b/openspec/changes/aarch64-mte-pac-hardening-v1/proposal.md
@@ -1,0 +1,68 @@
+# aarch64-mte-pac-hardening-v1
+
+## Summary
+
+Cortex-A78AE (the CPU in Jetson Orin's Tegra234 SoC) implements ARMv8.5-A — including two memory-safety hardware features that SmallAIOS does not yet exercise: **Memory Tagging Extension (MTE)** and **Pointer Authentication (PAC)**. MTE hardware-tags every 16-byte allocation granule and traps mismatched memory accesses; PAC signs return addresses and indirect function pointers with a per-process secret, making ROP/JOP exploits orders of magnitude harder. Both features impose <2% steady-state runtime overhead on real workloads (Google's MTE measurements on Pixel 8, Apple's PAC measurements on M-series), neither requires source changes beyond a small `unsafe` allocator hook, and both are baseline hardware-mitigation expectations in any 2026-era safety-critical OS deployment.
+
+This change enables MTE and PAC under a new `mte-pac` Cargo feature on `smallaios-arch-aarch64`, gated on Tegra234 / Orin builds (the only ARMv8.5-A platform SmallAIOS currently targets — `aarch64-unknown-uefi --features tegra234`). The feature splits into two cleanly-separable phases: PAC first (smaller, no allocator changes, ROP hardening only), then MTE (needs allocator integration to assign and check tags). A new `arch-aarch64-security` capability spec documents the contract.
+
+## Why
+
+- **SmallAIOS's safety-critical positioning demands hardware-level memory safety where it exists.** The kernel is `#![no_std]` Rust — the type system already prevents the most common UAF / OOB patterns at the source level. But the moment we touch `unsafe { ... }` (allocator, DMA, FFI to the NVIDIA HAL, hand-rolled UEFI bindings in `arch/aarch64/src/uefi.rs`, syscall argument decoding in `kernel/src/syscall/`), source-level guarantees evaporate. MTE catches whatever those `unsafe` blocks get wrong, at hardware speed, with no recompile of the offending code path. PAC catches return-address smashes regardless of source-language. Both are exactly the kind of *defense in depth* the DO-178C "design assurance" framework rewards.
+- **The hardware is free on Orin and we are not using it.** Cortex-A78AE supports MTE (FEAT_MTE2) and PAC (FEAT_PAuth + FEAT_PAuth2) in silicon. JetPack 6's L4T kernel enables them — `cat /proc/cpuinfo | grep -E "(mte|paca|pacg)"` returns hits on a stock Orin NX. SmallAIOS's bare-metal aarch64 path (the `unikernel-orin-bringup-v1` Phase 2 BSP, currently in interim mode) does not yet program `SCTLR_EL1.{TCF, EnIB, EnIA}` or related control bits. Until we do, every CPU cycle that runs SmallAIOS on Orin runs without those features active.
+- **PAC closes one of the few remaining low-friction exploit primitives in a Rust unikernel.** Even pure-Rust code is vulnerable to ROP if an attacker can corrupt a stack frame (e.g., a misused `transmute`, an `unsafe` slice indexing bug, a syscall arg with a missed bounds check). PAC's `pacia`/`autib` instruction pair makes the return address self-validating — a corrupted return address fails authentication on `RET` and traps. Cost: one instruction at function entry, one at exit. Net effect: return-oriented programming requires breaking PAC's per-process key, which on ARMv8.5-A requires either a side-channel or kernel-privileged register reads.
+- **MTE is the right complement to the SMMU isolation work.** `tegra-smmu-isolation-v1` (parallel change) contains DMA-side corruption to specific stream IDs. MTE contains CPU-side corruption to specific allocations. Together they cover both the "GPU scribbles random DRAM" and "kernel scribbles random kernel struct" failure modes that any safety-critical certification will ask about. The two changes don't interact at the spec level — they just both reduce the blast radius of the same underlying class of memory-safety bugs.
+- **The Rust target supports it already.** The standard Rust compiler emits BTI (branch target identification) and supports MTE-aware allocator hooks via `-Z sanitizer=memtag` (nightly). `aarch64-unknown-none` and `aarch64-unknown-uefi` both accept `-C target-feature=+mte,+pauth` on the toolchain pinned in `rust-toolchain.toml`. No upstream-rust changes are needed.
+
+## Scope — phases
+
+The two features ship in series because PAC is genuinely easier (no allocator changes, no fault paths to design) and de-risks the rest.
+
+### Phase 1 — PAC (Pointer Authentication, ~1 week)
+
+PAC has three independent sub-features in ARMv8.5-A. We enable all three:
+
+- **PACIASP / AUTIASP** — sign + authenticate the link register on function entry/exit. Compiled in via `-C target-feature=+pauth -C codegen-options=branch-protection=pac-ret`. Catches stack-smashing ROP.
+- **PACGA** — sign generic pointers. We use this for indirect call sites in ONNX op dispatch (`kernel/src/syscall/onnx.rs`) — every operator function pointer is signed when stored, authenticated when called. Catches indirect-call ROP/JOP.
+- **PACDA / AUTDA** — sign data pointers. We use this for capability handles (`kernel/src/cap.rs`) — every capability is signed with its resource type, so confused-deputy attacks that smash a `ResourceType` field fail authentication.
+
+Boot setup: write the per-boot PAC keys to `APIAKeyHi_EL1`, `APIBKeyHi_EL1`, `APDAKeyHi_EL1`, `APDBKeyHi_EL1`, `APGAKeyHi_EL1` (one 128-bit key per algorithm). Keys are derived from a hardware RNG (Orin has TRNG via `RNGSR_EL0`) plus a build-time per-image salt for development determinism.
+
+`SCTLR_EL1.{EnIA, EnIB, EnDA, EnDB}` enable instructions in EL1 (kernel-only). `SCTLR_EL1.EnIB` enables `pacib`/`autib` for the secondary instruction key.
+
+No allocator changes are needed. No syscall changes. The user-visible boot diff is a `[pac] keys installed, branch-protection=pac-ret active` line.
+
+### Phase 2 — MTE (Memory Tagging Extension, ~1-1.5 weeks)
+
+MTE tags every 16-byte allocation granule with a 4-bit tag and a 4-bit "log" tag stored in DRAM (Orin's DRAM controllers support this — LPDDR5 has the spare bits). Loads/stores check that the tag in the pointer matches the tag in memory; mismatches trap.
+
+Three pieces:
+
+1. **Tag assignment in the allocator** (`kernel/src/mem/heap.rs` or wherever the `GlobalAlloc` impl lives). Every `alloc` call generates a random 4-bit tag, writes it to all granules of the allocation (`stg` instruction), and embeds the tag in the returned pointer's bits 56-59 (the ARM "top byte ignore" address space, which MTE repurposes).
+2. **Tag check enablement** — write `SCTLR_EL1.TCF = 0b01` (sync MTE) for the kernel. Sync mode traps immediately on mismatch; async mode batches and is faster but less precise. We pick sync for safety-critical correctness and re-evaluate if benchmarks show measurable overhead.
+3. **Fault handler** — sync MTE faults raise a Data Abort with `ESR_EL1.EC = 0x24/0x25` and a specific FSC code. The handler in `arch/aarch64/src/interrupts.rs` decodes the fault, logs the offending PC + tag mismatch info, and panics (or, on safety-critical builds, calls into the watchdog).
+
+A future polish: stack tagging (`-Z sanitizer=memtag-stack`). This requires Rust toolchain support that's nightly-only and gated; we defer it as Phase 2.5 follow-up.
+
+## Out of scope
+
+- **MTE on the GPU side.** MTE is a CPU feature. The GA10B GPU on Orin does not implement MTE — GPU-side memory safety is the SMMU's job (`tegra-smmu-isolation-v1` parallel change).
+- **BTI (Branch Target Identification).** Already enabled in the default `aarch64-unknown-none` codegen via Rust's `-Z branch-protection=bti`. Not a delta this change introduces; we document it for completeness.
+- **PAC on the userspace boundary.** SmallAIOS is a unikernel — there is no userspace transition, so the EL0/EL1 PAC key separation doesn't apply. We use EL1 keys exclusively.
+- **Heap stack-tagging.** Defer to Phase 2.5 follow-up once the toolchain story for stack MTE on bare-metal is stable.
+- **x86_64 / RISC-V analogs.** Intel's LAM (Linear Address Masking) is the rough equivalent of TBI, MPK has overlap with MTE, CET shadow stack overlaps with PAC. Each is its own change; we do aarch64 first because Orin is our reference platform.
+- **Verified Boot integration.** Whether MTE-tagged kernel images need their own measurement is a question for the `verified-boot` feature owner; we don't touch it here.
+
+## Sequencing
+
+Phase 1 (PAC) is independent and lands first — small, low-risk, compiler-driven. Phase 2 (MTE) builds on Phase 1 only in that they share the boot-time RNG / key-install code path. The change can run fully in parallel with `tegra-smmu-isolation-v1` (different hardware features, different code paths). It depends only on `unikernel-orin-bringup-v1` Phase 2e landing (need a working AArch64 boot path on Orin to test on hardware).
+
+The MTE benchmark gate (Phase 2 task 2.4) is the most likely point of friction: if our specific workloads hit higher overhead than the ~2% expected (e.g., due to ONNX runtime's allocation churn), we either accept it as the safety-critical price or add an `mte-async` Cargo feature for async-mode tag checking. We document the decision in `design.md`.
+
+## Effort estimate
+
+| Phase | Scope | Estimate |
+|-------|-------|----------|
+| 1 | PAC (compiler flag + key install + boot wiring) | ~1 week |
+| 2 | MTE (allocator integration + fault handler + benchmark) | ~1-1.5 weeks |
+| **Total** | | **~2-3 weeks** |

--- a/openspec/changes/aarch64-mte-pac-hardening-v1/specs/arch-aarch64-security/spec.md
+++ b/openspec/changes/aarch64-mte-pac-hardening-v1/specs/arch-aarch64-security/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: Pointer Authentication (PAC) enabled on Tegra234 builds
+
+The kernel SHALL enable ARMv8.5-A Pointer Authentication on every Cortex-A78AE-class platform (default-on for `--features tegra234`), installing five per-boot keys derived from a hardware RNG, and SHALL refuse to boot if the silicon does not advertise PAC support.
+
+#### Scenario: PAC keys installed at boot
+
+- **GIVEN** a SmallAIOS kernel built with `--features tegra234,mte-pac` running on an Orin NX device
+- **WHEN** the boot sequence reaches `security::init()`
+- **THEN** the kernel SHALL read `ID_AA64ISAR1_EL1.{APA, GPA}` to confirm PAC support — if either field is zero the kernel SHALL panic with `[pac] silicon does not support PAC`
+- **AND** the kernel SHALL derive five 128-bit keys (`APIA`, `APIB`, `APDA`, `APDB`, `APGA`) from the hardware TRNG (`RNGSR_EL0`) on platforms that advertise it
+- **AND** the kernel SHALL fall back to a `CNTPCT_EL0`-mixed PRNG with a boot-time warning if TRNG is unavailable
+- **AND** the kernel SHALL write all five keys to their `*KeyHi_EL1` / `*KeyLo_EL1` system registers and SHALL set `SCTLR_EL1.{EnIA, EnIB, EnDA, EnDB}` to enable PAC instructions in EL1
+- **AND** the kernel SHALL print a structured boot line of the form `[pac] keys installed, branch-protection=pac-ret active`
+
+#### Scenario: Return-address corruption is trapped
+
+- **GIVEN** a `--features mte-pac` build with branch-protection compiled in
+- **WHEN** a stack-frame corruption causes a function's signed return address to fail authentication
+- **THEN** the CPU SHALL raise a PAC fault exception (`ESR_EL1.EC = 0x1C`)
+- **AND** the kernel SHALL log a structured line `[pac-fault] pc=<addr> elr=<addr> reason=auth-failure` and SHALL panic — the corrupted control flow SHALL NOT execute
+
+#### Scenario: Capability handle integrity via APDA signing
+
+- **GIVEN** the capability system in `kernel/src/cap.rs` building with `--features mte-pac`
+- **WHEN** a capability handle is constructed
+- **THEN** the kernel SHALL sign the handle with `pacda` using the `ResourceType` discriminant as the PAC modifier
+- **AND** when the handle is dereferenced the kernel SHALL authenticate the signature with `autda`
+- **AND** any modification to the handle (including a `ResourceType` flip via a buggy `transmute`) SHALL cause `autda` to fail and SHALL trap before the handle can be used for a syscall authorization decision
+
+### Requirement: Memory Tagging Extension (MTE) enabled in synchronous mode on Tegra234
+
+The kernel SHALL enable ARMv8.5-A Memory Tagging Extension in synchronous mode on every Cortex-A78AE-class platform (default-on for `--features tegra234`), with per-allocation random tags assigned by the global allocator and a fault handler that converts mismatches into structured panics.
+
+#### Scenario: Allocator tags every allocation
+
+- **GIVEN** a kernel built with `--features mte-pac` (sync MTE, the default mode)
+- **WHEN** any code path calls into the global allocator (`GlobalAlloc::alloc`) and the allocation succeeds
+- **THEN** the allocator SHALL pick a random 4-bit tag from the range 1-15 (zero reserved)
+- **AND** the allocator SHALL write that tag to every 16-byte granule of the allocation via the `stg` instruction
+- **AND** the allocator SHALL embed the tag in bits 56-59 of the returned pointer so subsequent loads/stores via that pointer carry the matching tag
+- **AND** symmetric `dealloc` SHALL clear the granule tags (write tag-zero) so a stale pointer from a use-after-free cannot match
+
+#### Scenario: Tag mismatch on load/store is trapped
+
+- **GIVEN** a sync-MTE build where the allocator has tagged a buffer with tag `N`
+- **WHEN** code accesses that buffer via a pointer whose embedded tag is `M ≠ N` (a use-after-free or off-by-one OOB)
+- **THEN** the CPU SHALL raise a Data Abort with `ESR_EL1.EC = 0x25` and `FSC = 0x11` (tag-check fault) at the offending instruction
+- **AND** the kernel fault handler SHALL read `FAR_EL1`, `ELR_EL1`, the address tag from bits 56-59 of `FAR_EL1`, and the granule tag via `ldg`
+- **AND** the handler SHALL log a structured line `[mte-fault] pc=<addr> addr=<addr> tag_pointer=<N> tag_memory=<M>`
+- **AND** the handler SHALL panic — execution SHALL NOT continue past the offending access
+
+#### Scenario: Safety-critical builds route MTE faults to the watchdog
+
+- **GIVEN** a kernel built with `--features mte-pac,mte-watchdog`
+- **WHEN** an MTE fault fires
+- **THEN** instead of panicking immediately the kernel SHALL signal the hardware watchdog
+- **AND** the kernel SHALL emit a coredump-shaped serial dump containing the structured fault info plus a stack trace
+- **AND** the kernel SHALL then halt — the watchdog reset SHALL be the recovery path
+
+#### Scenario: Async-mode opt-out for non-safety-critical builds
+
+- **GIVEN** a kernel built with `--features mte-pac,mte-async`
+- **WHEN** `mte::enable_sync()` runs
+- **THEN** the kernel SHALL instead write `SCTLR_EL1.TCF = 0b10` to enable async tag-check
+- **AND** the fault may be deferred to the next exception entry rather than raised at the offending instruction (with a corresponding loss of fault-PC precision)
+- **AND** documentation in `docs/aarch64-security.md` SHALL warn that async mode is intended for non-safety-critical performance-sensitive builds
+
+### Requirement: PAC/MTE boot wiring ordering and idempotence
+
+The `security::init` sequence SHALL run in a well-defined order with respect to interrupt vector installation and global allocator setup, and SHALL be idempotent in the sense that re-entering boot from a watchdog-induced reset converges to the same enabled state.
+
+#### Scenario: Ordering — interrupts first, then PAC, then allocator, then MTE
+
+- **GIVEN** the boot sequence in `arch/aarch64/src/main.rs` (or `main_uefi.rs`)
+- **WHEN** the kernel enters `kernel_main`
+- **THEN** the sequence SHALL be: (1) install exception vectors, (2) call `security::pac::install_keys()` + `security::pac::enable_in_sctlr()`, (3) install the global allocator, (4) call `security::mte::enable_sync()` (or `enable_async()` with the `mte-async` feature), (5) proceed to platform driver init
+- **AND** no function call past the boot stub SHALL execute without PAC return-address signing active
+- **AND** no allocator call SHALL execute without MTE tagging active
+
+#### Scenario: UEFI-residual SCTLR state is overwritten, not inherited
+
+- **GIVEN** an Orin NX boot via UEFI firmware that may have programmed its own PAC/MTE bits in `SCTLR_EL1` before `ExitBootServices`
+- **WHEN** `security::init` runs
+- **THEN** the kernel SHALL first clear the relevant `SCTLR_EL1` bits (`TCF`, `ATA`, `EnIA`, `EnIB`, `EnDA`, `EnDB`) to a known-zero baseline
+- **AND** the kernel SHALL then install its own keys and SHALL re-enable the bits per its own policy — UEFI's prior choices SHALL NOT carry over

--- a/openspec/changes/aarch64-mte-pac-hardening-v1/tasks.md
+++ b/openspec/changes/aarch64-mte-pac-hardening-v1/tasks.md
@@ -1,0 +1,88 @@
+# Tasks — aarch64-mte-pac-hardening-v1
+
+## 0. Hardware + toolchain verification (prereq)
+
+- [ ] 0.1 Confirm Orin NX silicon advertises MTE + PAC: on a JetPack 6 host, run `cat /proc/cpuinfo | grep -E "(features|isar)" | head -2` and `lscpu | grep Flags`. Expected: `mte`, `paca`, `pacg` in the features list. Paste in the PR description.
+- [ ] 0.2 Confirm `ID_AA64ISAR1_EL1.{APA, GPA}` and `ID_AA64PFR1_EL1.MTE` indicate the expected ARMv8.5-A levels by reading them from EL1 via a small Rust probe binary (run under KVM on Orin via the existing `run-jetson-kvm` recipe).
+- [ ] 0.3 Confirm the pinned Rust toolchain `nightly-2026-02-01` accepts `-C target-feature=+mte,+pauth` and `-C codegen-options=branch-protection=pac-ret` for `aarch64-unknown-uefi` and `aarch64-unknown-none`. Document in `docs/aarch64-security.md`.
+- [ ] 0.4 Confirm QEMU `qemu-system-aarch64` ≥ 7.0 supports `-cpu cortex-a78,mte=on,pauth=on` (it does; document the exact version requirement).
+
+## 1. Phase 1 — PAC (Pointer Authentication)
+
+### 1a. Module scaffolding
+
+- [ ] 1.1 Create `arch/aarch64/src/security/mod.rs` with public API: `pub fn init()`, `pub fn pac_enabled() -> bool`, `pub fn mte_enabled() -> bool`. Doc-comment cites the ARMv8.5-A spec sections.
+- [ ] 1.2 Create `arch/aarch64/src/security/pac.rs` with `pub fn install_keys()` and `pub fn enable_in_sctlr()`. Inline asm via `core::arch::asm!` for the `MSR APIAKeyHi_EL1, x0` family.
+- [ ] 1.3 Add `mte-pac` Cargo feature to `arch/aarch64/Cargo.toml`. Doc-comment distinguishes it from MTE-only / PAC-only sub-features.
+- [ ] 1.4 Default-on for `tegra234` builds via `default-features = ["mte-pac"]` in the relevant Cargo.toml stanza.
+
+### 1b. Key derivation + install
+
+- [ ] 1.5 Implement `pac::derive_keys_from_trng()` — reads `RNGSR_EL0` (or falls back to a CNTPCT-mixed Xoshiro PRNG with a boot-time warning if TRNG is unavailable) and produces five 128-bit keys.
+- [ ] 1.6 Implement `pac::install_keys(keys: &PacKeys)` — writes all five key pairs (`APIAKeyHi_EL1`/`Lo`, `APIBKeyHi_EL1`/`Lo`, `APDAKeyHi_EL1`/`Lo`, `APDBKeyHi_EL1`/`Lo`, `APGAKeyHi_EL1`/`Lo`) via inline asm.
+- [ ] 1.7 Implement `pac::enable_in_sctlr()` — read `SCTLR_EL1`, set `EnIA | EnIB | EnDA | EnDB`, write back, `isb`. Clear them first if UEFI left stale bits set.
+- [ ] 1.8 Add `mte-pac-deterministic` Cargo feature that uses fixed keys (printed at boot) for development debugger use. Off by default.
+
+### 1c. Compiler-level branch protection
+
+- [ ] 1.9 Add `[target.'cfg(target_arch = "aarch64")']` rustflags `-C codegen-options=branch-protection=pac-ret,bti` to `.cargo/config.toml` (or set via `RUSTFLAGS` in the `mte-pac`-feature build job). Verify with `objdump -d` that emitted prologues contain `pacibsp` / `autibsp`.
+- [ ] 1.10 Verify BTI is also on (compiler should emit `bti c` at function entries) — this is free baseline hardening.
+
+### 1d. Capability handle signing via APDA
+
+- [ ] 1.11 Modify `kernel/src/cap.rs` so that capability handles are signed with `pacda` on construction using `(resource_type as u64)` as the modifier; signature is verified with `autda` on dereference.
+- [ ] 1.12 Audit all sites that construct/dereference capabilities to use the new signed accessors. Run the existing capability tests to confirm no regression.
+
+### 1e. ONNX op dispatch signing via APGA
+
+- [ ] 1.13 Modify `onnx-rt`'s op-dispatch table so each function pointer is signed with `pacga` (modifier = op-name hash) at table init; the dispatch call site authenticates before calling.
+- [ ] 1.14 Run the existing ONNX runtime tests to confirm no regression.
+
+### 1f. PAC boot wiring
+
+- [ ] 1.15 Modify `arch/aarch64/src/main.rs` (and `main_uefi.rs`) to call `security::pac::install_keys()` + `security::pac::enable_in_sctlr()` after exception vectors are installed and before any function call past the boot stub. Print `[pac] keys installed, branch-protection active` on success.
+- [ ] 1.16 PAC fault path: `autia` failure raises a PAC-fault exception (`ESR_EL1.EC = 0x1C`). Add a handler in `interrupts.rs` that logs `[pac-fault] pc=…` and panics.
+- [ ] 1.17 Test on QEMU `cortex-a78,pauth=on`: assert the kernel boots, prints the PAC banner, runs the existing test suite to completion.
+
+## 2. Phase 2 — MTE (Memory Tagging Extension)
+
+### 2a. MTE module + allocator hook
+
+- [ ] 2.1 Create `arch/aarch64/src/security/mte.rs` with `pub fn enable_sync()`, `pub fn handle_fault(esr, far) -> !`, and the `tag_alloc`/`tag_dealloc` allocator helpers.
+- [ ] 2.2 Modify `kernel/src/mem/heap.rs` (or wherever `GlobalAlloc` is implemented) to call `mte::tag_alloc(ptr, size)` after every successful allocation and `mte::tag_dealloc(ptr, size)` before every deallocation. Gated behind `#[cfg(feature = "mte-pac")]`.
+- [ ] 2.3 Implement `mte::tag_alloc(ptr, size)` — pick a random tag from 1-15 via the PAC-share TRNG, embed it in `ptr` bits 56-59, write the tag to all granules via the `stg` instruction.
+- [ ] 2.4 Benchmark on Orin: run the existing `bench/` ONNX inference benchmarks with and without MTE. Gate merge on <5% steady-state throughput regression on the representative model.
+
+### 2b. SCTLR enable + fault handler
+
+- [ ] 2.5 Implement `mte::enable_sync()` — write `SCTLR_EL1.TCF = 0b01` (sync MTE), `SCTLR_EL1.ATA = 1` (enable MTE in EL1 normal). `isb` to commit.
+- [ ] 2.6 Modify `arch/aarch64/src/interrupts.rs` Data Abort handler to dispatch `ESR_EL1.EC == 0x25 && FSC == 0x11` (sync tag-check fault) to `security::mte::handle_fault`.
+- [ ] 2.7 Implement `mte::handle_fault` — read `FAR_EL1`, `ELR_EL1`, `ESR_EL1`; decode the address tag (bits 56-59) and the granule tag (via `ldg` on `FAR_EL1`); log `[mte-fault] pc=… addr=… tag_pointer=N tag_memory=M`; panic.
+- [ ] 2.8 Add an `mte-watchdog` Cargo feature that, in lieu of panic, signals the hardware watchdog and emits a coredump-shaped serial dump before halt.
+
+### 2c. MTE async opt-out
+
+- [ ] 2.9 Add an `mte-async` Cargo feature that programs `SCTLR_EL1.TCF = 0b10` (async mode) instead. Document the precision trade-off in `docs/aarch64-security.md`.
+
+### 2d. MTE boot wiring
+
+- [ ] 2.10 Modify `arch/aarch64/src/main.rs` / `main_uefi.rs` to call `security::mte::enable_sync()` after `interrupts::init()` and *after* the global allocator is installed but before any other allocation happens.
+- [ ] 2.11 Print `[mte] sync tag-check enabled` on success.
+
+### 2e. Tests + smoke
+
+- [ ] 2.12 Add a `just mte-fault-test` recipe that runs a tiny test binary under QEMU `-cpu cortex-a78,mte=on` which deliberately reads an allocation through a stale (wrong-tagged) pointer, asserts the fault handler fires with the expected structured log.
+- [ ] 2.13 Add an `aarch64-mte-pac-smoke` CI job (advisory initially) that runs the smoke under QEMU.
+- [ ] 2.14 On Orin NX hardware: capture the boot output showing `[pac] keys installed` and `[mte] sync tag-check enabled`, the existing ONNX test suite completion, and a deliberate-tag-mismatch fault triggered by an injected test syscall. Paste in the PR description.
+
+## 3. Docs
+
+- [ ] 3.1 Create `docs/aarch64-security.md` covering: MTE/PAC overview, what each key/feature catches, the exact compiler flags + `cargo build` invocation, the per-boot key derivation, the fault decode procedure (interpreting `ESR_EL1.EC`, `FAR_EL1`, granule tag), the Cargo sub-features (`mte-async`, `mte-watchdog`, `mte-pac-deterministic`), and DO-178C alignment notes.
+- [ ] 3.2 Update `docs/architecture.md` Layer 2 (HAL) section to call out hardware memory-safety on aarch64.
+- [ ] 3.3 Update `CLAUDE.md` "Current state" to note MTE+PAC active on `tegra234` builds.
+
+## 4. Verify + archive
+
+- [ ] 4.1 Run `openspec validate aarch64-mte-pac-hardening-v1 --strict`.
+- [ ] 4.2 Squash-merge both phases.
+- [ ] 4.3 Open archive PR moving the change to `openspec/changes/archive/YYYY-MM-DD-aarch64-mte-pac-hardening-v1`.

--- a/openspec/changes/cheri-capability-v1/design.md
+++ b/openspec/changes/cheri-capability-v1/design.md
@@ -1,0 +1,106 @@
+# Design — cheri-capability-v1
+
+## Goal
+
+Produce two artifacts that prove SmallAIOS is CHERI-aware on paper and CHERI-clean in critical code paths:
+
+1. `docs/cheri-alignment.md` — the side-by-side mapping of SmallAIOS's capability model to CHERI's hardware capability model, with explicit gap analysis.
+2. `notes/cheri-compile-experiment.md` — empirical evidence from a one-shot attempt to compile the capability primitives under the `cheri-rust` research toolchain.
+
+This is a research-track change. It does not produce running code on CHERI silicon and does not block any other proposal.
+
+## Design decisions
+
+### Decision 1: Document-driven, not implementation-driven
+
+A typical OpenSpec change ships running code. This one ships documentation. The justification: CHERI hardware is not deployable in any environment SmallAIOS targets in 2026, so producing running code would be either (a) only-useful-on-research-FPGA — limited audience, high maintenance cost, or (b) emulator-only — which doesn't prove anything about real silicon behavior. The documentation deliverable is the highest-leverage option for the current state of CHERI maturity.
+
+If CHERI hardware matures (Phase 3+ becomes feasible), a future change `cheri-capability-v2` opens the implementation track. This proposal explicitly does not commit to that follow-up.
+
+### Decision 2: CHERI-RISC-V target, not Morello (CHERI-ARM)
+
+CHERI exists in two production research targets:
+
+| Target | ISA | Status | Why pick / not pick |
+|--------|-----|--------|--------------------|
+| **CHERI-RISC-V** (CHERIoT-Ibex / Sail-RISC-V) | RISC-V | Multiple FPGA + ASIC variants | **Pick** — aligns with SmallAIOS's existing riscv64 target, embedded-friendly |
+| Morello | aarch64 (Armv8.2-A extended) | Single Arm Research prototype, ~2021 | Reject — research-only, no embedded/avionics variant planned |
+
+If a flight-qualified CHERI-ARM variant ever emerges, the trait shape designed here would let us add a second target without restructuring.
+
+### Decision 3: Capability model alignment table — explicit field-by-field
+
+The CHERI hardware capability is a 128-bit object with these fields (CHERI ISAv9):
+
+| CHERI field | Size | Meaning | SmallAIOS analog |
+|-------------|------|---------|------------------|
+| `tag` | 1 bit | Validity bit, hardware-managed | Implicit — `Capability` exists or it doesn't |
+| `base` | 64 bits | Lower bound of accessible region | No direct analog — handle indexes into pools |
+| `length` | 64 bits | Region size | No direct analog — pool entry has its own size |
+| `address` | 64 bits | Current pointer position | The handle's `resource_id` field |
+| `perms` | 16 bits | R/W/X/LC/SC/SE/CINV/etc. | `Permissions` enum (much smaller domain) |
+| `otype` | 16 bits | Sealed-capability type | `ResourceType` enum |
+| `flags` | 8 bits | Implementation-defined | Unused in SmallAIOS analog |
+
+The mapping is clean for the conceptual fields (perms ↔ Permissions, otype ↔ ResourceType) and somewhat awkward for the spatial fields (CHERI's base/length/address vs SmallAIOS's pool-index model). The alignment doc explicitly calls this out — porting to CHERI would require migrating from "handle indexes a pool" to "capability carries its own bounds", which is a kernel-side refactor of moderate scope (estimated 2-3 weeks if and when it happens).
+
+### Decision 4: Sealed capabilities as the hardware analog of PAC-signed handles
+
+CHERI's *sealing* mechanism lets a capability be wrapped with an `otype` so that it can only be unsealed (used as a normal pointer) by code that holds an unseal capability for that type. This is the hardware analog of the PAC-signed capability handles in `aarch64-mte-pac-hardening-v1` (sign with `pacda` using `ResourceType` as modifier). The alignment doc maps:
+
+- `Capability { resource_type: TensorBuffer, ... }` (SmallAIOS today) → `CHERI capability sealed with otype = TENSOR_BUFFER_OTYPE` (CHERI future).
+- `autda` fails because of a wrong `ResourceType` modifier (SmallAIOS today) → hardware unseal-fault because the otype doesn't match the unseal-capability's otype (CHERI future).
+
+This is one of the cleanest semantic alignments — both designs catch confused-deputy attacks via the same conceptual mechanism (typed unforgeable handles).
+
+## Alternatives considered
+
+### Alt A: Don't write the proposal at all — wait for CHERI silicon to mature
+
+**Rejected.** The cost of writing the alignment doc + compile experiment is low (~2 weeks) and the option-value of being CHERI-ready is high. Not having a proposal makes us reactive when silicon timelines firm up; having one makes us proactive.
+
+### Alt B: Implement CHERI in software (capability emulation in the unikernel)
+
+**Rejected.** Software-emulated CHERI capabilities (a `Capability<T>` newtype that does runtime bounds + permission checks) lose the entire performance + certification value proposition. The point of CHERI is hardware enforcement. A software emulation costs runtime cycles for no measurable security gain over what we already get from Rust's type system + MTE.
+
+### Alt C: Skip RISC-V, focus on Morello
+
+**Rejected.** Morello is a single prototype board, primarily a research vehicle, not a path to deployed hardware. Even though SmallAIOS's aarch64 path is more mature than riscv64 (Orin is our reference platform), the deployment path for CHERI is the embedded-RISC-V variants (CHERIoT-Ibex).
+
+### Alt D: Make the CHERI feature a public roadmap commitment
+
+**Considered, rejected.** Publicly committing to CHERI support before silicon timelines firm up creates implicit deadlines we can't meet. The proposal is internal-facing and the docs are internal — the roadmap commitment, if any, is a separate communications decision.
+
+## Risks
+
+### Risk 1: CHERI silicon never reaches a flight-qualified state
+
+The largest risk. If CHERI remains research-only for the next decade, the alignment doc remains a planning artifact with no production value. Mitigation: the cost of the proposal is bounded (Phase 1+2 = ~2 weeks); the upside if silicon does mature is large. We treat it as a low-cost hedge.
+
+### Risk 2: `cheri-rust` toolchain bit-rots
+
+The CHERI Rust fork is maintained by SRI International / University of Cambridge research groups and lags upstream Rust by months. The Phase 2 compile experiment may need to use an older Rust target than `nightly-2026-02-01`. Mitigation: Phase 2 deliverable explicitly documents the toolchain version used; the experiment is reproducible from the documented invocation, not bit-perfect against a future toolchain.
+
+### Risk 3: Capability model evolution
+
+The SmallAIOS capability model itself is evolving. Major changes (e.g., adding revocation, hierarchical capabilities) would invalidate parts of the CHERI alignment doc. Mitigation: the doc is dated; future capability-model changes trigger a doc refresh.
+
+### Risk 4: Misleading "CHERI-ready" claims
+
+Saying "SmallAIOS is CHERI-ready" without running on hardware is over-promising. Mitigation: the alignment doc explicitly states "alignment-on-paper, not hardware-tested" in its opening section; the proposal restricts itself to "research-stage, exploratory".
+
+## Build/CI surface
+
+- No build changes. No new Cargo feature.
+- No CI changes.
+- New file: `docs/cheri-alignment.md`.
+- New file (in this change's `notes/`): `notes/cheri-compile-experiment.md` (if Phase 2 produces evidence).
+
+## What this change explicitly does NOT do
+
+- Does not produce any Rust code.
+- Does not add a CHERI-related Cargo feature to any crate.
+- Does not commit to a CHERI implementation timeline.
+- Does not modify any existing capability code.
+- Does not require any hardware.
+- Does not interact with any of the four parallel memory-safety changes — it is purely a forward-looking planning artifact.

--- a/openspec/changes/cheri-capability-v1/proposal.md
+++ b/openspec/changes/cheri-capability-v1/proposal.md
@@ -1,0 +1,63 @@
+# cheri-capability-v1
+
+## Summary
+
+CHERI (Capability Hardware Enhanced RISC Instructions) is a research-stage instruction-set extension that replaces raw pointers with 128-bit hardware *capabilities* — pointers that carry bounds, permissions, and an unforgeable tag bit. A CHERI capability cannot be forged, cannot exceed its installed bounds, and cannot be widened in scope. The result is hardware-enforced spatial + temporal memory safety at the *pointer* level, complementary to MTE (tag-per-allocation, see `aarch64-mte-pac-hardening-v1`) and SMMU isolation (per-peripheral DMA bounds, see `tegra-smmu-isolation-v1`).
+
+This proposal is **exploratory and research-stage**: no production CHERI silicon exists for SmallAIOS to target today. The reference hardware is the **CHERI-RISC-V** family (Morello prototype boards from Arm Research and the FETT trial; the SCI's Sunburst board; the upcoming CHERIoT-Ibex variants for embedded). All run RISC-V — which aligns with SmallAIOS's existing `riscv64gc-unknown-none-elf` target — but none are production-ready and none are deployable in an avionics box today.
+
+The change is framed as **research alignment**: SmallAIOS already uses a capability-based security model in software (`kernel/src/cap.rs`'s `ResourceType` + `Permissions` + handle-based authorization). Moving that model to *hardware-enforced* capabilities is a natural future step if CHERI matures. This proposal documents the alignment, defines a research-track Cargo feature (`cheri`, off by default, riscv64 only), and lays out what a SmallAIOS-on-CHERI port would look like — *as a planning document*, not an implementation timeline.
+
+## Why
+
+- **SmallAIOS's existing capability model is structurally CHERI-aligned.** `kernel/src/cap.rs` already treats every resource handle as a capability: `Capability { resource_type, permissions, ... }` is the kernel-side authorization primitive for every syscall. CHERI takes that same shape and moves it from "kernel-checked at every dereference" to "hardware-enforced at every load/store". The semantic match is unusually clean — there is no design impedance between our software capabilities and CHERI's hardware ones.
+- **The DO-178C / avionics value of provable memory safety is enormous.** If CHERI silicon ever ships in a flight-qualified part, the certification value proposition shifts: instead of "we have done our best to write memory-safe Rust, plus MTE/PAC, plus SMMU, plus speculation barriers" we can say "every pointer in the kernel is hardware-enforced to its bounds, every capability is unforgeable, every cross-component pointer transfer is monotonic in permissions". That story changes the cert risk profile materially.
+- **The cost of being CHERI-ready is low if we start now.** The SmallAIOS Rust code is small (~30 crates, mostly `#![no_std]`). Porting to CHERI's `cheri-rust` toolchain — which exists upstream as a research fork — is mechanical in many places (raw pointers become explicit capabilities) and exposes safety issues in others (any `unsafe` block that bypasses bounds becomes immediately visible). Even *not yet running on CHERI silicon*, the static-analysis value of "would this compile under CHERI?" is high. We can run the compile in CI without ever booting on CHERI hardware.
+- **It is the right time to plan for it, not to ship it.** The CHERIoT-Ibex variant targets embedded workloads in particular. Industrial partners are beginning to evaluate flight-qualified CHERI silicon timelines. None of that is product-ready in 2026. But a proposal that lays out the alignment now lets us track the maturity from the inside — and lets us push back on alternative roadmaps that ignore CHERI.
+
+## Scope — exploratory phases
+
+This proposal does NOT commit to implementation. It commits to producing artifacts that prove SmallAIOS is CHERI-compatible-on-paper and ready to test on hardware as soon as such hardware is available.
+
+### Phase 1 — Documentation + capability-model alignment doc (~1 week)
+
+Produce `docs/cheri-alignment.md` covering:
+
+- A side-by-side mapping of SmallAIOS's `Capability { resource_type, permissions, ... }` struct to CHERI's capability fields (`base`, `length`, `perms`, `otype`, `tag`).
+- Which existing `unsafe` blocks in SmallAIOS would become CHERI-trapped if compiled under `cheri-rust` (e.g., raw pointer arithmetic in the allocator).
+- Which CHERI permissions map to which SmallAIOS `Permissions` enum variants — `R` ↔ `LOAD`, `W` ↔ `STORE`, `X` ↔ `EXECUTE`, with notes on the CHERI-only permissions (`LOAD_CAP`, `STORE_CAP`, `SEAL`, etc.) that have no SmallAIOS analog yet.
+- Suggested mapping of `ResourceType` discriminants to CHERI `otype` values for sealed capabilities (which would prevent cross-resource-type confusion at the hardware level — a hardware analog of the `pacda`-based confused-deputy defense in `aarch64-mte-pac-hardening-v1`).
+
+### Phase 2 — Toolchain experiment (~1 week)
+
+Attempt to compile a small subset of SmallAIOS (the `smallaios-security` crate's capability primitives) under the `cheri-rust` toolchain. Document what compiles, what doesn't, what changes would be needed. No CI integration — this is one-shot research evidence.
+
+The deliverable is a short report (`notes/cheri-compile-experiment.md`) covering: build command used, errors encountered, hand-applied fixes, conclusion ("the capability core is N% CHERI-clean, with M issues clustered around X pattern").
+
+### Phase 3 — Defer everything else
+
+Anything beyond Phase 2 — actually running on Morello / CHERIoT silicon, integrating CHERI capabilities with the SMMU work, performance benchmarks — is **deferred until production-grade CHERI silicon is available for embedded workloads**. The proposal explicitly tracks this as "open question, revisit when hardware matures".
+
+## Out of scope
+
+- **All other implementation work.** Phase 3+ is explicitly deferred.
+- **Toolchain CI integration.** `cheri-rust` is a research fork; adding it as a CI dependency adds maintenance burden for no current return. The compile experiment in Phase 2 is one-shot, not gated.
+- **Hardware procurement.** Morello boards are available via Arm Research; CHERIoT FPGA targets via Microsoft Research. Procurement decisions are deferred.
+- **CHERI for x86_64 or aarch64.** CHERI extensions to those ISAs exist as research (Morello is aarch64-based), but the path SmallAIOS prioritizes is CHERI-RISC-V because (a) our existing riscv64 target needs the most security work anyway, (b) CHERIoT-Ibex is the closest-to-production embedded variant, (c) Morello is an aarch64 prototype that is unlikely to ship in flight-qualified form.
+
+## Sequencing
+
+This change is fully independent of the four parallel changes (`tegra-smmu-isolation-v1`, `aarch64-mte-pac-hardening-v1`, `spec-exec-mitigations-v1`, `ecc-scrubbing-v1`). It can land anytime; it produces docs only. The right time to do Phase 1+2 is when there is a research-track sprint week available — for example, between major implementation pushes when the team has bandwidth for forward-looking work.
+
+The proposal pre-positions SmallAIOS to move quickly *if and when* CHERI silicon becomes flight-qualified. The risk of not doing this now: another OS (a CHERI-native research kernel from Cambridge or SRI, for instance) becomes the default platform for CHERI inference workloads, and SmallAIOS plays catch-up.
+
+## Effort estimate
+
+| Phase | Scope | Estimate |
+|-------|-------|----------|
+| 1 | Alignment documentation | ~1 week |
+| 2 | Toolchain compile experiment | ~1 week |
+| 3+ | All implementation work | Deferred indefinitely |
+| **Total in-scope** | | **~2 weeks** |
+
+Beyond Phase 2 — the actual hardware port — is a multi-quarter effort once silicon and a cert-viable timeline emerge. This proposal does not estimate that.

--- a/openspec/changes/cheri-capability-v1/specs/kernel-cheri/spec.md
+++ b/openspec/changes/cheri-capability-v1/specs/kernel-cheri/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: CHERI alignment documentation maintained alongside the capability system
+
+The repository SHALL maintain a CHERI alignment document (`docs/cheri-alignment.md`) that maps the SmallAIOS in-software capability model (`kernel/src/cap.rs`) to the CHERI hardware capability model, identifies gaps between them, and is refreshed whenever the SmallAIOS capability model changes substantively.
+
+#### Scenario: Alignment document exists and opens with a research-stage disclaimer
+
+- **GIVEN** the SmallAIOS repository
+- **WHEN** a reader opens `docs/cheri-alignment.md`
+- **THEN** the document's opening section SHALL contain the statement "This document is alignment-on-paper, not hardware-tested. SmallAIOS does not run on CHERI silicon today." (or substantively equivalent wording)
+- **AND** the document SHALL contain at least three sections: capability-field mapping, permissions mapping, and gap analysis
+- **AND** the document SHALL cite specific `kernel/src/cap.rs` line numbers when describing the SmallAIOS-side primitives
+
+#### Scenario: Capability-field mapping table
+
+- **GIVEN** the alignment document
+- **WHEN** a reader inspects the field-mapping section
+- **THEN** it SHALL include a table covering at least these CHERI capability fields: `tag`, `base`, `length`, `address`, `perms`, `otype`
+- **AND** for each CHERI field, the table SHALL state the corresponding SmallAIOS-side primitive (or "no direct analog" with an explanation)
+- **AND** the table SHALL be sourced from CHERI ISAv9 (or whatever version is current at doc-update time) with a citation
+
+#### Scenario: Alignment doc refreshes on capability-model change
+
+- **GIVEN** a future SmallAIOS change that modifies `kernel/src/cap.rs`'s capability shape
+- **WHEN** that change is proposed
+- **THEN** the change's tasks list SHALL include refreshing `docs/cheri-alignment.md` to reflect the new shape
+- **AND** validation of the change SHALL fail if the doc is not updated
+
+### Requirement: CHERI compile experiment evidence published
+
+The repository SHALL publish empirical evidence from at least one attempt to compile the SmallAIOS capability primitives under the CHERI-Rust research toolchain, as a one-shot snapshot rather than a CI-gated activity.
+
+#### Scenario: Compile experiment results stored under the change's notes
+
+- **GIVEN** the change `cheri-capability-v1` has completed Phase 2
+- **WHEN** a reviewer inspects the change directory
+- **THEN** the directory SHALL contain `notes/cheri-compile-experiment.md` (or, when the change is archived, the equivalent file under `openspec/changes/archive/<date>-cheri-capability-v1/notes/`)
+- **AND** the file SHALL document: the `cheri-rust` toolchain version used, the build invocation, the errors encountered (clustered by category), the hand-fixes applied if any, and the conclusion (% of the targeted code that compiled cleanly)
+
+#### Scenario: Experiment is one-shot, not CI-gated
+
+- **GIVEN** the SmallAIOS CI configuration
+- **WHEN** the CI pipeline runs
+- **THEN** no CI job SHALL depend on the `cheri-rust` toolchain
+- **AND** the experiment SHALL NOT be automated to re-run on every PR — the published evidence is a snapshot, not a continuous regression check
+
+### Requirement: CHERI implementation work is explicitly deferred
+
+The change `cheri-capability-v1` SHALL produce documentation only, and SHALL NOT modify any Rust source code or Cargo manifest in the repository. Implementation work targeting CHERI silicon is explicitly deferred to a future change (`cheri-capability-v2` or successor) that is gated on production-grade CHERI hardware availability.
+
+#### Scenario: This change introduces no Rust code
+
+- **GIVEN** the diff of the `cheri-capability-v1` change against `develop`
+- **WHEN** a reviewer inspects the diff
+- **THEN** the diff SHALL contain no `.rs` files, no `Cargo.toml` modifications, no `.cargo/config.toml` modifications, and no CI workflow changes
+- **AND** the diff SHALL consist of documentation (`docs/`, `notes/`) and the OpenSpec change directory only
+
+#### Scenario: Implementation follow-up is named and tracked
+
+- **GIVEN** the alignment doc's "roadmap if silicon matures" section
+- **WHEN** a reader inspects it
+- **THEN** the section SHALL name the follow-up change (`cheri-capability-v2`) and list its in-dependency-order tasks at a high level
+- **AND** the section SHALL state explicitly that the follow-up is gated on production-grade CHERI silicon availability — it is NOT a committed roadmap item

--- a/openspec/changes/cheri-capability-v1/tasks.md
+++ b/openspec/changes/cheri-capability-v1/tasks.md
@@ -1,0 +1,39 @@
+# Tasks — cheri-capability-v1
+
+## 0. Reference reading
+
+- [ ] 0.1 Read the CHERI ISAv9 specification (Watson et al., "Capability Hardware Enhanced RISC Instructions: CHERI Instruction-Set Architecture", UCAM-CL-TR-987). Focus on the 128-bit capability representation, sealing/unsealing semantics, and the RISC-V instruction subset (`cgetbase`, `cgetlen`, `cseal`, `cunseal`, etc.).
+- [ ] 0.2 Read the CHERIoT specification (Microsoft Research) for the embedded variant. Note the simplifications (no compressed-encoding 64-bit variant; pure 32-bit) and the implications for an embedded SmallAIOS port.
+- [ ] 0.3 Read SRI's "CHERI for the Linux Kernel" porting notes and the FreeBSD-on-CHERI experience reports for porting lessons.
+- [ ] 0.4 Survey the `cheri-rust` toolchain status as of the change date — what version of upstream Rust it tracks, what Cargo features are supported, what is broken.
+
+## 1. Phase 1 — Alignment documentation
+
+- [ ] 1.1 Create `docs/cheri-alignment.md` with an opening section: "This document is alignment-on-paper, not hardware-tested. SmallAIOS does not run on CHERI silicon today."
+- [ ] 1.2 Add the field-by-field mapping table (CHERI capability fields ↔ SmallAIOS `Capability` struct fields). Cite `kernel/src/cap.rs` line numbers.
+- [ ] 1.3 Add the permissions mapping table (CHERI `perms` bits ↔ SmallAIOS `Permissions` enum variants). Call out the CHERI-only permissions (`LOAD_CAP`, `STORE_CAP`, `SEAL`, etc.) that have no SmallAIOS analog today.
+- [ ] 1.4 Add the otype/sealed-capability mapping section (CHERI sealing ↔ SmallAIOS PAC-signed handle from `aarch64-mte-pac-hardening-v1`).
+- [ ] 1.5 Add a gap-analysis section: list the SmallAIOS capability-model changes that would be required for a hardware CHERI port (handle-pool model → carried-bounds model). Estimate effort.
+- [ ] 1.6 Add an "unsafe surface area" section: enumerate the `unsafe` blocks in SmallAIOS that would compile-fail under `cheri-rust` and explain why each one is or isn't a real bug. Focus on the allocator (`kernel/src/mem/heap.rs`), DTB parsing (`kernel/src/mem/phys.rs`), and FFI surfaces (CUDA bindings in `arch/nvidia/`).
+- [ ] 1.7 Add a "roadmap if silicon matures" section: bullet list of follow-up changes that would be needed in dependency order (`cheri-capability-v2` for the first hardware test, then SMMU integration, then performance benchmarking, then certification artifacts).
+
+## 2. Phase 2 — Toolchain compile experiment
+
+- [ ] 2.1 Set up a `cheri-rust` development environment on a Linux workstation (Docker image preferred — SRI publishes a `cheri-rust` toolchain image). Document the version + image hash in `notes/cheri-compile-experiment.md`.
+- [ ] 2.2 Attempt to compile the `smallaios-security` crate's capability primitives (the `Capability` struct, the `require_capability` function, and the `Permissions` enum) for the `riscv64gc-unknown-cheri-elf` (or equivalent CHERI-RISC-V) target.
+- [ ] 2.3 Document each compile error encountered, the hand-fix applied (if any), and the conclusion in `notes/cheri-compile-experiment.md`. Format: errors clustered by category (pointer arithmetic, raw FFI, etc.), counts per category.
+- [ ] 2.4 If the capability primitives compile cleanly, attempt one syscall (`sys_mem_alloc`) as a stretch goal. Document the result.
+- [ ] 2.5 Write the conclusion section: % CHERI-clean, biggest gaps, recommendation for next steps.
+
+## 3. Phase 3+ — Deferred
+
+- [ ] (Deferred indefinitely) Hardware port — requires production CHERI silicon.
+- [ ] (Deferred indefinitely) SMMU + CHERI integration — requires hardware and a settled spec for CHERI + IOMMU interaction.
+- [ ] (Deferred indefinitely) Performance benchmarking on CHERI silicon.
+- [ ] (Deferred indefinitely) Certification artifacts for CHERI-on-SmallAIOS.
+
+## 4. Verify + archive
+
+- [ ] 4.1 Run `openspec validate cheri-capability-v1 --strict`.
+- [ ] 4.2 Squash-merge to `develop`. (No code changes — the merge is doc-only.)
+- [ ] 4.3 Open archive PR moving the change to `openspec/changes/archive/YYYY-MM-DD-cheri-capability-v1` and sync the spec deltas to main specs. The archived state retains the deferred Phase 3+ tasks as open research questions.

--- a/openspec/changes/ecc-scrubbing-v1/design.md
+++ b/openspec/changes/ecc-scrubbing-v1/design.md
@@ -1,0 +1,132 @@
+# Design — ecc-scrubbing-v1
+
+## Goal
+
+A background ECC memory-scrubbing service that walks every kernel-managed DRAM region at a configurable interval, surfaces correctable / uncorrectable error counts per region, and integrates with the watchdog to detect scheduler hangs. Two backends: Tegra234 EMC hardware scrub (preferred when available) and software read-modify-write scrub (universal fallback). One async task per region, all running in the cooperative scheduler.
+
+## Design decisions
+
+### Decision 1: Per-region scrub state, not global
+
+Different memory regions have different scrub priorities:
+
+| Region | Scrub interval | Why |
+|--------|---------------|-----|
+| ONNX model weights | 24 h | Static once loaded, but a flipped weight bit persists indefinitely until corrected |
+| Heap | 6 h | Transient — most allocations don't live long enough to accumulate error, but long-lived ones (graph builders, capability tables) do |
+| DTB region | 7 d | Read-once at boot, kept around for debug |
+| Kernel `.bss` / `.data` | 24 h | Mostly static after boot |
+| GPU-shared (post `tegra-smmu-isolation-v1`) | 12 h | Live workload, but the GPU's own ECC may already cover |
+
+Per-region state means we can apply per-region intervals. A single global scrub would either be too slow (24 h baseline on all regions = ONNX activations get under-protected) or wasteful (1 h on all regions = DTB scrubbed pointlessly).
+
+### Decision 2: Cooperative async task, not interrupt-driven
+
+The scrub task is a normal async task in the SmallAIOS cooperative scheduler. It walks pages one chunk (default 64 KiB) at a time and yields between chunks. This naturally interleaves with inference work — the scheduler doesn't preempt, so a long ONNX op completes before scrub resumes.
+
+Alternative — driving scrub from a timer interrupt — was considered. Rejected because (a) interrupt handlers in `#![no_std]` should be short, and even a 64 KiB read-modify-write loop is too long; (b) cooperative async is the existing scheduling discipline and adding interrupt-driven exceptions to it adds complexity for marginal benefit; (c) the EMC hardware scrub *is* interrupt-driven internally — we just program its registers and poll completion in our task.
+
+### Decision 3: TOML config at boot, programmatic API for runtime adjustment
+
+Static config (`/etc/smallaios-scrub.toml` for container builds, embedded in the kernel image for unikernel builds) defines the default regions and intervals. A programmatic API (`scrub::add_region(...)` and `scrub::set_interval(...)`) lets the kernel re-tune at runtime — e.g., when a new ONNX model loads, register its weight region with a 24 h interval.
+
+This mirrors how the existing `peripheral` config layer works.
+
+### Decision 4: Backend abstraction — `ScrubBackend` trait
+
+```rust
+trait ScrubBackend {
+    fn name(&self) -> &'static str;
+    async fn scrub_region(&mut self, region: &Region) -> ScrubResult;
+    fn supports_async_completion(&self) -> bool;
+    fn error_counters(&self) -> (u64, u64); // (correctable, uncorrectable) since boot
+}
+```
+
+Two implementations:
+
+- `TegraEmcBackend` — programs the Tegra234 EMC patrol-scrub registers, polls completion, reads error counters from `EMC_ECC_STATUS`.
+- `SoftwareBackend` — `usize`-stride read+write loop. Yields after every chunk. Doesn't actually report correctable-error counts (those come from the DRAM controller in any case; software backend just *triggers* corrections by reading); we wire a separate `ras_counters` API for that on platforms that expose them.
+
+Backend is selected at runtime (`ScrubBackend::probe()` returns the best available) so the same binary runs on Orin NX (EMC path) and an x86 dev box (software path).
+
+### Decision 5: Watchdog correlation — scrub-advance feeds watchdog
+
+The watchdog "wants" to be fed periodically. Tying the feed to scrub-advance has a beneficial property: if the scheduler is starved, scrub stops advancing, and the watchdog fires. If the EMC stops responding, scrub stops advancing, and the watchdog fires. If the scrub task itself panics, scrub stops advancing, and the watchdog fires.
+
+This is *too aggressive* without nuance — between scrub cycles the task is idle, and we don't want the watchdog firing during legitimate idle. Solution: the scrub task feeds the watchdog every loop iteration regardless of whether it advanced the cursor, but it tracks a separate "advanced recently" flag that toggles. The watchdog policy is configurable:
+
+- **Aggressive (DAL A default)**: cursor must advance every `watchdog_threshold` seconds, else reset.
+- **Permissive (development default)**: any scrub task heartbeat (even idle) feeds the watchdog.
+
+### Decision 6: Boot-time hardware probe + demand-mode wipe
+
+At boot, after the EMC is configured, run one full demand-mode scrub of the kernel image + heap region. This serves three purposes:
+
+1. **Verify EMC responds** — if `EMC_ECC_STATUS` reads back garbage, fall back to software scrub with a warning.
+2. **Establish a known-good baseline** — initial scrub corrects any error that accumulated in DRAM between power-on and kernel init.
+3. **Surface UEFI-residual errors** — UEFI may have left correctable errors in its own pages; scrubbing surfaces them in the boot log.
+
+Demand mode blocks until complete (no async yield) so we get a clean baseline. After boot, the patrol-mode service takes over.
+
+## Alternatives considered
+
+### Alt A: Rely on the DRAM controller's autonomous patrol scrub (no kernel involvement)
+
+**Rejected.** Most DRAM controllers (Tegra234's EMC included) can run patrol scrub autonomously without kernel intervention, but:
+
+- Error counters are still kernel-readable only via MMIO; without kernel polling we don't *see* the errors.
+- Configuration (interval, region selection) is firmware-set on most platforms — we lose the per-region tuning.
+- Watchdog correlation requires kernel-side visibility into scrub progress.
+
+Autonomous patrol is the lowest-friction path but it gives up the certification evidence we need.
+
+### Alt B: Memory mirroring (RAID-1 of DRAM regions) instead of scrubbing
+
+**Rejected for now.** Some server platforms support memory mirroring at the BIOS level (write to two physical regions; reads consistency-check). It would catch double-bit errors as well. Cost: 2× memory, complex firmware setup, not available on Jetson Orin or any embedded part we target. Tracked for future server-platform-only consideration.
+
+### Alt C: Stop the world during scrub
+
+**Rejected.** Synchronous scrub of a 16 GB region takes seconds at memory-bus bandwidth. Pausing inference for seconds every interval is unacceptable. The cooperative async approach interleaves naturally.
+
+### Alt D: Use Linux's existing scrub user-space tools and call them via FFI
+
+**Rejected.** SmallAIOS is `#![no_std]` and the unikernel has no path to Linux user-space. The container build could in principle pipe out to a user-space scrub tool, but that's the wrong layering — scrub is a kernel concern.
+
+## Risks
+
+### Risk 1: ECC support varies by deployment
+
+Orin NX (P3767-0000) ships with LPDDR5 ECC enabled in NVIDIA's standard config; verify on the specific board before relying. x86 server platforms vary widely. RISC-V dev boards rarely have ECC at all. Mitigation: `scrub::probe()` detects whether ECC is configured at boot; on non-ECC platforms it logs `[ecc-scrub] DRAM does not advertise ECC; service disabled` and the scrub task does not start. Software fallback is still available as a defense-in-depth correctness check, but its value is much lower without ECC.
+
+### Risk 2: Scrub interval misconfiguration starves inference
+
+Too-aggressive intervals on too-large regions could consume measurable memory bandwidth. Mitigation: (a) `scrub::stats` surfaces bandwidth usage; (b) the default intervals (6-24 h depending on region) are conservative; (c) the cooperative yield ensures inference progress regardless of scrub rate; (d) Phase 5 docs include a calibration table for different operational environments.
+
+### Risk 3: Tegra234 EMC register documentation gaps
+
+NVIDIA's published Tegra234 TRM covers `EMC_ECC_SCRUB_*` registers but some Linux-driver lore (the `tegra-mc` driver in L4T's NVIDIA fork) suggests there are undocumented fields that the firmware uses. Mitigation: (a) verify register semantics against L4T fork source code; (b) test against real Orin NX hardware with deliberate bit-error injection (some boards expose DBI registers); (c) if a register is too undocumented, fall back to software scrub on Tegra234 with a warning rather than guessing.
+
+### Risk 4: Soak-test workload availability
+
+Verifying the service requires running for days under realistic workload. Mitigation: post-merge, schedule a 7-day soak on a dedicated Orin NX with a fixed LLM workload; track the correctable-error counter as the baseline. Treat this as a "release readiness" gate for the avionics-cert track.
+
+### Risk 5: Watchdog tuning is environment-specific
+
+Aggressive-mode watchdog reset on scrub stall is right for DAL A; wrong for development where a debugger pause is legitimate. Mitigation: clearly-named Cargo features (`scrub-watchdog-aggressive`, `scrub-watchdog-permissive`) with explicit docs about which is appropriate when.
+
+## Build/CI surface
+
+- New Cargo feature `ecc-scrub` on `smallaios-kernel`, off by default. Default-on for `tegra234`-feature builds once Phase 2 lands hardware verification.
+- New module `kernel/src/mem/scrub/{mod.rs, task.rs, config.rs, stats.rs, sw_backend.rs}`.
+- New module `arch/aarch64/src/scrub/tegra_emc.rs` (when `tegra234` + `ecc-scrub` are both on).
+- New `just ecc-scrub-test` recipe that boots a kernel with the service on, runs a 30-minute software-scrub cycle on a 1 MB test region, asserts no errors and correct cycle-count increment.
+- New CI advisory job `ecc-scrub-smoke` (TCG-emulated, software backend only — hardware backend requires self-hosted Orin runner).
+- New `docs/ecc-scrubbing.md`.
+
+## What this change explicitly does NOT do
+
+- Does not modify any non-mem code paths (syscalls, ONNX, networking, capability system).
+- Does not change syscall ABI — scrub stats are surfaced via the telemetry path, not via a new syscall.
+- Does not add a new dependency — all new code is `#![no_std]` core+alloc.
+- Does not require any change to the existing DRAM init in `mem::init` — scrub runs *after* mem-init completes.

--- a/openspec/changes/ecc-scrubbing-v1/proposal.md
+++ b/openspec/changes/ecc-scrubbing-v1/proposal.md
@@ -1,0 +1,83 @@
+# ecc-scrubbing-v1
+
+## Summary
+
+Single-event upsets (SEUs) — DRAM bit flips caused by cosmic rays, alpha particles, or thermal noise — are a measurable failure mode in any system that runs continuously for weeks at altitude or in radiation-exposed environments (avionics > 30,000 ft, satellites, ground stations near reactor sites, high-altitude balloon platforms). Single-bit errors are detected *and* corrected by ECC DRAM at the controller level; double-bit errors are detected but uncorrectable. The mitigation against the second class is **periodic memory scrubbing**: walk every DRAM region in the background, force a read-modify-write at ECC-granularity, so single-bit errors are silently corrected before they accumulate into double-bit errors.
+
+This change adds an ECC scrubbing service to the SmallAIOS kernel under a new `ecc-scrub` Cargo feature on `smallaios-kernel`, gated to platforms with ECC DRAM controllers (Jetson Orin AGX Industrial, modern x86 server platforms, certain RISC-V dev boards with LPDDR4-ECC). The service runs as a low-priority background task in the cooperative scheduler, scrubs a configurable region at a configurable interval, integrates with the existing watchdog, and surfaces per-region scrub-cycle counters + correctable-error counts via telemetry. New capability: `kernel-mem` extended with scrub-related Requirements.
+
+## Why
+
+- **DO-178C DAL A and DO-254 design-assurance both expect single-event-effect (SEE) mitigation in any system fielded above 30,000 ft.** Avionics environments accumulate ~1 SEU per gigabit per 1000 hours at cruise altitude (industry rule-of-thumb, varies by latitude and solar activity). A 16 GB Jetson Orin NX deployed in a UAV computing pod for a 1000-hour mission expects 16 single-bit corrections statistically. If we don't scrub, single-bit errors accumulate at the bit positions they occur — and when a second flip hits the same ECC word, the error becomes uncorrectable. RTCA DO-160G section 22 (lightning-induced upset) and section 25 (electrostatic discharge) explicitly call out memory-system error-rate budgets. The certification answer for "what is your scrub interval" cannot be "we don't scrub".
+- **SmallAIOS targets long-running inference workloads where the math just works against us.** Continuous LLM inference on Jetson Orin in an avionics pod is exactly the workload where scrubbing matters most: every weight tensor sits in DRAM for weeks, every activation walks through DRAM hundreds of times per second, and any single-bit flip in a weight is permanent until corrected. ML workloads are also (helpfully) resilient to single-bit weight perturbations — the network keeps producing roughly-correct outputs even with a corrupted weight — which means errors go undetected by the workload itself. Scrubbing is the only mechanism that surfaces them.
+- **The Tegra234 memory controller exposes scrub registers via the EMC (External Memory Controller).** NVIDIA's Tegra234 TRM documents the EMC's `EMC_CFG_DIG_DLL` and `EMC_ECC_SCRUB_*` register family for hardware-accelerated scrubbing. Linux's `tegra-mc` driver doesn't currently expose them (L4T treats them as firmware-managed). SmallAIOS as a unikernel can drive them directly — the EMC is part of the SoC's MMIO surface and the registers are documented. On x86 server platforms the equivalent is `ECC Scrub` controlled via the memory controller's PCIe-config registers; on AMD EPYC it's `SCRUBCTRL` MSRs. The interface is platform-specific but the abstraction is uniform: "scrub region R every interval I".
+- **The cooperative scheduler is the right home for the scrub task.** SmallAIOS uses cooperative async with yields at ONNX op boundaries (`docs/scheduling-model.md`). A scrub task that yields after every N pages naturally interleaves with inference work without blocking it. The scrub is also a watchdog-correlated signal: if scrub progress halts (no advance in scrub cursor for >N seconds) the watchdog fires — because either the scheduler deadlocked or the EMC stopped responding.
+- **This is niche, but it's the kind of niche that DAL A demands.** SmallAIOS's competitive position is not "fastest inference" — it's "inference you can ship into an avionics box and certify". ECC scrubbing is on the short list of mitigations every avionics OS has and every commodity OS lacks. Investing here strengthens the cert-track value proposition.
+
+## Scope — phases
+
+### Phase 1 — Scrub service core (~1 week)
+
+Create `kernel/src/mem/scrub/` as a new module:
+
+- `mod.rs` — public API: `init(config)`, `add_region(name, base, size, interval)`, `pause(name)`, `resume(name)`, `cursor(name) -> Position`, `stats(name) -> ScrubStats`.
+- `task.rs` — async task driver: loops over registered regions, advances each region's cursor by `chunk_size` per scheduler tick, yields between chunks. Implements the per-region interval timer.
+- `config.rs` — `ScrubConfig { regions: Vec<Region>, default_chunk_size, default_interval, watchdog_threshold }`. Loaded from a kernel-side TOML at boot or constructed programmatically.
+- `stats.rs` — `ScrubStats { cycles_completed, last_cycle_duration, correctable_errors, uncorrectable_errors, cursor_position }`. Atomic counters readable from telemetry.
+
+Boot wiring: `kernel_main` registers a scrub region covering the heap and the ONNX-resident weight region after `mem::init` completes. Default interval = 24 hours per region (industry-standard for DAL A workloads), configurable per region.
+
+### Phase 2 — Tegra234 EMC backend (~1 week)
+
+`arch/aarch64/src/scrub/tegra_emc.rs` — backend that drives the Tegra234 EMC's hardware-accelerated scrub. Probes the EMC registers (MMIO base in DTB), configures `EMC_ECC_SCRUB_*` for a region descriptor, kicks off the scrub, polls completion. Returns the count of correctable/uncorrectable errors observed in the cycle.
+
+The Tegra234 EMC supports two scrub modes: **patrol** (background, autonomous, low priority — what we want) and **demand** (synchronous, blocking — used for boot-time wipe). We use patrol mode for the steady-state service; demand mode is used once at boot to verify the controller responds.
+
+### Phase 3 — Software-fallback backend (~3-5 days)
+
+For platforms without a hardware scrub controller (development boards, some RISC-V parts) the kernel can do software scrubbing: read every cache line, write the same value back. The DRAM controller's ECC engine then walks the data on the bus and corrects single-bit errors as a side effect of the read.
+
+`kernel/src/mem/scrub/sw_backend.rs` — uses `core::ptr::read_volatile` + `core::ptr::write_volatile` in a `usize`-stride loop with a yield every N pages. Slower than the EMC patrol mode but always available.
+
+### Phase 4 — Watchdog integration (~3-4 days)
+
+If the scrub cursor doesn't advance for `watchdog_threshold` seconds (default 60s), the watchdog timer fires. Two scenarios:
+
+- **Cooperative scheduler stuck** — some other task is monopolizing the scheduler. Watchdog reset.
+- **EMC stopped responding** — register-level failure; treated as a hardware fault. Watchdog reset, with a serial log line documenting the suspected cause.
+
+Wiring: the scrub task records the last-advance timestamp on every chunk. A separate `watchdog::feed` call happens *only when* the scrub cursor advances. A scrub that's idle (no work to do — between cycles) calls `feed` to keep the watchdog happy.
+
+### Phase 5 — Telemetry + docs (~3-4 days)
+
+- Surface `ScrubStats` per region via the same telemetry path as `telemetry-otel-export-v1` (or, if that hasn't landed, via the kernel console log).
+- Document the service in `docs/ecc-scrubbing.md` covering: what SEUs are, why scrubbing matters for DAL A, the per-region config knobs, the recommended intervals for different operational environments (ground vs. cruise altitude vs. orbital), the supported platforms, and the failure modes.
+- Update `docs/architecture.md` and `CLAUDE.md` to note the feature.
+
+## Out of scope
+
+- **ECC algorithm changes.** We use the DRAM controller's existing ECC (single-error-correction, double-error-detection — SECDED, the industry default). Stronger ECC (Chipkill, double-bit-correction) requires DRAM-vendor support we can't add in software.
+- **Non-DRAM scrubbing.** SoC SRAM, cache, and register-file scrubbing are different mechanisms (often hardware-only) and out of scope here. We surface a TODO note for future work.
+- **Bit-error injection for testing.** Validating the scrub service against real injected errors requires hardware support (some boards expose ECC error injection via debug registers). We document the test procedure for boards that support it but don't ship an injection harness.
+- **Per-tenant scrub policy.** A future multi-tenant SmallAIOS might want per-tenant scrub guarantees. The unikernel single-tenant model makes this irrelevant for now.
+- **RAS (Reliability/Availability/Serviceability) error injection compliance.** RAS frameworks like ACPI APEI on x86 standardize error reporting and recovery; integrating with them is a follow-up change.
+- **Cache-line scrubbing.** The CPU's L1/L2/L3 caches typically have their own ECC (Cortex-A78AE has cache ECC enabled by default). We rely on that.
+
+## Sequencing
+
+Phase 1 (core service) lands first; it is fully testable on any platform via the software-fallback backend (Phase 3, which can land alongside Phase 1). Phase 2 (Tegra234 EMC) lands when on-Orin hardware verification is available — depends on `unikernel-orin-bringup-v1` Phase 2e. Phase 4 (watchdog) depends on Phase 1 completing. Phase 5 (telemetry / docs) closes the change.
+
+The change is independent of `tegra-smmu-isolation-v1` (different MMIO surfaces), `aarch64-mte-pac-hardening-v1` (CPU vs DRAM), and `spec-exec-mitigations-v1` (data-path vs control-path). All four can land in parallel.
+
+## Effort estimate
+
+| Phase | Scope | Estimate |
+|-------|-------|----------|
+| 1 | Scrub service core (task + config + stats) | ~1 week |
+| 2 | Tegra234 EMC hardware backend | ~1 week |
+| 3 | Software-fallback backend | ~3-5 days |
+| 4 | Watchdog integration | ~3-4 days |
+| 5 | Telemetry + docs | ~3-4 days |
+| **Total** | | **~3-4 weeks** |
+
+Bench-of-record: post-merge, run a 7-day soak test on an Orin NX with a 16 GB weight load, scrub interval 6 h, and capture the correctable-error count. Use that as the baseline for future regressions.

--- a/openspec/changes/ecc-scrubbing-v1/specs/kernel-mem/spec.md
+++ b/openspec/changes/ecc-scrubbing-v1/specs/kernel-mem/spec.md
@@ -1,0 +1,112 @@
+## ADDED Requirements
+
+### Requirement: Background ECC memory scrubbing service
+
+The kernel SHALL provide a background memory-scrubbing service that periodically walks every configured DRAM region, surfaces correctable and uncorrectable ECC error counts per region, and runs as a cooperative async task without blocking inference workloads, on builds with the `ecc-scrub` Cargo feature enabled.
+
+#### Scenario: Scrub task registered at boot
+
+- **GIVEN** a SmallAIOS kernel built with `--features ecc-scrub` (and a platform that advertises ECC DRAM)
+- **WHEN** `kernel_main` reaches the scrub-init phase after `mem::init` completes
+- **THEN** the kernel SHALL register default scrub regions for the kernel heap, the ONNX-resident weight region (when known), and the kernel `.bss` / `.data` sections
+- **AND** the kernel SHALL spawn one async scrub task into the cooperative scheduler
+- **AND** the task SHALL begin advancing the cursor for the first registered region
+
+#### Scenario: Configurable per-region interval
+
+- **GIVEN** a `ScrubConfig` with regions `A` (interval 6 h) and `B` (interval 24 h)
+- **WHEN** the scrub task runs
+- **THEN** region `A` SHALL complete approximately four cycles for every cycle of region `B`
+- **AND** the `stats(name).cycles_completed` counter SHALL reflect the per-region progress accurately
+- **AND** the cooperative-yield behavior SHALL ensure no scrub chunk holds the scheduler for longer than the configured chunk-size budget
+
+#### Scenario: Stats surfaced via telemetry
+
+- **GIVEN** the scrub service active for at least one full cycle on a registered region
+- **WHEN** an operator queries the kernel telemetry surface
+- **THEN** the response SHALL include per-region `ScrubStats { cycles_completed, last_cycle_duration, correctable_errors, uncorrectable_errors, cursor_position, advanced_at }`
+- **AND** all counters SHALL be monotonic across the boot — they SHALL reset only on kernel reboot
+
+### Requirement: Tegra234 EMC hardware-accelerated scrub backend
+
+When running on a Tegra234 platform with hardware ECC support, the scrub service SHALL drive the EMC's hardware patrol-scrub registers in preference to the software backend.
+
+#### Scenario: EMC probe succeeds and is selected
+
+- **GIVEN** a SmallAIOS kernel built with `--features tegra234,ecc-scrub` running on an Orin NX
+- **WHEN** the scrub service initializes
+- **THEN** it SHALL walk the DTB for a node matching `compatible = "nvidia,tegra234-emc"` and SHALL read the EMC MMIO base from the node's `reg` property
+- **AND** it SHALL probe `EMC_ECC_STATUS` to confirm the controller responds — if the probe fails the service SHALL fall back to the software backend with a warning log line
+- **AND** on success the service SHALL log `[ecc-scrub] backend=tegra-emc, ECC=enabled`
+
+#### Scenario: Boot-time demand-mode wipe + baseline
+
+- **GIVEN** a successful EMC probe
+- **WHEN** the scrub service finishes init
+- **THEN** it SHALL run one demand-mode scrub of the kernel image + heap regions, blocking until complete
+- **AND** it SHALL read `EMC_ECC_STATUS` and log the post-baseline correctable / uncorrectable counts
+- **AND** any non-zero uncorrectable count at this point SHALL be treated as a fatal pre-existing fault and SHALL trigger a kernel panic with a structured `[ecc-scrub] uncorrectable error at <addr>` message
+
+#### Scenario: Patrol-mode steady state
+
+- **GIVEN** the boot-time wipe completed cleanly
+- **WHEN** the scrub task enters steady state
+- **THEN** it SHALL drive the EMC in patrol mode, advancing the cursor one chunk at a time
+- **AND** it SHALL poll `EMC_ECC_SCRUB_STATUS.DONE` between chunks with cooperative yields so inference workloads are not blocked
+- **AND** when one full cycle of a region completes, the `cycles_completed` counter SHALL increment and the next due region SHALL be selected per its configured interval
+
+### Requirement: Software-fallback scrub backend
+
+When no hardware scrub backend is available, the scrub service SHALL fall back to a portable software backend that reads and re-writes every `usize` in each region, triggering DRAM-controller ECC corrections as a read side-effect.
+
+#### Scenario: Software backend on non-Tegra platform
+
+- **GIVEN** a SmallAIOS kernel built with `--features ecc-scrub` on a platform without a hardware scrub backend (e.g., development x86 build, RISC-V dev board)
+- **WHEN** the scrub service initializes and no hardware backend probes successfully
+- **THEN** the service SHALL select the software backend
+- **AND** SHALL log `[ecc-scrub] backend=software, hardware scrub unavailable`
+- **AND** the scrub task SHALL still advance the cursor per the configured interval
+
+#### Scenario: Software backend preserves content
+
+- **GIVEN** an active software-backend scrub on a region containing application data
+- **WHEN** the scrub completes a full cycle
+- **THEN** the region content SHALL be byte-identical to its pre-scrub content (the scrub is a read-modify-write of the existing value, not a write of a new value)
+- **AND** unit tests SHALL verify this property against a synthetic test region
+
+### Requirement: Watchdog correlation with scrub progress
+
+The scrub task's cursor-advance SHALL be a watchdog-feed event, and a stalled scrub task SHALL trigger a watchdog reset, with the aggressiveness selectable by Cargo feature for development vs. safety-critical deployments.
+
+#### Scenario: Aggressive mode (safety-critical default)
+
+- **GIVEN** a kernel built with `--features ecc-scrub,scrub-watchdog-aggressive` (the default on `ecc-scrub`)
+- **WHEN** the scrub cursor fails to advance for `watchdog_threshold` seconds (default 60 s)
+- **THEN** the watchdog SHALL fire and reset the system
+- **AND** on boot after the reset the kernel SHALL detect the `WdReason::ScrubStall` reset code and SHALL log it prominently
+
+#### Scenario: Permissive mode (development)
+
+- **GIVEN** a kernel built with `--features ecc-scrub,scrub-watchdog-permissive`
+- **WHEN** the scrub task heartbeats (regardless of cursor advance)
+- **THEN** the watchdog SHALL be fed
+- **AND** a stalled cursor SHALL NOT cause a reset — but the scrub stats SHALL surface the stall via the `advanced_at` timestamp being stale
+
+#### Scenario: Mutually exclusive features
+
+- **GIVEN** an attempted build with both `scrub-watchdog-aggressive` and `scrub-watchdog-permissive` enabled
+- **THEN** the Cargo build SHALL fail with a `compile_error!` message
+- **AND** the doc-comments on each feature SHALL state the mutual exclusion
+
+### Requirement: Scrub service is opt-out on platforms without ECC DRAM
+
+The scrub service SHALL be safe to enable on platforms that do not advertise ECC DRAM — in that case the service SHALL log its absence and SHALL NOT enable the scrub task, so the binary remains correct.
+
+#### Scenario: Non-ECC platform gracefully disables scrub
+
+- **GIVEN** a kernel built with `--features ecc-scrub` on a platform whose DRAM controller does not advertise ECC support (e.g., a typical desktop x86 box without ECC RAM, a RISC-V dev board with plain LPDDR4)
+- **WHEN** the scrub service initializes
+- **THEN** it SHALL detect the lack of ECC support via the platform-specific probe
+- **AND** SHALL log `[ecc-scrub] DRAM does not advertise ECC; service disabled`
+- **AND** SHALL NOT spawn the scrub task
+- **AND** the kernel SHALL continue to boot normally — the missing scrub service SHALL NOT be fatal

--- a/openspec/changes/ecc-scrubbing-v1/tasks.md
+++ b/openspec/changes/ecc-scrubbing-v1/tasks.md
@@ -1,0 +1,64 @@
+# Tasks — ecc-scrubbing-v1
+
+## 0. Reference reading + hardware verification
+
+- [ ] 0.1 Read Tegra234 TRM section "External Memory Controller (EMC) — ECC and Scrubbing". Document the `EMC_ECC_SCRUB_*`, `EMC_ECC_STATUS`, `EMC_ECC_CONTROL` register fields, scrub modes (patrol vs. demand), and completion-polling semantics.
+- [ ] 0.2 On an Orin NX 16 GB host, confirm ECC is configured: read `cat /proc/meminfo | grep -i ecc`, `dmesg | grep -i 'ecc\|emc'`. Paste in PR description.
+- [ ] 0.3 Inspect L4T's `tegra-mc` driver source for register-access patterns and any undocumented-field hints.
+- [ ] 0.4 Identify a representative LLM workload for the post-merge soak test (e.g., `Qwen 3 8B instruct` quantized, continuous inference). Document the workload definition in `docs/ecc-scrubbing.md`.
+
+## 1. Phase 1 — Scrub service core
+
+### 1a. Module scaffolding
+
+- [ ] 1.1 Create `kernel/src/mem/scrub/mod.rs` with the public API: `pub fn init(config: ScrubConfig)`, `pub fn add_region(name, base, size, interval)`, `pub fn pause(name)`, `pub fn resume(name)`, `pub fn cursor(name) -> Position`, `pub fn stats(name) -> ScrubStats`.
+- [ ] 1.2 Create `kernel/src/mem/scrub/config.rs` with `ScrubConfig`, `Region`, `Interval` types. Support a TOML-loaded form (`scrub::Config::from_toml(&str)`) and a programmatic builder form.
+- [ ] 1.3 Create `kernel/src/mem/scrub/stats.rs` with `ScrubStats { cycles_completed, last_cycle_duration, correctable_errors, uncorrectable_errors, cursor_position, advanced_at }`. All counters atomic so telemetry can read concurrently.
+- [ ] 1.4 Add `ecc-scrub` Cargo feature on `smallaios-kernel`. Off by default. Doc-comment notes that hardware-accelerated scrub requires platform-specific backend features.
+
+### 1b. Scrub task
+
+- [ ] 1.5 Create `kernel/src/mem/scrub/task.rs` with the async task entry point: a loop that walks each registered region's interval timer, picks the next region due, drives one cycle via the active backend, updates stats, yields between chunks.
+- [ ] 1.6 Implement chunked iteration: configurable `chunk_size` (default 64 KiB), yield-now after each chunk to keep the cooperative scheduler responsive.
+- [ ] 1.7 Wire `scrub::init` into `kernel_main` after `mem::init` completes — register default regions (heap, ONNX weight region when known, kernel `.bss` / `.data`).
+- [ ] 1.8 Unit tests: fake backend (in-memory counter), drive a 1 MB region, assert correct cursor advance, correct cycle counting, correct yield behavior.
+
+## 2. Phase 2 — Tegra234 EMC backend
+
+- [ ] 2.1 Create `arch/aarch64/src/scrub/tegra_emc.rs` implementing the `ScrubBackend` trait via Tegra234's EMC.
+- [ ] 2.2 Implement `probe()` that walks the DTB for the EMC node (`compatible = "nvidia,tegra234-emc"`), reads the MMIO base, returns `Some(TegraEmcBackend)` on success.
+- [ ] 2.3 Implement `scrub_region`: program `EMC_ECC_SCRUB_REGION_LO/HI` for the region descriptor, set `EMC_ECC_SCRUB_CONTROL.SCRUB_EN`, poll `EMC_ECC_SCRUB_STATUS.DONE` (with cooperative yield between polls), read `EMC_ECC_STATUS` for the correctable / uncorrectable counts since last reset, return them.
+- [ ] 2.4 Implement boot-time demand-mode wipe: configure `SCRUB_MODE = demand`, kick off, block-poll until done, log the baseline error counts. Verifies the EMC responds and establishes a known-good baseline.
+- [ ] 2.5 Implement fallback detection: if `EMC_ECC_STATUS` reads back as `0xFFFF_FFFF` (a typical "register unimplemented" pattern) or otherwise fails sanity, return `None` from `probe` and fall through to the software backend with a `[scrub] EMC probe failed, falling back to software` log line.
+
+## 3. Phase 3 — Software-fallback backend
+
+- [ ] 3.1 Create `kernel/src/mem/scrub/sw_backend.rs` implementing the `ScrubBackend` trait via `core::ptr::read_volatile` / `write_volatile`.
+- [ ] 3.2 Implement chunked walk: read every `usize` in a 4 KiB page, write the same value back. Yield between pages.
+- [ ] 3.3 Surface correctable / uncorrectable counts via the DRAM controller's RAS interface where exposed (`ras_counters` API on x86 via PCIe config; on aarch64 via `ERR<n>FR_EL1` system registers if the silicon exposes the RAS extension). When unavailable, return `(0, 0)` and document that.
+- [ ] 3.4 Unit-test the software backend against a known memory region with synthetic content; assert content unchanged after scrub.
+
+## 4. Phase 4 — Watchdog integration
+
+- [ ] 4.1 Add `scrub-watchdog-aggressive` and `scrub-watchdog-permissive` Cargo features (mutually exclusive, default = aggressive on `--features ecc-scrub`).
+- [ ] 4.2 Modify the scrub task to call `watchdog::feed()` per loop iteration in permissive mode, and per cursor-advance in aggressive mode.
+- [ ] 4.3 Add a watchdog reset reason code `WdReason::ScrubStall` (or extend existing reasons). On boot, if the kernel detects it woke from a `ScrubStall` reset, log it prominently.
+- [ ] 4.4 Test: inject a scheduler-block scenario (a deliberately-uncooperative task) and confirm the watchdog fires within `watchdog_threshold` seconds.
+
+## 5. Phase 5 — Telemetry + docs
+
+- [ ] 5.1 Surface `ScrubStats` per region via the existing telemetry path (or, if `telemetry-otel-export-v1` hasn't landed, via a periodic boot-log line).
+- [ ] 5.2 Create `docs/ecc-scrubbing.md` covering: what SEUs are and why they matter, the DO-178C DAL A motivation, supported platforms / backends, the configuration knobs (region, interval, chunk size, watchdog mode), recommended intervals for different operational environments (ground / cruise / orbital), failure modes, and the soak-test procedure.
+- [ ] 5.3 Update `docs/architecture.md` to note the scrub service as a Layer 0 (Foundation) service.
+- [ ] 5.4 Update `CLAUDE.md` "Current state" to note ECC scrubbing is available on `tegra234`-feature builds.
+
+## 6. Verify
+
+- [ ] 6.1 Run `openspec validate ecc-scrubbing-v1 --strict`.
+- [ ] 6.2 Run the `just ecc-scrub-test` recipe locally under QEMU; assert clean exit.
+- [ ] 6.3 On Orin NX hardware: boot with `--features tegra234,ecc-scrub`, observe one boot-time demand wipe, observe at least one patrol cycle, capture the telemetry counters. Paste in PR description.
+- [ ] 6.4 Schedule the post-merge 7-day soak test as a follow-up activity (not gating, but tracked in the change archive note).
+
+## 7. Archive
+
+- [ ] 7.1 Open archive PR moving the change to `openspec/changes/archive/YYYY-MM-DD-ecc-scrubbing-v1` and sync the spec deltas to main specs. Include the soak-test pointer in the archive note.

--- a/openspec/changes/spec-exec-mitigations-v1/design.md
+++ b/openspec/changes/spec-exec-mitigations-v1/design.md
@@ -1,0 +1,117 @@
+# Design — spec-exec-mitigations-v1
+
+## Goal
+
+Five trust boundaries × three architectures × the relevant speculation classes (v1, v2, v4, Meltdown, Retbleed, Spectre-BHB) yields a 5 × 3 × 6 = 90-cell mitigation matrix. The deliverable is a populated matrix plus the code/config changes implied by it. The matrix lives in the new `kernel-security` capability spec; the code changes are scattered across `arch/*/src/syscall.rs`, `kernel/src/cap.rs`, `.cargo/config.toml`, and `onnx-rt/`.
+
+## Design decisions
+
+### Decision 1: Single `kernel-security` capability spec, not per-arch specs
+
+Trust boundaries are *cross-arch* concepts ("the syscall entry point", "the capability check") even though the mitigation instructions differ per ISA. A reviewer asking "is this kernel hardened against Spectre v2 at the op-dispatch boundary?" wants a single answer in a single document, with per-arch citations under each Requirement. The alternative — three specs (`x86-security`, `aarch64-security`, `riscv-security`) — fragments the audit trail and makes the safety case harder to assemble.
+
+`aarch64-mte-pac-hardening-v1`'s `arch-aarch64-security` spec stays separate because *those* mitigations are CPU-feature-specific memory protections, not trust-boundary-specific speculation barriers. The two specs cross-reference each other.
+
+### Decision 2: Compiler flags via Cargo feature, not blanket `RUSTFLAGS`
+
+The chosen feature is `spec-exec` on `smallaios-kernel`, default-on for `--release` profiles. It pulls in arch-specific sub-features (`spec-exec-x86`, `spec-exec-aarch64`, `spec-exec-riscv`) selected by `cfg(target_arch)`. Each sub-feature gates an arch-specific `build.rs` that emits `cargo:rustc-link-arg` and `cargo:rustc-flags` entries.
+
+Why not just set `RUSTFLAGS` globally in `.cargo/config.toml`: those flags apply to *every* dep including build-script-host code, which is undesirable (Retpoline thunks have no meaning when compiling a build script on a Mac laptop). The feature-gated `build.rs` path applies the flags only to the kernel and its arch HALs.
+
+### Decision 3: IBRS on always-set, IBPB on syscall-entry only
+
+Intel's recommendation for kernel mitigation:
+
+- **IBRS (Indirect Branch Restricted Speculation)** — set in `IA32_SPEC_CTRL` on every kernel entry, cleared on kernel exit. Modern CPUs (Ice Lake+) support "Enhanced IBRS" which is sticky — set once, no per-entry overhead. SmallAIOS targets the modern x86 silicon assumption (Sapphire Rapids+ for inference servers), so we use Enhanced IBRS where available, fall back to per-entry IBRS where not (with a boot log line documenting the choice).
+- **IBPB (Indirect Branch Predictor Barrier)** — flushes branch prediction state. Expensive (~hundreds of cycles). We emit it on syscall entry — every transition from "untrusted task graph" to "kernel" — but not on intra-kernel function calls. This is the same policy Linux uses for syscall entry.
+- **STIBP (Single Thread Indirect Branch Predictors)** — relevant only with SMT. Cortex-A78AE has no SMT; modern Xeon variants do. We set STIBP if SMT is detected at boot.
+
+### Decision 4: LFENCE placement — *after* capability check, *before* attacker-controlled load
+
+The Spectre v1 pattern that matters in SmallAIOS:
+
+```rust
+// pseudocode, hand-rolled in arch/x86_64/src/syscall.rs
+fn syscall_entry(args: &SyscallArgs) -> i64 {
+    // 1. Decode syscall number + capability check
+    let cap = check_capability(args.cap_handle)?;
+    // 2. Speculative window: CPU may speculate through here even if check_capability returned an error
+    lfence();  // <-- explicit fence, after the check
+    // 3. Now-safe load from args
+    let tensor = decode_tensor_handle(args.tensor)?;
+    ...
+}
+```
+
+Putting `lfence` *before* the capability check is wrong — it serializes the harmless decode but does nothing about the speculation past the check. The right placement is documented in this design doc and enforced by code review (no lint can catch placement automatically). We add a unit test that disassembles the syscall entry and asserts the `lfence` opcode appears between the check and the first attacker-controlled load.
+
+### Decision 5: CSV2/CSV3 silicon check on aarch64 boot
+
+Cortex-A78AE advertises hardware mitigation of branch-target-injection (Spectre v2) via `ID_AA64PFR0_EL1.{CSV2, CSV3}`. If the silicon reports `CSV2 ≥ 1` (hardware mitigated) and `CSV3 ≥ 1` (similar for cache-allocate side channels), the kernel can skip software-driven Retpoline-shaped mitigations. We read the register at boot; the result is logged and the build profile (`spec-exec-aarch64-hw` vs `spec-exec-aarch64-sw`) is selected accordingly.
+
+If the silicon reports the lower levels (hypothetical future Orin-class part), the kernel boots with a warning and the software-mitigation path is taken (which adds some `csdb` insertions to the op-dispatch).
+
+### Decision 6: SmallAIOS structural Meltdown immunity
+
+Meltdown (CVE-2017-5754) exploits speculative loads through the user-space view of kernel pages. Linux's KPTI mitigation maps kernel pages out of the user-space page table.
+
+SmallAIOS is a unikernel: there is no user-space page table. The "task graph" runs in the same address space as the kernel. There is nothing to leak across, because there is no privilege boundary at the page-table level. Spectre v1 and v2 still apply (those exploit speculation across *function-call* boundaries, not page-table boundaries), but Meltdown specifically does not.
+
+We document this as a structural property — "Meltdown does not apply to the SmallAIOS unikernel address-space model" — rather than as a software mitigation. The DO-178C safety case explicitly cites the structural absence rather than the absence of an applied mitigation, because the two are different evidence kinds.
+
+## Alternatives considered
+
+### Alt A: Rely on compiler defaults, no kernel-side instrumentation
+
+**Rejected.** Compiler defaults for `*-unknown-none` targets do not include Retpoline, SLH, or LFENCE-after-bounds-check. They never will (those flags add overhead, and the compiler's stance is "no_std users opt in"). We are the no_std user; we must opt in.
+
+### Alt B: Disable indirect calls in the ONNX dispatcher (compile-time op switch)
+
+**Considered, deferred.** Generating a giant `match op_id { 0 => Conv::dispatch, 1 => Gemm::dispatch, ... }` instead of a function-pointer table eliminates the indirect-branch attack surface entirely. The catch: the `match` compiles to a different shape per LLVM optimization (it may itself become an indirect jump via a jump table in `.rodata`, defeating the point). And the code-gen bloat is large for the ~150 ONNX op variants. We pick the function-pointer table + per-arch indirect-call hardening (BTI / Retpoline) as the better engineering trade. Revisit if a compiler analysis ever proves the `match` shape avoids the jump table.
+
+### Alt C: Compile with `-mllvm -x86-speculative-execution-side-effect-suppression` instead of explicit fences
+
+**Considered, on for builds that support it.** Modern LLVM has an SLH-class pass that inserts speculation barriers automatically based on a CPU-fence cost model. Output is broadly Retpoline-shaped but the placement is compiler-driven, not author-driven. Mitigation: enable on x86_64 builds where LLVM supports it cleanly; keep the *explicit* `lfence` in syscall entry as a backstop in case the LLVM pass misses it (defense in depth).
+
+### Alt D: Defer until DO-178C tooling demands it
+
+**Rejected** for the same reason as the MTE/PAC change. Speculative side channels are now a baseline mitigation expectation for any safety-critical OS, with or without explicit DO-178C tooling support.
+
+## Risks
+
+### Risk 1: IBPB overhead in inference-heavy workloads
+
+IBPB costs ~100-500 cycles depending on the microarchitecture. ONNX-runtime workloads that do many small syscalls (e.g., tensor pool churn) could see measurable throughput drops. Mitigation: (a) benchmark before/after; (b) batch syscalls where possible (this is a separate optimization angle, but spec-exec mitigations highlight where it matters); (c) `spec-exec-ibpb-off` Cargo opt-out for performance-mode-only deployments that explicitly accept the residual Spectre v2 risk.
+
+### Risk 2: LLVM flag drift between Rust toolchain versions
+
+The `-mllvm -x86-speculative-load-hardening` flag has shifted shape across LLVM versions. The 2026-02-01 pinned toolchain bundles LLVM 19; we test on that version and pin the flag form in `.cargo/config.toml`. Toolchain upgrades go through a separate compatibility check.
+
+### Risk 3: Per-arch coverage gaps
+
+We have full coverage on aarch64 (silicon checked, barriers inserted, op-dispatch hardened) and x86_64 (compiler flags + explicit fences + MSR programming). RISC-V coverage is partial — the relevant CFI extensions are not yet ratified. Mitigation: document the gap in `docs/spec-exec-audit.md` and treat RISC-V Phase 4 as scaffolding to be filled in when Zicfilp lands. Production deployments on RISC-V should be flagged in the safety case as "speculation mitigations partial".
+
+### Risk 4: False sense of security
+
+Speculation mitigations are *not* a complete defense — side channels keep being discovered (Meltdown 2018, Spectre 2018, Foreshadow 2018, MDS 2019, CrossTalk 2020, Retbleed 2022, Downfall / Inception 2023, GhostRace 2024). This change covers the *known* classes; new classes will emerge. Mitigation: the `kernel-security` spec includes a "review trigger" — every new CVE in this class triggers a review of the mitigation matrix, tracked as an OpenSpec change.
+
+### Risk 5: Compiler-emitted barriers missing in `panic_handler` or other compiler-magic functions
+
+The Rust compiler may emit indirect calls in `panic_handler`, `core::ops::Drop`, async state machines, etc. that are not under our direct control. Mitigation: the unit tests disassemble the linked kernel binary and assert (a) no unprotected indirect branches in `arch/*/src/syscall.rs`, (b) every Retpoline thunk is the expected shape on x86_64, (c) every aarch64 indirect branch has a BTI landing pad.
+
+## Build/CI surface
+
+- New Cargo feature `spec-exec` on `smallaios-kernel` (default-on for release), with arch-specific sub-features.
+- New module `arch/x86_64/src/security/spec_exec.rs` — `init()` programs IBRS, IBPB-on-entry trampolines, LFENCE placement.
+- New module `arch/aarch64/src/security/spec_exec.rs` — CSV2/CSV3 silicon check, CSDB / DSB SY insertion points.
+- Modify `arch/*/src/syscall.rs` to insert explicit barriers at trust boundaries.
+- New `docs/spec-exec-audit.md` with the full trust-boundary × arch × attack-class matrix.
+- New CI advisory job `spec-exec-disasm-audit` — runs `objdump -d` on the built kernel and asserts the expected barrier opcodes appear at the expected addresses. Catches regressions where someone refactors syscall entry and accidentally drops the `lfence` / `csdb`.
+
+## What this change explicitly does NOT do
+
+- Does not modify cryptographic code paths — they have their own (already-applied) constant-time discipline.
+- Does not change syscall ABI — barriers are CPU-internal, invisible to callers.
+- Does not enable SMT-specific mitigations on Cortex-A78AE (no SMT in silicon).
+- Does not patch any specific CVE individually — it covers classes of attacks via class-level mitigations.
+- Does not introduce a JIT — Spectre-RSB / Spectre-BTI variants that need a JIT remain structurally absent.

--- a/openspec/changes/spec-exec-mitigations-v1/proposal.md
+++ b/openspec/changes/spec-exec-mitigations-v1/proposal.md
@@ -1,0 +1,88 @@
+# spec-exec-mitigations-v1
+
+## Summary
+
+Speculative-execution side channels — Spectre v1 (bounds-check bypass), Spectre v2 (branch-target injection), Spectre v4 (speculative store bypass), Meltdown (rogue data-cache load), Retbleed (return-address mispredict on AMD/Intel) — have reshaped what a "correct" trust boundary means on modern out-of-order CPUs. Compiler-default mitigations exist on every architecture SmallAIOS targets (x86_64, aarch64, riscv64), but they are *not all on* by default in `#![no_std]` Rust profiles, and the kernel-side discipline of inserting explicit serialization at trust boundaries (syscall entry, capability checks, indirect calls into ONNX op dispatch) is a code-author responsibility that is currently uncovered in our spec set.
+
+This change audits SmallAIOS's trust boundaries, adds per-arch speculation barriers at the documented points (syscall entry, capability check, indirect-call sites in the ONNX op dispatcher, GPU command submission), wires the compiler-level mitigations (LFENCE / SLH / Retpoline on x86, CSDB on aarch64, future fence.t on RISC-V when ratified), and documents the coverage in a new `kernel-security` capability spec. The work is deliberately conservative — these are well-trodden mitigation patterns, not a research contribution. The novelty is making them explicit in SmallAIOS's safety case rather than relying on implicit compiler defaults.
+
+## Why
+
+- **Trust boundaries that look like ordinary function calls in Rust are not protected against speculation by default.** When userspace (a future construct in SmallAIOS — today everything is in-kernel, but the syscall surface remains the trust boundary between "untrusted task graph" and "kernel-managed capability state") invokes a syscall, the CPU may speculatively load through attacker-controlled addresses before the capability check resolves. Spectre v1 is the classic instance: a bounds check that always succeeds in observed execution can mispredict, and the speculative path loads attacker-chosen memory into cache, becoming observable via a cache-timing side channel. Rust's type system catches none of this — it is a CPU-level concern that needs explicit `lfence` (x86) or `csdb` (aarch64) at the right point in the syscall entry assembly.
+- **Compiler-level mitigations have known gaps that documentation must address.** Retpoline (the GCC/clang mitigation for Spectre v2) is on by default in upstream Rust for `x86_64-unknown-linux-musl` but *off* by default for `x86_64-unknown-none` (our bare-metal target). IBRS / IBPB / STIBP — Intel's hardware-level branch prediction barriers — require explicit MSR writes from the kernel; they are not compiler-driven. Speculative Load Hardening (SLH) on x86 is a `-mllvm` flag we don't currently pass. AArch64's `csdb` / `dsb sy` barriers are inserted by the compiler at `core::hint::black_box` boundaries but never inside hand-rolled syscall entry code (`arch/aarch64/src/syscall.rs`). We need explicit instrumentation.
+- **SmallAIOS's ONNX op-dispatch indirect-call table is a textbook Spectre v2 surface.** The runtime in `onnx-rt` dispatches each ONNX operator through a function-pointer table — exactly the indirect-branch construct that branch-target injection exploits. Compiler-driven Retpoline addresses this on x86_64; the aarch64 equivalent is BTI (Branch Target Identification, already enabled via `aarch64-mte-pac-hardening-v1`'s codegen flags). RISC-V has no equivalent yet — we document the gap and plan for the (still-being-ratified) Zicfilp control-flow-integrity extension.
+- **DO-178C DAL A asks "what is the worst observable side effect of an out-of-order CPU mispredict" — and demands a defensible answer.** Avionics certification is starting to ask explicit questions about speculative side-channels following CVE-2022-23960 (Retbleed) and the Branch History Injection class of attacks (Spectre-BHB). Our cert-track positioning needs to enumerate covered attacks, applied mitigations, and residual risk explicitly. This change produces that documentation as a spec, not just a code patch.
+
+## Scope — phases
+
+The work fans out per-architecture but shares one tabular structure: at each documented trust boundary, what speculation barrier (compiler-emitted, kernel-emitted, or both) does each arch need?
+
+### Phase 1 — Trust-boundary audit (~3-4 days)
+
+Produce a per-arch table covering five trust boundaries: (a) syscall entry, (b) capability check, (c) ONNX op-dispatch indirect call, (d) GPU command submission, (e) bus-backed dataflow runner message receive. For each, document the speculation-exploitable code path, the currently-applied mitigation (if any), and the gap.
+
+Audit deliverable: `docs/spec-exec-audit.md` table. No code changes in Phase 1.
+
+### Phase 2 — x86_64 mitigations (~1 week)
+
+- **Compiler flags:** enable Retpoline for `x86_64-unknown-none` via `RUSTFLAGS = -C target-feature=+retpoline-external-thunk,+retpoline-indirect-branches,+retpoline-indirect-calls` set in `.cargo/config.toml` under a `spec-exec-x86` Cargo feature.
+- **SLH (Speculative Load Hardening):** add `-C llvm-args=-x86-speculative-load-hardening` for kernel build targets. This is the LLVM-emitted SLH that converts speculative-bounds-bypass into a hard branch.
+- **IBRS / IBPB / STIBP MSR programming:** on boot, after exception vectors install but before the first syscall is dispatched, write `IA32_SPEC_CTRL` to enable IBRS (Indirect Branch Restricted Speculation). On every syscall entry, emit an `IBPB` (Indirect Branch Predictor Barrier) — costly but eliminates the cross-privilege branch prediction state. Document the latency overhead.
+- **LFENCE at syscall entry:** explicit `lfence` instruction in the syscall trampoline (`arch/x86_64/src/syscall.rs` if it exists; otherwise the equivalent hand-rolled entry) immediately after capability check, before any attacker-controlled-address load. Spectre v1 mitigation.
+- **Meltdown:** Tegra234 is aarch64-only, so Meltdown specifically doesn't apply to our reference platform. For x86_64 we document KPTI (Kernel Page Table Isolation) as the standard Linux-world answer; in our unikernel single-address-space model, Meltdown is structurally absent (there is no user-space page-table view to leak from), and we document that as the architectural mitigation.
+
+### Phase 3 — aarch64 mitigations (~3-4 days)
+
+- **CSDB barriers at syscall entry:** insert `csdb` (Consumption of Speculative Data Barrier) into the syscall entry in `arch/aarch64/src/syscall.rs` after the capability check, before any tensor / device handle dereference. The `csdb` barrier is a no-op on CPUs without Spectre v1 hardware speculation, costless on Cortex-A78AE where it matters.
+- **DSB SY at capability boundaries:** `dsb sy` (Data Synchronization Barrier, system-wide) before transferring control across a capability check that gates DMA setup. Same shape as `csdb` but stronger — pairs with the SMMU work in `tegra-smmu-isolation-v1`.
+- **BTI (Branch Target Identification):** already enabled by `aarch64-mte-pac-hardening-v1`; we document the cross-reference.
+- **ARM-specific Spectre v2 mitigation:** Cortex-A78AE implements the "hardware mitigation" of Spectre v2 (per Arm's TRM) via `CSV2` and `CSV3` features; we read `ID_AA64PFR0_EL1` to confirm and refuse to boot with a warning if the silicon downgrades them. The kernel does not need to install software Retpoline analogs on this silicon, but we document the assumption.
+
+### Phase 4 — RISC-V mitigations (~2-3 days)
+
+RISC-V's speculative-execution story is the youngest. The relevant extensions:
+
+- **Zicbom / Zicbop / Zicboz** (cache-block management) — used for explicit cache-state cleanup, partial mitigation for cache-timing channels.
+- **Zicfiss / Zicfilp** (Shadow stack + landing-pad CFI) — Spectre v2-class mitigation analogous to PAC + BTI on aarch64. Still being ratified at proposal time.
+- **`fence.i` after privileged transitions** — instruction-fetch barrier between privilege levels.
+
+The bring-up state of RISC-V in SmallAIOS is `riscv64gc-unknown-none-elf` boot only; full syscall paths aren't exercised yet. Phase 4 documents the planned mitigations and inserts `fence.i` at the future syscall trampoline boundary so the entry shape is correct even without active workloads. Production-grade RISC-V mitigations are a follow-up change once Zicfilp ratifies.
+
+### Phase 5 — ONNX op-dispatch hardening (~2-3 days)
+
+The ONNX runtime's op-dispatch table (one function pointer per ONNX operator) is a Spectre v2 attack surface. Mitigations:
+
+- **On aarch64:** BTI on every dispatch entry is sufficient (already enabled via `aarch64-mte-pac-hardening-v1`).
+- **On x86_64:** Retpoline-driven dispatch is sufficient when `+retpoline-indirect-calls` is on.
+- **On both:** add a kernel-side audit that the dispatch table is read-only after init (move to `.rodata`) so an attacker who has gained code-execution cannot tamper with the table itself.
+
+### Phase 6 — Documentation + safety-case integration (~2-3 days)
+
+Produce the formal mitigation matrix as part of the `kernel-security` capability spec. Cross-reference to the existing `safety-critical` and `security` specs so the DO-178C safety case can cite this single table.
+
+## Out of scope
+
+- **Side-channel-resistant cryptography.** The PQC stack already uses constant-time implementations; that's tracked in `pqc-crypto` not here.
+- **Hyperthreading-specific mitigations.** Cortex-A78AE has no SMT; future SmallAIOS targets with SMT (rare in the embedded inference space) would need separate review. Documented but not patched.
+- **Pre-boot speculative leakage.** UEFI firmware's own speculative behavior is out of our control. We document it as a residual risk.
+- **`flush_cache` instruction-level audit.** Cache-flush is sometimes used as a side-channel mitigation but mostly as a coherence mechanism in our codebase. A future audit could classify each `flush` for its security intent.
+- **JIT / dynamic codegen.** SmallAIOS has no JIT path; the ONNX runtime is fully AOT. The Spectre v1 patterns that depend on JIT-emitted gadgets (Spectre-RSB chains) are structurally absent.
+- **Microcode update plumbing.** Intel / AMD microcode updates are the manufacturer's responsibility; we don't ship them. We document the assumption that the deployment environment keeps microcode current.
+
+## Sequencing
+
+Phase 1 (audit) gates everything else and lands first. Phases 2 (x86_64), 3 (aarch64), 4 (RISC-V) can land in parallel — different files, different conditional compilation paths. Phase 5 (op-dispatch) is small but depends on Phases 2-3 to define the per-arch context. Phase 6 (docs) closes the change.
+
+This change runs in parallel with `tegra-smmu-isolation-v1` (DMA-side, no CPU speculation touch) and depends on `aarch64-mte-pac-hardening-v1` for BTI being on (a hard dep for Phase 3 / 5 aarch64 coverage). On the x86_64 side it is fully independent.
+
+## Effort estimate
+
+| Phase | Scope | Estimate |
+|-------|-------|----------|
+| 1 | Audit + trust-boundary table | ~3-4 days |
+| 2 | x86_64 (Retpoline + SLH + IBRS / IBPB + LFENCE) | ~1 week |
+| 3 | aarch64 (CSDB + DSB SY + CSV2/3 silicon check) | ~3-4 days |
+| 4 | RISC-V (fence.i scaffolding, Zicfilp documentation) | ~2-3 days |
+| 5 | ONNX op-dispatch hardening | ~2-3 days |
+| 6 | Spec + safety-case documentation | ~2-3 days |
+| **Total** | | **~2 weeks** |

--- a/openspec/changes/spec-exec-mitigations-v1/specs/kernel-security/spec.md
+++ b/openspec/changes/spec-exec-mitigations-v1/specs/kernel-security/spec.md
@@ -1,0 +1,134 @@
+## ADDED Requirements
+
+### Requirement: Speculative-execution mitigations at syscall entry
+
+The kernel SHALL insert explicit speculation barriers at every syscall entry point, after the capability check succeeds and before any decode of attacker-controlled syscall arguments, for every architecture target.
+
+#### Scenario: x86_64 emits LFENCE after capability check
+
+- **GIVEN** a SmallAIOS kernel built for `x86_64-unknown-none` with `--features spec-exec-x86` (default-on for the release profile)
+- **WHEN** a syscall enters the trampoline in `arch/x86_64/src/syscall.rs`
+- **THEN** the trampoline SHALL invoke `require_capability` first
+- **AND** SHALL emit an `lfence` instruction immediately after a successful capability check and before any load that uses caller-supplied addresses
+- **AND** a disassembly-level CI audit (`spec-exec-disasm-audit`) SHALL assert the `lfence` opcode appears at the expected offset
+
+#### Scenario: aarch64 emits CSDB after capability check
+
+- **GIVEN** a SmallAIOS kernel built for `aarch64-unknown-uefi` with `--features tegra234,spec-exec-aarch64`
+- **WHEN** a syscall enters the trampoline in `arch/aarch64/src/syscall.rs`
+- **THEN** the trampoline SHALL emit a `csdb` (Consumption of Speculative Data Barrier) instruction immediately after the capability check
+- **AND** for capability-gated DMA-setup syscall paths the trampoline SHALL ALSO emit `dsb sy` before transferring control into the DMA driver
+
+#### Scenario: RISC-V emits fence.i scaffolding ahead of ratified CFI
+
+- **GIVEN** a SmallAIOS kernel built for `riscv64gc-unknown-none-elf` (scaffolding only — syscall workloads not yet exercised)
+- **WHEN** the syscall trampoline placeholder runs
+- **THEN** the trampoline SHALL emit `fence.i` at the privileged-transition boundary so the entry shape is correct for future Zicfilp / Zicfiss adoption
+- **AND** a boot log line SHALL note `[spec-exec-riscv] scaffolding — extensions not yet ratified, software mitigations partial`
+
+### Requirement: Speculation barriers at ONNX op-dispatch boundaries
+
+The ONNX runtime's operator dispatch table SHALL be hardened against speculative branch-target injection on every architecture, using compiler-emitted mitigations and runtime placement in read-only memory.
+
+#### Scenario: x86_64 op dispatch uses Retpoline thunks
+
+- **GIVEN** a `--features spec-exec-x86` release build
+- **WHEN** the ONNX runtime dispatches to an operator via its function-pointer table
+- **THEN** the emitted indirect call SHALL go through a Retpoline thunk rather than a naked `jmp *%reg` / `call *%reg`
+- **AND** disassembly of the dispatch site SHALL show the expected `call 0(%rsp); int3` Retpoline shape
+- **AND** the op-dispatch table SHALL reside in `.rodata` after init — writes to the table after init SHALL fault on the page-table permission bits
+
+#### Scenario: aarch64 op dispatch lands on BTI guards
+
+- **GIVEN** a `--features spec-exec-aarch64` release build (BTI enabled by the `aarch64-mte-pac-hardening-v1` change's codegen flags)
+- **WHEN** the ONNX runtime dispatches to an operator via its function-pointer table
+- **THEN** every dispatch target function SHALL begin with a `bti c` (or `bti jc`) landing-pad instruction
+- **AND** a branch to an address without a BTI landing pad SHALL raise a branch-target exception
+
+#### Scenario: Op-dispatch table is read-only after init
+
+- **GIVEN** the ONNX runtime initialization sequence
+- **WHEN** the runtime finishes installing operator function pointers into the dispatch table
+- **THEN** the kernel SHALL ensure the table resides in a `.rodata` section (or equivalent read-only memory region)
+- **AND** any post-init write to the table from any code path SHALL fault
+
+### Requirement: x86_64 IBRS / IBPB / STIBP MSR programming
+
+The x86_64 kernel SHALL detect the Spectre-class hardware mitigations at boot via `CPUID`, configure them appropriately, and emit `IBPB` at the syscall-entry boundary.
+
+#### Scenario: Enhanced IBRS detected and set once
+
+- **GIVEN** an x86_64 platform that reports Enhanced IBRS support via `CPUID` leaf 7 `EDX[29]`
+- **WHEN** `spec_exec::init()` runs during boot
+- **THEN** the kernel SHALL set `IA32_SPEC_CTRL.IBRS = 1` once and rely on its sticky semantics — no per-entry IBRS toggling
+- **AND** the boot log SHALL include `[spec-exec-x86] IBRS=enhanced`
+
+#### Scenario: Legacy IBRS toggled per syscall entry
+
+- **GIVEN** an x86_64 platform that reports only legacy IBRS (no Enhanced IBRS in `CPUID`)
+- **WHEN** the syscall trampoline runs
+- **THEN** the trampoline SHALL set `IA32_SPEC_CTRL.IBRS = 1` at entry and clear it at exit
+- **AND** the boot log SHALL include `[spec-exec-x86] IBRS=legacy-per-entry` with a warning that latency is higher
+
+#### Scenario: IBPB emitted on every syscall entry
+
+- **GIVEN** any x86_64 `--features spec-exec-x86` build
+- **WHEN** a syscall enters the trampoline
+- **THEN** the trampoline SHALL write to `IA32_PRED_CMD` to emit an `IBPB` after capability check
+- **AND** an opt-out Cargo feature `spec-exec-ibpb-off` SHALL skip the `IBPB` for performance-mode-only deployments that explicitly accept the residual Spectre v2 risk — its documentation SHALL state the trade-off
+
+### Requirement: aarch64 silicon-level mitigation detection
+
+The aarch64 kernel SHALL detect the Cortex-A78AE-class silicon mitigations (CSV2 / CSV3) via system register reads at boot and SHALL select the appropriate mitigation profile.
+
+#### Scenario: Silicon advertises Spectre-v2 hardware mitigation
+
+- **GIVEN** an aarch64 platform reporting `ID_AA64PFR0_EL1.CSV2 ≥ 1` (Cortex-A78AE and most ARMv8.5-A+ silicon)
+- **WHEN** `spec_exec::init()` runs during boot
+- **THEN** the kernel SHALL select the hardware-mitigation profile — no software Retpoline-shaped insertion in indirect-call sites
+- **AND** the boot log SHALL include `[spec-exec-aarch64] CSV2=<n> CSV3=<n> profile=hardware-mitigated`
+
+#### Scenario: Silicon downgrades CSV2 (warn + fallback)
+
+- **GIVEN** a hypothetical future aarch64 platform reporting `ID_AA64PFR0_EL1.CSV2 = 0` (no hardware mitigation)
+- **WHEN** `spec_exec::init()` runs
+- **THEN** the kernel SHALL log a warning and SHALL select the software-mitigation profile (extra `csdb` insertions at indirect-call sites)
+- **AND** the boot SHALL continue — the kernel SHALL NOT panic, since the software path is functional, just slower
+
+### Requirement: Meltdown structural immunity documented as a safety-case property
+
+The unikernel single-address-space architecture SHALL be documented as structurally immune to Meltdown (CVE-2017-5754), and the DO-178C safety case SHALL cite this structural property rather than an applied software mitigation.
+
+#### Scenario: Safety case lists Meltdown as structurally absent
+
+- **GIVEN** the `kernel-security` spec and `docs/spec-exec-audit.md`
+- **WHEN** a reviewer inspects the mitigation matrix for Meltdown
+- **THEN** the entry SHALL state "structurally absent — no user/kernel page-table split exists in the unikernel address-space model"
+- **AND** the safety case SHALL cite the unikernel architectural model (`docs/architecture.md`) as the evidence
+- **AND** no software mitigation (KPTI-equivalent) SHALL be applied because none is required
+
+#### Scenario: A future hypervisor / multi-AS change re-opens the question
+
+- **GIVEN** a future SmallAIOS change introducing a user/kernel address-space split (e.g., a hypervisor mode)
+- **THEN** the change SHALL be required to re-evaluate Meltdown applicability and SHALL add the relevant mitigation if applicable
+- **AND** the `kernel-security` spec SHALL be updated alongside that change
+
+### Requirement: Trust-boundary mitigation audit matrix
+
+The `kernel-security` spec SHALL include a complete trust-boundary × architecture × attack-class matrix populated for every supported architecture, maintained in `docs/spec-exec-audit.md`, and refreshed on every new CVE in the speculative-execution class.
+
+#### Scenario: Matrix covers all five trust boundaries
+
+- **GIVEN** the `docs/spec-exec-audit.md` audit document
+- **WHEN** a reviewer inspects it
+- **THEN** the matrix SHALL include rows for: (a) syscall entry, (b) capability check, (c) ONNX op-dispatch indirect call, (d) GPU command submission, (e) bus-backed dataflow runner message receive
+- **AND** for each row, the matrix SHALL have a column per supported architecture (x86_64, aarch64, riscv64) and a sub-column per attack class (Spectre v1, v2, v4, Meltdown, Retbleed, Spectre-BHB)
+- **AND** each cell SHALL state the applied mitigation (compiler flag, kernel-emitted instruction, structural absence, or "partial — see notes")
+
+#### Scenario: New CVE in the class triggers a re-audit
+
+- **GIVEN** a new CVE published in the speculative-execution attack class
+- **WHEN** a maintainer becomes aware of it
+- **THEN** they SHALL open a new OpenSpec change to re-audit the affected boundaries
+- **AND** the `docs/spec-exec-audit.md` matrix SHALL be updated as part of that change
+- **AND** any newly-needed mitigation SHALL be added as a delta to the `kernel-security` spec

--- a/openspec/changes/spec-exec-mitigations-v1/tasks.md
+++ b/openspec/changes/spec-exec-mitigations-v1/tasks.md
@@ -1,0 +1,82 @@
+# Tasks — spec-exec-mitigations-v1
+
+## 0. Audit + matrix population (Phase 1 — gates all others)
+
+- [ ] 0.1 Enumerate trust boundaries in SmallAIOS today: syscall entry, capability check (`require_capability` in `kernel/src/cap.rs`), ONNX op-dispatch indirect call (`onnx-rt/`), GPU command submission (when the NVIDIA HAL lands), bus-backed dataflow runner message receive (`ipc/`). Document each in `docs/spec-exec-audit.md` with the file path + line number where the boundary lives.
+- [ ] 0.2 Per architecture (x86_64, aarch64, riscv64), populate the trust-boundary × attack-class matrix in `docs/spec-exec-audit.md`. Attack classes covered: Spectre v1 (BCB), Spectre v2 (BTI), Spectre v4 (SSB), Meltdown, Retbleed, Spectre-BHB.
+- [ ] 0.3 Identify silicon-level mitigations already present (CSV2/CSV3 on Cortex-A78AE, Enhanced IBRS on modern Xeon) and note the silicon-detection method (read `ID_AA64PFR0_EL1` on aarch64, `CPUID` leaf 7 on x86_64).
+- [ ] 0.4 Identify compiler-flag mitigations available per arch + Rust toolchain pinned in `rust-toolchain.toml`. Document the exact `RUSTFLAGS` / `-C` / `-mllvm` flags needed.
+
+## 1. Phase 2 — x86_64 mitigations
+
+### 1a. Compiler flags
+
+- [ ] 1.1 Add a `spec-exec-x86` Cargo feature on `smallaios-kernel`. Default-on when `target_arch = "x86_64"`.
+- [ ] 1.2 Create `arch/x86_64/build.rs` that emits `cargo:rustc-link-arg` and `cargo:rustc-flags` for the Retpoline + SLH flags when `spec-exec-x86` is active.
+- [ ] 1.3 Verify with `cargo build --target x86_64-unknown-none --features spec-exec-x86` then `objdump -d` that indirect calls are emitted as Retpoline thunks (no naked `jmp *%rax`).
+
+### 1b. IBRS / IBPB / STIBP MSR programming
+
+- [ ] 1.4 Create `arch/x86_64/src/security/spec_exec.rs` with `pub fn init()`.
+- [ ] 1.5 Detect Enhanced IBRS via `CPUID` leaf 7, `EDX[29]`. If present, set `IA32_SPEC_CTRL.IBRS = 1` once at boot — sticky.
+- [ ] 1.6 If only legacy IBRS, emit IBRS set/clear in the syscall entry trampoline.
+- [ ] 1.7 Detect SMT via `CPUID` leaf 1, `EBX[23]`. If SMT enabled, set `IA32_SPEC_CTRL.STIBP = 1` for the duration of kernel execution.
+- [ ] 1.8 Emit `IBPB` (write `IA32_PRED_CMD`) at syscall entry boundary, after capability check.
+- [ ] 1.9 Log `[spec-exec-x86] IBRS=<level> STIBP=<n/y> IBPB-on-entry=on` at boot.
+
+### 1c. LFENCE at syscall entry
+
+- [ ] 1.10 Modify `arch/x86_64/src/syscall.rs` (or the equivalent hand-rolled entry) to emit `lfence` *after* `require_capability` succeeds and *before* any tensor / device handle decode.
+- [ ] 1.11 Add a unit test that disassembles the syscall entry and asserts the `lfence` opcode appears at the expected offset (regression catcher).
+
+### 1d. SLH (Speculative Load Hardening)
+
+- [ ] 1.12 Add `-C llvm-args=-x86-speculative-load-hardening` to the `spec-exec-x86` build.rs flag emit. Verify the compiler accepts it on the pinned toolchain.
+- [ ] 1.13 Spot-check `objdump` output for the SLH-style branchless bounds-check pattern at known sites.
+
+## 2. Phase 3 — aarch64 mitigations
+
+### 2a. Silicon-level checks
+
+- [ ] 2.1 Add `arch/aarch64/src/security/spec_exec.rs` with `pub fn init()` that reads `ID_AA64PFR0_EL1` and decodes `CSV2`, `CSV3`. Log `[spec-exec-aarch64] CSV2=<level> CSV3=<level>`.
+- [ ] 2.2 If `CSV2 < 1` (hardware Spectre-v2 mitigation absent), boot with a warning and select the software-mitigation profile (extra `csdb` insertions in indirect-call sites).
+
+### 2b. CSDB / DSB SY barriers
+
+- [ ] 2.3 Modify `arch/aarch64/src/syscall.rs` to emit `csdb` after `require_capability` succeeds and before tensor/device handle decode (mirror of LFENCE on x86_64).
+- [ ] 2.4 Emit `dsb sy` before any capability-gated DMA-setup syscall path (cross-references the `tegra-smmu-isolation-v1` work).
+- [ ] 2.5 Add a unit test that disassembles the aarch64 syscall entry and asserts `csdb` appears at the expected offset.
+
+### 2c. BTI cross-reference
+
+- [ ] 2.6 Document in `arch/aarch64/src/security/mod.rs` that BTI is enabled by `aarch64-mte-pac-hardening-v1`'s `mte-pac` feature (or by default codegen flags) and provides the Spectre v2 indirect-call mitigation on this arch.
+
+## 3. Phase 4 — RISC-V mitigations (scaffolding)
+
+- [ ] 3.1 Document the planned mitigations in `docs/spec-exec-audit.md` Section "RISC-V": Zicbom / Zicbop for cache-state cleanup, Zicfiss / Zicfilp (ratification status TBD) for CFI, `fence.i` after privileged transitions.
+- [ ] 3.2 Add `arch/riscv64/src/security/spec_exec.rs` (currently empty / scaffolding) with a `pub fn init()` that, when the relevant extensions ratify and our silicon supports them, will program the right CSRs. Until then it logs `[spec-exec-riscv] scaffolding — extensions not yet ratified, software mitigations partial`.
+- [ ] 3.3 Insert `fence.i` placeholder in the future syscall trampoline so the entry shape is correct.
+
+## 4. Phase 5 — ONNX op-dispatch hardening
+
+- [ ] 4.1 Audit `onnx-rt`'s op-dispatch table location — confirm it is in `.rodata` after init (not writable). If it is currently writable post-init, move it.
+- [ ] 4.2 On aarch64 builds, confirm every dispatch entry has a BTI landing pad (compiler-emitted). Disassemble and assert.
+- [ ] 4.3 On x86_64 builds with Retpoline on, confirm the dispatch indirect call goes through a Retpoline thunk. Disassemble and assert.
+- [ ] 4.4 Document the op-dispatch attack surface + mitigations in `docs/onnx-runtime.md` or equivalent.
+
+## 5. Phase 6 — Spec + safety-case integration
+
+- [ ] 5.1 Populate the `kernel-security` capability spec (this change) with the trust-boundary × attack-class × mitigation matrix as Requirements.
+- [ ] 5.2 Cross-reference from the existing `safety-critical` and `security` specs to `kernel-security` so the DO-178C safety case can cite one canonical table.
+- [ ] 5.3 Add a "review trigger" line to `docs/spec-exec-audit.md` — every new CVE in the speculation-class space triggers a re-audit, tracked as a new OpenSpec change.
+
+## 6. CI
+
+- [ ] 6.1 Add `spec-exec-disasm-audit` CI advisory job that runs `objdump -d` on the kernel binary (per arch) and greps for the expected barrier opcodes at the expected sites; fails if any barrier is missing.
+- [ ] 6.2 Add a release-profile build smoke that confirms `spec-exec` feature is default-on for `cargo build --release` on each arch.
+
+## 7. Verify + archive
+
+- [ ] 7.1 Run `openspec validate spec-exec-mitigations-v1 --strict`.
+- [ ] 7.2 Capture before/after benchmark on the existing `bench/` ONNX workloads on Orin NX — show <5% steady-state throughput regression with `spec-exec` on.
+- [ ] 7.3 Open archive PR moving the change to `openspec/changes/archive/YYYY-MM-DD-spec-exec-mitigations-v1`.

--- a/openspec/changes/tegra-smmu-isolation-v1/design.md
+++ b/openspec/changes/tegra-smmu-isolation-v1/design.md
@@ -1,0 +1,109 @@
+# Design — tegra-smmu-isolation-v1
+
+## Goal
+
+Wire Tegra234's System MMU (SMMU500 / arm-mmu-500, SMMUv2-shaped) into the SmallAIOS bare-metal aarch64 path so that **every DMA-capable peripheral on the SoC is hardware-contained**: the GPU, host1x clients, PCIe root complex, USB, and SDMMC each see only the pages the kernel has explicitly mapped into their stream ID. By the end of this change, an exploit or bug in any DMA-capable driver cannot scribble outside the pages that driver was authorized to touch.
+
+Verification: SMMU fault register reads back as "no faults" during a green boot, and a deliberately-broken driver (test-only) triggers a fault that is logged with the correct stream ID, fault address, and syndrome.
+
+## Design decisions
+
+### Decision 1: SMMUv2 (SMMU500), not SMMUv3
+
+| Variant | Tegra234 silicon | Driver complexity | Linux upstream maturity | Why we pick / reject |
+|---------|------------------|-------------------|-------------------------|---------------------|
+| **SMMUv2 (SMMU500)** | Yes — this is what Orin NX ships | Lower (register-bank model) | `drivers/iommu/arm/arm-smmu/` is mature since ~2014 | **Pick** — matches the silicon and is the simpler driver |
+| SMMUv3 | Future Orin variants (AGX Industrial, Thor) | Higher (queue-based command/event interface) | `drivers/iommu/arm/arm-smmu-v3/` is mature since ~2017 | Reject for Phase 1 — not in target silicon |
+
+We design the `Iommu` trait surface so that a future `smmu_v3.rs` can implement it without changing callers. This is the same shape Linux uses (`struct iommu_ops`).
+
+### Decision 2: Identity map first, then enforce
+
+Phase 1 brings up the SMMU in a transient "identity map everything" mode before any peripheral has attached. This is unsafe but lets us validate that the SMMU driver itself works (registers respond, fault handler installs) before we start denying DMA. As soon as `init` returns, the policy flips: **no stream ID is mapped, so no peripheral can DMA**. Each driver then opts in via `attach_stream`.
+
+The alternative — bring up SMMU in deny-everything mode from cold — was rejected because it makes early-boot DRAM training and UEFI hand-off harder to debug. UEFI itself programs the SMMU passthrough during its boot services phase; we don't want to fight that until our own drivers are ready. Flipping to enforced mode after `init` is a single register write (S2CR `Type` field) so the transition is atomic.
+
+### Decision 3: Stream IDs are kernel-constants, not allocated dynamically
+
+The Tegra234 TRM (and matching `tegra234.dtsi` upstream) assigns stream IDs statically to hardware engines:
+
+```
+GPU (GA10B)         = 0x07
+host1x clients      = 0x01 - 0x06
+PCIe controllers    = 0x10 - 0x17
+USB XHCI            = 0x18
+SDMMC               = 0x20 - 0x21
+```
+
+These are baked into silicon — we don't allocate them. The new `arch/aarch64/src/smmu/stream_id.rs` defines them as `const StreamId`s and the type system prevents driver code from passing the wrong one. The Linux `tegra-mc` driver does the same thing in a less type-safe way.
+
+### Decision 4: IOVA pool per stream, not per-tensor
+
+`sys_tensor_map_gpu` returns a `GpuPtr` that is an IOVA. The naive design — "the IOVA equals the physical address" — works but creates collisions when two tensors come from different physical regions but the GPU's IOVA space wraps. The safer design is a per-stream IOVA allocator that hands out non-overlapping IOVAs and installs the SMMU page-table entries to point at the (possibly disjoint) physical pages.
+
+We use a bitmap allocator over a 2-GiB IOVA window per stream, page-aligned. 2 GiB matches Orin NX's typical model-side working set (16 GB total DRAM, ~8 GB available, ~2 GB ML-resident at peak). Larger windows are a follow-up if a model needs it.
+
+### Decision 5: TLB invalidation is a yield point
+
+SMMU TLB invalidation involves writing to TLBIALLNSNH-equivalent registers and polling a status register for completion. Worst case is multiple microseconds on Tegra234. SmallAIOS uses cooperative async scheduling that yields at ONNX operator boundaries (`docs/scheduling-model.md`); SMMU TLB invalidation gets the same treatment — the syscall handler issues the invalidate, then `yield_now().await` while polling status, then resumes when the invalidation completes.
+
+This matters because tensor map/unmap calls happen inside the inference loop, not just at model load.
+
+### Decision 6: No userspace IOMMU API
+
+VFIO-style userspace IOMMU access is rejected. SmallAIOS is a unikernel — there is no userspace in the Linux sense. The "tasks" that call syscalls are still part of the kernel address space (`docs/architecture.md` AMP unikernel model). Exposing SMMU programming directly would let a buggy task install a mapping that lets a peripheral read another task's tensors. The kernel-only model keeps the trusted computing base small and makes the capability checks the sole authorization decision.
+
+## Alternatives considered
+
+### Alt A: Use UEFI's existing SMMU passthrough setup, do nothing in the kernel
+
+**Rejected.** UEFI programs the SMMU permissively during Boot Services so that block I/O and console output work. As soon as we call `ExitBootServices` (which we do in `unikernel-orin-bringup-v1`'s Phase 2e), that state is *retained* — the SMMU continues to permit DMA, and we inherit whatever stream-table state UEFI left. Inheriting permissive state is the worst of all worlds: we look isolated on paper, but a malicious peripheral can still hit any DRAM region. We have to take over SMMU programming explicitly.
+
+### Alt B: Software-only DMA bounce buffers (no SMMU)
+
+**Rejected.** Bounce buffering routes every DMA through a kernel-managed staging buffer, then copies in/out via the CPU. It avoids the SMMU entirely but doubles memory bandwidth and adds memcpy latency on every tensor map. Orin NX has ~100 GB/s LPDDR5 bandwidth and ML workloads saturate it; halving it via bounce buffers is a non-starter for an inference-focused OS. (Linux uses bounce buffers as a fallback on hardware without an IOMMU; we have an IOMMU.)
+
+### Alt C: Per-task SMMU contexts (one context bank per inference task)
+
+**Considered, deferred.** SMMU500 has 16 context banks (CB0-CB15). One per inference task would give task-level DMA isolation in addition to peripheral-level isolation. Deferred because (a) the unikernel-task model is cooperative — tasks already trust each other within the address space — and (b) 16 context banks is not enough for any future scale-out scenario where dozens of inference tasks coexist. We use one context bank per *stream ID*, which is enough for peripheral isolation today; per-task partitioning is a separate follow-up if and when SmallAIOS grows a tenant-isolation model.
+
+### Alt D: ARM SMMU upstream Rust driver
+
+**Considered, no upstream exists.** As of this proposal, there is no `arm-smmu` crate in `std`-or-`no_std` form on crates.io. The TockOS project has an experimental arm-smmu driver but it's MMU400 focused and not in a state to vendor. We port the Linux driver shape to `#![no_std]` Rust, similar to how the existing virtio drivers in `arch/aarch64/src/virtio_blk.rs` were written.
+
+## Risks
+
+### Risk 1: UEFI hand-off race
+
+UEFI may still have outstanding DMA in flight at `ExitBootServices` (e.g., a console flush). If we tear down SMMU passthrough immediately, those in-flight DMAs fault and we see spurious early-boot fault interrupts. Mitigation: the SMMU `init` call quiesces all stream IDs (deny-all, but with a 100ms grace period during which faults are logged as warnings, not errors). After the grace period the policy is enforced.
+
+### Risk 2: Stream-ID assignment drift between L4T / mainline / OpenSUSE Tegra234 device-trees
+
+Different distributions of the Tegra234 device tree (NVIDIA L4T R36.4 vs. upstream Linux 6.6+ vs. OE/Yocto meta-tegra) assign slightly different stream IDs to host1x sub-clients. Mitigation: the `stream_id.rs` constants reference the **Tegra234 TRM** (NVIDIA's authoritative reference), not a particular Linux DTS. Where the TRM is ambiguous, we test on actual hardware (Orin NX 16 GB, the same `nx` host used by `unikernel-orin-bringup-v1`).
+
+### Risk 3: Fault interrupt routing
+
+SMMU500 raises fault interrupts via GICv3 as SPI (shared peripheral interrupts). The GICv3 driver currently in `unikernel-orin-bringup-v1` Phase 2e is bring-up-quality, not fully featured. Mitigation: Phase 4 of this change (fault handler) is sequenced *after* the parent change lands the full GICv3 dispatch. If the parent change's GICv3 driver is incomplete by the time we need it, we add the missing SPI dispatch as a small Phase 4 sub-task.
+
+### Risk 4: Performance regression
+
+SMMU page-table walks are hardware-accelerated but every cold TLB miss costs cycles. Inference workloads that re-map tensors on every batch could see throughput drops. Mitigation: (a) keep IOVA mappings long-lived (allocate-once-per-model-load, not per-batch); (b) benchmark `bench/` cuDNN throughput on Orin before/after SMMU enablement and gate the merge on <5% regression in steady-state; (c) document a `smmu-disable` Cargo feature for non-safety-critical builds that want the raw passthrough performance.
+
+### Risk 5: SMMU500 register-bank discovery
+
+Tegra234's SMMU500 registers sit at MMIO bases that differ between platform variants (Orin Nano / NX / AGX). We read them from the DTB at runtime rather than hard-coding. The DTB parser in `kernel/src/mem/phys.rs` already handles `reg = <...>` properties; we extend it to walk the `arm,mmu-500` compatible node.
+
+## Build/CI surface
+
+- New module `arch/aarch64/src/smmu/{mod.rs, smmu_v2.rs, stream_id.rs, fault.rs}`.
+- New Cargo feature `smmu` on `smallaios-arch-aarch64`, off by default initially, default-on for `--features tegra234` builds once Phase 4 lands.
+- New CI advisory job `smmu-on-orin-smoke` (self-hosted Orin runner; gated behind the same runner-availability flag as the parent change's Phase 2 promotion).
+- New `just smmu-fault-test` recipe that boots the kernel under QEMU with a virt-smmu-v2 model and validates fault handling against a deliberately-broken test driver.
+- Module-level acyclicity (the standing `just arch-check` gate) must still pass — `arch/aarch64/src/smmu/` depends only on `kernel/` foundation services (allocator, syscall types), never the other way.
+
+## What this change explicitly does NOT do
+
+- Does not modify any x86_64 IOMMU code (there is none today; that's a separate change).
+- Does not change syscall ABI numbers — `sys_tensor_map_gpu` keeps its current number; only the meaning of the returned `GpuPtr` changes from "physical" to "IOVA".
+- Does not touch userspace ONNX-rt code paths — the SMMU is invisible above the kernel/HAL boundary.
+- Does not add new capabilities beyond `kernel-iommu`; `TensorBuffer:WRITE` + `GpuDevice:EXECUTE` remain the authorization gates.

--- a/openspec/changes/tegra-smmu-isolation-v1/proposal.md
+++ b/openspec/changes/tegra-smmu-isolation-v1/proposal.md
@@ -1,0 +1,87 @@
+# tegra-smmu-isolation-v1
+
+## Summary
+
+The `sys_tensor_map_gpu` syscall (`kernel/src/syscall/memory.rs:361`) is the gateway between SmallAIOS-managed DRAM and the Ampere GA10B GPU's view of memory on Jetson Orin. Today it performs capability checks (`TensorBuffer:WRITE` + `GpuDevice:EXECUTE`) and then returns `NotSupported` because the NVIDIA HAL integration hasn't landed yet. When that HAL does land, the syscall path will hand a physical buffer pointer to the GPU command submission code — which on Tegra234 means **DMA from a peripheral that does not share the CPU's address space**. Without explicit System MMU (SMMU) programming, every DMA-capable engine on the SoC (GA10B GPU, host1x clients, PCIe root complex, USB, SDMMC, security engine) sees the full physical-address space, and a buggy or hostile peripheral can read or scribble anywhere in DRAM regardless of what page tables the CPU thinks are in effect. This is the SoC-level analog of running without an MMU.
+
+Tegra234 ships a Cortex-A78AE-class **SMMU500** (Arm SMMUv2) for client peripherals and an **MMU400** (SMMUv1-shaped) for legacy host1x v6 stream IDs — both are documented in the Tegra234 TRM and exposed via the upstream Linux `arm,mmu-500` / `nvidia,tegra234-smmu` device-tree bindings. This change wires those IOMMUs into SmallAIOS so that every DMA path crosses a hardware translation step gated by an IOMMU stream-table entry the kernel controls. The Cargo feature `smmu` on `smallaios-arch-aarch64` (default off until Phase 2 lands hardware verification on Orin) selects the driver; a new `kernel-iommu` capability covers the per-stream-ID lifecycle.
+
+## Why
+
+- **DMA isolation is a DO-178C DAL A prerequisite, not a polish item.** Avionics safety reviewers ask "what stops a peripheral from corrupting the partition's address space" and the only acceptable answer is hardware-enforced IOMMU isolation. RTCA DO-254 (the hardware companion to DO-178C) and the IMA partitioning model in ARINC 653 both presume bus-master containment. Today SmallAIOS has no story for this on aarch64 — `arch/aarch64/src/paging.rs` programs the CPU MMU (translation regime EL1) but nothing touches the System MMU's stream tables (translation regime "non-secure stage-1/stage-2 for peripherals"). For x86_64 the situation is similar (Intel VT-d / AMD-Vi are stubbed). On Orin specifically, the GPU is the worst offender: a single bad GR class submission can DMA-write anywhere in DRAM unless `arm-smmu-500` is the gatekeeper.
+- **The syscall surface is already shaped for it.** `sys_tensor_map_gpu` returns a `GpuPtr` (`u64`) that the GPU sees. Today that's expected to be a physical address. Once the SMMU is in the loop, the `GpuPtr` becomes an *IO virtual address* (IOVA) — a number that means something only inside the GPU's translation context. That re-typing is mechanical once the SMMU driver exists; the syscall ABI stays binary-compatible because both forms are `u64`. The capability checks already in place (`require_capability(GpuDevice, EXECUTE)`) become the authorization gate for "may this caller install an SMMU mapping at all".
+- **Tegra234's SMMU500 is well-documented and Linux-tested.** Upstream Linux's `drivers/iommu/arm/arm-smmu/arm-smmu.c` plus `drivers/iommu/arm/arm-smmu-v3/` provide a working reference for SMMUv2 + SMMUv3 programming. NVIDIA's L4T fork exposes the SMMU on Tegra234 through the standard `arm,mmu-500` binding with extra `nvidia,memory-controller` properties for stream-ID-to-engine assignment. We are not reinventing the protocol — we are porting a known-good driver to `#![no_std]` with no allocator (or with the page-aligned allocator from `kernel/src/mem/`).
+- **A unikernel with hardware-enforced DMA isolation is a stronger story than a Linux-based competitor.** Linux-based ML appliances (NVIDIA's own JetPack 6 host stack included) leave the SMMU "passthrough" by default for performance reasons; userspace can request DMA-API mappings but the kernel does not enforce that *every* DMA-capable engine is contained. A unikernel that ships SMMU-enforced isolation by default differentiates SmallAIOS on the same hardware NVIDIA ships, without giving up performance (SMMU500 walks page tables in hardware — overhead is a single-digit-percent TLB-miss tax once warm).
+
+## Scope — phases
+
+The work is sequenced so the highest-risk pieces (initial SMMU init, GPU stream-ID isolation) land first, with peripheral coverage following once the framework is proven.
+
+### Phase 1 — SMMU500 driver scaffold (~1 week)
+
+Create `arch/aarch64/src/smmu/` as a new module:
+
+- `mod.rs` — public API: `init(dtb)`, `attach_stream(stream_id, page_table_root)`, `detach_stream(stream_id)`, `flush_tlb(stream_id)`. Trait-shaped so the SMMUv3 variant slots in later.
+- `smmu_v2.rs` — SMMU500 implementation (SMMUv2-shaped per the arm-smmu Linux driver): probe register banks at the Tegra234 MMIO base, allocate context banks (CB0-CB15), program global address translation tables (GR0/GR1), wire stream-match registers (SMR/S2CR). Identity-mapped + stage-1 only initially.
+- `stream_id.rs` — type-safe `StreamId(u16)` newtype with Tegra234-specific constants extracted from the Tegra234 TRM (GA10B GPU = `0x7`, host1x = `0x1`, PCIe controllers = `0x10-0x17`, USB = various). One source of truth so syscall-side code never hand-writes literals.
+
+Boot-time sequence (called from `kernel_main` after `mem::init` but before any DMA-capable driver init): probe SMMU registers, install a permissive identity map as a transient default, then immediately switch to "no stream mapped = no DMA allowed" once each peripheral is explicitly attached.
+
+Verification: read back the SMR/S2CR registers and assert the kernel-side stream-table matches programmed expectations. Boot output prints `[smmu] SMMU500 attached, N stream IDs reserved`.
+
+### Phase 2 — GPU stream-ID enforcement (~1-1.5 weeks)
+
+Tie `sys_tensor_map_gpu` to the SMMU. Today the syscall short-circuits at `NotSupported`; once the NVIDIA HAL lands, the syscall must:
+
+1. Compute an IOVA from the tensor's physical pages (allocator-friendly: pick from an SMMU IOVA pool, *not* return raw physical).
+2. Install an SMMU stage-1 mapping for the GPU's stream ID (`StreamId(0x7)` on Tegra234) covering those pages with the requested permissions (`R`, `RW`).
+3. Invalidate the SMMU TLB for that stream.
+4. Return the IOVA as the `GpuPtr`.
+
+`sys_tensor_unmap_gpu` is the symmetric tear-down: invalidate + free the IOVA region.
+
+A new `kernel-iommu` capability spec (this change) governs stream-table modifications. Only the kernel itself (via the syscall handler) may write to SMMU registers; userspace never has direct register access. The cooperative-async scheduler treats SMMU TLB invalidation as a yield point because the invalidate-and-wait sequence can take microseconds.
+
+### Phase 3 — Peripheral coverage (~1 week)
+
+Extend the same machinery to every other DMA-capable Tegra234 peripheral surfaced by SmallAIOS today or planned in the next two releases:
+
+- **host1x v6** — the video/ISP/encoder controller. Stream IDs `0x1-0x6`. Shares the GPU's GR class submission shape, so the same `attach_stream` API works.
+- **PCIe root complex** — stream IDs `0x10-0x17`. NVMe and Wi-Fi M.2 cards arrive here.
+- **USB XHCI** — stream ID `0x18`. The USB stack is a current SmallAIOS deliverable (`smallaios-usb` crate) so this matters even for "no GPU" deployments.
+- **SDMMC** — stream IDs `0x20-0x21`. eMMC and SD card access.
+
+For each peripheral, the driver init code calls `smmu::attach_stream(<id>, this_driver's_page_table_root)` before enabling DMA. Peripherals without an attached stream are simply unable to DMA — register access still works (CPU MMIO), DMA is hardware-blocked.
+
+### Phase 4 — Fault handling + telemetry (~0.5-1 week)
+
+SMMU500 raises a fault interrupt when a peripheral attempts an untranslated or denied access (FSR register + GICv3 SPI). We wire that to a kernel-side handler that:
+
+- Logs the offending stream ID, address, fault syndrome (translation fault vs. permission fault vs. external abort).
+- Increments per-stream-ID fault counters surfaced via the existing telemetry / OTEL export path (`telemetry-otel-export-v1` proposal).
+- Optionally panics under a `smmu-fatal-fault` Cargo feature for safety-critical builds where any DMA fault is a definite bug.
+
+## Out of scope
+
+- **x86_64 IOMMU (VT-d / AMD-Vi).** Different protocol, different driver. Tracked separately as `iommu-x86-vtd-v1` when the x86 path is prioritized.
+- **RISC-V IOMMU.** The riscv64 target doesn't currently have a documented IOMMU on the bring-up hardware. When we cross that bridge, the trait shape introduced here (`Iommu::attach_stream` etc.) is the right re-use point.
+- **SMMUv3 promotion.** Tegra234 ships SMMUv2 (SMMU500) — the AGX Orin Industrial / Thor parts use SMMUv3. We pick SMMUv2 first because that is what Orin NX ships; the abstraction allows a v3 driver to slot in later without touching syscall callers.
+- **Per-process page tables.** SmallAIOS is a single-address-space unikernel by design (`docs/architecture.md`); the SMMU stage-1 page tables are kernel-managed and shared across "tasks". We are not introducing per-process page tables on the IOMMU side either; we are partitioning the *peripheral* view of DRAM, not the CPU view.
+- **Userspace IOMMU API (VFIO-style).** No syscall surfaces SMMU programming directly; the kernel is the sole gatekeeper. A future change might expose a `sys_iommu_*` family for advanced use cases but the default story is "kernel-only".
+- **Live SMMU reconfiguration during inference.** Streams are attached at driver-init time and tensor-map mappings are added/removed per `sys_tensor_map_gpu` call, but global SMMU configuration (which stream IDs exist, fault-handler installation) does not change after boot.
+
+## Sequencing
+
+Phase 1 lands first and is independent — the SMMU driver compiles, boots on the Orin via the existing `unikernel-orin-bringup-v1` path, and prints the attach banner without changing any existing syscall behavior. Phase 2 is the value-delivery phase but depends on Phase 1 and on the NVIDIA HAL integration sub-PR (out of scope for this change but a soft dependency). Phase 3 can run partially in parallel with Phase 2 (different peripherals, same `attach_stream` API). Phase 4 closes the change once enough drivers are attached to make per-stream-ID telemetry meaningful.
+
+This change can run in parallel with `aarch64-mte-pac-hardening-v1` (CPU-side memory safety, no SMMU touch) and `spec-exec-mitigations-v1` (instruction-level mitigations, no MMU touch). It is logically antecedent to any future GPU bring-up change (`unikernel-orin-gpu-v1`): the GPU HAL must call into `smmu::attach_stream` from day one.
+
+## Effort estimate
+
+| Phase | Scope | Estimate |
+|-------|-------|----------|
+| 1 | SMMU500 driver scaffold, boot-time init | ~1 week |
+| 2 | GPU stream-ID + `sys_tensor_map_gpu` wiring | ~1-1.5 weeks |
+| 3 | Peripheral coverage (host1x, PCIe, USB, SDMMC) | ~1 week |
+| 4 | Fault handler + telemetry | ~0.5-1 week |
+| **Total** | | **~3-4 weeks** |

--- a/openspec/changes/tegra-smmu-isolation-v1/specs/kernel-iommu/spec.md
+++ b/openspec/changes/tegra-smmu-isolation-v1/specs/kernel-iommu/spec.md
@@ -1,0 +1,102 @@
+## ADDED Requirements
+
+### Requirement: SMMU500 driver initialization on Tegra234
+
+The kernel SHALL initialize the Tegra234 System MMU (ARM SMMU500, SMMUv2-shaped) during boot, before any DMA-capable peripheral driver is allowed to issue DMA transactions, on builds enabling the `smmu` Cargo feature on `smallaios-arch-aarch64`.
+
+#### Scenario: SMMU registers are probed from the device tree
+
+- **GIVEN** a SmallAIOS kernel built with `--features tegra234,smmu` running on an Orin NX device with a JetPack 6 / L4T R36.4 device tree
+- **WHEN** `smmu::init(dtb)` runs during boot
+- **THEN** the driver SHALL walk the DTB for nodes matching `compatible = "arm,mmu-500"` or `compatible = "nvidia,tegra234-smmu"` and SHALL read the SMMU MMIO base address from the node's `reg` property
+- **AND** the driver SHALL read `GR0::IDR0`, `GR0::IDR1`, and `GR0::IDR2` to determine the number of context banks, the number of stream-match registers, and the supported translation regimes
+- **AND** the driver SHALL log a structured boot line of the form `[smmu] SMMU500 attached, <N> context banks, <M> stream-match entries` over the configured serial console
+
+#### Scenario: Boot-time policy transitions from identity-map to enforce
+
+- **GIVEN** the SMMU driver has completed register probing
+- **WHEN** the kernel proceeds past `smmu::init` and before any peripheral driver init
+- **THEN** the SMMU SHALL be programmed with a deny-all default for every stream ID (S2CR type = fault) — peripherals that have not been explicitly attached via `attach_stream` SHALL be unable to issue DMA
+- **AND** a 100-millisecond grace period SHALL log any UEFI-residual DMA faults as informational warnings rather than fatal errors
+- **AND** after the grace period any subsequent fault SHALL be handled by the structured fault handler (see "SMMU fault handling" requirement)
+
+#### Scenario: No DMA-capable driver init runs before SMMU init
+
+- **GIVEN** the kernel boot sequence
+- **WHEN** the kernel boots
+- **THEN** `smmu::init` SHALL be called after `mem::init` and before any DMA-capable driver init (host1x, GPU HAL, PCIe controller, USB XHCI, SDMMC)
+- **AND** a debug assertion SHALL trip if a driver init runs while `smmu::is_initialized()` returns false
+
+### Requirement: Stream-ID-based DMA isolation for GPU tensor mappings
+
+The `sys_tensor_map_gpu` syscall SHALL, on builds with the `smmu` feature active, route GPU-visible tensor pointers through a per-stream IOMMU translation rather than handing the GPU a raw physical address.
+
+#### Scenario: sys_tensor_map_gpu returns an IOVA, not a physical address
+
+- **GIVEN** a tensor allocated via `sys_mem_alloc` and the caller has both `TensorBuffer:WRITE` on the handle and `GpuDevice:EXECUTE` on the target device
+- **WHEN** the caller invokes `sys_tensor_map_gpu(handle, device_id)`
+- **THEN** the syscall SHALL allocate an IOVA range from the GPU stream's IOVA allocator covering the tensor's physical pages
+- **AND** the syscall SHALL install an SMMU stage-1 mapping for the GPU's Tegra234 stream ID (`0x07`) pointing the IOVA range at the tensor's physical pages with the requested permissions
+- **AND** the syscall SHALL flush the SMMU TLB for the GPU stream before returning
+- **AND** the syscall SHALL return the IOVA as the `GpuPtr` value — the value SHALL NOT equal the physical address of the tensor pages in the general case
+- **AND** the cooperative-async runtime SHALL treat the TLB-flush poll loop as a yield point per the SmallAIOS scheduling model
+
+#### Scenario: Capability denial blocks the SMMU programming
+
+- **GIVEN** a caller that does NOT hold `GpuDevice:EXECUTE` on the requested device
+- **WHEN** the caller invokes `sys_tensor_map_gpu(handle, device_id)`
+- **THEN** the syscall SHALL return the existing capability-denial error code unchanged
+- **AND** the SMMU SHALL NOT be modified — no IOVA allocation, no page-table edit, no TLB flush
+
+#### Scenario: Symmetric unmap releases SMMU resources
+
+- **GIVEN** a tensor that has been mapped to the GPU via `sys_tensor_map_gpu` (returning IOVA `X`)
+- **WHEN** the caller invokes `sys_tensor_unmap_gpu(handle, device_id)`
+- **THEN** the syscall SHALL remove the SMMU stage-1 mapping covering IOVA `X`
+- **AND** the syscall SHALL flush the SMMU TLB for the GPU stream
+- **AND** the syscall SHALL return the IOVA range to the GPU stream's IOVA allocator so that a subsequent `sys_tensor_map_gpu` for a different tensor MAY reuse those IOVAs
+
+### Requirement: Per-peripheral stream attachment for non-GPU DMA paths
+
+Every DMA-capable peripheral driver in SmallAIOS SHALL, on `smmu`-feature builds, attach its hardware engine's stream ID to the SMMU before enabling DMA in that engine.
+
+#### Scenario: USB XHCI attaches before enabling DMA
+
+- **GIVEN** the `smallaios-usb` XHCI controller driver running on a `--features tegra234,smmu` build
+- **WHEN** the driver's `init` function executes
+- **THEN** the driver SHALL call `smmu::attach_stream(StreamId::USB, <driver's root PA>, Perms::RW)` before writing any USB controller register that enables DMA
+- **AND** a deny-all DMA attempt from the USB controller SHALL produce a kernel fault interrupt (see "SMMU fault handling") rather than scribbling DRAM
+
+#### Scenario: host1x, PCIe, SDMMC attach symmetrically
+
+- **GIVEN** the host1x v6 driver, PCIe root-complex driver, and SDMMC driver
+- **WHEN** each driver's init executes on a `--features tegra234,smmu` build
+- **THEN** each driver SHALL call `smmu::attach_stream` with its corresponding Tegra234 stream ID(s) before enabling DMA in its engine
+- **AND** the stream-ID constants used SHALL come from `arch/aarch64/src/smmu/stream_id.rs` (the canonical Tegra234 TRM-derived constants) — drivers SHALL NOT hand-write stream-ID literals
+
+### Requirement: SMMU fault handling and telemetry
+
+The SMMU global fault interrupt SHALL be routed to a structured fault handler that logs the offending stream, address, and syndrome, and SHALL increment per-stream fault counters surfaced via the kernel telemetry interface.
+
+#### Scenario: Fault on an unmapped IOVA produces structured output
+
+- **GIVEN** an SMMU-enabled build with at least one stream attached
+- **WHEN** any peripheral attempts a DMA access that the SMMU page-table walk fails (unmapped IOVA, permission violation, or external abort)
+- **THEN** the SMMU SHALL raise a global fault interrupt
+- **AND** the kernel handler SHALL read `FSR`, `FSYNR0`, `FSYNR1`, `FAR` from the relevant context bank and produce a structured `SmmuFault { stream_id, iova, fault_kind, syndrome }` value
+- **AND** the handler SHALL log the structured fault to the boot console with severity `error`
+- **AND** the per-stream fault counter SHALL increment
+
+#### Scenario: Fatal-fault Cargo feature converts faults to panics
+
+- **GIVEN** a kernel built with `--features tegra234,smmu,smmu-fatal-fault`
+- **WHEN** any SMMU fault occurs after the boot-time grace period
+- **THEN** the kernel SHALL panic with a structured message naming the stream ID, IOVA, and fault kind — the run SHALL NOT continue
+- **AND** this behavior SHALL be the recommended configuration for safety-critical (DO-178C DAL A) builds where any DMA fault indicates a definite software defect
+
+#### Scenario: Telemetry exposes per-stream counters
+
+- **GIVEN** a kernel built with `--features tegra234,smmu` and the existing kernel telemetry surface enabled
+- **WHEN** an operator queries the telemetry endpoint
+- **THEN** the response SHALL include per-stream-ID fault-counter values for every stream that has ever been attached during the current boot
+- **AND** the counters SHALL be monotonic — they SHALL reset only on kernel boot, never on attach/detach

--- a/openspec/changes/tegra-smmu-isolation-v1/tasks.md
+++ b/openspec/changes/tegra-smmu-isolation-v1/tasks.md
@@ -1,0 +1,78 @@
+# Tasks — tegra-smmu-isolation-v1
+
+## 0. Hardware verification + reference reading (prereq)
+
+- [ ] 0.1 Capture and record the SMMU MMIO bases from a stock JetPack 6 / L4T R36.4 Orin NX boot: `cat /sys/firmware/devicetree/base/smmu*/reg | hexdump`, `dmesg | grep -i smmu`, `cat /proc/iomem | grep -i smmu`. Paste in the change PR description.
+- [ ] 0.2 Read Tegra234 TRM section "System MMU (ARM SMMU500)" — confirm register bank layout (GR0, GR1, SMR, S2CR, CB0-CB15), stream-ID assignments for every DMA-capable engine, and fault syndrome encoding.
+- [ ] 0.3 Read upstream Linux `drivers/iommu/arm/arm-smmu/arm-smmu.c` + `arm-smmu-impl.c` + Tegra-specific glue in `drivers/iommu/tegra-smmu.c`. Document which initialization steps are silicon-mandated vs. Linux-policy.
+- [ ] 0.4 Confirm SMMU500 fault routing GICv3 SPI number by inspecting the Orin NX device tree and matching against the GICv3 driver landing in `unikernel-orin-bringup-v1` Phase 2e.
+
+## 1. Phase 1 — SMMU500 driver scaffold
+
+### 1a. Module scaffolding
+
+- [ ] 1.1 Create `arch/aarch64/src/smmu/mod.rs` with the public API surface: `Iommu` trait + `pub fn init(dtb: *const u8)` + `pub fn attach_stream(stream_id, root_pa, perms)` + `pub fn detach_stream(stream_id)` + `pub fn flush_tlb(stream_id)`.
+- [ ] 1.2 Create `arch/aarch64/src/smmu/stream_id.rs` defining the `StreamId(u16)` newtype and Tegra234 constants (GPU, host1x clients, PCIe, USB, SDMMC) from the TRM, with doc-comments citing the TRM section for each constant.
+- [ ] 1.3 Add `smmu` Cargo feature to `arch/aarch64/Cargo.toml`. Off by default. Doc-comment distinguishes it from the parent `tegra234` feature (this one toggles the IOMMU driver; `tegra234` toggles the whole BSP).
+- [ ] 1.4 Gate the new module in `arch/aarch64/src/lib.rs` behind `#[cfg(feature = "smmu")]`.
+
+### 1b. SMMUv2 register driver
+
+- [ ] 1.5 Create `arch/aarch64/src/smmu/regs.rs` — typed MMIO accessor structs for `GR0`, `GR1`, `SMR[0..=N]`, `S2CR[0..=N]`, `CB[0..=15]` per the SMMUv2 spec. Use `volatile-register` style accessors (already used in `arch/aarch64/src/uart.rs`).
+- [ ] 1.6 Create `arch/aarch64/src/smmu/smmu_v2.rs` implementing the `Iommu` trait. `init`: probe `GR0::IDR0/IDR1/IDR2` for capability detection (number of context banks, S2 supported, etc.); program a transient identity-map state; install fault-handler interrupt vector via `interrupts.rs`.
+- [ ] 1.7 Implement `attach_stream` — pick a free context bank (CB), program SMR with the stream ID, point S2CR at the chosen CB, install the page-table root (a stage-1 walk with the kernel's existing `paging.rs` 4 KiB-page format), set CB context attributes (`TCR`, `SCTLR`, `TTBR0`).
+- [ ] 1.8 Implement `detach_stream` and `flush_tlb` — TLBIALL on the context bank, poll status register, return when complete. Cooperative-yield while polling per design decision 5.
+- [ ] 1.9 Wire `smmu::init(dtb)` into the boot sequence (`arch/aarch64/src/main.rs` or `main_uefi.rs`) after `mem::init` and before any DMA-driver init.
+
+### 1c. Unit tests + QEMU virt-smmu smoke
+
+- [ ] 1.10 Add unit tests under `arch/aarch64/src/smmu/tests.rs` exercising the register-level state machine (mocked MMIO via `volatile-register` test shims).
+- [ ] 1.11 Add a `just smmu-qemu-smoke` recipe that boots SmallAIOS under `qemu-system-aarch64 -M virt,iommu=smmuv2 -cpu cortex-a72 ...` (QEMU's virt-smmu model is SMMUv2-compatible) and asserts the boot banner includes `[smmu] SMMU attached`.
+- [ ] 1.12 Add an `smmu-qemu-smoke` CI job (advisory initially) that runs the recipe.
+
+## 2. Phase 2 — GPU stream-ID enforcement
+
+### 2a. IOVA allocator
+
+- [ ] 2.1 Create `arch/aarch64/src/smmu/iova.rs` — per-stream bitmap IOVA allocator with a 2-GiB window per stream, 4 KiB page granularity. API: `alloc_iova(stream, n_pages, align) -> Iova`, `free_iova(stream, iova, n_pages)`.
+- [ ] 2.2 Unit-test the IOVA allocator: random alloc/free patterns, alignment edge cases, exhaustion behavior.
+
+### 2b. sys_tensor_map_gpu wiring
+
+- [ ] 2.3 Modify `kernel/src/syscall/memory.rs::sys_tensor_map_gpu` to, instead of returning `NotSupported`, call into a HAL-level `gpu_map_tensor` that: (a) resolves the tensor handle to its physical pages, (b) allocates an IOVA range from the GPU stream's allocator, (c) calls `smmu::map_pages(StreamId::GPU, iova, &phys_pages, perms)`, (d) flushes the GPU stream TLB, (e) returns the IOVA as `GpuPtr`. Gated by a new `gpu` feature on `smallaios-kernel` so non-GPU builds compile unchanged.
+- [ ] 2.4 Add `smmu::map_pages` + `smmu::unmap_pages` (page-table edit helpers — the stage-1 walk happens in hardware, but the kernel owns the page-table memory).
+- [ ] 2.5 Modify `sys_tensor_unmap_gpu` symmetrically: unmap pages, free IOVA, flush TLB.
+- [ ] 2.6 Add unit + integration tests covering capability rejection (no `EXECUTE` on `GpuDevice` -> error) and IOVA non-collision (two tensors get non-overlapping IOVA ranges).
+
+### 2c. kernel-iommu capability spec
+
+- [ ] 2.7 Add `ResourceType::IommuStream` to `kernel/src/cap.rs` (or wherever `ResourceType` lives). Permissions: `BIND` (attach a stream), `WRITE` (modify mappings under an attached stream).
+- [ ] 2.8 Document in the new `kernel-iommu` capability spec that only the syscall handler and HAL driver code may construct an `IommuStream` capability — never user-graph nodes.
+
+## 3. Phase 3 — Peripheral coverage
+
+- [ ] 3.1 host1x v6 — attach `StreamId::HOST1X_*` in the host1x driver's `init` path (if/when the driver lands). Update `arch/nvidia/src/tegra/` notes.
+- [ ] 3.2 PCIe root complex — attach `StreamId::PCIE_*` in the PCIe driver's `init`. (Driver may not exist yet; add a TODO comment and a unit-test stub.)
+- [ ] 3.3 USB XHCI — attach `StreamId::USB` from the `smallaios-usb` crate's controller init. This is the highest-impact non-GPU stream: USB is the easiest physical attack surface.
+- [ ] 3.4 SDMMC — attach `StreamId::SDMMC_*` from the eMMC/SD driver init.
+- [ ] 3.5 Document in `docs/architecture.md` (Layer 2 section) the SMMU-enforced DMA isolation model with a table of stream-ID → driver mappings.
+
+## 4. Phase 4 — Fault handler + telemetry
+
+- [ ] 4.1 Implement `arch/aarch64/src/smmu/fault.rs` — handler for SMMU global fault SPI. Reads FSR, FAR, syndrome registers; produces a structured `SmmuFault` value.
+- [ ] 4.2 Wire the handler into the GICv3 dispatch (depends on `unikernel-orin-bringup-v1` Phase 2e landing first).
+- [ ] 4.3 Add per-stream fault counters surfaced via the same telemetry path as the `telemetry-otel-export-v1` change (or, if that hasn't landed, via the existing console-log path).
+- [ ] 4.4 Add a `smmu-fatal-fault` Cargo feature that turns any SMMU fault into a kernel panic — opt-in for safety-critical builds.
+- [ ] 4.5 Test: write a deliberately-broken in-kernel test driver that attempts a DMA outside its mapped region; assert the fault handler fires, the counter increments, and (with `smmu-fatal-fault` on) the kernel panics with a structured message.
+
+## 5. Docs
+
+- [ ] 5.1 Add `docs/smmu-isolation.md` covering: the IOMMU model, stream-ID table, how a new DMA-capable driver attaches itself, fault triage, the per-stream telemetry counters, and the `smmu-disable` / `smmu-fatal-fault` Cargo features.
+- [ ] 5.2 Update `docs/architecture.md` Layer 2 section to call out SMMU-enforced isolation.
+- [ ] 5.3 Update `CLAUDE.md` to note SMMU isolation is enabled on `tegra234` builds.
+
+## 6. Verify + archive
+
+- [ ] 6.1 Run `openspec validate tegra-smmu-isolation-v1 --strict` after all phases land.
+- [ ] 6.2 Capture on-Orin-NX evidence: boot output showing `[smmu] SMMU500 attached, 5 stream IDs reserved`, fault-test output, telemetry counter snapshot. Paste in the final PR description.
+- [ ] 6.3 Open archive PR moving the change to `openspec/changes/archive/YYYY-MM-DD-tegra-smmu-isolation-v1` and sync the spec deltas to main specs.


### PR DESCRIPTION
## Summary

Drafts five new OpenSpec changes covering hardware-enforced memory safety and DMA isolation for SmallAIOS, anchored on Jetson Orin (Tegra234 / Cortex-A78AE / ARMv8.5-A) but written to scale across the rest of the target matrix (x86_64, RISC-V). Documentation only — no Rust code changes. Each change has `proposal.md`, `design.md`, `tasks.md`, and a `specs/<capability>/spec.md` with `## ADDED Requirements`; all five validate cleanly under `openspec validate <name> --strict`.

The roadmap addresses four memory-safety dimensions plus one research-track exploration:

1. **DMA isolation** at the SoC fabric (SMMU)
2. **CPU-side memory safety** (MTE + PAC)
3. **Speculative-execution side channels** at trust boundaries
4. **Single-event-upset / cosmic-ray bit-flip resilience** (ECC scrubbing) for avionics / DAL A long-running inference
5. **CHERI alignment** as a forward-looking research artifact

## Changes

- `openspec/changes/tegra-smmu-isolation-v1/proposal.md` — Wire Tegra234 SMMU500 into the kernel; route `sys_tensor_map_gpu` through IOVA mappings; per-peripheral stream-ID isolation for GPU, host1x, PCIe, USB, SDMMC. Tier 1, ~3-4 weeks. New capability `kernel-iommu`.
- `openspec/changes/aarch64-mte-pac-hardening-v1/proposal.md` — Enable ARMv8.5-A MTE (sync tag-check via the global allocator) + PAC (return-address signing + capability-handle APDA signing + ONNX op-dispatch APGA signing) on Cortex-A78AE. Tier 1, ~2-3 weeks. New capability `arch-aarch64-security`.
- `openspec/changes/spec-exec-mitigations-v1/proposal.md` — Audit and add Spectre v1/v2/v4 + Meltdown + Retbleed mitigations at five named trust boundaries (syscall entry, capability check, ONNX op-dispatch indirect call, GPU command submission, bus-backed dataflow runner). Per-arch: x86_64 (IBRS / IBPB / STIBP / LFENCE / Retpoline / SLH), aarch64 (CSDB / DSB SY / CSV2-CSV3 silicon check), RISC-V (scaffolding). Documents Meltdown structural immunity in the unikernel single-address-space model. Tier 2, ~2 weeks. New capability `kernel-security` with the full trust-boundary × attack-class matrix.
- `openspec/changes/ecc-scrubbing-v1/proposal.md` — Background ECC memory scrub service for long-running inference in radiation environments. Tegra234 EMC hardware backend + software fallback; cooperative-async task with per-region intervals; watchdog correlation. Tier 3, ~3-4 weeks. Extends `kernel-mem`.
- `openspec/changes/cheri-capability-v1/proposal.md` — Documentation-only research-stage alignment between SmallAIOS's software capability model and CHERI hardware capabilities. One-shot compile experiment under `cheri-rust`. Implementation deferred until production CHERI silicon is available. ~2 weeks, doc-only. New capability `kernel-cheri`.

## Sequencing

**Implement first (Tier 1, parallelizable):**
- `tegra-smmu-isolation-v1` — closes the largest unmitigated attack surface (peripheral DMA can scribble any DRAM today). Direct DAL A blocker.
- `aarch64-mte-pac-hardening-v1` — pure additive CPU-feature enable, low risk, high security return. Compiler-level PAC has zero allocator coupling and can land in days.

These two run in full parallel — different code paths, different hardware features.

**Implement next (Tier 2):**
- `spec-exec-mitigations-v1` — depends on `aarch64-mte-pac-hardening-v1` for BTI being on (Phase 5 ONNX op-dispatch coverage). Parallel on x86_64.

**Implement when long-running deployments need it (Tier 3):**
- `ecc-scrubbing-v1` — niche but cert-critical for avionics / high-altitude. Independent of the others. Best implemented when an Orin NX 7-day soak test is available as part of the verification gate.

**Forward-looking (research-stage):**
- `cheri-capability-v1` — doc-only, can land anytime. Best done in a research-track sprint week. Re-evaluate the implementation track when CHERI silicon roadmaps firm up.

The four implementation-track changes (1-4) are all independent of one another at the spec level — they target different hardware features and different code paths. They can land in any order and in parallel, except for the `spec-exec → mte-pac` BTI dependency noted above. All four depend on `unikernel-orin-bringup-v1` Phase 2e being green on Orin NX hardware (already mostly landed; post-EBS UART is the residual gap).

## Test plan

- [x] `openspec validate tegra-smmu-isolation-v1 --strict`
- [x] `openspec validate aarch64-mte-pac-hardening-v1 --strict`
- [x] `openspec validate spec-exec-mitigations-v1 --strict`
- [x] `openspec validate ecc-scrubbing-v1 --strict`
- [x] `openspec validate cheri-capability-v1 --strict`
- [x] `openspec list` shows all five new changes alongside the existing roadmap.
- [N/A] No Rust code changes — no `cargo test`, `cargo clippy`, `cargo fmt` impact.
- [N/A] No CI workflow changes in this PR. Each implementation change will introduce its own CI jobs as documented in its `design.md` "Build/CI surface" section.

Marked **DRAFT** because these are proposals for review, not implementation. Reviewer feedback on scope, sequencing, capability naming, and effort estimates is welcomed before any of the five enters implementation.