### PR TITLE
docs(openspec): propose boot Root-of-Trust + attestation roadmap (boot-rot, op-tee, remote-attestation, confidential-compute)

### DIFF
--- a/openspec/changes/boot-root-of-trust-v1/design.md
+++ b/openspec/changes/boot-root-of-trust-v1/design.md
@@ -1,0 +1,177 @@
+# Design — boot-root-of-trust-v1
+
+## Goal
+
+Four sequenced milestones, each with an observable boot-time or off-host verification artifact:
+
+1. **Phase 1 — x86-64 TPM 2.0 hardware-extended measurement log.** Success = `swtpm`-emulated PCRs 11-14 match the SmallAIOS in-DRAM `BootMeasurementLog` after boot, and a `TPM2_Quote` over those PCRs verifies against the AK public key.
+2. **Phase 2 — AArch64 TF-A event log consumption.** Success = SmallAIOS's `BootMeasurementLog` begins with TF-A-supplied entries (BL1/BL2/BL31 hashes) ahead of SmallAIOS's own entries, and the merged log replays into a consistent root hash.
+3. **Phase 3 — RISC-V PMP request SBI extension.** Success = SmallAIOS issues `SBI_EXT_SMALLAIOS_PMP_REQUEST` and records the response (`Success` on patched OpenSBI, `NotSupported` on stock); boot succeeds either way.
+4. **Phase 4 — Signed UEFI kernel image.** Success = `sbverify --cert <vendor.crt> smallaios-x86_64.efi` returns OK; same for `smallaios.efi` on AArch64; firmware logs (where exposed) record signature-verified load.
+
+## Phase 1 — TPM 2.0 driver
+
+### Why a clean-room driver, not `tpm2-tss`
+
+The well-known `tpm2-tss` C library is GPL/BSD, depends on POSIX I/O and dynamic memory, and pulls in OpenSSL. SmallAIOS is `#![no_std]`, single-binary, no dynamic allocation in the hot path, and uses its own crypto (`security/src/crypto/`). A clean-room driver also keeps `cargo-vet` happy — no `external_audit` line item, no supply-chain review pending an upstream maintainer — and aligns with the clean-room ONNX runtime and clean-room PQC stacks that are already in the workspace.
+
+The downside is implementation surface: the TPM 2.0 command set is large (~120 commands per the spec). Phase 1 implements only the seven commands listed in the proposal. Future phases (sealing for `op-tee-bridge-v1`, NV ram for credential storage) add more.
+
+### Transport detection
+
+TPM 2.0 hardware exposes one of two transports:
+
+- **TIS** (TPM Interface Specification rev. 1.3): MMIO at `0xFED40000`-`0xFED44FFF`. Used by legacy / discrete TPMs and most firmware-emulated TPMs on Windows-target platforms.
+- **CRB** (Command Response Buffer): MMIO at a base discovered via ACPI. Used by modern fTPMs (AMD fTPM, Intel PTT) and newer dTPMs.
+
+The `TPM2` ACPI table (TCG-defined, type ID `TPM2`) discloses both: the table's `StartMethod` field indicates which transport, and the `ControlAreaPhysicalAddress` field gives the CRB base when applicable. The existing `kernel/src/acpi/` ACPI table walker is extended with a TPM2 parser; no new RSDP / XSDT code.
+
+If no `TPM2` ACPI table is present, the driver returns `TpmAbsent` and Phase 1 falls back gracefully: `BootMeasurementLog` continues to operate in software-only mode (today's behavior) and `tpm2_quote` returns `Err(TpmAbsent)`. CI tests both paths.
+
+### PCR bank selection
+
+TPM 2.0 supports multiple PCR banks (SHA-1, SHA-256, SHA-384, SHA-512, SM3). Phase 1 uses **SHA-256** because:
+
+- SHA-256 is mandatory per the TCG PC Client spec (every TPM 2.0 supports it).
+- SHA-1 is deprecated (collision attacks practical since 2017).
+- SHA-3-256 (which SmallAIOS uses internally for its own measurements) is **not** a standard TPM PCR bank; we hash inputs to SHA-3-256 in software, then re-hash the SHA-3-256 digest into a SHA-256 PCR for hardware extension. The hybrid bridges between SmallAIOS's PQC-default choice (SHA-3) and the TPM's hardware-fixed choice (SHA-256).
+
+A `#[cfg(feature = "tpm-sha384-bank")]` opt-in for SHA-384 PCRs is documented for high-security deployments, but Phase 1 ships SHA-256 only.
+
+### Hybrid quote format
+
+The PQC-default constraint means the TPM-signed quote alone is insufficient — a future PQC-only deployment can't accept an RSA-2048 TPM signature as the sole proof of integrity. The hybrid quote format addresses this:
+
+```
+HybridQuote := CBOR-Map {
+  1: TpmQuote,           // raw TPM2_Quote output (TPMS_ATTEST + TPMT_SIGNATURE)
+  2: MeasurementLog,     // SmallAIOS BootMeasurementLog entries (CBOR array)
+  3: HybridSignature,    // ML-DSA-65 + Ed25519 over (1 || 2 || nonce || timestamp)
+  4: HybridPubKeyDigest, // SHA-3-256 of the public counter-signing key (also extended into PCR 14)
+  5: Nonce,              // verifier-supplied freshness nonce
+  6: Timestamp,          // SmallAIOS monotonic timestamp at quote time
+}
+```
+
+A verifier can require:
+
+- Classical only (today's TPM ecosystem): verify (1) against the AK pub.
+- PQC only (future): verify (3) against the counter-signing pub, check (4) was extended into PCR 11-14 chain.
+- Both: belt-and-braces, the recommended default.
+
+The CBOR encoding is `security/src/cbor/` (already exists for audit log records). No new wire-format crate.
+
+### Alternatives considered
+
+- **`tpm2-tss` as a vendored static C dependency.** Rejected for `no_std` incompatibility, OpenSSL dep, supply-chain surface. Also: clean-room is a stated DAL A advantage; bringing in C would require certification of the C build environment.
+- **Skip the hybrid quote, ship classical-only.** Rejected — contradicts the PQC-default project stance and forces a wire-format break later. The hybrid format degrades gracefully (verifier can check one signature or both).
+- **PCR 0-7 instead of 11-14.** Rejected — PCR 0-7 are owned by firmware/bootloader by TCG convention. Extending them from SmallAIOS would clobber firmware measurements and confuse any out-of-band verifier (e.g. an `tpm2_pcrread` from a recovery shell). PCR 11-14 mirror the IMA / LinuxKit convention, which keeps SmallAIOS audit tools interoperable with the wider ecosystem.
+- **Use TPM `NV` storage for the kernel hash.** Out of scope for Phase 1 — NV storage has its own ownership / locking story and isn't needed for the measurement-log use case. Considered for `op-tee-bridge-v1` for sealing.
+
+## Phase 2 — TF-A event log
+
+### Why consumption-only, not driver
+
+TF-A BL1/BL2 measurements are produced by the firmware vendor (NVIDIA on Tegra Orin, Arm reference firmware on Neoverse boards, etc.). SmallAIOS has no ability — and no need — to *produce* TF-A-side measurements. Our job is to *consume* the event log TF-A leaves behind, validate its TCG-spec format, and merge it as a prefix into our own log.
+
+### Event log location
+
+Two TF-A conventions:
+
+- **Reserved DRAM region described in DTB**: `/reserved-memory/tf-a-event-log { reg = <0x... 0x...>; };`. Used by NVIDIA Tegra234 BSP and Arm reference platforms.
+- **SMC vendor call**: TF-A exposes an SMC handler returning a pointer to the log. Less common, used by some Marvell platforms.
+
+Phase 2 supports the DTB path first (matches Tegra Orin, which is SmallAIOS's primary AArch64 target). The SMC path is a follow-up. Detection is straightforward: walk the DTB, look for `/reserved-memory/tf-a-event-log`; if absent, log "no TF-A event log" and continue with SmallAIOS-only measurements.
+
+### DTB parser dependency
+
+`unikernel-orin-bringup-v1` task 2.12 calls out a real DTB-parser gap on Tegra234: `kernel::mem::phys::parse_dtb` doesn't recognize Tegra234's memory-node layout. Phase 2 must fix that gap — extending the parser to handle multi-cell `reg = <…>` values and `/reserved-memory/` subnodes. The Phase 2 deliverable includes this DTB-parser improvement as a sub-task.
+
+### Reconciliation
+
+After parsing TF-A's event log entries and SmallAIOS's measurement log, the kernel computes a merged-replay root hash (SHA-256, matching the TPM PCR algorithm even though no hardware PCR is present on most AArch64 boards). The merged root is the value SmallAIOS quotes when it later signs the quote with its ML-DSA-65 hybrid key. If the AArch64 board *does* have a TPM (rare — usually only on AArch64 servers), the same merged-replay can extend a hardware PCR; that path reuses the Phase 1 driver.
+
+## Phase 3 — RISC-V SBI vendor extension
+
+### Calling convention
+
+Per the RISC-V SBI specification (v2.0+), vendor extensions use extension IDs in `0x09000000 - 0x09FFFFFF`. SmallAIOS picks `0x09534149` (ASCII `\x09SAI` for SmallAIOS) as its vendor ID. Function IDs:
+
+- `0x00 SBI_EXT_SMALLAIOS_PMP_REQUEST(base, length, permissions)` — request a PMP region. Returns `Success`, `NotSupported`, `InvalidParam`.
+- `0x01 SBI_EXT_SMALLAIOS_PROBE()` — probe for extension presence. Returns extension version or `NotSupported`.
+
+### Why best-effort
+
+Vendor SBI extensions are not portable. SiFive Freedom U boots stock OpenSBI; T-Head TH1520 boots a SiFive-derived OpenSBI; future RISC-V SoCs ship vendor-customized OpenSBI. SmallAIOS can't require a specific OpenSBI build because it would fragment the deployment matrix.
+
+Phase 3's value is therefore the **request** itself, recorded in the measurement log: an auditor can see SmallAIOS asked for PMP region `X-Y` with permissions `Z`, and whether OpenSBI honored it. If a fleet operator wants the request honored, they deploy SmallAIOS-patched OpenSBI (the patch is documented but not part of the SmallAIOS repo).
+
+### Alternative: skip RISC-V entirely
+
+Considered. Rejected because (a) RISC-V is a documented SmallAIOS target, (b) the boot-security-matrix doc calls out RISC-V's gap explicitly so a no-op pretending to be a feature would be worse than nothing, (c) a documented best-effort with audit-log capture is cheap (~1 week) and keeps the matrix's bottom row honest. The graceful-fallback shape (best-effort SBI call, ignore-on-failure, log either way) becomes a reusable pattern for any future SBI extensions.
+
+## Phase 4 — Signed kernel image
+
+### Key management
+
+The release vendor key lives in two halves:
+
+- Classical: Ed25519 (existing `security/src/crypto/ed25519.rs`). UEFI Secure Boot accepts ECDSA-P256 and RSA-2048; we add an ECDSA-P256 sibling under the same release flow because UEFI doesn't yet accept Ed25519 in `sbsign`.
+- PQC: ML-DSA-65 (existing `security/src/crypto/ml_dsa.rs`). No firmware accepts ML-DSA today, so the counter-signature is recorded in the SmallAIOS audit log and verifiable off-host, not by firmware. When firmware-side PQC arrives, the same key promotes.
+
+Key storage: `docs/release-runbook.md` is extended with a signing-ceremony section. The release-engineering surface is HSM-backed in production (the runbook covers the YubiHSM 2 layout). Development builds use file-backed keys with a clear "DEV — DO NOT USE FOR RELEASE" warning baked into the signed artifact's `.note.signing` section.
+
+### sbsigntools dependency
+
+`sbsigntools` is the standard UEFI signing toolchain (Debian / Fedora packaged). Phase 4 wraps it in a `just sign-release` recipe that consumes a `release.toml`-listed key path. Verification on the verifier side uses `sbverify`. No new Rust dependencies are required — signing is a build-system step, not a runtime concern.
+
+### UEFI enrollment
+
+`docs/uefi-secure-boot-enrollment.md` (new) walks through:
+
+1. Disabling Microsoft's default keys (PK/KEK) on production hardware.
+2. Enrolling the SmallAIOS vendor PK / KEK / db using `efi-updatevar` or platform firmware setup UI.
+3. Verifying the firmware load logs (where exposed via `efivar` or platform-specific tooling) show signature verification.
+
+For Tegra Orin specifically, the Phase 2 (`unikernel-orin-bringup-v1`) "disable Secure Boot in firmware menu" instruction is replaced by an "enroll the SmallAIOS vendor key" instruction once Phase 4 lands. The old instruction stays as a fallback.
+
+## Build / CI surface
+
+### Phase 1
+
+- New module: `security/src/tpm2/` (TIS + CRB transports, command serialization, response parsing).
+- New module: `security/src/tpm2_quote.rs` (CBOR hybrid quote format).
+- New module: `kernel/src/acpi/tpm2_table.rs` (TPM2 ACPI table parser).
+- New cargo feature: `tpm-attest` on `smallaios-security`.
+- Extended: `kernel/src/boot_integrity.rs` — `BootMeasurementLog::add_entry()` extends a hardware PCR when `tpm-attest` is enabled.
+- New CI job: `tpm2-swtpm-smoke` — boots kernel under QEMU + swtpm, asserts PCR-extend path, verifies a quote.
+- New docs: `docs/attestation-quote-format.md`, `docs/tpm2-driver.md`.
+
+### Phase 2
+
+- Extended: `kernel/src/mem/phys::parse_dtb` — multi-cell `reg`, `/reserved-memory/` subnodes (closes the gap from `unikernel-orin-bringup-v1` task 2.12).
+- New module: `arch/aarch64/src/tf_a_event_log.rs` (TCG event log parser).
+- Extended: `kernel/src/boot_integrity.rs` — chain reconciliation API.
+- New CI job: `tf-a-event-log-replay` — synthetic event log fixture, asserts replay against expected root hash.
+- New docs: `docs/aarch64-measured-boot.md`.
+
+### Phase 3
+
+- New module: `arch/riscv64/src/sbi/smallaios_ext.rs` (vendor extension client).
+- Extended: `kernel/src/boot_integrity.rs` — records request + response.
+- New CI job: none (best-effort, no observable change on stock OpenSBI).
+- New docs: `docs/riscv-opensbi-pmp.md` (documented OpenSBI patch, not part of repo).
+
+### Phase 4
+
+- New `just` recipe: `sign-release`.
+- New release-runbook section: "Signing ceremony".
+- New docs: `docs/uefi-secure-boot-enrollment.md`.
+- No new Rust modules — signing is post-build.
+
+## What this change does NOT do
+
+- Does not add any *new* attestation protocol surface. `remote-attestation-v1` consumes the Phase 1 hybrid quote format and adds the network-side protocol; this change defines the format only.
+- Does not enable OP-TEE-side fTPM. `op-tee-bridge-v1` is a parallel change; SmallAIOS will read from an OP-TEE-hosted fTPM through that bridge in a future change.
+- Does not change the existing `verified-boot` software-only path. Builds without `tpm-attest` behave exactly as today; this is purely additive.
+- Does not change the AArch64 / RISC-V boot ELF format. Phase 4 signs the *UEFI* binary (PE/COFF); bare-metal `aarch64-unknown-none` builds remain unsigned (they're loaded by a trusted U-Boot anyway).

--- a/openspec/changes/boot-root-of-trust-v1/proposal.md
+++ b/openspec/changes/boot-root-of-trust-v1/proposal.md
@@ -1,0 +1,86 @@
+# boot-root-of-trust-v1
+
+## Summary
+
+`docs/boot-security-matrix.md` documents that SmallAIOS today has a **software-only** integrity story: the `verified-boot` Cargo feature (defined in `security/Cargo.toml`, re-exported by `kernel/Cargo.toml` and `onnx-rt/Cargo.toml`) computes SHA-3-256 over the kernel image, the Multiboot2 / DTB info, and ONNX model files, and records them in an in-memory `BootMeasurementLog` (`kernel/src/boot_integrity.rs`). That log is **not anchored to any hardware root of trust** on any of the three target architectures (x86-64, AArch64, RISC-V), and SmallAIOS itself is **not** loaded by a signature-verified firmware chain: x86-64 boot uses Multiboot2 direct-load with no UEFI Secure Boot signature, AArch64 boot uses U-Boot `booti` without FIT signature verification, and RISC-V boot trusts OpenSBI implicitly with no PMP request from the kernel side.
+
+This change closes the boot-side gap in **four sequenced phases**, each independently valuable, each with a serial-console or quote-output observable success criterion. Phase 1 introduces a clean-room `#![no_std]` TPM 2.0 driver (TIS / CRB transport) on x86-64 and extends the existing `BootMeasurementLog` to drive **hardware** PCR extends — turning the software measurement log into the canonical software record of what was also extended into the TPM, plus a `tpm2_quote` API that signs a PCR digest with the TPM's AK. Phase 2 brings AArch64 onto an equivalent footing: SmallAIOS becomes aware of the TF-A BL31 hand-off, reads the optional TCG-format event log left by BL1/BL2 in DRAM (TPM Event Log structure, `TCG_PCClientPCRSelection`), and reconciles its own measurements against the firmware chain. Phase 3 requests PMP regions via an OpenSBI-side SBI vendor extension for RISC-V (vendor-specific, best-effort), giving M-mode a kernel-asserted memory layout to enforce. Phase 4 signs the kernel binary (`smallaios.efi` for AArch64 UEFI; `smallaios-x86_64.efi` for x86-64 UEFI-loadable builds) with a vendor key and produces a documented enrollment procedure for both UEFI Secure Boot (PK/KEK/db) and platform-fused boot guards (Tegra fuse-burn, Intel Boot Guard — documented, not automated, since they're OEM-provisioning operations).
+
+Capability: `kernel-verified-boot` (new). The existing `verified-boot` Cargo feature stays — this change extends it from "software self-hash" to "hardware-anchored measured boot + signed image". A new `tpm-attest` Cargo feature on `smallaios-security` gates the TPM driver; a `verified-boot` build that lacks `tpm-attest` keeps today's software-only behavior so the QEMU / dev-loop path doesn't regress.
+
+## Why
+
+- **`verified-boot` is software-only and easily defeated.** A `BootMeasurementLog` that lives in DRAM, computed by the kernel that's measuring itself, is a TOCTOU joke without a hardware anchor. An attacker who can patch the kernel binary on disk patches the measurement code at the same time. The measurement log is useful as a *post-hoc audit record*, but it cannot answer "is this kernel I'm talking to the one I signed?" without TPM PCRs (x86-64), TF-A event log + signed image (AArch64), or PMP-enforced layout (RISC-V). The boot-security-matrix doc says exactly this: every "SmallAIOS Integration" cell under "Hardware Root of Trust" reads **No**.
+- **DO-178C DAL A coverage requires evidence the running binary is the certified binary.** The certification claim "the kernel binary executing in the field is bit-identical to the kernel binary tested against the requirements" needs a verifiable artifact, not a developer's assertion. A TPM 2.0 quote signed by an attestation key (AK) certified by an endorsement key (EK) gives an auditor a cryptographic chain back to a TPM manufacturer's root certificate. The same evidence shape (a quote over a measurement) is what the `remote-attestation-v1` change consumes — Phase 1 here is the prerequisite for that change's x86-64 backend.
+- **PQC-default stance demands the quote be hybrid-signable.** SmallAIOS already has ML-DSA-65 + Ed25519 hybrid signatures in `security/src/crypto/`. TPM 2.0 hardware signs with RSA-2048/3072 or ECDSA-P256 (no PQC support in current TPM generations). The Phase 1 quote MUST therefore be a *hybrid*: the TPM signs the raw quote with its hardware AK (classical), and SmallAIOS counter-signs the same quote-plus-context with an ML-DSA-65 software key whose public half is itself measured into a PCR. Downstream verifiers get both signatures and can require either or both — supporting today's TPM hardware while not blocking a future PQC-only deployment.
+- **Phase 1 is independently valuable.** Even without Phases 2-4, a TPM-extended `BootMeasurementLog` + a working `tpm2_quote` on x86-64 lets us claim hardware-anchored measured boot on the most common deployment target (x86-64 datacenter / cloud / desktop). Phase 1 is the deliverable that unblocks `remote-attestation-v1` Phase 1 and gives DAL A its first piece of cryptographic boot-integrity evidence.
+- **Tegra Orin already provides the firmware half of what Phase 2 needs.** TF-A BL31 ships with JetPack 6, runs at EL3, and emits an optional TCG event log if `MEASURED_BOOT=1` is set in the TF-A build. Existing NVIDIA documentation (`docs/orin-secure-boot-flow.md` in the L4T 36.4 release notes) confirms TF-A's measured-boot mode is enabled in the NVIDIA-shipped firmware. SmallAIOS's job in Phase 2 is therefore *consumption*, not driver work: read the event log from the documented memory location, parse it against the TCG spec, and reconcile against our own measurements. No new EL3-side code is required.
+- **RISC-V is the least mature platform and the matrix calls it out explicitly.** OpenSBI doesn't define a standard "request PMP region" extension, so Phase 3 is documented as best-effort and vendor-scoped (SiFive Freedom U, T-Head TH1520) with a graceful no-op fallback. The value is small but the fallback shape (best-effort SBI ecall, ignore on failure) is reusable for future SBI extensions and keeps the matrix's bottom row honest.
+
+## Phase 1 — TPM 2.0 driver + hardware-extended measurement log (x86-64, ~2 weeks)
+
+A clean-room `#![no_std]` TPM 2.0 driver lives in `security/src/tpm2/` (new module). Two transports: TIS (TPM Interface Specification, MMIO at `0xFED40000`+) for legacy / discrete TPMs and CRB (Command Response Buffer, also MMIO) for modern fTPM / dTPM 2.0 in firmware-Tier mode. Detection by reading the `TPM2` ACPI table from the RSDP chain (existing `kernel/src/acpi/` shape extended). The driver implements the minimum command set Phase 1 needs: `TPM2_Startup`, `TPM2_GetCapability` (probe for PCR bank layout — SHA-256 mandatory), `TPM2_PCR_Extend` (extend each measurement event), `TPM2_PCR_Read` (read final PCR state), `TPM2_CreatePrimary` + `TPM2_LoadExternal` for a transient AK if no AK is provisioned, `TPM2_Quote` (sign a PCR digest with the AK).
+
+The `BootMeasurementLog::add_entry()` path (currently a pure software append) gains a `cfg(feature = "tpm-attest")` extension: when a TPM is present, every entry also drives `TPM2_PCR_Extend` against a documented PCR mapping (Phase 1 uses PCR 11-14 to follow the convention used by Linux IMA without colliding with PCR 0-7 / 8-10 owned by firmware and shim/grub):
+
+| PCR | Content | Measured by |
+|-----|---------|-------------|
+| 11 | Kernel binary (SHA-3-256 of `smallaios.efi` text + rodata) | SmallAIOS at boot |
+| 12 | Boot config (Multiboot2 / DTB info, kernel cmdline) | SmallAIOS at boot |
+| 13 | ONNX model binaries (concatenated SHA-3-256 of each `.onnx` measured at load) | SmallAIOS on model load |
+| 14 | SmallAIOS configuration (capability config, policy bundle) | SmallAIOS after `init` |
+
+Phase 1 also defines the **hybrid quote format**: a CBOR document containing the raw TPM2_Quote output (TPM-AK-signed), the SmallAIOS software measurement log entries that fed the PCRs, and an ML-DSA-65 + Ed25519 hybrid signature over the whole bundle by a key whose public half is itself measured into PCR 14. The wire shape is documented in `docs/attestation-quote-format.md` (new) so `remote-attestation-v1` can consume it without re-design.
+
+CI gains a `tpm2-swtpm-smoke` job running the kernel under QEMU with `swtpm` providing a software TPM 2.0 socket, asserting the PCR-extend path executes end-to-end and a quote verifies via the openssl `tss2-engine` (advisory until a self-hosted TPM-equipped runner exists).
+
+## Phase 2 — TF-A BL31 measurement chain consumption (AArch64, ~2 weeks)
+
+SmallAIOS's AArch64 boot path (currently `arch/aarch64/src/boot.rs` for the bare-metal path and `arch/aarch64/src/boot_uefi.rs` from `unikernel-orin-bringup-v1` for the UEFI path) gains a TF-A event-log reader. Per Arm DEN 0028 (SMC Calling Convention) and TBBR specs, BL31 either places the event log in a documented DRAM region (described by a TF-A-installed `EFI_TCG2_FINAL_EVENTS_TABLE`-equivalent configuration entry) or exposes it via an SMC vendor call. SmallAIOS reads it, validates the TCG event log structure, and merges entries 0-N (firmware) into its own `BootMeasurementLog` as prefix entries — so the final log covers the whole chain (BL1 → BL2 → BL31 → SmallAIOS → models) with a single audit shape.
+
+On Jetson Orin specifically, the JetPack 6.2.1 TF-A build emits the event log at the location described in the device tree under `/reserved-memory/tf-a-event-log`. Phase 2's DTB parser (extending `kernel/src/mem/phys::parse_dtb` — note the existing Tegra234 DTB parsing gap called out in `unikernel-orin-bringup-v1` task 2.12) reads that reserved region and exposes it.
+
+If a TPM is not present (the common AArch64 server case — most ARM SoCs don't ship a discrete TPM and the fTPM-in-OP-TEE path is the future story), the measurement chain is **software-only but multi-stage**: TF-A's measurements + SmallAIOS's measurements, all signed at the SmallAIOS layer with ML-DSA-65 hybrid. When OP-TEE is present (the `op-tee-bridge-v1` follow-up change), the same chain can be sealed inside the TEE — that's covered in the dependent change.
+
+## Phase 3 — RISC-V PMP via SBI vendor extension (best-effort, ~1 week)
+
+The OpenSBI SBI spec defines vendor-extension space (`0x09000000 - 0x09FFFFFF`). Phase 3 specifies a SmallAIOS-defined vendor function `SBI_EXT_SMALLAIOS_PMP_REQUEST` that takes (base, length, permissions) and asks the M-mode firmware to install a PMP region matching the kernel's desired layout. Whether the firmware honors the request is implementation-defined — on stock OpenSBI it's a no-op (which is fine), on a SmallAIOS-friendly OpenSBI fork (provided in `docs/riscv-opensbi-pmp.md` as a documented patch series) it installs the requested region. Either way, SmallAIOS records the request and the firmware's response into the measurement log so an auditor sees whether PMP was actually configured.
+
+Phase 3 explicitly does **not** require a custom OpenSBI build to work — the no-op fallback is intentional. Boot succeeds whether the extension is honored or not; only the measurement log reflects the difference.
+
+## Phase 4 — Signed kernel image (UEFI Secure Boot enrollment, ~1 week)
+
+Phase 4 produces a UEFI-signed kernel artifact for both x86-64 and AArch64 UEFI builds. The vendor signing key is an Ed25519 / ML-DSA-65 hybrid key managed in `docs/release-runbook.md` (extended in this change) — release artifacts are signed by both halves. The x86-64 build produces `smallaios-x86_64.efi` signed with `sbsign`; the AArch64 build extends the existing `unikernel-orin-bringup-v1` Phase 2 UEFI image to a signed `smallaios.efi`. Documentation covers UEFI Secure Boot key enrollment (`efi-updatevar` / firmware setup), and references — but does not automate — the platform-fused secure boot procedures (Intel Boot Guard fuse provisioning, Tegra secure boot fuse-burn) as those are OEM operations that vary per device.
+
+## Out of scope
+
+- **Intel Boot Guard fuse provisioning**: documented as OEM-coordinated, not automated. Same for Tegra secure boot fuses.
+- **OP-TEE-hosted fTPM**: a natural future story but blocked on `op-tee-bridge-v1`. Phase 2 reads TF-A event logs without OP-TEE; fTPM-backed PCRs land in a later change.
+- **Boot integrity via DRTM (Intel TXT / AMD SKINIT)**: skipped — DRTM requires SINIT-ACM provisioning and a different threat model. Out of scope here.
+- **Confidential compute integration**: Phase 1-4 don't depend on or block `confidential-compute-v1`. Memory encryption at boot is a separate concern.
+- **Live PCR re-extends post-boot**: PCRs 11-14 are extended at boot and on model-load (PCR 13). Continuous runtime PCR extension (e.g. on every cap-flip) is out of scope; we use signed audit records (`security/src/audit/`) for that.
+
+## Sequencing
+
+Phase 1 (x86-64 TPM) first, independently mergeable. Phase 2 (AArch64 TF-A event log) and Phase 3 (RISC-V PMP request) can land in parallel after Phase 1 — they share no code with Phase 1 and only consume Phase 1's measurement-log shape. Phase 4 (signed image) lands last because it's a release-engineering surface change and benefits from Phases 1-3 being in for the signature-verification chain to anchor against. If schedule pressure forces a split, Phase 1 alone is a complete deliverable; Phase 2 alone is also a complete deliverable for AArch64 deployments without TPMs.
+
+## Effort estimate
+
+| Phase | Scope | Estimate |
+|-------|-------|----------|
+| 1 | TPM 2.0 driver (TIS + CRB), PCR extend wiring, `TPM2_Quote`, hybrid CBOR quote, swtpm CI | ~2 weeks |
+| 2 | TF-A event log reader, DTB reserved-memory parse, chain reconciliation | ~2 weeks |
+| 3 | SBI vendor extension, no-op fallback, documented OpenSBI patch | ~1 week |
+| 4 | Vendor signing key in release-runbook, sbsign / sbsigntools wiring, UEFI enrollment docs | ~1 week |
+| **Total** | | **~6-8 weeks** |
+
+## DO-178C alignment
+
+| Phase | Certification claim it supports |
+|-------|--------------------------------|
+| 1 | "The x86-64 kernel binary in the field is bit-identical to the certified binary." Evidence: TPM2 quote over PCR 11 verified against the certified-build hash artifact in the release record. |
+| 2 | "The AArch64 boot chain (TF-A through SmallAIOS) is unmodified relative to certification." Evidence: TCG event log replay against the certified release-record event-log snapshot. |
+| 3 | "The RISC-V kernel runs with the certified memory layout." Evidence: SBI vendor-extension request log + (when honored) firmware-side PMP state. |
+| 4 | "The kernel artifact loaded by firmware was signed by SmallAIOS Engineering." Evidence: UEFI Secure Boot signature verification record in firmware logs (where firmware exposes them) + ML-DSA-65 counter-signature audit record. |
+
+Together, Phases 1-4 close the "boot integrity" objective row in the DAL A traceability matrix maintained in `openspec/changes/archive/2026-02-27-boot-security-comparison-v10/` and referenced by `docs/boot-security-matrix.md`.

--- a/openspec/changes/boot-root-of-trust-v1/specs/kernel-verified-boot/spec.md
+++ b/openspec/changes/boot-root-of-trust-v1/specs/kernel-verified-boot/spec.md
@@ -1,0 +1,170 @@
+## ADDED Requirements
+
+### Requirement: TPM 2.0 driver with TIS and CRB transports
+
+The `smallaios-security` crate SHALL provide a clean-room `#![no_std]` TPM 2.0 driver supporting both TIS (TPM Interface Specification rev. 1.3) and CRB (Command Response Buffer) MMIO transports, gated by a new `tpm-attest` Cargo feature.
+
+#### Scenario: ACPI-driven transport detection
+
+- **GIVEN** an x86-64 system with a TPM 2.0 device described in the `TPM2` ACPI table
+- **WHEN** SmallAIOS boots with the `tpm-attest` Cargo feature enabled
+- **THEN** the kernel SHALL parse the `TPM2` ACPI table (`StartMethod`, `ControlAreaPhysicalAddress`, `LAML`, `LASA`) to determine whether to use the TIS or CRB transport
+- **AND** the driver SHALL successfully issue `TPM2_Startup(Clear)` and `TPM2_GetCapability(TPM_CAP_PCRS)` to verify the SHA-256 PCR bank is present
+- **AND** the boot measurement log SHALL record the detected transport (`tis` or `crb`) and the TPM manufacturer / firmware version returned by `TPM2_GetCapability`
+
+#### Scenario: Graceful fallback when no TPM is present
+
+- **GIVEN** an x86-64 system with no `TPM2` ACPI table
+- **WHEN** SmallAIOS boots with `tpm-attest` enabled
+- **THEN** the driver SHALL return `TpmAbsent` from its probe step
+- **AND** `BootMeasurementLog` SHALL continue to operate in software-only mode (matching today's `verified-boot` behavior)
+- **AND** subsequent calls to `produce_hybrid_quote()` SHALL return `Err(TpmAbsent)` rather than panicking
+
+#### Scenario: Build without tpm-attest is byte-identical to today
+
+- **GIVEN** a build with `--features verified-boot` but without `--features tpm-attest`
+- **THEN** the resulting kernel binary SHALL NOT link any `tpm2` module symbols
+- **AND** the `BootMeasurementLog` behavior SHALL be unchanged from the pre-change `verified-boot` behavior
+- **AND** the `tpm2-swtpm-smoke` CI job SHALL skip cleanly (advisory failure exemption documented inline)
+
+### Requirement: Hardware-extended boot measurement log
+
+When the `tpm-attest` feature is enabled and a TPM 2.0 device is present, every `BootMeasurementLog::add_entry` call SHALL extend the corresponding PCR using `TPM2_PCR_Extend`, per a documented PCR-to-measurement-category mapping.
+
+#### Scenario: Documented PCR mapping
+
+- **GIVEN** the `tpm-attest` feature is enabled and a TPM is present
+- **THEN** the kernel SHALL extend PCR 11 with the SHA-256 of the SHA-3-256 digest of the kernel image (text + rodata sections)
+- **AND** the kernel SHALL extend PCR 12 with the SHA-256 of the SHA-3-256 digest of the boot configuration (Multiboot2 info structure, kernel cmdline, or DTB blob)
+- **AND** the kernel SHALL extend PCR 13 with the SHA-256 of the SHA-3-256 digest of each loaded ONNX model, in load order
+- **AND** the kernel SHALL extend PCR 14 with the SHA-256 of the SHA-3-256 digest of the SmallAIOS configuration (capability config, policy bundle) plus the public key half of the counter-signing key used for hybrid quotes
+- **AND** the PCR mapping SHALL be documented in `docs/attestation-quote-format.md`
+
+#### Scenario: SHA-3 to SHA-256 bridge is observable
+
+- **GIVEN** a SmallAIOS-computed SHA-3-256 digest `D3`
+- **WHEN** the digest is extended into PCR `N`
+- **THEN** the PCR-extend input SHALL be `SHA-256(D3)` (the SHA-256 of the SHA-3-256 digest, not `D3` directly)
+- **AND** the bridge step SHALL be logged as a `BridgeDigest` entry in `BootMeasurementLog` so an off-host verifier can reconcile the SmallAIOS-side and TPM-side digests
+
+#### Scenario: PCR-extend failure is fail-loud
+
+- **GIVEN** a TPM that returns an error from `TPM2_PCR_Extend` mid-boot
+- **WHEN** SmallAIOS attempts to extend a measurement
+- **THEN** the kernel SHALL log the error to the boot measurement log with a `TpmExtendFailed { pcr, tpm_rc }` entry
+- **AND** the kernel SHALL NOT silently proceed — the entry SHALL be marked as "unsealed" (no hardware anchor) and `produce_hybrid_quote` SHALL refuse to issue a quote covering any unsealed entry unless the caller passes an explicit `allow_unsealed: true` flag (default false)
+
+### Requirement: Hybrid PQC-friendly attestation quote format
+
+The `smallaios-security` crate SHALL produce a hybrid attestation quote (`HybridQuote`) combining a hardware TPM 2.0 quote with an ML-DSA-65 + Ed25519 software counter-signature, encoded in CBOR.
+
+#### Scenario: Hybrid quote structure
+
+- **GIVEN** the `tpm-attest` feature is enabled, a TPM is present, and a verifier-supplied nonce
+- **WHEN** the kernel produces a hybrid quote via `produce_hybrid_quote(nonce)`
+- **THEN** the returned `HybridQuote` SHALL be a CBOR map containing:
+  - key 1: raw `TPM2_Quote` output (`TPMS_ATTEST` + `TPMT_SIGNATURE` from `TPM2_Sign`-style signature)
+  - key 2: the full `BootMeasurementLog` entries (CBOR array)
+  - key 3: an ML-DSA-65 + Ed25519 hybrid signature over the concatenation of (1) || (2) || nonce || timestamp
+  - key 4: SHA-3-256 of the public counter-signing key used in (3)
+  - key 5: the verifier-supplied nonce
+  - key 6: a SmallAIOS monotonic timestamp at quote generation time
+- **AND** the wire format SHALL be documented in `docs/attestation-quote-format.md`
+- **AND** the counter-signing key's public half SHALL be measured into PCR 14 at boot, so the value at key 4 is verifiable against the PCR chain
+
+#### Scenario: Verifier can require either signature
+
+- **GIVEN** a `HybridQuote` and a verifier configured for classical-only checking
+- **WHEN** the verifier calls `verify_hybrid_quote(quote, ak_pub, None, expected_root)`
+- **THEN** verification SHALL succeed if the TPM-side signature (key 1) validates against `ak_pub` and the measurement log replays to `expected_root`
+- **AND** the ML-DSA-65 counter-signature SHALL be ignored in classical-only mode
+
+- **GIVEN** the same quote and a verifier configured for PQC-only checking
+- **WHEN** the verifier calls `verify_hybrid_quote(quote, None, counter_pub, expected_root)`
+- **THEN** verification SHALL succeed if the counter-signature validates against `counter_pub` AND `counter_pub`'s SHA-3-256 digest appears in PCR 14 of the measurement log
+- **AND** the TPM-side signature SHALL be ignored in PQC-only mode
+
+- **GIVEN** the same quote and a verifier configured for hybrid (both) checking
+- **WHEN** the verifier calls `verify_hybrid_quote(quote, ak_pub, counter_pub, expected_root)`
+- **THEN** both signatures SHALL be required to validate; if either fails, verification SHALL fail
+
+### Requirement: TF-A measurement chain consumption (AArch64)
+
+On AArch64 platforms where Arm Trusted Firmware (TF-A) BL31 has emitted a TCG-format event log (via `MEASURED_BOOT=1` in the TF-A build), SmallAIOS SHALL read and merge that event log into its own `BootMeasurementLog` as prefix entries.
+
+#### Scenario: DTB-described event log is consumed
+
+- **GIVEN** a Tegra Orin (or other AArch64) boot where the DTB exposes `/reserved-memory/tf-a-event-log { reg = <...>; };`
+- **WHEN** SmallAIOS boots
+- **THEN** the kernel SHALL parse the reserved-memory region as a TCG_PCClientPCREvent v2 event log
+- **AND** the kernel SHALL merge the TF-A entries (BL1, BL2, BL31) as prefix entries in `BootMeasurementLog`, ahead of SmallAIOS's own entries
+- **AND** a `merged_root_hash()` API SHALL return the SHA-256 replay over the merged log
+
+#### Scenario: Missing or malformed event log is non-fatal
+
+- **GIVEN** a boot where the `/reserved-memory/tf-a-event-log` node is absent or contains malformed data
+- **WHEN** SmallAIOS attempts to read it
+- **THEN** the kernel SHALL log a `TfAEventLogAbsent` or `TfAEventLogMalformed` entry and continue with SmallAIOS-only measurements
+- **AND** the boot SHALL NOT fail solely because TF-A did not emit a log (e.g. on a TF-A build without `MEASURED_BOOT=1`)
+
+#### Scenario: DTB parser handles Tegra234 reserved-memory layout
+
+- **GIVEN** a Tegra234 DTB with multi-cell `reg = <hi lo hi lo>` and `/reserved-memory/` subnodes
+- **WHEN** `kernel::mem::phys::parse_dtb` parses the blob
+- **THEN** the parser SHALL correctly resolve 64-bit addresses split across two 32-bit cells
+- **AND** the parser SHALL expose `/reserved-memory/` subnodes by name to callers
+- **AND** the parser SHALL satisfy the gap called out in `unikernel-orin-bringup-v1` task 2.12
+
+### Requirement: Best-effort RISC-V PMP request via SBI vendor extension
+
+On RISC-V, SmallAIOS SHALL issue an SBI vendor-extension call requesting that M-mode firmware install a PMP region matching the kernel's desired memory layout, and SHALL record the firmware's response in the boot measurement log. The boot SHALL succeed regardless of whether the request is honored.
+
+#### Scenario: Vendor extension identifiers are documented
+
+- **THEN** SmallAIOS SHALL use vendor extension ID `0x09534149` (ASCII `\x09SAI`) in the RISC-V SBI vendor-extension space (`0x09000000`-`0x09FFFFFF`)
+- **AND** function ID `0x00` SHALL be `SBI_EXT_SMALLAIOS_PMP_REQUEST(base, length, permissions)`
+- **AND** function ID `0x01` SHALL be `SBI_EXT_SMALLAIOS_PROBE()` returning the extension version or `NotSupported`
+- **AND** the identifiers SHALL be documented in `docs/riscv-opensbi-pmp.md`
+
+#### Scenario: Stock OpenSBI returns NotSupported, boot continues
+
+- **GIVEN** a RISC-V boot under unpatched OpenSBI (which does not implement the SmallAIOS vendor extension)
+- **WHEN** SmallAIOS issues `SBI_EXT_SMALLAIOS_PROBE`
+- **THEN** the call SHALL return `NotSupported`
+- **AND** SmallAIOS SHALL record a `SbiPmpRequestSkipped { reason: NotSupported }` entry in `BootMeasurementLog`
+- **AND** boot SHALL proceed normally
+
+#### Scenario: Patched OpenSBI honors the request
+
+- **GIVEN** a RISC-V boot under a SmallAIOS-patched OpenSBI build (per `docs/riscv-opensbi-pmp.md`)
+- **WHEN** SmallAIOS issues `SBI_EXT_SMALLAIOS_PMP_REQUEST(kernel_text_base, kernel_text_len, RX)`
+- **THEN** the call SHALL return `Success`
+- **AND** SmallAIOS SHALL record a `SbiPmpRequestHonored { base, length, perms }` entry in `BootMeasurementLog`
+- **AND** the requested PMP region SHALL be installed in the firmware's PMP CSRs (verifiable by reading the relevant CSRs from M-mode debug output)
+
+### Requirement: Signed UEFI kernel image with PQC counter-signature
+
+The release build pipeline SHALL produce a UEFI-signed kernel artifact for both x86-64 (`smallaios-x86_64.efi`) and AArch64 (`smallaios.efi`), with both a classical UEFI Secure Boot signature (ECDSA-P256 or RSA-2048 via `sbsign`) and an ML-DSA-65 PQC counter-signature embedded in a documented binary section.
+
+#### Scenario: Classical signature is verifiable by sbverify
+
+- **GIVEN** a release-pipeline build of `smallaios.efi` invoked via `just sign-release smallaios.efi`
+- **WHEN** an off-host verifier runs `sbverify --cert <SmallAIOS-vendor.crt> smallaios.efi`
+- **THEN** `sbverify` SHALL report `Signature verification OK`
+- **AND** the firmware on a UEFI Secure Boot-enabled system with the SmallAIOS vendor key enrolled in `db` SHALL load the artifact without prompting
+- **AND** on Tegra Orin specifically, the `unikernel-orin-bringup-v1` "disable Secure Boot" workflow SHALL have a documented "enroll the SmallAIOS vendor key" alternative in `docs/jetson-orin-uefi-boot.md`
+
+#### Scenario: PQC counter-signature is verifiable by SmallAIOS tooling
+
+- **GIVEN** the same signed artifact
+- **WHEN** an off-host verifier runs `just verify-release-signature smallaios.efi`
+- **THEN** the recipe SHALL extract the ML-DSA-65 signature from the `.note.signing` PE section
+- **AND** the recipe SHALL verify the signature against the SmallAIOS PQC vendor public key
+- **AND** the verification SHALL succeed for any binary signed by the canonical release pipeline
+- **AND** any tampered byte in the artifact (other than the signature section itself) SHALL cause verification to fail
+
+#### Scenario: Development builds carry a clear non-release marker
+
+- **GIVEN** a non-release build signed with a development key (not the release HSM-backed key)
+- **THEN** the `.note.signing` section SHALL contain a `DEV — DO NOT USE FOR RELEASE` ASCII string preceding the signature bytes
+- **AND** `just verify-release-signature` SHALL print a prominent warning and exit with code 2 (verified-but-dev), not code 0 (verified-release)

--- a/openspec/changes/boot-root-of-trust-v1/tasks.md
+++ b/openspec/changes/boot-root-of-trust-v1/tasks.md
@@ -1,0 +1,131 @@
+# Tasks — boot-root-of-trust-v1
+
+## 0. Prerequisites
+
+- [ ] 0.1 Confirm the existing `verified-boot` Cargo feature (`security/Cargo.toml:16`) + the `BootMeasurementLog` API (`kernel/src/boot_integrity.rs`) are stable. Pin to the develop SHA at change start; any breaking change to either surface during the change forces a re-base of this work.
+- [ ] 0.2 Confirm `swtpm` (software TPM 2.0 emulator) is available in CI runners (`apt install swtpm swtpm-tools`); if not, add to the CI image bootstrap step before Phase 1.
+- [ ] 0.3 Capture and pin the JetPack 6.2.1 TF-A build's event-log location (DTB reserved-memory node name + offset) on a representative Orin NX host. Paste in the PR description for Phase 2 ground truth.
+- [ ] 0.4 Capture the current `cargo-vet` audit status for any newly-touched dependencies (none expected — clean-room — but verify).
+
+## 1. Phase 1 — TPM 2.0 driver + hardware-extended measurement log (x86-64)
+
+### 1a. ACPI TPM2 table parser
+
+- [ ] 1.1 Extend `kernel/src/acpi/` (existing) with a `tpm2_table.rs` module parsing the TPM2 ACPI table (TCG spec, table ID `TPM2`). Returns `StartMethod`, `ControlAreaPhysicalAddress`, `LAML/LASA` (event log pointers — also useful for Phase 2 / future fTPM).
+- [ ] 1.2 Add detection logic: if no `TPM2` table, return `TpmAbsent`; expose as a probe API.
+
+### 1b. TIS + CRB transports
+
+- [ ] 1.3 Create `security/src/tpm2/mod.rs` exposing a `Tpm2Device` trait with `send_command(&[u8]) -> Result<Vec<u8>>` and `bank() -> PcrBank`. Two implementations: `tis.rs` (MMIO at `0xFED40000`), `crb.rs` (MMIO at ACPI-supplied base).
+- [ ] 1.4 Implement `Tpm2Device::send_command` for TIS: STS / DATA_FIFO / locality 0 sequencing per TCG TIS spec rev 1.3.
+- [ ] 1.5 Implement `Tpm2Device::send_command` for CRB: command/response buffer write + doorbell + status poll.
+- [ ] 1.6 Add a software shim `swtpm.rs` (cfg-gated to `test` + `feature = "tpm-swtpm-shim"`) that proxies to `swtpm` over a socket for in-CI testing — used by the `tpm2-swtpm-smoke` CI job.
+
+### 1c. Minimal TPM 2.0 command set
+
+- [ ] 1.7 Implement `TPM2_Startup(Clear)` — required at every boot.
+- [ ] 1.8 Implement `TPM2_GetCapability(TPM_CAP_PCRS)` to enumerate PCR banks and confirm SHA-256 is present.
+- [ ] 1.9 Implement `TPM2_PCR_Extend(pcr_index, sha256_digest)` — the core extend primitive.
+- [ ] 1.10 Implement `TPM2_PCR_Read(pcr_indices)` — return the current PCR state, used by `quote` and by audit dumps.
+- [ ] 1.11 Implement `TPM2_CreatePrimary` + `TPM2_LoadExternal` to materialize a transient AK in the endorsement hierarchy (when no provisioned AK exists).
+- [ ] 1.12 Implement `TPM2_Quote(ak_handle, pcr_selection, nonce)` returning `TPMS_ATTEST` + `TPMT_SIGNATURE`.
+
+### 1d. BootMeasurementLog hardware-extend wiring
+
+- [ ] 1.13 Add a `tpm-attest` Cargo feature to `smallaios-security`. Gates the `tpm2` module.
+- [ ] 1.14 Modify `kernel/src/boot_integrity.rs::BootMeasurementLog::add_entry` so that when `tpm-attest` is on AND a TPM is present, the entry's digest is also extended into the configured PCR (PCR 11-14 per the proposal mapping).
+- [ ] 1.15 Document the PCR mapping in `docs/attestation-quote-format.md` (new). PCR 11 = kernel image, 12 = boot config, 13 = ONNX models, 14 = SmallAIOS configuration.
+- [ ] 1.16 Add the SHA-3→SHA-256 bridge: SmallAIOS-side measurements are SHA-3-256; the PCR-extend input is SHA-256 of the SHA-3-256 digest. Document the bridge in the same file.
+
+### 1e. Hybrid quote format
+
+- [ ] 1.17 Create `security/src/tpm2_quote.rs` defining the `HybridQuote` CBOR structure (proposal: TpmQuote, MeasurementLog, HybridSignature, HybridPubKeyDigest, Nonce, Timestamp).
+- [ ] 1.18 Implement `produce_hybrid_quote(nonce: &[u8]) -> HybridQuote`: gather measurement log, call `TPM2_Quote`, ML-DSA-65 + Ed25519 hybrid sign the bundle.
+- [ ] 1.19 Implement `verify_hybrid_quote(quote: &HybridQuote, ak_pub, counter_pub, expected_root) -> Result<()>` — used by `remote-attestation-v1` and by the CI smoke job.
+- [ ] 1.20 Extend PCR 14 with `SHA-3-256(counter_pub)` at boot, so the counter-signing public key is in the chain of trust.
+
+### 1f. CI smoke (swtpm)
+
+- [ ] 1.21 Add `tpm2-swtpm-smoke` job to `.github/workflows/ci.yml`: launches `swtpm socket --tpmstate dir=/tmp/swtpm --ctrl type=unixio,path=/tmp/swtpm.sock --tpm2`, boots kernel under QEMU with `-chardev socket,id=chrtpm,path=/tmp/swtpm.sock -tpmdev emulator,id=tpm0,chardev=chrtpm -device tpm-tis,tpmdev=tpm0`, asserts PCR-extend path executes, dumps PCRs via `swtpm_ioctl`.
+- [ ] 1.22 In the same CI job, request a quote, verify it externally (using `swtpm`'s exported AK), assert success. Advisory (`continue-on-error: true`) initially; promote to gate after one stable week.
+
+### 1g. Phase 1 close-out
+
+- [ ] 1.23 Update `docs/boot-security-matrix.md` x86-64 row: TPM Measured Boot column flips from **No** to **Yes (Phase 1)** with a link to this change.
+- [ ] 1.24 Update `CLAUDE.md` "Current state" with the TPM 2.0 driver capability.
+- [ ] 1.25 PR title: `feat(security/tpm2): boot-root-of-trust-v1 phase 1 — TPM 2.0 measured boot on x86-64`. Target `develop`.
+
+## 2. Phase 2 — TF-A BL31 measurement chain consumption (AArch64)
+
+### 2a. DTB parser improvements (also closes unikernel-orin-bringup-v1 task 2.12)
+
+- [ ] 2.1 Extend `kernel::mem::phys::parse_dtb` to handle multi-cell `reg = <hi lo hi lo>` (Tegra234 uses 64-bit addresses split across two 32-bit cells).
+- [ ] 2.2 Extend the parser to walk `/reserved-memory/` and expose its subnodes by name.
+- [ ] 2.3 Unit-test against (a) the existing QEMU-virt DTB fixture, (b) a captured Tegra234 DTB snippet (added as a test fixture).
+
+### 2b. TF-A event log reader
+
+- [ ] 2.4 Create `arch/aarch64/src/tf_a_event_log.rs` parsing the TCG event log format (TCG_PCClientPCREvent v2). Validate header magic, walk entries, return a `Vec<EventLogEntry>` (no-alloc with `heapless::Vec` at compile-time-known max-entry count).
+- [ ] 2.5 Wire `parse_dtb` discovery → `tf_a_event_log` parser: at AArch64 boot, look up `/reserved-memory/tf-a-event-log`, parse the contents, fail gracefully if absent.
+- [ ] 2.6 Capture a real Tegra Orin TF-A event log via JTAG / serial dump, save as a CI fixture for replay testing.
+
+### 2c. Chain reconciliation
+
+- [ ] 2.7 Extend `BootMeasurementLog` with a `prepend_chain(entries: &[EventLogEntry])` API. Order: TF-A entries (oldest first), SmallAIOS entries appended.
+- [ ] 2.8 Add a `merged_root_hash() -> [u8; 32]` API computing the SHA-256 replay hash over the merged log.
+- [ ] 2.9 If a TPM is present (rare on AArch64 but possible on Neoverse server boards), reuse Phase 1's PCR-extend wiring against the merged chain.
+
+### 2d. CI replay test
+
+- [ ] 2.10 Add `tf-a-event-log-replay` CI job: feeds the captured fixture into the parser + reconciler, asserts the merged-root hash matches the expected value.
+
+### 2e. Docs
+
+- [ ] 2.11 Create `docs/aarch64-measured-boot.md` covering: TF-A BL31 measurement model, where the event log lives, how SmallAIOS reads it, what happens when it's absent.
+- [ ] 2.12 Update `docs/boot-security-matrix.md` AArch64 row: TF-A event log column flips from **Partial** to **Yes (Phase 2)**.
+
+### 2f. Phase 2 close-out
+
+- [ ] 2.13 PR title: `feat(arch/aarch64): boot-root-of-trust-v1 phase 2 — TF-A event log consumption`. Target `develop`.
+
+## 3. Phase 3 — RISC-V PMP via SBI vendor extension (best-effort)
+
+- [ ] 3.1 Create `arch/riscv64/src/sbi/smallaios_ext.rs` defining `SBI_EXT_SMALLAIOS = 0x09534149`, `SBI_FN_PMP_REQUEST = 0x00`, `SBI_FN_PROBE = 0x01`.
+- [ ] 3.2 Implement a `pmp_request(base: u64, length: u64, perms: PmpPerms) -> SbiResult` client that issues the ecall and returns `Success`, `NotSupported`, or `InvalidParam`.
+- [ ] 3.3 Wire into the RISC-V boot path: at S-mode entry, request a PMP region matching the kernel's text/rodata, record the result in `BootMeasurementLog`.
+- [ ] 3.4 Verify the no-op path: with stock OpenSBI, the call returns `NotSupported` and boot succeeds. Capture serial output proving this.
+- [ ] 3.5 Document the OpenSBI patch needed to honor the extension in `docs/riscv-opensbi-pmp.md`. The patch lives in the doc, not in the repo (it's a downstream firmware change).
+- [ ] 3.6 Update `docs/boot-security-matrix.md` RISC-V row: PMP column flips from **No** to **Best-effort (Phase 3)** with a link.
+- [ ] 3.7 PR title: `feat(arch/riscv64): boot-root-of-trust-v1 phase 3 — best-effort SBI PMP request`. Target `develop`.
+
+## 4. Phase 4 — Signed UEFI kernel image
+
+### 4a. Vendor signing keys
+
+- [ ] 4.1 Generate development Ed25519 + ML-DSA-65 hybrid signing keys, document storage layout in `docs/release-runbook.md` (new section: "Signing ceremony").
+- [ ] 4.2 Generate ECDSA-P256 + RSA-2048 UEFI-compatible classical sibling keys for `sbsign` consumption.
+- [ ] 4.3 Document HSM-backed production layout (YubiHSM 2 PIV slot allocation) in the runbook.
+
+### 4b. Signing pipeline
+
+- [ ] 4.4 Add a `just sign-release ARTIFACT` recipe that wraps `sbsign --cert <cert> --key <key> --output <artifact>.signed <artifact>`.
+- [ ] 4.5 Extend the same recipe to ML-DSA-65 counter-sign the signed artifact, embedding the PQC signature in a `.note.signing` ELF / PE section so verifiers can find it.
+- [ ] 4.6 Add `just verify-release-signature ARTIFACT` calling `sbverify --cert <cert>` + the PQC verification side.
+- [ ] 4.7 Update CI release pipeline to invoke `just sign-release` on tagged releases.
+
+### 4c. UEFI enrollment docs
+
+- [ ] 4.8 Create `docs/uefi-secure-boot-enrollment.md` covering Microsoft default-key removal, SmallAIOS vendor PK/KEK/db enrollment, signature-verification logging on platforms that expose it.
+- [ ] 4.9 Update `unikernel-orin-bringup-v1`'s `docs/jetson-orin-uefi-boot.md` to add a "Enrolling the SmallAIOS vendor key" section as an alternative to "Disable Secure Boot".
+- [ ] 4.10 Update `docs/boot-security-matrix.md`: x86-64 + AArch64 "Secure Boot" cells flip from **No** to **Yes (Phase 4)** with a link.
+
+### 4d. Phase 4 close-out
+
+- [ ] 4.11 PR title: `feat(release): boot-root-of-trust-v1 phase 4 — signed UEFI kernel image`. Target `develop`.
+
+## 5. Cross-phase verification
+
+- [ ] 5.1 End-to-end smoke: x86-64 build with `tpm-attest` + Phase 4 signing, boots under QEMU + swtpm, produces a hybrid quote that verifies against the embedded counter-signing pub key. Captured PCRs 11-14 reflect kernel + boot config + (no models loaded in smoke) + capability config.
+- [ ] 5.2 AArch64 smoke: Tegra Orin boot (extending `unikernel-orin-bringup-v1`'s capture), TF-A event log read, SmallAIOS chain appended, merged root hash matches expected.
+- [ ] 5.3 RISC-V smoke: QEMU `virt` with stock OpenSBI, SBI vendor probe returns `NotSupported`, boot proceeds, measurement log entry records the no-op.
+- [ ] 5.4 `openspec validate boot-root-of-trust-v1` returns valid.

--- a/openspec/changes/confidential-compute-v1/design.md
+++ b/openspec/changes/confidential-compute-v1/design.md
@@ -1,0 +1,232 @@
+# Design — confidential-compute-v1
+
+## Goal
+
+A SmallAIOS instance booting as a hardware-isolated, memory-encrypted enclave on at least one production confidential-compute platform, observable as:
+
+1. Boot under `qemu-system-aarch64 -cpu max,rme=on -machine virt` with tf-rmm as the Realm Management Monitor.
+2. SmallAIOS in the Realm initializes, requests an attestation token via `RSI_ATTEST_TOKEN_*`, returns it via the `remote-attestation-v1` surface with `Backend: "cca-realm"`.
+3. An ONNX model bundle, encrypted with a key the model owner releases to the Realm after verifying the attestation, decrypts into Realm-private memory.
+4. An inference call across the Realm boundary (input in shared memory → encrypted compute → output in shared memory) succeeds with expected output.
+5. Verifier confirms (a) the Realm Attestation Token signature against the RMM attestation root, (b) the SmallAIOS counter-signature, (c) the measurement matches the certified release.
+
+The same observable shape applies to Phase 2 (TDX) and Phase 3 (SEV-SNP); only the inner attestation report format differs.
+
+## Cross-platform abstraction (Phase 1 design output)
+
+The largest single design effort is the **abstraction layer**: a Rust trait that all three platform paths implement, so the inference runtime and the attestation surface don't carry platform-specific code.
+
+```rust
+// security/src/confidential/mod.rs
+
+/// A memory region that the hardware enclave has marked private.
+/// Reads/writes by a non-enclave context (hypervisor, host OS, co-tenant)
+/// see either ciphertext or hardware-enforced abort, depending on platform.
+pub trait SealedRegion: Sized {
+    /// Allocate a private region of `pages` 4KB pages.
+    fn allocate(pages: usize) -> Result<Self, ConfidentialError>;
+
+    /// Get a Rust slice view of the private region. Only callable from
+    /// inside the enclave.
+    fn as_slice(&self) -> &[u8];
+    fn as_slice_mut(&mut self) -> &mut [u8];
+
+    /// Free the region back to the enclave's heap.
+    fn free(self);
+}
+
+/// An enclave that can produce a platform-specific attestation report.
+pub trait AttestableEnclave {
+    type Report: AsRef<[u8]>;  // CBOR / DER / vendor-specific bytes
+
+    /// Returns the platform tag for the `AttestResponse::Backend` field.
+    fn backend_tag() -> &'static str;
+
+    /// Produces an attestation report covering the enclave's identity
+    /// (measurement of its loaded code), the supplied claims (typically
+    /// the nonce + SmallAIOS measurement bundle), and a hardware signature.
+    fn produce_report(claims: &[u8]) -> Result<Self::Report, ConfidentialError>;
+}
+
+/// Shared-memory window between enclave and host. Used for I/O.
+pub trait SharedWindow: Sized {
+    fn allocate(pages: usize) -> Result<Self, ConfidentialError>;
+    fn as_slice(&self) -> &[u8];           // visible to host (DON'T trust it for confidential data)
+    fn as_slice_mut(&mut self) -> &mut [u8];
+    fn free(self);
+}
+```
+
+Phase 1 implements `SealedRegion`, `AttestableEnclave`, `SharedWindow` for CCA Realms. Phase 2 reimplements for TDX. Phase 3 reimplements for SEV-SNP. The `onnx-rt` confidential loader and the `remote-attestation-v1` glue speak to the traits, not the concrete implementations.
+
+## Alternatives considered
+
+### 1. Skip the cross-platform abstraction; build separate kernels per platform
+
+Rejected. Three platform-specific kernels triples the maintenance burden, balkanizes the test surface, and prevents the verifier crate from working uniformly. The trait abstraction is ~150 LOC of Rust and saves multi-thousand-LOC duplication downstream.
+
+### 2. Start with TDX (highest commercial deployment) instead of CCA
+
+Considered. TDX shipped first in volume on Sapphire Rapids (2023), and the cloud-vendor offerings (Azure DCsv5, GCP Confidential VMs Gen 2) have the biggest existing customer base.
+
+Rejected for Phase 1 because (a) SmallAIOS's AArch64 surface (Jetson Orin, planned Neoverse server) is heavier than its x86-64 datacenter surface today; (b) CCA's open RMM (`tf-rmm`) lets us CI in pure-open-source — TDX requires proprietary Intel TDX-module artifacts which (while signed and freely-distributable) are a separate trust-anchor story we don't want in the abstraction-design phase; (c) the CCA threat model is simpler to walk through first (one CPU vendor, one specification, one RMM implementation) — Phase 1's design output is cleaner if we don't have to defend "but TDX does it differently" decisions while still iterating on the abstraction.
+
+Phase 2 picks up TDX as the natural extension once Phase 1's abstractions are stable. TDX-first deployment customers are not blocked — they wait for Phase 2 just as Phase 1 customers wait for CCA silicon.
+
+### 3. Use a process-level enclave (Intel SGX) instead of a VM-level enclave (TDX/CCA/SNP)
+
+Rejected. SGX is a different deployment model — application-as-enclave with the OS outside. SmallAIOS is a unikernel; the whole runtime IS the application. VM-level enclaves (TDX, CCA Realms, SNP) match the deployment shape: one SmallAIOS unikernel per enclave, the host hypervisor untrusted. SGX would require a different kernel architecture (running atop a host kernel, exposing SGX-tailored syscalls to the application) — incompatible with the unikernel design.
+
+SGX is also being deprecated by Intel for server platforms (DCAP-style fleet attestation is officially supported but the SGX server roadmap is effectively maintenance-only). Going TDX-first when we extend to x86-64 is the future-facing choice.
+
+### 4. Build a "confidential mode" feature flag and gate the existing kernel
+
+Rejected. The existing kernel's memory model assumes a single address space, freely-allocatable DRAM, no encryption boundaries. Confidential compute fundamentally changes the memory model: pages have *states* (private vs shared), state transitions are mediated by the platform's trusted firmware (RMM/TDX-module/SEV-firmware), and some operations (debug breakpoints, performance counters) are restricted. Trying to retrofit the existing kernel would force every memory-touching subsystem to learn about enclave states, polluting code that has no business knowing about confidential compute.
+
+Cleaner: a separate build path (`--features cca-realm` etc.) that links a `confidential/` runtime alongside the standard runtime. The standard build is unchanged; the confidential build adds the page-state and attestation paths. Most of the kernel (scheduler, ONNX runtime, networking) is shared.
+
+### 5. ARM CCA via Phase 1 only; skip x86-64 entirely
+
+Rejected. x86-64 is the largest deployment surface for SmallAIOS today (cloud datacenter, NVIDIA-CUDA-on-x86-64 container path). Confidential compute on x86-64 is the most-asked-for feature in customer conversations. CCA-only would be technically sound but commercially incomplete.
+
+Phases 2 and 3 are committed in this proposal even though they're multi-quarter deliverables. The OpenSpec change covers the multi-quarter plan; landing happens phase-by-phase.
+
+## Phase 1 implementation details
+
+### Realm build target
+
+There's no canonical `aarch64-unknown-realm` Rust target. Phase 1 uses `aarch64-unknown-none` (the existing target for bare-metal AArch64) plus:
+
+- The `cca-realm` Cargo feature enables Realm-specific modules and removes incompatible bare-metal HAL bits.
+- A custom linker script `arch/aarch64/linker-cca-realm.ld` sets the Realm's image base per the CCA spec (the RMM places the initial Realm image at an RMM-determined address; the linker script matches).
+- A custom Cargo `[[bin]] required-features = ["cca-realm"]` produces a `smallaios-cca-realm` binary.
+
+The build command becomes `cargo build --release --target aarch64-unknown-none -p smallaios-arch-aarch64 --bin smallaios-cca-realm --features cca-realm` — pattern-consistent with the `tegra234` and `tegra-x1` paths from `unikernel-orin-bringup-v1`.
+
+### RMM interface client
+
+The Realm Services Interface (RSI) is the API a Realm uses to ask the RMM for services. RSI calls are issued via the `SMC` instruction, same calling-convention as the OP-TEE bridge (`op-tee-bridge-v1`) — so the `arch/aarch64/src/smc.rs` module is reused.
+
+Phase 1 implements the minimum RSI subset:
+
+| RSI call | Purpose |
+|----------|---------|
+| `RSI_REALM_CONFIG` | Query Realm's IPA size, hash algo, attestation algo. |
+| `RSI_IPA_STATE_GET` | Query a page's state (RAM-private / RAM-shared / unassigned). |
+| `RSI_IPA_STATE_SET` | Transition a page between states. |
+| `RSI_ATTEST_TOKEN_INIT` | Begin generating an attestation token; supplies challenge nonce. |
+| `RSI_ATTEST_TOKEN_CONTINUE` | Fetch the next chunk of the token (tokens are large; multi-call). |
+| `RSI_HOST_CALL` | Yield to host for I/O (similar to TDX's `TDG.VP.VMCALL`). |
+
+The RSI is a stable Arm spec; the FIDs are pinned in `security/src/confidential/cca_rsi_ids.rs`. ~30 const definitions.
+
+### Granule (page) state management
+
+A Realm sees memory in three states:
+
+- **RAM-private**: encrypted, only Realm reads/writes succeed. Host sees ciphertext (or possibly an abort, platform-defined).
+- **RAM-shared**: cleartext shared region. Used for I/O — host can read inputs and write outputs.
+- **Unassigned**: not part of the Realm. Reads/writes generate exceptions.
+
+`arch/aarch64/src/cca/granule.rs` exposes `transition_to_shared(ipa, count)` and `transition_to_private(ipa, count)` wrapping `RSI_IPA_STATE_SET`. Higher-level types (`SealedRegion`, `SharedWindow`) wrap the transitions in RAII.
+
+The transition is *destructive*: moving a page from private → shared zeroes the page. Moving shared → private zeroes the page. This is hardware-enforced — there's no way to "leak" data across the transition by accident. The Rust API enforces it via type-state: a `SealedRegion` becomes a `SharedWindow` only by consuming the `SealedRegion` and explicitly zeroizing.
+
+### Confidential ONNX model loader
+
+```
+[Model Owner]                    [Cloud / Untrusted Host]            [SmallAIOS Realm]
+    │                                     │                                 │
+    │ 1. Encrypt model.onnx with K_model   │                                 │
+    │ 2. Ship encrypted blob + AAD         │                                 │
+    │────────────────────────────────────► │                                 │
+    │                                     │  3. Host hands blob to Realm    │
+    │                                     │     via shared-memory window    │
+    │                                     │ ──────────────────────────────► │
+    │                                     │                                 │  4. Realm requests
+    │                                     │                                 │     attestation token
+    │                                     │                                 │     (claims = K_model
+    │                                     │                                 │     wrap params, nonce)
+    │ ◄─────────────────────────────────────────────────────────────────────│
+    │ 5. Model Owner verifies attestation │                                 │
+    │    matches expected Realm identity, │                                 │
+    │    expected SmallAIOS measurement,  │                                 │
+    │    expected nonce                   │                                 │
+    │                                     │                                 │
+    │ 6. Releases K_model wrapped to      │                                 │
+    │    Realm's attest-key-pair-wrap-pub │                                 │
+    │──────────────────────────────────────────────────────────────────────►│
+    │                                     │                                 │  7. Realm unwraps
+    │                                     │                                 │     K_model, decrypts
+    │                                     │                                 │     model bytes into
+    │                                     │                                 │     private memory.
+```
+
+The flow is the standard "attested key release" pattern: model owner only releases the decryption key after verifying the Realm is the certified SmallAIOS running on a certified RMM. The verification piggybacks on `remote-attestation-v1`'s verifier crate, extended with a `--release-key-to-attested-target` subcommand in Phase 1.
+
+### Realm attestation token (RAT)
+
+A CCA RAT is a CBOR-encoded structure with two sub-tokens:
+
+- **Platform token**: signed by a CPU-resident attestation key, attests to the platform's CCA configuration and the RMM identity.
+- **Realm token**: signed by an RMM-derived key, attests to the Realm's measurement (initial code hash + extended measurements like model hashes).
+
+Together they form a chain rooted at a CPU-vendor key publicly announced by Arm (the "CCA Platform Attestation Key" — Arm publishes the root of trust per silicon generation). SmallAIOS wraps the RAT in the existing `HybridQuote` envelope from `remote-attestation-v1`, adding the SmallAIOS counter-signature as the PQC half.
+
+The verifier crate gains:
+
+- A `cca-platform-roots/` directory under `trust-anchors/` for the Arm-published CCA Platform Attestation Key roots per silicon generation.
+- RAT-specific verification logic — CBOR parse, signature chain check, measurement extraction.
+
+### CI strategy
+
+`qemu-system-aarch64 -cpu max,rme=on -machine virt,gic-version=3 -bios tf-a.bin -kernel smallaios-cca-realm` boots a Realm under tf-rmm. The CI job:
+
+1. Builds tf-rmm from the upstream `tf-rmm` repository (pinned commit).
+2. Builds SmallAIOS with `--features cca-realm`.
+3. Boots the combined image under QEMU.
+4. Runs `attest-verifier verify --backend cca-realm` against the booted Realm.
+5. Asserts PASS.
+
+This is software-only verification — QEMU emulates the RME extension and tf-rmm runs as a software RMM. It does *not* validate hardware-side correctness, only software-side correctness. Hardware verification follows when CCA-capable silicon is generally available; the CI gate is documented as covering only the software side until then.
+
+## Threat model captures (cross-phase)
+
+### Adversary classes (recurring)
+
+The same six adversary classes from the proposal's sketch table apply across all three phases. Phase 1 produces the full threat model document; Phases 2 and 3 add columns:
+
+| Adversary | CCA defense | TDX defense | SEV-SNP defense |
+|-----------|-------------|-------------|-----------------|
+| Co-tenant VM (Spectre-class) | RME boundary + Arm branch-history isolation | TDX page-key separation + Intel branch-history clearing on TD-entry | SEV-SNP page-state metadata + AMD's IBPB on entry |
+| Hypervisor (passive read) | RMM-mediated enclave entry — hypervisor sees ciphertext | TDX-module-mediated — same | SEV firmware-mediated — same |
+| Datacenter operator (physical) | Memory encryption (per-Realm key) | Memory encryption (per-TD key) | Memory encryption (per-VM key) |
+| Compromised firmware | None (firmware trusted) | None (firmware trusted) | None (firmware trusted) |
+| Compromised CPU | None | None | None |
+| Side-channel timing | App-level only (constant-time ONNX) | Same | Same |
+
+### Residual risks (documented honestly)
+
+- **Speculative execution gadgets**. All three platforms have published-and-patched gadgets historically. SmallAIOS's mitigation is to keep the in-enclave codebase small (the unikernel surface is much smaller than a Linux guest), and to follow each platform's prescribed entry/exit barrier sequence. Documented as residual.
+- **Memory-encryption replay attacks**. CCA, TDX, and SEV-SNP all use AES-XTS or similar with per-page tweaks; replay attacks at the physical-DRAM layer are mitigated by anti-replay metadata. Documented.
+- **DMA from untrusted I/O devices** (pre-TDISP). Phase 1-3 don't address PCIe TEE-IO. DMA-capable peripherals can read enclave memory if the platform doesn't enforce IOMMU separation. Documented as a known limitation; deployment guidance is "treat all I/O as crossing the trust boundary".
+
+## Build / CI surface (Phase 1)
+
+- New: `arch/aarch64/src/cca/{mod.rs, granule.rs, rsi_ids.rs}`.
+- New: `security/src/confidential/{mod.rs, cca_backend.rs}`.
+- New: `onnx-rt/src/confidential.rs`.
+- New: `arch/aarch64/linker-cca-realm.ld`.
+- New Cargo feature: `cca-realm` on `smallaios-arch-aarch64` + `smallaios-onnx-rt`.
+- New `[[bin]]`: `smallaios-cca-realm` (in `arch/aarch64/Cargo.toml`).
+- New CI job: `cca-realm-qemu-smoke` (advisory at land).
+- New `tools/attest-verifier/` extensions: CCA RAT parsing, `--release-key-to-attested-target` subcommand.
+- New docs: `docs/cca-realm-deployment.md`, `docs/confidential-compute-threat-model.md`, `docs/cca-attestation-key-release.md`.
+
+## What this change does NOT do
+
+- Does not modify the non-confidential SmallAIOS build paths. Standard `tegra234`, `tegra-x1`, x86-64, RISC-V builds are unchanged. Confidential builds are additive.
+- Does not require any non-confidential deployment to enable any new feature flag. The default-features build is unchanged.
+- Does not commit to a specific cloud-vendor confidential-VM service. The change targets the open standards (CCA, TDX, SNP); cloud-vendor specifics are deployment notes only.
+- Does not bring up any specific TPM-or-equivalent inside the enclave. Each platform's attestation primitive replaces a TPM for confidential-compute purposes.
+- Does not bring confidential GPU compute. CPU-side ONNX only in Phase 1-3. Confidential GPU is a future change.

--- a/openspec/changes/confidential-compute-v1/proposal.md
+++ b/openspec/changes/confidential-compute-v1/proposal.md
@@ -1,0 +1,133 @@
+# confidential-compute-v1
+
+## Summary
+
+Confidential AI inference is the SmallAIOS deployment model where **(a)** model weights are licensed intellectual property and the model owner does not want them readable by the host infrastructure provider, and **(b)** customer inputs to inference are confidential and the customer does not want them readable by either the model owner or the infrastructure provider. Today SmallAIOS provides neither: model weights live as plaintext bytes in DRAM and on disk; customer tensor data is plaintext in DRAM during inference. A privileged host (hypervisor, fabric admin, datacenter operator) with sufficient access can read both.
+
+This change targets that gap via **hardware-enforced memory confidentiality** on three platform paths, sequenced as a multi-quarter, multi-phase effort. Phase 1 (~6-8 weeks) is design and threat-model work plus a Tier-1 ARM CCA (Confidential Compute Architecture, Realm Management Extension) targeted bring-up. Phase 2 (~8-10 weeks) extends to Intel TDX (Trust Domain Extensions). Phase 3 (~8-10 weeks) extends to AMD SEV-SNP. Each phase produces an independently-deployable confidential SmallAIOS variant on its target platform.
+
+ARM CCA is Phase 1 because:
+
+- SmallAIOS already has heavy AArch64 investment (`unikernel-orin-bringup-v1` on Tegra Orin, `boot-root-of-trust-v1` Phase 2 TF-A integration, `op-tee-bridge-v1`, `remote-attestation-v1` PSA-IA backend). ARM CCA's RME extends the TrustZone trust model SmallAIOS will already understand by the time this change starts.
+- Production silicon ships in 2026 on Neoverse N3 / V3 datacenter cores and Cortex-X / A-series for client. SmallAIOS is positioned for a clean "production-silicon, day-1 software" story on the platform.
+- The Realm Management Monitor (RMM) is open source (Arm releases reference RMM as the `tf-rmm` project under TF-A), so SmallAIOS can develop and CI-test against a real RMM implementation in QEMU `-cpu max,rme=on` without proprietary firmware dependencies.
+
+Intel TDX and AMD SEV-SNP follow as Phase 2 and Phase 3 because (a) they target datacenter x86-64, which is the highest-volume confidential-compute deployment surface; (b) both are production-shipping in 2026 (Sapphire Rapids + TDX, Genoa + SNP); (c) the SmallAIOS-side abstractions defined in Phase 1 (`SealedRegion`, `AttestableEnclave`, `ConfidentialOnnxRuntime`) transfer to either x86-64 platform with platform-specific glue.
+
+Capability: `security-confidential-compute` (new). Cargo features: `cca-realm` (AArch64, RME-based confidential VM), `intel-tdx`, `amd-sev-snp` (x86-64). Each is mutually exclusive with the others at build time (a CCA-realm kernel doesn't link the TDX driver, etc.).
+
+## Why
+
+- **AI weights are the deployment IP of 2026.** Model owners (foundation model providers, fine-tuned domain experts) are increasingly unwilling to deploy weights to infrastructure they don't fully control. The current options are (a) self-host the weights yourself, expensive at scale, or (b) trust the infrastructure operator, which doesn't work for high-value IP. Hardware confidential compute is the third option: weights are decrypted only inside an attestable, memory-encrypted enclave, never visible to the hypervisor or host OS. SmallAIOS is purpose-built for AI inference and is therefore the natural unikernel to package as a confidential workload.
+- **Customer data is the deployment IP of every other workload.** A financial-services customer sending tensor inputs to an inference endpoint doesn't want the cloud operator (or another tenant on the same physical host) reading those tensors. Confidential compute is the *only* technology that gives customers cryptographic proof their data is protected even from the cloud operator.
+- **The three platforms diverge in detail but converge in shape.** ARM CCA, Intel TDX, and AMD SEV-SNP all give you: (1) hardware-encrypted memory pages tagged with a per-enclave key, (2) a small trusted firmware component (RMM / TDX module / SEV firmware) that mediates enclave entry/exit, (3) hardware-rooted attestation reporting the enclave's identity to a remote verifier. SmallAIOS designs the abstraction layer in Phase 1 (CCA-anchored) so Phases 2 and 3 are platform glue, not redesign.
+- **Aligns with the existing PQC and attestation work.** Confidential compute attestation reports are signed by hardware keys (classical). SmallAIOS's PQC-default stance means the reports SHALL be carry-counter-signable with ML-DSA-65 + Ed25519 hybrid — extending the `remote-attestation-v1` `HybridQuote` format to add a `ConfidentialEvidence` field for the platform-specific report. The same verifier crate consumes confidential-compute evidence transparently.
+- **DO-178C DAL A becomes more tractable when the certified workload is isolated.** A confidential SmallAIOS enclave with a sharply-defined boundary (the enclave's measured pages) is easier to certify than a workload that shares DRAM with arbitrary co-tenants. The enclave's measurement IS the certification artifact: anything inside is certified; anything outside is irrelevant to the certification scope.
+- **Phase 1 is independently valuable.** Even without Phases 2 and 3, ARM CCA support on production Neoverse silicon is a deployable product. CCA datacenter platforms (NVIDIA Grace, Ampere Altra Max successors, AWS Graviton 4 / 5 — once ARM CCA-capable cores reach those platforms) are SmallAIOS's clearest fit. Phases 2 and 3 widen the platform matrix but don't gate Phase 1's value.
+
+## Threat model (Phase 1 design output)
+
+The threat model is the largest single design artifact this change produces, because it determines what each phase's enclave actually defends against. Captured in `docs/confidential-compute-threat-model.md` (new), reviewed independently from the implementation work. Sketch:
+
+| Adversary | Capability | Phase 1 (CCA) defense | Notes |
+|-----------|------------|---------------------|-------|
+| Co-tenant VM | Read DRAM via cache side channels (Spectre-class) | Memory encryption + Arm's branch-history isolation (`CSV2`, `BHB` invalidation on enclave-entry) | Speculative-execution gadgets remain a residual risk; mitigations are best-effort. |
+| Host hypervisor | Read enclave DRAM | Hardware encryption (per-realm key) — hypervisor sees ciphertext | Strong. RMM-mediated enclave entry/exit prevents register exfiltration. |
+| Datacenter operator with physical access (cold-boot, bus probing) | Read enclave DRAM via physical attack | Memory encryption (per-realm key) | Strong against cold-boot. Bus probing requires DRAM-controller compromise; out of scope. |
+| Compromised RMM | Read or modify enclave state | None — RMM is trusted | RMM is open source (tf-rmm), verifiable by inspection. |
+| Compromised CPU microcode | Anything | None — CPU is trusted | Mitigated by vendor signing of microcode; out of scope. |
+| Side-channel via timing of inference | Infer input properties from inference time | Out of scope — application-level mitigations only (constant-time ONNX ops in `onnx-rt`) | Documented as a separate concern. |
+
+Phase 2 (TDX) and Phase 3 (SEV-SNP) re-evaluate against the same adversary list — different mitigations, similar coverage. Each phase's deliverable includes its specific threat-model entry in the matrix.
+
+## Phase 1 — ARM CCA Realm bring-up
+
+### Build target
+
+A new build target `aarch64-unknown-none-realm` is a synthetic name in the SmallAIOS workspace mapping to `aarch64-unknown-none` plus a `cca-realm` Cargo feature plus a CCA-specific linker script. The artifact is a Realm-compatible flat binary loaded by the Realm Management Monitor (`tf-rmm`) at Realm-mode entry.
+
+### Realm boot flow
+
+```
+[Host VM (untrusted Linux KVM)] requests Realm creation
+       │
+       │  RMI_REALM_CREATE  (Realm Management Interface)
+       ▼
+[RMM at EL3] allocates Realm structures, measures Realm image
+       │
+       ▼
+[RMM] sets initial Realm Personalization Value (RPV)
+       │
+       ▼
+[SmallAIOS Realm at R-EL1] starts execution in encrypted memory
+       │
+       ▼
+[SmallAIOS] runs ONNX inference; model weights and tensors live in
+encrypted DRAM. Inference traffic crosses the Realm boundary only
+through encrypted shared memory windows ("Granule Inhibit" pages).
+```
+
+The Realm sees memory as if it were a normal VM. The hypervisor (host KVM) cannot read Realm memory — even though KVM scheduled the Realm and provisioned its initial state. RMM enforces all of this; SmallAIOS just runs.
+
+### What ships in Phase 1
+
+- `arch/aarch64/src/cca/mod.rs` — Realm-side RMM interface client. Implements the small subset of RMI calls SmallAIOS issues from inside the Realm (RSI: Realm Services Interface): `RSI_ATTEST_TOKEN_INIT`, `RSI_ATTEST_TOKEN_CONTINUE`, `RSI_HOST_CALL`, `RSI_REALM_CONFIG`, `RSI_IPA_STATE_*` (page state).
+- `arch/aarch64/src/cca/granule.rs` — Granule (4 KB Realm page) state management. SmallAIOS asks RMM to mark pages as `RAM` (private to Realm) or `SHARED` (visible to host, used for I/O).
+- `security/src/confidential/mod.rs` — generic abstraction layer (`SealedRegion`, `AttestableEnclave`). Platform-specific backends plug in here; Phase 1 provides the CCA backend.
+- `security/src/confidential/cca_backend.rs` — CCA-specific attestation report fetching via `RSI_ATTEST_TOKEN_*`. Report shape: a CBOR-encoded Realm Attestation Token (RAT) per Arm's CCA attestation specification. Integrates with `remote-attestation-v1` so the existing attestation surface returns a CCA report when the kernel runs as a Realm.
+- `onnx-rt/src/confidential.rs` — encrypted-model-weights loading. Model bytes arrive in shared (host-visible) memory, are decrypted into Realm-private memory using a key the model owner provisioned via attested key release.
+- Documentation: `docs/cca-realm-deployment.md`, `docs/confidential-compute-threat-model.md`, `docs/cca-attestation-key-release.md`.
+- CI: `cca-realm-qemu-smoke` job using `qemu-system-aarch64 -cpu max,rme=on -machine virt,gic-version=3` plus tf-rmm as the RMM payload. Boots SmallAIOS as a Realm, runs an attestation round-trip, asserts PASS.
+
+### Phase 1 success criterion
+
+A SmallAIOS Realm boots under QEMU+tf-rmm, returns an attestation report via `remote-attestation-v1`'s extended surface (`Backend: "cca-realm"`), and the verifier validates the report against tf-rmm's reference attestation public key. Model weights load into Realm-private DRAM via an attested-key-release pattern; a smoke ONNX inference (vector-add) succeeds with inputs/outputs flowing through shared-memory windows.
+
+## Phase 2 — Intel TDX
+
+Intel TDX (Trust Domain Extensions, Sapphire Rapids+) provides a similar shape with Intel-specific glue. The TDX module mediates TD (Trust Domain) creation; SmallAIOS in a TD calls `tdcall(TDG.VP.VMCALL)` for host I/O and `tdcall(TDG.MR.REPORT)` for attestation. Phase 2 ports the `SealedRegion` / `AttestableEnclave` abstractions to TDX-specific implementations and produces an `intel-tdx` Cargo feature.
+
+The Phase 2 deliverable mirrors Phase 1: kernel patches, attestation backend, ONNX confidential loader, docs, CI. The threat-model column for TDX is filled in. Estimated 8-10 weeks (more than Phase 1 because we need to do x86-64 enclave boot, which is a different shape than the existing x86-64 SmallAIOS boot).
+
+## Phase 3 — AMD SEV-SNP
+
+AMD SEV-SNP (Secure Encrypted Virtualization — Secure Nested Paging, Genoa+) is the third datacenter confidential-compute platform. Architecturally closer to CCA in some ways (page-state metadata enforced by hardware, similar to CCA's granule states); operationally closer to TDX in others (x86-64 with a small TDX-module-like SEV firmware). Phase 3 adds the `amd-sev-snp` Cargo feature.
+
+Estimated 8-10 weeks. The cross-platform `SealedRegion` abstraction designed in Phase 1 is the value-multiplier here: porting to a third platform is mostly platform-glue work.
+
+## Out of scope (across all phases)
+
+- **Confidential GPU compute.** NVIDIA's H100 / H200 / B100 expose confidential-compute modes (CC mode + UVM encryption), but SmallAIOS's GPU integration is currently CPU-side cuDNN-backed (`Dockerfile.jetson`). Confidential GPU is its own follow-up change (`confidential-gpu-v1`) after Phase 1 / Phase 2 land.
+- **Confidential I/O (TDISP).** PCIe TEE-IO (TDISP) is too new (production silicon 2027+) and bundles NIC / NVMe vendors. Documented as a future-future story.
+- **Side-channel hardening of ONNX operators.** Constant-time matmul, attention, and softmax are valuable but orthogonal — they belong with the inference runtime, not the confidential-compute boot path. Tracked separately as `onnx-constant-time-ops-v1` (future).
+- **Trusted I/O between confidential enclaves.** Multi-enclave coordination is a research topic; for SmallAIOS, one inference workload per enclave is the deployment model.
+- **Vendor cloud confidential services** (AWS Nitro Enclaves, Azure Confidential VMs, GCP Confidential Computing). SmallAIOS targets the *standards* (CCA, TDX, SNP); cloud-vendor wrappers can adapt by speaking those.
+- **Pre-silicon / FPGA-emulated CCA.** Phase 1 CI uses QEMU `+rme=on` with tf-rmm; FPGA platforms (Arm's CCA Reference Platform on the Juno SoC FPGA) are valuable for hardware-team validation but not for SmallAIOS-side CI.
+
+## Sequencing
+
+| Phase | Scope | Estimate | Depends on |
+|-------|-------|----------|------------|
+| Design + threat model | `docs/confidential-compute-threat-model.md`, abstraction layer design, build-target wiring | 2-3 weeks (within Phase 1) | None |
+| 1: ARM CCA | Realm boot, RMM interface, attestation backend, ONNX confidential loader, QEMU+tf-rmm CI | 4-5 weeks (after design) | `op-tee-bridge-v1` (for SMC-related infrastructure), `remote-attestation-v1` (for the protocol surface to extend) |
+| 2: Intel TDX | TD boot, tdcall driver, attestation backend, ONNX integration, CI | 8-10 weeks | Phase 1 abstractions |
+| 3: AMD SEV-SNP | SNP enclave boot, GHCB driver, attestation backend, CI | 8-10 weeks | Phase 1 abstractions |
+| **Total** | | **~12-16 weeks for Phase 1 alone; 28-36 weeks for all three** | |
+
+Phases 2 and 3 are independent of each other and can land in parallel after Phase 1.
+
+The 12-16 week range for Phase 1 reflects the unknown of "production CCA silicon availability for end-to-end verification on real hardware". QEMU + tf-rmm covers software-side CI; hardware-side verification slips into when CCA silicon ships in volume. The change ships against software-only verification first and adds hardware verification as silicon arrives.
+
+## DO-178C alignment
+
+Confidential compute is the strongest **isolation** claim DAL A can make. The certified kernel runs inside a hardware-enclosed boundary; any DAL A objective relating to "freedom from interference" by co-running workloads is structurally satisfied. The attestation report is the auditor's proof that a given inference result was produced inside the enclave.
+
+Specific claims unlocked per phase:
+
+- **Phase 1**: "The Realm executing SmallAIOS for tenant T on ARM CCA platform P is bit-identical to certified release X.Y.Z, isolated from co-tenant interference by the Realm Management Monitor." Evidence: Realm Attestation Token signed by the RMM's attestation key, plus the SmallAIOS counter-signature.
+- **Phase 2**: same claim, TDX platform, TD Report signed by Intel's TDX attestation chain.
+- **Phase 3**: same claim, SEV-SNP platform, SNP attestation report signed by AMD's SEV firmware.
+
+## PQC stance
+
+Each phase's attestation report integrates with `remote-attestation-v1`'s `HybridQuote` envelope: the platform-specific report (RAT, TD Report, SNP Report) is the inner hardware signature, and the SmallAIOS counter-signature (ML-DSA-65 + Ed25519) is the outer PQC half. Verifiers can require PQC, classical, or both per existing `PqcMode` semantics. No new protocol surface is needed; this change extends the existing one.

--- a/openspec/changes/confidential-compute-v1/specs/security-confidential-compute/spec.md
+++ b/openspec/changes/confidential-compute-v1/specs/security-confidential-compute/spec.md
@@ -1,0 +1,134 @@
+## ADDED Requirements
+
+### Requirement: Cross-platform confidential-compute abstraction layer
+
+The `smallaios-security` crate SHALL provide platform-agnostic abstraction traits (`SealedRegion`, `AttestableEnclave`, `SharedWindow`) that all confidential-compute backends (ARM CCA Realms, Intel TDX, AMD SEV-SNP) implement, so the inference runtime and the attestation surface depend only on the traits, not on platform-specific backends.
+
+#### Scenario: SealedRegion zeroes on transition to shared
+
+- **GIVEN** a `SealedRegion` containing decrypted model weights inside a confidential enclave
+- **WHEN** the runtime consumes the region via `region.into_shared()` to expose it as a `SharedWindow`
+- **THEN** the underlying pages SHALL be zeroed before the platform-level state transition completes
+- **AND** the resulting `SharedWindow`'s contents SHALL be observable by the host as all-zero bytes (no leakage of the previously-private content)
+- **AND** the type-state design SHALL make leakage by accidental in-place mutation impossible — only `into_shared()` produces a `SharedWindow` from a `SealedRegion`
+
+#### Scenario: AttestableEnclave produces platform-tagged reports
+
+- **GIVEN** a SmallAIOS build with exactly one confidential-compute backend feature enabled (e.g. `cca-realm`)
+- **WHEN** the runtime calls `AttestableEnclave::produce_report(claims)`
+- **THEN** the returned report SHALL be the platform-native attestation evidence (Realm Attestation Token for CCA, TD Report for TDX, SNP Attestation Report for SEV-SNP)
+- **AND** the runtime SHALL surface the platform tag via `AttestableEnclave::backend_tag()` returning one of `"cca-realm"`, `"intel-tdx"`, `"amd-sev-snp"`
+- **AND** the tag SHALL appear in the `AttestResponse::Backend` field per the `remote-attestation-v1` protocol
+
+#### Scenario: Mutually-exclusive backend features
+
+- **GIVEN** a build attempting to enable two confidential-compute backend features simultaneously (e.g. `cca-realm` + `intel-tdx`)
+- **WHEN** Cargo compiles
+- **THEN** a `compile_error!` SHALL halt the build with a documented message naming the conflicting features and the rationale (one enclave per kernel image)
+
+### Requirement: ARM CCA Realm bring-up (Phase 1)
+
+When built with `--features cca-realm` and run as a Realm under a CCA-RME-capable host, SmallAIOS SHALL execute correctly, produce a Realm Attestation Token via the Realm Services Interface, and run a confidential ONNX inference path.
+
+#### Scenario: Realm boots under QEMU + tf-rmm
+
+- **GIVEN** the `cca-realm` build (`smallaios-cca-realm` bin) and a pinned `tf-rmm` build
+- **WHEN** `qemu-system-aarch64 -cpu max,rme=on -machine virt,gic-version=3 -bios tf-a.bin -kernel smallaios-cca-realm` runs
+- **THEN** the Realm SHALL initialize, print a boot banner to the documented Realm-side console, and reach its scheduler idle loop without exception
+- **AND** the Realm's first action SHALL be `RSI_REALM_CONFIG` to discover its IPA size, hash algorithm, and attestation algorithm — recorded in the boot measurement log
+- **AND** the smoke job SHALL complete within 60 seconds wall-clock
+
+#### Scenario: Attestation token round-trip via RSI_ATTEST_TOKEN_*
+
+- **GIVEN** a booted Realm and a verifier-supplied 32-byte nonce N
+- **WHEN** the Realm receives an attestation request, it SHALL call `RSI_ATTEST_TOKEN_INIT(N)`, then loop `RSI_ATTEST_TOKEN_CONTINUE` until the full token is fetched
+- **THEN** the assembled token SHALL be a valid CBOR-encoded Realm Attestation Token (RAT) containing a Platform Token (signed by the CCA Platform Attestation Key) and a Realm Token (signed by an RMM-derived key)
+- **AND** the token SHALL be wrapped in the `remote-attestation-v1` `HybridQuote` envelope with the `cca-realm` backend tag
+- **AND** the verifier crate SHALL validate the RAT against the configured `cca-platform-roots/` trust anchors and assert PASS
+
+#### Scenario: Confidential ONNX model loading via attested key release
+
+- **GIVEN** an encrypted ONNX model bundle + a wrapped decryption key released by the model owner only after attestation verification
+- **WHEN** the Realm receives the wrapped key
+- **THEN** the runtime SHALL unwrap `K_model` using the Realm's RSI-supplied attestation key pair
+- **AND** the runtime SHALL decrypt the model bytes from a shared-memory input window into a `SealedRegion` allocated in Realm-private memory
+- **AND** the decrypted model bytes SHALL never appear in shared memory at any point during loading or inference
+- **AND** the CI smoke SHALL run a vector-add inference and assert correct output
+
+#### Scenario: Granule state transitions follow the documented RSI flow
+
+- **WHEN** the runtime allocates a new `SealedRegion`
+- **THEN** the implementation SHALL call `RSI_IPA_STATE_SET` with the target page IPA and the `RAM_PRIVATE` state
+- **AND** the call SHALL succeed for any page within the Realm's permitted IPA range
+- **AND** subsequent reads/writes from the Realm SHALL succeed
+- **AND** reads from the host (outside the Realm) SHALL see ciphertext or platform-defined abort behavior
+
+### Requirement: Intel TDX bring-up (Phase 2)
+
+When built with `--features intel-tdx` and run as a Trust Domain under a TDX-capable host, SmallAIOS SHALL execute correctly, produce a TD Report via `TDG.MR.REPORT`, and run the same confidential ONNX inference path as Phase 1.
+
+#### Scenario: TD boots and round-trips a TD Report
+
+- **GIVEN** the `intel-tdx` build (`smallaios-tdx` bin) and a TDX-capable QEMU + TDX-module artifact pinning
+- **WHEN** `qemu-system-x86_64 -cpu host,+tdx` boots the TD
+- **THEN** the TD SHALL initialize, reach its idle loop, and accept attestation requests
+- **AND** an attestation request SHALL produce a TD Report via `TDG.MR.REPORT(nonce)` wrapped in the existing `HybridQuote` envelope with `Backend: "intel-tdx"`
+- **AND** the verifier crate SHALL validate the TD Report against Intel's DCAP attestation collateral and assert PASS
+
+#### Scenario: Cross-platform abstraction is honored
+
+- **GIVEN** the TDX backend
+- **THEN** `SealedRegion::allocate(pages)` SHALL succeed using TDX `TDG.MEM.PAGE.ACCEPT` semantics
+- **AND** `AttestableEnclave::backend_tag()` SHALL return `"intel-tdx"`
+- **AND** the same `onnx-rt/src/confidential.rs` loader code path SHALL function unchanged when built with `--features intel-tdx`
+
+### Requirement: AMD SEV-SNP bring-up (Phase 3)
+
+When built with `--features amd-sev-snp` and run as an SNP VM under an SNP-capable host, SmallAIOS SHALL execute correctly, produce an SNP Attestation Report via `SNP_GUEST_REQUEST MSG_REPORT_REQ`, and run the same confidential ONNX inference path.
+
+#### Scenario: SNP VM boots and round-trips an Attestation Report
+
+- **GIVEN** the `amd-sev-snp` build and an SEV-SNP-capable QEMU + SEV firmware pinning
+- **WHEN** `qemu-system-x86_64 -cpu host,+sev-snp` boots the VM
+- **THEN** the VM SHALL initialize, reach its idle loop, and accept attestation requests
+- **AND** an attestation request SHALL produce an SNP Attestation Report wrapped in the existing `HybridQuote` envelope with `Backend: "amd-sev-snp"`
+- **AND** the verifier crate SHALL validate the report against AMD's attestation collateral (vcek cert + AMD root) and assert PASS
+
+### Requirement: Documented threat model
+
+The repository SHALL maintain a `docs/confidential-compute-threat-model.md` covering the six standard adversary classes (co-tenant VM, hypervisor, datacenter operator with physical access, compromised firmware, compromised CPU, side-channel timing), with a per-phase defense column for ARM CCA, Intel TDX, and AMD SEV-SNP.
+
+#### Scenario: Threat model exists, is reviewed, and is updated per phase
+
+- **GIVEN** the change at Phase 1 close-out
+- **THEN** `docs/confidential-compute-threat-model.md` SHALL exist with all six adversary rows populated for the CCA column
+- **AND** the document SHALL note that the TDX and SEV-SNP columns are pending Phases 2 and 3
+- **AND** the document SHALL be reviewed by at least one engineer who did not implement Phase 1 (independent review)
+
+- **GIVEN** the change at Phase 2 close-out
+- **THEN** the TDX column SHALL be filled
+- **AND** the residual-risks section SHALL be updated with any TDX-specific findings
+
+- **GIVEN** the change at Phase 3 close-out
+- **THEN** the SEV-SNP column SHALL be filled
+- **AND** the residual-risks section SHALL be finalized for the change's archival
+
+### Requirement: Verifier crate accepts all three platform reports
+
+The `tools/attest-verifier/` crate SHALL accept `AttestResponse` payloads with `Backend` values `"cca-realm"`, `"intel-tdx"`, or `"amd-sev-snp"` and SHALL dispatch to the appropriate platform-specific report-parsing logic + trust-anchor directory automatically.
+
+#### Scenario: Single verifier binary covers all platforms
+
+- **GIVEN** a developer with the `attest-verifier` binary and a populated `~/.config/smallaios-attest/trust-anchors/` containing CCA roots, TDX collateral, and SNP collateral
+- **WHEN** the developer runs `attest-verifier verify` against any of the three platform backends
+- **THEN** the verifier SHALL detect the backend from `AttestResponse::Backend`
+- **AND** the verifier SHALL load the matching trust anchor set automatically
+- **AND** the audit record SHALL identify the platform clearly so downstream auditors see which confidential-compute path was used
+
+#### Scenario: Attested key release subcommand
+
+- **GIVEN** an attested-target endpoint and an encrypted key the operator wants to release only to a verified-attested target
+- **WHEN** the operator runs `attest-verifier release-key-to-attested-target --target <endpoint> --release-record release-X.Y.Z.json --key-to-release encrypted-key.bin`
+- **THEN** the verifier SHALL first issue an attestation request and validate the response
+- **AND** only on PASS SHALL the verifier transmit the key (encrypted to the target's attestation-supplied wrap public key) to the target
+- **AND** the verifier SHALL emit an audit record of the release decision

--- a/openspec/changes/confidential-compute-v1/tasks.md
+++ b/openspec/changes/confidential-compute-v1/tasks.md
@@ -1,0 +1,159 @@
+# Tasks — confidential-compute-v1
+
+## 0. Phase 1 prerequisites + design
+
+- [ ] 0.1 Confirm `op-tee-bridge-v1` has merged (gives us the `arch/aarch64/src/smc.rs` infrastructure that RSI calls reuse).
+- [ ] 0.2 Confirm `remote-attestation-v1` Sub-phase A has merged (gives us the `HybridQuote` envelope and the verifier crate to extend).
+- [ ] 0.3 Pin `tf-rmm` upstream commit SHA to use for CI. Document in `docs/cca-realm-deployment.md` after that doc is created.
+- [ ] 0.4 Pin the QEMU version that supports `+rme=on` (needs QEMU 8.2+ — confirm CI runner image carries it).
+- [ ] 0.5 Pin the Arm CCA spec version + RSI spec version that Phase 1 targets. Document.
+- [ ] 0.6 Capture and write the threat model in `docs/confidential-compute-threat-model.md` covering all six adversary classes per the design table. Independent review (security-aware engineer, not the implementer) before implementation starts.
+
+## 1. Phase 1 — ARM CCA Realm bring-up
+
+### 1a. Cross-platform abstraction layer
+
+- [ ] 1.1 Create `security/src/confidential/mod.rs` defining `SealedRegion`, `AttestableEnclave`, `SharedWindow` traits per the design.
+- [ ] 1.2 Add `ConfidentialError` enum covering platform-agnostic failure modes (`AllocationFailed`, `StateTransitionDenied`, `AttestationUnavailable`, `BackendNotInitialized`).
+- [ ] 1.3 Add doc comments explaining each trait's responsibilities and noting the three intended backends (CCA, TDX, SNP).
+
+### 1b. CCA RSI client
+
+- [ ] 1.4 Create `security/src/confidential/cca_rsi_ids.rs` with `const u32` for each RSI FID per the Arm RSI spec.
+- [ ] 1.5 Create `arch/aarch64/src/cca/mod.rs` exposing `rsi_realm_config()`, `rsi_ipa_state_get(ipa)`, `rsi_ipa_state_set(ipa, count, state)`, `rsi_attest_token_init(challenge)`, `rsi_attest_token_continue(buf)`, `rsi_host_call(args)`. Each wraps an `smc_call` to the appropriate FID.
+- [ ] 1.6 Unit-test the RSI client against a mock SMC dispatcher (cfg(test) shim — same pattern as `op-tee-bridge-v1`'s tests).
+
+### 1c. Granule state management + Sealed/SharedRegion
+
+- [ ] 1.7 Create `arch/aarch64/src/cca/granule.rs` with `transition_to_shared(ipa, count)` and `transition_to_private(ipa, count)` wrappers.
+- [ ] 1.8 Implement `SealedRegion` and `SharedWindow` traits in `arch/aarch64/src/cca/region.rs`. RAII drops transition pages back to the default state and zero them.
+- [ ] 1.9 Implement type-state transitions: `SealedRegion::into_shared(self) -> SharedWindow` consumes the sealed region, zeroes it, transitions to shared. Reverse direction also provided.
+- [ ] 1.10 Unit-test the type-state transitions (zero-on-transition behavior, no leakage across the boundary).
+
+### 1d. Realm attestation backend
+
+- [ ] 1.11 Create `security/src/confidential/cca_backend.rs` implementing `AttestableEnclave` for CCA. `Report = Vec<u8>` (CBOR-encoded RAT).
+- [ ] 1.12 Implement `CcaBackend::produce_report(claims)`: call `rsi_attest_token_init(claims_hash)`, loop on `rsi_attest_token_continue` until EOF, return the assembled CBOR.
+- [ ] 1.13 Wire into `remote-attestation-v1`'s backend selection: when running as a Realm, `AttestBackend::select()` returns `Cca(CcaBackend::initialize())`. The `AttestResponse::Backend` field carries `"cca-realm"`.
+
+### 1e. Verifier crate CCA support
+
+- [ ] 1.14 Extend `tools/attest-verifier/` with CCA RAT parsing: pull the CBOR, validate the platform token signature against the configured Arm CCA Platform Attestation Key root, validate the Realm token signature against the platform-token-supplied RMM key, extract Realm measurements.
+- [ ] 1.15 Add `trust-anchors/cca-platform-roots/` documented directory layout.
+- [ ] 1.16 Add `attest-verifier release-key-to-attested-target --target https://realm-endpoint --release-record release-X.Y.Z.json --key-to-release encrypted-key.bin` subcommand implementing the attested key release pattern.
+- [ ] 1.17 Document the verifier-side CCA flow in `docs/cca-attestation-key-release.md`.
+
+### 1f. Confidential ONNX loader
+
+- [ ] 1.18 Create `onnx-rt/src/confidential.rs` exposing `ConfidentialOnnxRuntime::load_encrypted_model(blob: &[u8], wrapped_key: &[u8])`.
+- [ ] 1.19 Implement the wrapped-key unwrap: use `RSI_REALM_CONFIG`-supplied attestation key pair to unwrap `K_model`. (The exact key-wrap scheme is documented in the design — likely ECDH-P384 + HKDF + AES-256-GCM.)
+- [ ] 1.20 Decrypt model bytes from a shared-memory input window into a `SealedRegion`. The decrypted model never appears in shared memory.
+- [ ] 1.21 Add a `cca-realm` Cargo feature on `smallaios-onnx-rt` that links the confidential loader. Without the feature, no symbol changes.
+- [ ] 1.22 Unit-test against a fixture (encrypted dummy ONNX model + valid wrapped key + matching Realm measurement).
+
+### 1g. Realm build pipeline
+
+- [ ] 1.23 Create `arch/aarch64/linker-cca-realm.ld` setting the Realm image base + section layout per the tf-rmm reference implementation's expected Realm entry point.
+- [ ] 1.24 Add `[[bin]] smallaios-cca-realm` to `arch/aarch64/Cargo.toml` with `required-features = ["cca-realm"]`.
+- [ ] 1.25 Add `just build-cca-realm` recipe: `cargo build --release --target aarch64-unknown-none -p smallaios-arch-aarch64 --bin smallaios-cca-realm --features cca-realm`.
+- [ ] 1.26 Document the produced artifact's expected boot-time layout in `docs/cca-realm-deployment.md`.
+
+### 1h. CI smoke
+
+- [ ] 1.27 Pre-bake tf-rmm into the CI runner image (or pre-cache its build artifacts). Pin tf-rmm SHA.
+- [ ] 1.28 Add `cca-realm-qemu-smoke` CI job:
+  - `cargo build --features cca-realm`;
+  - `qemu-system-aarch64 -cpu max,rme=on -machine virt,gic-version=3 -bios tf-a.bin -kernel smallaios-cca-realm`;
+  - run `attest-verifier verify --backend cca-realm --endpoint <Realm's exposed endpoint>` against the booted Realm;
+  - assert PASS.
+- [ ] 1.29 Add a smoke test for the confidential ONNX path: provision an encrypted model + wrapped key fixture, run the loader, assert decryption succeeds + a tiny inference returns expected output.
+- [ ] 1.30 Advisory (`continue-on-error: true`) at land. Promotion to gate happens when CCA-capable hardware is available for additional validation.
+
+### 1i. Docs
+
+- [ ] 1.31 `docs/cca-realm-deployment.md`: architecture diagram, boot flow, build command, deployment notes for prospective customer environments.
+- [ ] 1.32 `docs/confidential-compute-threat-model.md`: full threat model per the design's adversary table; Phase 1 covers the CCA column, Phases 2/3 fill the others.
+- [ ] 1.33 `docs/cca-attestation-key-release.md`: model-owner-side and Realm-side flows for attested key release. References the verifier crate's `release-key-to-attested-target` subcommand.
+- [ ] 1.34 Update `docs/boot-security-matrix.md` with a new "Confidential compute" section detailing Phase 1's CCA coverage.
+- [ ] 1.35 Update `CLAUDE.md` "Current state" with the CCA Realm capability.
+
+### 1j. Phase 1 close-out
+
+- [ ] 1.36 PR title: `feat(security/confidential): confidential-compute-v1 phase 1 — ARM CCA Realm bring-up`. Target `develop`.
+- [ ] 1.37 PR description includes a captured RAT round-trip log from the QEMU+tf-rmm smoke, plus a confidential-inference output trace.
+
+## 2. Phase 2 — Intel TDX
+
+### 2a. TDX abstraction backend
+
+- [ ] 2.1 Create `arch/x86_64/src/tdx/mod.rs` exposing `tdcall(leaf, args)` wrapping the `TDCALL` instruction.
+- [ ] 2.2 Create `security/src/confidential/tdx_backend.rs` implementing `SealedRegion`, `AttestableEnclave`, `SharedWindow` for TDX. Page-state transitions use `TDG.MEM.PAGE.ACCEPT` and `TDG.VP.VMCALL` flavors.
+- [ ] 2.3 Implement `AttestableEnclave::produce_report` via `TDG.MR.REPORT` plus `TDG.MR.RTMR.EXTEND` for measurement-log extends mid-execution.
+- [ ] 2.4 Pin the TDX-module spec version and the Intel SGX DCAP attestation-key shape SmallAIOS targets.
+
+### 2b. TDX build target
+
+- [ ] 2.5 Add `intel-tdx` Cargo feature on `smallaios-arch-x86_64`. Mutually exclusive with `cca-realm` and `amd-sev-snp` (compile_error! on conflict).
+- [ ] 2.6 Add `[[bin]] smallaios-tdx` with `required-features = ["intel-tdx"]`.
+- [ ] 2.7 Linker / build wiring per Intel TDX guest specs.
+
+### 2c. Verifier crate TDX support
+
+- [ ] 2.8 Extend the verifier with TDX TD Report parsing (Intel-defined binary format).
+- [ ] 2.9 Add Intel SGX DCAP attestation-collateral fetching (the verifier downloads the platform's TCB info + QE identity from Intel's PCS endpoint or a local mirror).
+- [ ] 2.10 Document the TDX-side trust anchors in `docs/intel-tdx-deployment.md`.
+
+### 2d. CI
+
+- [ ] 2.11 Add `intel-tdx-qemu-smoke` CI job using `qemu-system-x86_64 -cpu host,+tdx` (Intel TDX QEMU support stabilized in QEMU 8.x with the Intel TDX-module artifact loaded). Boot SmallAIOS as a TD, attest, verify.
+- [ ] 2.12 Advisory at land; gate-promote criteria same as Phase 1.
+
+### 2e. Phase 2 close-out
+
+- [ ] 2.13 Update `docs/confidential-compute-threat-model.md` TDX column.
+- [ ] 2.14 Update `docs/boot-security-matrix.md` x86-64 confidential-compute cell.
+- [ ] 2.15 PR title: `feat(security/confidential): confidential-compute-v1 phase 2 — Intel TDX`. Target `develop`.
+
+## 3. Phase 3 — AMD SEV-SNP
+
+### 3a. SNP abstraction backend
+
+- [ ] 3.1 Create `arch/x86_64/src/sev_snp/mod.rs` exposing the GHCB (Guest-Hypervisor Communication Block) interface for hypervisor calls.
+- [ ] 3.2 Create `security/src/confidential/sev_snp_backend.rs` implementing the three traits. Page-state transitions use `PSMASH` and `RMP_ADJUST` (or rather, request via GHCB).
+- [ ] 3.3 Implement `produce_report` via `SNP_GUEST_REQUEST` `MSG_REPORT_REQ`.
+
+### 3b. SNP build target
+
+- [ ] 3.4 Add `amd-sev-snp` Cargo feature on `smallaios-arch-x86_64`, mutually exclusive with `intel-tdx` and `cca-realm`.
+- [ ] 3.5 Add `[[bin]] smallaios-sev-snp`.
+- [ ] 3.6 Linker / build wiring per AMD SEV-SNP guest specs.
+
+### 3c. Verifier crate SNP support
+
+- [ ] 3.7 Extend the verifier with SNP attestation report parsing (AMD-defined binary format).
+- [ ] 3.8 Add AMD attestation-collateral fetching (vcek certificate, AMD root keys).
+- [ ] 3.9 Document trust anchors in `docs/amd-sev-snp-deployment.md`.
+
+### 3d. CI
+
+- [ ] 3.10 Add `amd-sev-snp-qemu-smoke` CI job using `qemu-system-x86_64 -cpu host,+sev-snp` (AMD SEV-SNP QEMU support is available with the SEV firmware loaded).
+- [ ] 3.11 Advisory at land.
+
+### 3e. Phase 3 close-out
+
+- [ ] 3.12 Update `docs/confidential-compute-threat-model.md` SEV-SNP column.
+- [ ] 3.13 Update `docs/boot-security-matrix.md` x86-64 confidential-compute cell to reflect both TDX and SNP coverage.
+- [ ] 3.14 PR title: `feat(security/confidential): confidential-compute-v1 phase 3 — AMD SEV-SNP`. Target `develop`.
+
+## 4. Cross-phase verification
+
+- [ ] 4.1 The same `attest-verifier` binary verifies CCA, TDX, and SNP responses transparently (selecting the correct trust-anchor / report-parser per `AttestResponse::Backend`).
+- [ ] 4.2 Confidential ONNX inference smoke runs on all three platforms (QEMU-emulated) with the same model bundle and the same encryption key wrap shape.
+- [ ] 4.3 `openspec validate confidential-compute-v1` returns valid.
+- [ ] 4.4 The threat-model document is reviewed by an independent reviewer before the Phase 3 PR merges.
+
+## 5. Long-term housekeeping
+
+- [ ] 5.1 Track CCA silicon GA dates and update `docs/cca-realm-deployment.md` with on-hardware verification results when hardware is available.
+- [ ] 5.2 Track confidential GPU compute (`confidential-gpu-v1`) as a follow-up change once Phase 1-3 land.
+- [ ] 5.3 Re-evaluate PCIe TEE-IO (TDISP) scope when production silicon ships (estimated 2027+).

--- a/openspec/changes/op-tee-bridge-v1/design.md
+++ b/openspec/changes/op-tee-bridge-v1/design.md
@@ -1,0 +1,146 @@
+# Design — op-tee-bridge-v1
+
+## Goal
+
+A Normal-World OP-TEE client driver in `#![no_std]` Rust that round-trips a `TEEC_InvokeCommand` against an unmodified upstream OP-TEE OS BL32 image, observable as:
+
+- A "hello world" TA returning a fixed response over an `OPTEE_SMC_CALL_WITH_ARG` session.
+- A captured serial log showing `TF-A → OP-TEE → SmallAIOS` SMC traversal latency in the < 100 µs range (well within ARM SMC call-and-return budgets per Arm DEN 0028C).
+- The bridge gracefully reporting `TeeError::NotPresent` when SmallAIOS boots on hardware without OP-TEE installed.
+
+## Alternatives considered
+
+### 1. Use Linux's `optee_armtz` driver via shim
+
+Rejected. The Linux driver is GPL-2.0 and assumes a Linux device-tree-driven probe path, request-queue infrastructure, and userspace `tee-supplicant` daemon for RPC handling. None of those map cleanly onto SmallAIOS's `#![no_std]` runtime. A wholesale port would also import GPL code into an Apache-2.0 / MIT-licensed workspace (license review surface SmallAIOS deliberately avoids).
+
+### 2. Implement the full GP TEE Client API including TEEC_RequestCancellation, TEEC_NotifyEvent, multi-session contexts
+
+Rejected for Phase 1. The full GP spec is ~150 pages and includes asynchronous cancellation, event notifications, and multi-context bookkeeping that no SmallAIOS use case needs at the start. Phase 1 ships the subset that round-trips a synchronous `TEEC_InvokeCommand` — about 30% of the spec, the part every real-world client actually uses.
+
+### 3. Use ARM PSA Crypto API instead of OP-TEE
+
+Considered. PSA Crypto is a higher-level abstraction over a TEE-resident crypto service. OP-TEE OS ships a PSA Crypto TA, so we could target PSA directly and skip the lower-level GP API.
+
+Rejected because (a) PSA Crypto narrows the bridge to "crypto operations only", but we want sealing, attestation, and possibly custom TA workloads later — the lower-level GP API supports all of those; (b) the PSA abstraction is just a TA built on top of GP, so building the GP bridge is the same engineering work plus optionality; (c) `remote-attestation-v1` will benefit from PSA Initial Attestation API (PSA-IA) — that's an *additional* TA that runs on top of the GP bridge we're building here, not an alternative to it.
+
+The PSA Crypto / PSA-IA TAs will be consumed by the follow-up changes. This change provides the GP-level bridge they sit on.
+
+### 4. SMC dispatch via firmware/PSCI-like interface instead of OP-TEE-specific FIDs
+
+Rejected. OP-TEE's SMC ABI is a documented stable interface (`OPTEE_SMC_CALL_WITH_ARG` and friends have been stable across OP-TEE OS 3.x → 4.x). The GP TEE Client API maps cleanly to it. Building a generic "TEE dispatch" layer that could swap to a non-OP-TEE secure OS is over-engineering — the only Secure-World OS that runs at S-EL1 on the target Tegra Orin platform is OP-TEE.
+
+### 5. Skip OP-TEE entirely, rely on Tegra-specific NVIDIA SE / Secure Engine
+
+Considered briefly. NVIDIA's Secure Engine (SE2) on Tegra234 provides AES, SHA, RSA, and TRNG accelerators accessible from Secure World. There is no documented Normal-World driver path that doesn't go through OP-TEE; NVIDIA's stack uses OP-TEE TAs to expose SE2 services. Going direct would require reverse-engineering closed NVIDIA Secure-World code. Rejected — OP-TEE is the right abstraction layer for both portability and access.
+
+## SMC dispatch (Phase 1's smallest module)
+
+```rust
+// arch/aarch64/src/smc.rs
+#[derive(Clone, Copy, Debug)]
+pub struct SmcResult { pub x0: u64, pub x1: u64, pub x2: u64, pub x3: u64 }
+
+/// SMC32 / SMC64 dispatch per Arm DEN 0028C.
+/// Issues `smc #0` with x0..x6 set, returns x0..x3.
+/// Safe: SMC is a privileged instruction but inherently synchronous; from
+/// EL1/EL2 it returns control to the caller. No memory model concerns
+/// beyond the input/output registers.
+pub unsafe fn smc_call(
+    fid: u32, a1: u64, a2: u64, a3: u64, a4: u64, a5: u64, a6: u64,
+) -> SmcResult {
+    let mut x0: u64 = fid as u64;
+    let (mut x1, mut x2, mut x3): (u64, u64, u64) = (a1, a2, a3);
+    core::arch::asm!(
+        "smc #0",
+        inout("x0") x0,
+        inout("x1") x1,
+        inout("x2") x2,
+        inout("x3") x3,
+        in("x4") a4, in("x5") a5, in("x6") a6,
+        options(nomem, nostack, preserves_flags),
+    );
+    SmcResult { x0, x1, x2, x3 }
+}
+```
+
+That's the entire low-level surface. Everything else is bytes-in / bytes-out built on top.
+
+## Trust model
+
+| Component | Trusted by SmallAIOS for what |
+|-----------|------------------------------|
+| TF-A BL31 | EL3 secure monitor routing SMCs faithfully; signed by platform vendor. |
+| OP-TEE OS BL32 | Holds TA private state, enforces TA isolation; signed by platform vendor. |
+| Trusted Application (per-use-case) | Holds key material, enforces use-case policy; signed by TA-signing key (vendor or SmallAIOS). |
+| Normal World (SmallAIOS) | Caller of TAs; SmallAIOS holds *TEE handles* and *shared-memory pointers*, never long-term private material. |
+
+The threat model assumes Normal World can be compromised independently of Secure World. A compromised Normal World can call arbitrary TA commands but cannot exfiltrate sealed-storage contents, raw private keys, or TA internal state — that's the TEE's whole job.
+
+The threat model **does** assume TF-A and OP-TEE OS are uncompromised. If the platform vendor's secure-firmware signature is forged, the bridge offers no defense — that's the responsibility of the platform's BootROM-rooted secure-boot chain (out of scope for this change; partially covered by `boot-root-of-trust-v1` Phase 4 and 100% covered by vendor-fused boot guards documented but not automated there).
+
+## Shared-memory pool design
+
+OP-TEE OS needs Normal World shared memory for parameter passing (the GP `TEEC_RegisterSharedMemory` surface). The OP-TEE OS publishes the allowed shared-memory range at boot via `OPTEE_SMC_GET_SHM_CONFIG` (function ID `0x32000007`); SmallAIOS reads that range and uses it as a heap.
+
+Two implementation choices:
+
+- **Dedicated DRAM region described in DTB** (`/reserved-memory/optee-shm { reg = <...>; };`). NVIDIA's Orin BSP uses this; it's pre-mapped, no kernel-side allocator interaction needed. Used when available.
+- **Dynamically allocated from the kernel heap, registered with OP-TEE OS via `OPTEE_SMC_RPC_FUNC_ALLOC`/`FREE`**. Required when no DTB-reserved region exists. Adds more SMC traffic per session but works everywhere.
+
+Phase 1 implements both, prefers DTB-reserved when available, falls back to dynamic. The choice is logged in `BootMeasurementLog` for audit clarity.
+
+A shared-memory parameter is a 4-tuple `(phys_addr, size, direction, attr)`. The bridge holds a `SharedMemory<'_>` lifetime-anchored to a SmallAIOS-side buffer; on drop, it unregisters from OP-TEE. The lifetime tracking is pure Rust — no global registry, no leakable handles.
+
+## GP TEE Client API mapping
+
+| GP API | SmallAIOS Rust API | SMC FID | Notes |
+|--------|--------------------|---------|-------|
+| `TEEC_InitializeContext` | `TeeContext::new()` | `OPTEE_SMC_CALL_GET_OS_REVISION` (probe) | Returns `Err(NotPresent)` on unknown FID. |
+| `TEEC_OpenSession` | `TeeContext::open_session(uuid)` | `OPTEE_SMC_CALL_WITH_ARG` (cmd = `OPTEE_MSG_CMD_OPEN_SESSION`) | UUID is the TA's GP UUID. |
+| `TEEC_InvokeCommand` | `TeeSession::invoke(cmd_id, &[Param])` | `OPTEE_SMC_CALL_WITH_ARG` (cmd = `OPTEE_MSG_CMD_INVOKE_COMMAND`) | The bread-and-butter call. |
+| `TEEC_CloseSession` | `Drop for TeeSession` | `OPTEE_SMC_CALL_WITH_ARG` (cmd = `OPTEE_MSG_CMD_CLOSE_SESSION`) | RAII-driven. |
+| `TEEC_RegisterSharedMemory` | `SharedMemory::register(&buf, dir)` | `OPTEE_MSG_CMD_REGISTER_SHM` | Returns a lifetime-bound handle. |
+| `TEEC_AllocateSharedMemory` | covered by `SharedMemory::register` | n/a | We always provide the buffer; no need for OP-TEE-allocated path. |
+| `TEEC_FinalizeContext` | `Drop for TeeContext` | n/a (no FID — local cleanup only) | RAII. |
+| `TEEC_RequestCancellation` | **deferred** | `OPTEE_MSG_CMD_CANCEL` | Add when a consumer needs it. |
+
+`Param` is a tagged enum mirroring GP's `TEEC_Parameter`:
+
+```rust
+pub enum Param<'a> {
+    None,
+    Value { a: u64, b: u64 },
+    ValueOutput { a: &'a mut u64, b: &'a mut u64 },
+    MemRef(&'a SharedMemory<'a>, usize, usize),  // offset, size
+    MemRefOutput(&'a mut SharedMemory<'a>, usize, usize),
+}
+```
+
+This is the entire client surface. ~40 public API items, all `#![no_std]`-friendly.
+
+## RPC handling
+
+OP-TEE TAs occasionally need Normal World assistance — wall-clock time, console output, wait-for-interrupt (used by some implementations of secure timers). The SMC return convention encodes "I need RPC, please call me back" via `OPTEE_SMC_RPC_FUNC_*` return codes. Phase 1 handles the minimal RPC subset:
+
+| RPC | What SmallAIOS does |
+|-----|--------------------|
+| `OPTEE_SMC_RPC_FUNC_ALLOC` | Allocate from the dynamic shared-memory path, return phys addr. |
+| `OPTEE_SMC_RPC_FUNC_FREE` | Free a previously-allocated shared-memory region. |
+| `OPTEE_SMC_RPC_FUNC_FOREIGN_INTR` | Re-issue the SMC after handling the interrupt (cooperative). |
+| `OPTEE_SMC_RPC_FUNC_CMD` (subcmd: wait-for-keypress, get-time) | Phase 1 returns `OPTEE_SMC_RETURN_ENOTSUP` for any subcmd not on a documented allowlist. |
+
+Anything beyond that allowlist is rejected — TAs that depend on it get a clean failure rather than a partial implementation. The allowlist grows as use-case TAs need more.
+
+## CI smoke
+
+The OP-TEE project ships `qemu_v8.mk` build configuration producing a complete TF-A + OP-TEE OS + Buildroot image bootable under `qemu-system-aarch64 -M virt -cpu cortex-a57 -smp 2 -bios bl1.bin`. The smoke job builds that fixture (one-time CI cache), boots SmallAIOS as BL33 (replacing the Buildroot Linux that the OP-TEE upstream provides), and runs a SmallAIOS test program that opens a session to OP-TEE's reference "hello_world" TA and asserts the round-trip works.
+
+The job is advisory at land time and promotes to gate after a stable week. The OP-TEE fixture is large (~50 MB), so the CI image will pre-bake it to avoid per-PR rebuild time.
+
+## What this change explicitly does NOT do
+
+- **Does not ship Secure-World code.** No TA source in this repo, no TF-A patches, no OP-TEE OS modifications. The bridge talks to *unmodified upstream* OP-TEE OS.
+- **Does not enable OP-TEE on Tegra Orin where NVIDIA's BSP doesn't ship it.** Users of Tegra Orin variants where OP-TEE BL32 is not built into the firmware see `TeeError::NotPresent` and the bridge no-ops cleanly. Enabling OP-TEE in the BSP is an NVIDIA-side decision.
+- **Does not modify the boot path.** OP-TEE is loaded by TF-A before SmallAIOS gets control. SmallAIOS just discovers it via SMC probe at runtime.
+- **Does not introduce a new dependency layer.** `security/src/tee/` is Layer 0 (foundation); `arch/aarch64/src/smc.rs` is Layer 2 (HAL). The dependency direction respects the workspace's existing 4-layer model.

--- a/openspec/changes/op-tee-bridge-v1/proposal.md
+++ b/openspec/changes/op-tee-bridge-v1/proposal.md
@@ -1,0 +1,115 @@
+# op-tee-bridge-v1
+
+## Summary
+
+SmallAIOS on AArch64 runs in **Normal World at EL1** (or EL2 in the unikernel path that came out of `unikernel-orin-bringup-v1`). The ARM TrustZone architecture defines a parallel **Secure World** at S-EL1, accessed through the firmware-managed Secure Monitor at EL3 via the `SMC` (Secure Monitor Call) instruction. On Jetson Orin specifically, JetPack 6 ships Arm Trusted Firmware (TF-A) at EL3 as BL31 and **optionally** ships OP-TEE OS as the S-EL1 payload (BL32). Today SmallAIOS has zero ability to call into Secure World: no SMC driver, no GP TEE Client API, no awareness of OP-TEE's existence. `docs/boot-security-matrix.md` AArch64 row marks TrustZone and OP-TEE as **No** under "SmallAIOS Integration".
+
+This change adds an OP-TEE client bridge to SmallAIOS — a minimal Normal World driver implementing the Global Platform TEE Client API subset that SmallAIOS actually needs (session open/close, command invoke, shared-memory register/unregister), backed by an SMC dispatcher that issues GP-standard SMC function IDs against the OP-TEE OS running in Secure World. The driver speaks the OP-TEE-specific SMC ABI (`OPTEE_SMC_CALL_WITH_ARG` = `0x32000004`, the standard Linux OP-TEE driver entry point) so it interoperates with an unmodified upstream OP-TEE OS build. SmallAIOS does not ship OP-TEE OS itself — OP-TEE is built and signed by the platform vendor (NVIDIA for Tegra Orin) and loaded by TF-A. SmallAIOS just talks to it.
+
+Use cases that the bridge unlocks:
+
+1. **Sealed key storage.** SmallAIOS's release-signing private key, ONNX model encryption keys, and PQC long-term identity keys move into OP-TEE Secure Storage. The Normal World never holds the raw bytes.
+2. **Model-signature verification in Secure World.** A pinning Trusted Application (TA) holds the model-signing root public key. SmallAIOS sends the model's hash + signature to the TA over a session; the TA verifies and returns `OK`/`FAIL` without exposing the root key.
+3. **Boot-integrity sealing.** PCRs from `boot-root-of-trust-v1` Phase 1 (x86-64 TPM 2.0) have no AArch64 counterpart on most Tegra hardware. With OP-TEE present, SmallAIOS seals its boot measurement log into Secure Storage at boot, then attests later (`remote-attestation-v1`) by asking the TA to unseal-and-sign with a Secure-World-resident key.
+4. **PQC key sealing in the TEE.** ML-DSA-65 private keys are large (~4 KB). Storing them in OP-TEE Secure Storage and using the TA as an opaque signing oracle keeps the Normal World free of long-term private-key material and aligns with the project's PQC-default stance.
+
+Capability: `security-tee` (new). The bridge lives in `security/src/tee/` (new module) with the platform-specific SMC layer in `arch/aarch64/src/smc.rs` (new module). The Cargo feature is `op-tee` on `smallaios-security`, default OFF (builds without OP-TEE see no overhead; production AArch64 deployments enable it).
+
+## Why
+
+- **TrustZone is the AArch64 hardware root of trust SmallAIOS isn't using.** The boot-security-matrix doc explicitly lists TrustZone under "AArch64 Hardware Root of Trust" alongside "SoC-fused BootROM keys", and lists "SmallAIOS Integration: No". TF-A's BL31 secure monitor is the *required* runtime layer SmallAIOS sits above on every modern ARM SoC; OP-TEE at S-EL1 is the *standard* way to access that secure monitor for application services. Bridging into it costs roughly the same effort as the AArch64 measured-boot work in `boot-root-of-trust-v1` Phase 2 (~3-4 weeks) and unlocks proportionally more capability — sealed storage, attestation backing, signature-verification oracle.
+- **Tegra Orin already ships an OP-TEE-ready firmware stack.** Per NVIDIA's L4T 36.4 release notes (`docs/orin-secure-boot-flow.md`-style document on NVIDIA Docs), the JetPack 6 firmware chain is `BootROM → MB1 → MB2 → TF-A BL31 → optional OP-TEE BL32 → BL33 (U-Boot) → kernel`. OP-TEE is built into the BSP and can be enabled by flag — no firmware re-flash needed in many deployments. SmallAIOS's job is the Normal World half; the Secure World half exists.
+- **GP TEE Client API is the standard, well-specified surface.** GlobalPlatform's TEE Client API (TEE_Client_API_Specification, v1.0 / v1.0.2) defines a stable C-level shape (`TEEC_Context`, `TEEC_Session`, `TEEC_InvokeCommand`, `TEEC_RegisterSharedMemory`, ...). Linux's `tee-supplicant` + `optee_armtz` driver implement it; SmallAIOS implements the same shape in Rust. Trusted Applications targeting this surface (the OP-TEE samples, NXP's Crypto TA, vendor-signed key-manager TAs) are immediately usable without TA-side changes.
+- **Sealed key storage is the project's biggest missing piece.** The `verified-boot` story signs ONNX models with a SmallAIOS-managed key. If that key lives in DRAM next to the kernel that owns the verification logic, an attacker who roots the kernel owns the key. The same is true of the release-signing key (proposal: `boot-root-of-trust-v1` Phase 4). OP-TEE Secure Storage backed by a SoC-fused hardware-unique key gives us a place to put long-term private material where Normal-World compromise doesn't equal key compromise.
+- **PQC-default fits the TEE story naturally.** ML-DSA-65 + ML-KEM-768 private keys are kilobytes-each, so even tiny TAs (a few-KB binary) become a meaningful key vault. The bridge lets SmallAIOS treat the TA as an opaque PQC signing oracle: "hash these bytes with SHA-3, ML-DSA-65 sign them with key handle K, return the signature". The Normal World never sees the private key, and the TA can enforce policy ("key K is only usable to sign objects whose first byte is 0x42") that the Normal World cannot.
+- **DO-178C DAL A alignment.** Storing safety-critical signing keys outside the certified runtime *adds* a trust boundary that simplifies the runtime's certification scope. A TA with a 50-line key-vault interface is easier to certify (or third-party-vouch) than a full kernel; pushing key handling out of the kernel reduces the certification surface area of the kernel itself.
+
+## Bridge architecture
+
+```
+SmallAIOS Normal World (EL1/EL2)
+┌────────────────────────────────────────────────────┐
+│  ONNX runtime, kernel, applications                │
+│           │                                        │
+│           ▼                                        │
+│  security/src/tee/  (GP TEE Client API in Rust)    │
+│  ├── TeeContext::initialize()                      │
+│  ├── TeeSession::open(uuid, &[Param])              │
+│  ├── TeeSession::invoke(cmd_id, &[Param])          │
+│  ├── SharedMemory::register(&[u8], dir)            │
+│           │                                        │
+│           ▼                                        │
+│  arch/aarch64/src/smc.rs  (raw SMC dispatch)       │
+│  ├── smc_call(fid, a1, a2, a3, a4, a5, a6) →       │
+│  │     SmcResult                                   │
+│  │   (issues `smc #0` instruction, x0=fid, ...)    │
+└─────────────────────────────│──────────────────────┘
+                              │ smc #0
+                              ▼
+              ┌─────────────────────────────────────┐
+              │  TF-A BL31 Secure Monitor (EL3)     │
+              │  Routes OP-TEE FIDs → OP-TEE OS     │
+              └─────────────────────────────────────┘
+                              │
+                              ▼
+              ┌─────────────────────────────────────┐
+              │  OP-TEE OS (S-EL1, BL32)            │
+              │  Manages Trusted Applications       │
+              │  ├── TA: Key Vault                  │
+              │  ├── TA: Model Signature Verifier   │
+              │  └── TA: Attestation Signer         │
+              └─────────────────────────────────────┘
+```
+
+The bridge is a single `cfg(feature = "op-tee")` module path. When OP-TEE is absent (the SMC returns `OPTEE_SMC_RETURN_UNKNOWN_FUNCTION`), the bridge fails initialization gracefully and SmallAIOS falls back to today's software-only key storage. Callers see a typed `Result<TeeContext, TeeError::NotPresent>` and choose behavior accordingly.
+
+## What ships
+
+1. **`arch/aarch64/src/smc.rs`** — raw SMC dispatch. Implements ARM SMC Calling Convention (DEN 0028C) `smc #0` instruction wrapper, returning the 4 return registers (`x0`-`x3`) per the convention. ~50 LOC plus tests.
+2. **`security/src/tee/mod.rs`** — GP TEE Client API surface in `#![no_std]` Rust. ~500 LOC. Exposes `TeeContext`, `TeeSession`, `SharedMemory`, `Operation`, `Param` (zero/value/ref/output flavors), `Error`.
+3. **`security/src/tee/optee_msg.rs`** — OP-TEE-specific SMC message format (`OPTEE_MSG_ARG`, `OPTEE_MSG_PARAM`, ...). The on-the-wire format the OP-TEE OS expects in shared memory.
+4. **`security/src/tee/smc_ids.rs`** — OP-TEE standard SMC function IDs (`OPTEE_SMC_CALL_GET_OS_REVISION = 0x32000000`, `OPTEE_SMC_CALL_WITH_ARG = 0x32000004`, `OPTEE_SMC_RPC_FUNC_FREE = 0x32000005`, etc.) as `const u32`.
+5. **`security/src/tee/shm_pool.rs`** — shared-memory pool. SmallAIOS allocates a contiguous physical region (described to OP-TEE via `OPTEE_SMC_GET_SHM_CONFIG`), maps it into Normal World as a heap, and uses it as the parameter-passing zone for invokes. ~200 LOC.
+6. **`security/src/tee/rpc.rs`** — Reverse-call (RPC) handling. OP-TEE TAs sometimes need to ask the Normal World for clock-reads, console output, or wait-for-interrupt; SmallAIOS implements the small subset of RPCs needed by the TAs we run. ~150 LOC.
+7. **`docs/op-tee-bridge.md`** (new) — architecture, build/run instructions for Tegra Orin (which OP-TEE BL32 builds NVIDIA ships, how to confirm OP-TEE is loaded), key-vault TA reference, troubleshooting.
+8. **CI: `op-tee-qemu-smoke`** — boots a kernel-build under QEMU `virt` with an unmodified upstream OP-TEE OS as BL32, drives a hello-world TA, asserts the round-trip works. Advisory initially.
+
+## Use cases unlocked (delivered as follow-up changes)
+
+This change ships **the bridge only**. The use cases that motivate it land as separate small changes:
+
+- **`tee-key-vault-v1`** — moves the SmallAIOS release-signing private key and the ONNX-model-encryption keys into OP-TEE Secure Storage. Uses the bridge from this change. Estimated +1-2 weeks.
+- **`tee-model-signature-verify-v1`** — replaces the in-kernel model-signature check in `onnx-rt` with a TA-side check. Estimated +1-2 weeks.
+- **Used by `remote-attestation-v1` AArch64 backend** — see that change for the consumer side.
+- **Used by `boot-root-of-trust-v1` Phase 2** for chain sealing — optional, lands as an additive enhancement to that change's spec.
+
+Splitting the bridge from its consumers keeps this change a tight ~3-4 weeks of plumbing work with a clean acceptance criterion (hello-world TA round-trip), and lets the consumers land independently.
+
+## Out of scope
+
+- **Shipping our own TA binaries.** The TA build toolchain is OP-TEE-side (cross-compile with the OP-TEE TA devkit, sign with the platform-vendor TA-signing key). Per-use-case TAs land in their respective follow-up changes; this change provides the Normal-World half only. We document how to build / load a TA but ship none.
+- **Multi-session / multi-context concurrency.** Phase 1 supports one `TeeContext` and one `TeeSession` open at a time. Concurrency lands when a consumer needs it (likely `tee-key-vault-v1` if multiple subsystems need parallel signing).
+- **x86-64 SGX / SEV-SNP**. SmallAIOS's x86-64 confidential-compute story is `confidential-compute-v1` (separate change). OP-TEE is ARM-only by definition.
+- **OP-TEE OS or TF-A modifications.** The bridge speaks the *standard* GP / OP-TEE SMC ABI against unmodified upstream firmware. Any SmallAIOS-specific Secure-World code (a custom TA, a vendor-specific PSA service) is its own change.
+- **TLS / network transport for sessions.** All TEE traffic is local SMC; no network surface exists in this change.
+
+## Effort estimate
+
+| Sub-task | Scope | Estimate |
+|----------|-------|----------|
+| 1 | `smc.rs` raw dispatch + tests | ~2 days |
+| 2 | GP TEE Client API surface in Rust | ~1 week |
+| 3 | OP-TEE message format + SMC IDs | ~3 days |
+| 4 | Shared-memory pool | ~3 days |
+| 5 | RPC handling (subset) | ~3 days |
+| 6 | QEMU + OP-TEE OS CI smoke | ~3 days |
+| 7 | Docs + Jetson Orin runbook | ~2 days |
+| **Total** | | **~3-4 weeks** |
+
+## DO-178C alignment
+
+Moving long-term private-key material out of the certified kernel runtime into a separately-managed Secure World component is a textbook trust-boundary reduction. The DAL A claim "the certified kernel never holds the release-signing private key in cleartext memory" becomes provable by inspection of the kernel's key-storage code (which only holds TEE *handles*, never raw bytes). The TA that holds the keys can be certified separately to a lower DAL or vouched-for via vendor attestation — the boundary is the SMC interface, which is a small, well-specified surface (the GP TEE Client API).
+
+## PQC stance
+
+The bridge is crypto-agnostic at the SMC level — TAs decide what crypto they implement. The follow-up `tee-key-vault-v1` TA SHALL hold ML-DSA-65 + Ed25519 hybrid keys and expose a hybrid-signing operation. The `tee-model-signature-verify-v1` TA SHALL accept ML-DSA-65 + Ed25519 hybrid signatures. The bridge itself imposes no crypto choice; the follow-ups carry the PQC-default forward.

--- a/openspec/changes/op-tee-bridge-v1/specs/security-tee/spec.md
+++ b/openspec/changes/op-tee-bridge-v1/specs/security-tee/spec.md
@@ -1,0 +1,113 @@
+## ADDED Requirements
+
+### Requirement: GP TEE Client API surface in #![no_std] Rust
+
+The `smallaios-security` crate SHALL provide a Normal-World OP-TEE client implementing the Global Platform TEE Client API subset required for synchronous `TEEC_InvokeCommand` round-trips, gated by a new `op-tee` Cargo feature, available only when compiled for AArch64.
+
+#### Scenario: Context initialization probes for OP-TEE presence
+
+- **GIVEN** a SmallAIOS build with `--features op-tee` on AArch64
+- **WHEN** the kernel calls `TeeContext::new()`
+- **THEN** the bridge SHALL issue `OPTEE_SMC_CALL_GET_OS_REVISION` (FID `0x32000000`) via `smc_call`
+- **AND** if the SMC returns a valid OS revision, the call SHALL return `Ok(TeeContext { … })` with the OP-TEE OS version recorded
+- **AND** if the SMC returns `OPTEE_SMC_RETURN_UNKNOWN_FUNCTION` (`0xFFFFFFFF`), the call SHALL return `Err(TeeError::NotPresent)` and the caller SHALL be free to fall back to software-only behavior
+
+#### Scenario: Build without op-tee feature is byte-identical to today
+
+- **GIVEN** a SmallAIOS build without `--features op-tee`
+- **THEN** the resulting kernel binary SHALL NOT link any `security::tee` symbols
+- **AND** the resulting kernel binary SHALL NOT contain the `smc #0` instruction emitted by `arch/aarch64/src/smc.rs`
+- **AND** all software-only key paths SHALL behave exactly as before this change
+
+#### Scenario: Session open + invoke + close round-trip
+
+- **GIVEN** an initialized `TeeContext`, a TA UUID, and a TA that exposes a known command
+- **WHEN** the caller does `let session = ctx.open_session(uuid)?; session.invoke(cmd_id, &mut [Param::Value { a: 1, b: 2 }])?;` and then drops the session
+- **THEN** three SMC calls SHALL be issued in order: `OPTEE_MSG_CMD_OPEN_SESSION`, `OPTEE_MSG_CMD_INVOKE_COMMAND`, `OPTEE_MSG_CMD_CLOSE_SESSION`, all wrapped in `OPTEE_SMC_CALL_WITH_ARG` (FID `0x32000004`)
+- **AND** the per-call `OPTEE_MSG_ARG` and `OPTEE_MSG_PARAM` structs in shared memory SHALL exactly match the OP-TEE upstream layout (`optee_msg.h` from the pinned OP-TEE OS commit)
+- **AND** the session's `Drop` impl SHALL be infallible — close-failure SHALL be logged but SHALL NOT panic
+
+#### Scenario: Parameter encoding covers Value, ValueOutput, MemRef, MemRefOutput
+
+- **GIVEN** an `invoke` call with the four parameter slots populated with `Param::Value { a, b }`, `Param::ValueOutput { a, b }`, `Param::MemRef(&shm, off, len)`, `Param::MemRefOutput(&mut shm, off, len)` respectively
+- **WHEN** the bridge encodes the OPTEE_MSG_PARAM slots
+- **THEN** slot 0 SHALL carry `OPTEE_MSG_ATTR_TYPE_VALUE_INPUT` with the (a, b) packed values
+- **AND** slot 1 SHALL carry `OPTEE_MSG_ATTR_TYPE_VALUE_OUTPUT` and on return the bridge SHALL write back the output (a, b) into the caller's `&mut u64` references
+- **AND** slot 2 SHALL carry `OPTEE_MSG_ATTR_TYPE_RMEM_INPUT` (registered memory) with the phys address + offset + length
+- **AND** slot 3 SHALL carry `OPTEE_MSG_ATTR_TYPE_RMEM_OUTPUT` and the output buffer SHALL be readable by the caller after the invoke returns
+
+### Requirement: Shared-memory pool with DTB-reserved and dynamic backends
+
+The bridge SHALL maintain a shared-memory pool for parameter passing to OP-TEE, preferring a DTB-reserved-region backend when available and falling back to dynamic allocation via `OPTEE_SMC_RPC_FUNC_ALLOC` otherwise.
+
+#### Scenario: DTB-reserved region is used when present
+
+- **GIVEN** a DTB exposing `/reserved-memory/optee-shm { reg = <…>; };` (or a vendor-specific equivalent recognized by the bridge)
+- **WHEN** `ShmPool::initialize()` runs
+- **THEN** the pool SHALL be backed by the DTB-described region
+- **AND** the boot measurement log SHALL record `OpTeeShmBackend::DtbReserved { base, size }`
+
+#### Scenario: Dynamic allocation fallback
+
+- **GIVEN** a DTB with no `/reserved-memory/optee-shm` (or equivalent) node
+- **WHEN** `ShmPool::initialize()` runs
+- **THEN** the pool SHALL initialize in dynamic mode
+- **AND** the first `ShmBlock` allocation SHALL issue `OPTEE_SMC_RPC_FUNC_ALLOC` to OP-TEE
+- **AND** the boot measurement log SHALL record `OpTeeShmBackend::Dynamic`
+
+#### Scenario: Pool exhaustion fails cleanly
+
+- **GIVEN** a pool with `N` bytes total capacity already fully allocated
+- **WHEN** the caller requests one more byte
+- **THEN** `ShmPool::alloc` SHALL return `Err(TeeError::SharedMemoryExhausted)`
+- **AND** the bridge SHALL NOT panic, leak, or corrupt previously-allocated blocks
+
+### Requirement: RPC handling with documented allowlist
+
+The bridge SHALL handle the OP-TEE RPC subset required for the `pta_invoke_tests` no-op smoke (allocation/free/foreign interrupt) and SHALL reject all other RPC subcommands with `OPTEE_SMC_RETURN_ENOTSUP`.
+
+#### Scenario: Allowlisted RPCs are serviced
+
+- **GIVEN** an OP-TEE TA invocation that triggers `OPTEE_SMC_RPC_FUNC_ALLOC` for an additional shared-memory block
+- **WHEN** the SMC returns the RPC request
+- **THEN** the bridge SHALL allocate from `ShmPool`, populate the response registers per the OP-TEE RPC convention, and re-issue the SMC to resume the invocation
+- **AND** the same SHALL hold for `OPTEE_SMC_RPC_FUNC_FREE` and `OPTEE_SMC_RPC_FUNC_FOREIGN_INTR`
+
+#### Scenario: Non-allowlisted RPCs are rejected
+
+- **GIVEN** a TA invocation that issues an `OPTEE_SMC_RPC_FUNC_CMD` subcommand not on the bridge's allowlist (e.g. wait-for-keypress)
+- **WHEN** the bridge sees the RPC return
+- **THEN** the bridge SHALL respond with `OPTEE_SMC_RETURN_ENOTSUP` (`0xFFFFFFFD`)
+- **AND** the TA invocation SHALL fail with a clean `TeeError::NotSupported` rather than hanging or panicking
+
+### Requirement: Raw SMC dispatch with Arm SMC Calling Convention compliance
+
+The `smallaios-arch-aarch64` crate SHALL expose an `unsafe fn smc_call(fid, a1..a6) -> SmcResult` implementing Arm DEN 0028C SMC dispatch, used by the OP-TEE bridge and available for future Secure-World callers.
+
+#### Scenario: Register layout matches Arm DEN 0028C
+
+- **WHEN** `smc_call(fid, a1, a2, a3, a4, a5, a6)` is invoked from EL1 or EL2
+- **THEN** the inline asm SHALL place `fid` (as u64) in x0, `a1` in x1, ..., `a6` in x6
+- **AND** the asm SHALL emit a single `smc #0` instruction
+- **AND** on return the asm SHALL capture x0-x3 into the returned `SmcResult`
+- **AND** the function SHALL be marked `unsafe` because SMC is a privileged instruction whose effects are platform-defined
+
+#### Scenario: smc.rs only compiles on AArch64 with op-tee feature
+
+- **GIVEN** a build invocation for x86-64 or RISC-V, or AArch64 without `--features op-tee`
+- **THEN** `arch/aarch64/src/smc.rs` SHALL not be compiled (cfg-gated out)
+- **AND** no `smc #0` instruction SHALL appear in the resulting binary
+
+### Requirement: Documentation surface
+
+The repository SHALL document the OP-TEE bridge architecture, its scope limits, and the Tegra Orin operational notes in `docs/op-tee-bridge.md`.
+
+#### Scenario: Architecture and ABI documentation
+
+- **THEN** `docs/op-tee-bridge.md` SHALL exist and SHALL contain the bridge architecture diagram, the GP TEE Client API → SMC FID mapping table, the SMC calling convention summary, and the OP-TEE OS commit-SHA pin
+- **AND** `docs/boot-security-matrix.md` AArch64 row SHALL be updated: "TrustZone" column annotated "Bridge (op-tee-bridge-v1)", "OP-TEE" column annotated "Client-side (op-tee-bridge-v1)"
+
+#### Scenario: Troubleshooting and platform notes
+
+- **THEN** `docs/op-tee-bridge.md` SHALL include a "Troubleshooting" section covering: NotPresent on platforms where OP-TEE was expected (causes + fixes), shared-memory exhaustion (how to raise the DTB-reserved size), and unknown TA UUID (the TA isn't loaded by OP-TEE OS)
+- **AND** the doc SHALL include a "Tegra Orin operational notes" section pinning the JetPack version where OP-TEE BL32 ships built-in vs requires a custom firmware build

--- a/openspec/changes/op-tee-bridge-v1/tasks.md
+++ b/openspec/changes/op-tee-bridge-v1/tasks.md
@@ -1,0 +1,77 @@
+# Tasks — op-tee-bridge-v1
+
+## 0. Prerequisites
+
+- [ ] 0.1 Confirm the upstream OP-TEE OS `qemu_v8.mk` build is reproducible on the CI runner image. Document exact commit SHA pinning in `docs/op-tee-bridge.md`.
+- [ ] 0.2 Capture a representative Tegra Orin TF-A + OP-TEE firmware version from a JetPack 6.2.1 install (`tegra_uefi_versions`, `cat /proc/device-tree/firmware/optee/compatible` if available). Paste in PR description.
+- [ ] 0.3 Confirm the Tegra Orin BSP exposes `/reserved-memory/optee@…` in its DTB. If not, document the dynamic-shared-memory fallback path in design.md as the only path; update the proposal "Out of scope" if needed.
+- [ ] 0.4 Pin the `unikernel-orin-bringup-v1` DTB-parser improvements (or absorb them into this change's prerequisites) — `parse_dtb` must support `/reserved-memory/` subnodes for the shared-memory pool detection.
+
+## 1. SMC dispatch (Layer 2 HAL)
+
+- [ ] 1.1 Create `arch/aarch64/src/smc.rs` with `SmcResult` struct and `smc_call(fid, a1..a6) -> SmcResult` using inline asm per Arm DEN 0028C.
+- [ ] 1.2 Unit-test `smc_call` against a mock dispatcher (cfg(test) version that intercepts `smc #0` via a function pointer set by the test). Verifies register layout matches Arm SMC Calling Convention.
+- [ ] 1.3 Document the SMC ABI assumptions in a doc comment: `fid` in x0 (32-bit SMC32 or 64-bit SMC64 indicated by bit 30), arguments in x1-x6, returns in x0-x3.
+- [ ] 1.4 Ensure `smc.rs` is gated `#[cfg(target_arch = "aarch64")]` and feature `op-tee` (no SMC instruction on x86-64 / RISC-V).
+
+## 2. OP-TEE SMC IDs + message format
+
+- [ ] 2.1 Create `security/src/tee/smc_ids.rs` defining the OP-TEE standard SMC FIDs as `const u32`: `OPTEE_SMC_CALL_GET_OS_REVISION = 0x32000000`, `OPTEE_SMC_CALL_WITH_ARG = 0x32000004`, `OPTEE_SMC_RPC_FUNC_ALLOC = 0xFFFFFFFE`, etc. Source: OP-TEE OS `core/include/optee_smc.h` (canonical reference, pin commit SHA).
+- [ ] 2.2 Create `security/src/tee/optee_msg.rs` defining `OPTEE_MSG_ARG` and `OPTEE_MSG_PARAM` structs matching OP-TEE OS's `optee_msg.h` exactly. Use `#[repr(C)]` and assert struct sizes match the C definitions at compile time.
+- [ ] 2.3 Define the GP `TeeError` enum with variants for OP-TEE return codes (`TEEC_ERROR_BAD_FORMAT`, `TEEC_ERROR_NOT_SUPPORTED`, ...) plus SmallAIOS-specific (`NotPresent`, `SharedMemoryExhausted`).
+- [ ] 2.4 Implement `From<u32> for TeeError` mapping OP-TEE numeric codes to enum variants.
+
+## 3. Shared-memory pool
+
+- [ ] 3.1 Create `security/src/tee/shm_pool.rs` exposing `ShmPool::initialize() -> Result<ShmPool>` and `ShmPool::alloc(size, align) -> Result<ShmBlock>`.
+- [ ] 3.2 Implement the DTB-reserved-region path: query `parse_dtb` for `/reserved-memory/optee-shm` (or vendor-specific equivalent), map it as a heap.
+- [ ] 3.3 Implement the dynamic path: on first allocation, ask OP-TEE via `OPTEE_SMC_RPC_FUNC_ALLOC` for a fresh region.
+- [ ] 3.4 Implement `Drop for ShmBlock` that returns the block to the pool / OP-TEE.
+- [ ] 3.5 Unit-test pool exhaustion behavior (should return `TeeError::SharedMemoryExhausted`, not panic).
+
+## 4. GP TEE Client API surface
+
+- [ ] 4.1 Create `security/src/tee/mod.rs` exposing public types: `TeeContext`, `TeeSession`, `SharedMemory`, `Param`, `Operation`.
+- [ ] 4.2 Implement `TeeContext::new() -> Result<TeeContext, TeeError>`: probe via `OPTEE_SMC_CALL_GET_OS_REVISION`. Returns `Err(NotPresent)` on `OPTEE_SMC_RETURN_UNKNOWN_FUNCTION`.
+- [ ] 4.3 Implement `TeeContext::open_session(uuid: &Uuid) -> Result<TeeSession>` using `OPTEE_MSG_CMD_OPEN_SESSION` over `OPTEE_SMC_CALL_WITH_ARG`.
+- [ ] 4.4 Implement `TeeSession::invoke(cmd_id: u32, params: &mut [Param]) -> Result<(), TeeError>` using `OPTEE_MSG_CMD_INVOKE_COMMAND`. Encode the four params into `OPTEE_MSG_PARAM` slots per GP conventions.
+- [ ] 4.5 Implement `Drop for TeeSession` calling `OPTEE_MSG_CMD_CLOSE_SESSION`.
+- [ ] 4.6 Implement `Drop for TeeContext` (local cleanup only, no SMC).
+- [ ] 4.7 Implement `SharedMemory::register(buf: &[u8], dir: ShmDir)` returning a lifetime-anchored handle. Drop unregisters.
+
+## 5. RPC handling
+
+- [ ] 5.1 Create `security/src/tee/rpc.rs` implementing the SMC return-code → RPC dispatch loop. After `smc_call`, if the return is an RPC request, handle it locally and re-issue.
+- [ ] 5.2 Implement `OPTEE_SMC_RPC_FUNC_ALLOC` handler (delegates to `ShmPool`).
+- [ ] 5.3 Implement `OPTEE_SMC_RPC_FUNC_FREE` handler.
+- [ ] 5.4 Implement `OPTEE_SMC_RPC_FUNC_FOREIGN_INTR` handler (re-issue after a hint to the scheduler).
+- [ ] 5.5 Implement allowlist enforcement for `OPTEE_SMC_RPC_FUNC_CMD` subcommands. Reject unknown subcommands with `OPTEE_SMC_RETURN_ENOTSUP`.
+
+## 6. Cargo wiring
+
+- [ ] 6.1 Add `op-tee = []` feature to `smallaios-security` `Cargo.toml`. Default OFF.
+- [ ] 6.2 Gate the `tee` module on `cfg(feature = "op-tee")`.
+- [ ] 6.3 Ensure a default-features build of every crate that depends on `smallaios-security` still works (the bridge is purely additive).
+- [ ] 6.4 Add doc-comment to the feature explaining the AArch64-only scope and the GP TEE Client API mapping.
+
+## 7. CI smoke
+
+- [ ] 7.1 Pre-bake the OP-TEE upstream `qemu_v8.mk` artifacts into the CI runner image (TF-A `bl1.bin`, OP-TEE OS `tee.bin`, U-Boot or direct BL33 stub). Pin to a specific OP-TEE OS commit SHA.
+- [ ] 7.2 Add `op-tee-qemu-smoke` CI job: builds the SmallAIOS kernel with `--features op-tee`, packages it as BL33, boots under `qemu-system-aarch64 -M virt -cpu cortex-a57 -smp 2 -bios bl1.bin -semihosting-config enable=on,target=native`.
+- [ ] 7.3 Smoke-test program in `tests/op_tee_smoke.rs`: opens a session to OP-TEE's built-in `pta_invoke_tests` PTA (UUID `d96a5b40-c3e5-21e3-8794-1002a5d5c61b`), invokes the no-op test, asserts success.
+- [ ] 7.4 Mark advisory (`continue-on-error: true`) at land. Promote to gate after one stable week.
+
+## 8. Docs
+
+- [ ] 8.1 Create `docs/op-tee-bridge.md` covering: architecture diagram, SMC ABI summary, GP API mapping table, how to verify OP-TEE is present on Tegra Orin (`/sys/firmware/devicetree/base/firmware/optee/method` exists on L4T; on SmallAIOS, the bridge's probe API is the only check), Trusted Application development pointers (link to OP-TEE upstream docs — we don't reproduce them).
+- [ ] 8.2 Update `docs/boot-security-matrix.md` AArch64 row: TrustZone column flips from **No** to **Yes (bridge)**, OP-TEE column flips from **No** to **Yes (client-side)**.
+- [ ] 8.3 Update `CLAUDE.md` "Current state" to note the OP-TEE bridge capability.
+- [ ] 8.4 Add a `docs/op-tee-bridge.md` troubleshooting section covering: `TeeError::NotPresent` on hardware where OP-TEE was expected (probably means the BL32 image isn't built — check the platform vendor's firmware build), shared-memory exhaustion (raise the DTB-reserved size), unknown TA UUID (TA is not loaded by OP-TEE OS — check OP-TEE's TA loading mechanism for the platform).
+
+## 9. Close-out
+
+- [ ] 9.1 Capture a successful round-trip log against the OP-TEE QEMU fixture in the PR description. Format: SMC probe response → session open → invoke result → session close.
+- [ ] 9.2 Run `cargo geiger` on `security/src/tee/`; document any `unsafe` blocks (the SMC inline-asm is the only one expected). Justify each in code comments.
+- [ ] 9.3 Run `cargo clippy --features op-tee -- -D warnings`. Fix or document any warnings.
+- [ ] 9.4 `openspec validate op-tee-bridge-v1` returns valid.
+- [ ] 9.5 PR title: `feat(security/tee): op-tee-bridge-v1 — Normal-World OP-TEE client driver`. Target `develop`.

--- a/openspec/changes/remote-attestation-v1/design.md
+++ b/openspec/changes/remote-attestation-v1/design.md
@@ -1,0 +1,180 @@
+# Design — remote-attestation-v1
+
+## Goal
+
+A verifier-driven, hardware-anchored, hybrid-signed attestation primitive observable as:
+
+1. Verifier on a developer workstation runs `attest-verifier verify --release-record release-0.3.0.json --endpoint https://target:8080/v1/attest`.
+2. Target SmallAIOS instance produces a hybrid quote in < 100 ms.
+3. Verifier validates the inner hardware signature (TPM AK or PSA-IA HUK-derived key), the SmallAIOS counter-signature, the nonce freshness, and the measurement bundle against the expected release record.
+4. Verifier emits `attest-record-2026-05-10T14:23:00Z.cbor` containing the request, response, verification trace, and verifier signature.
+
+## Alternatives considered
+
+### 1. Reuse the EAT (Entity Attestation Token) standard verbatim, no hybrid signing
+
+Rejected. EAT is COSE-based, COSE supports only the classical signature algorithm suite (RSA, ECDSA, EdDSA). SmallAIOS's PQC-default stance requires ML-DSA support, which COSE has draft proposals for but no standard. We use EAT as the *inner* report format on the AArch64 path (PSA-IA is already EAT-shaped); the *outer* envelope is SmallAIOS-defined CBOR carrying the EAT plus the PQC counter-signature. Pure EAT verifiers can still consume the inner report, ignoring the outer counter-sig — degrades gracefully.
+
+### 2. Use TLS client-certificate-based attestation
+
+Considered. Could embed a TPM-backed cert in the TLS handshake, let the verifier check it as part of TLS. Rejected because (a) it limits attestation to TLS-fronted endpoints, no IPC story; (b) the verifier has no nonce control — the TLS-time cert is static, not request-bound; (c) it doesn't carry the measurement log, just identity; (d) PQC-hybrid TLS already exists in SmallAIOS's `net/quic/` — adding attestation as TLS extensions would conflate concerns. Keep attestation as an explicit application-layer protocol.
+
+### 3. Skip the hybrid signing, use TPM / PSA classical only
+
+Rejected. The classical-only path is supported (`PqcMode: "classical-only"` in the request), but the default and the recommendation is hybrid. Reasoning is the same as `boot-root-of-trust-v1`'s hybrid quote: future PQC-only deployments need the counter-sig pre-baked, and the cost of adding it (a few hundred microseconds) is negligible relative to the TPM/PSA round-trip.
+
+### 4. Implement a vendor-specific attestation backend (AWS Nitro NSM, Azure HSM)
+
+Rejected for this change. The cloud vendor attestation services have their own private signatures, key-distribution flows, and (frankly) lock-in concerns. SmallAIOS sticks to the open standards (TPM 2.0, PSA-IA) and lets cloud customers wrap our output in their vendor flow if they want. We don't ship vendor adapters.
+
+### 5. RISC-V backend via Keystone enclave
+
+Considered. Keystone is research-stage as of 2026-05; no production RISC-V hardware ships with Keystone enabled, and the protocol is still in flux. Deferred to a future change once Keystone (or its successor) stabilizes. RISC-V SmallAIOS instances can opt into the SmallAIOS counter-signature half only, marking the hardware half as `null` in the response — verifiers configured for `PqcMode: "pqc-only"` accept it; verifiers requiring classical hardware reject it. The matrix doc update will be explicit about this gap.
+
+## Wire format details
+
+### Report content (`HybridQuote` for TPM2, `EAT-CWT-wrapped` for PSA-IA)
+
+Both backends produce a CBOR structure with the following normalized fields under the outer envelope:
+
+```
+NormalizedReport := CBOR-Map {
+  1: "SmallAIOS-Attest-v1",       // version magic
+  2: Nonce ([u8; 32]),
+  3: Timestamp (uint, monotonic SmallAIOS time),
+  4: MeasurementBundle ({
+       kernel_hash: SHA-3-256,
+       boot_config_hash: SHA-3-256,
+       model_hashes: [SHA-3-256, ...],
+       config_hash: SHA-3-256,
+       counter_pub_digest: SHA-3-256,
+     }),
+  5: HardwareQuote (TpmQuote OR PsaCwt),  // per backend
+  6: HybridSignature (ML-DSA-65 || Ed25519 over fields 1-5),
+}
+```
+
+The verifier checks:
+
+- field 1 magic;
+- field 2 matches its sent nonce;
+- field 5 verifies against the appropriate trust anchor (TPM EK cert chain → AK pub for TPM; PSA-IA spec key → HUK-derived pub for PSA);
+- field 6 verifies against the SmallAIOS counter-signing public key, which is itself measured into the chain (PCR 14 on x86-64, included in the PSA-IA `psa_arg_t` payload on AArch64);
+- field 4 matches the expected release-record bundle for the policy ID.
+
+If all five pass, the verifier emits a PASS audit record. Any failure → FAIL with a documented error code.
+
+### Transport encoding
+
+`AttestRequest` and `AttestResponse` are CBOR over the wire. HTTP/QUIC carry them as `application/cbor`; IPC carries them as opaque byte buffers through the existing capability-call path.
+
+The `AttestRequest`'s `Extensions` field (key 5) is a map of CBOR. Documented extension keys:
+
+- `session_binding_nonce` (`[u8; 32]`): for QUIC channel-binding, lets the verifier prove the attestation is bound to the specific transport session.
+- `policy_max_age_seconds` (uint): if set, the SmallAIOS server rejects the request if the measurement log was sealed (locked from further extends) more than N seconds ago. Defaults to "no age check" if absent.
+
+Unknown extension keys are ignored by the server (forward-compatible).
+
+## Backend selection
+
+```rust
+// security/src/attest/mod.rs
+
+pub enum AttestBackend {
+    #[cfg(feature = "tpm-attest")]    Tpm2(Tpm2Backend),
+    #[cfg(feature = "op-tee")]        PsaIa(PsaIaBackend),
+    SoftwareOnly(SwBackend),  // counter-sig only; verifier policy decides if acceptable
+}
+
+impl AttestBackend {
+    pub fn select() -> Self {
+        #[cfg(feature = "tpm-attest")] {
+            if let Ok(t) = Tpm2Backend::initialize() { return Self::Tpm2(t); }
+        }
+        #[cfg(feature = "op-tee")] {
+            if let Ok(p) = PsaIaBackend::initialize() { return Self::PsaIa(p); }
+        }
+        Self::SoftwareOnly(SwBackend::new())
+    }
+}
+```
+
+Backend selection is a one-time runtime probe at attest-server startup. The selected backend is logged into the boot measurement log so the choice is itself attested.
+
+The `SoftwareOnly` backend produces a report with `HardwareQuote: null`; verifiers configured for `pqc-only` accept it, others reject. This is the RISC-V path and the no-TPM x86-64 path. It is documented as "weakest" tier — useful for development but not for production.
+
+## Verifier crate
+
+Lives at `tools/attest-verifier/`, **outside** the no-std workspace. Uses `std`, `tokio` (for HTTP/QUIC client work), `serde_cbor`, our own clean-room PQC libs from `security/` (re-exported for `std`).
+
+CLI subcommands:
+
+- `verify` — issue a request, validate the response, emit an audit record.
+- `inspect` — pretty-print a saved audit record.
+- `verify-batch` — repeat `verify` against a fleet manifest, emit a per-instance audit record set.
+
+Trust anchor management: the verifier expects a directory layout under `~/.config/smallaios-attest/`:
+
+```
+trust-anchors/
+  tpm-ek-roots/        # PEM-format EK CA certificates from TPM manufacturers
+  psa-ia-pub-keys/     # PSA-IA HUK-derived public keys per Tegra Orin SKU / generation
+  smallaios-counter-pub-keys/  # SmallAIOS Engineering's PQC counter-signing pub keys per release
+release-records/
+  release-0.3.0.json
+  release-0.3.1.json
+  ...
+```
+
+Release-record JSON shape:
+
+```json
+{
+  "version": "0.3.0",
+  "kernel_hash_sha3_256": "...",
+  "boot_config_hash_sha3_256": "...",
+  "model_hashes_sha3_256": ["..."],
+  "config_hash_sha3_256": "...",
+  "counter_pub_digest_sha3_256": "...",
+  "released_at": "2026-04-15T12:00:00Z",
+  "vendor_signature_ml_dsa_65": "..."
+}
+```
+
+The release record is itself signed by SmallAIOS Engineering's release key (covered by `boot-root-of-trust-v1` Phase 4). The verifier checks the record's own signature before using it as ground truth.
+
+## Latency / capacity
+
+| Backend | Latency target | Throughput (single-server) |
+|---------|----------------|----------------------------|
+| TPM 2.0 (x86-64) | < 50 ms p99 | ~20 attests/sec (TPM bottleneck) |
+| PSA-IA (AArch64) | < 100 ms p99 | ~10 attests/sec (TA bottleneck) |
+| SoftwareOnly | < 5 ms p99 | ~200 attests/sec (CPU only) |
+
+The attestation server is not on the inference fast-path. Verifiers poll on the order of once-per-hour-per-instance, not per-request. The throughput targets are deliberately modest — there is no need for thousands of attests/sec.
+
+## Anti-replay
+
+Two layers:
+
+1. **Nonce-driven freshness.** Every request supplies a 32-byte verifier-generated nonce. The response embeds the nonce in the signed report. A replayed response carries a stale nonce, which the verifier detects.
+2. **Server-side anti-replay window** (defense in depth). The attest server keeps a small bloom filter of recently-seen nonces (1-minute window). Repeats are rejected with an `AttestError::ReplayedNonce`. Protects against an attacker replaying a verifier's old request against the same server within the window.
+
+The bloom filter is conservatively sized for ~10k req/min — orders of magnitude above the expected throughput. False positives are acceptable (verifier retries with a fresh nonce).
+
+## Build / CI surface
+
+- New crate-internal module: `security/src/attest/` (Layer 0).
+- New backend modules: `security/src/attest/tpm2_backend.rs` (gated `tpm-attest`), `security/src/attest/psa_ia_backend.rs` (gated `op-tee`).
+- New transport adapter: `container/src/attest_handler.rs` (HTTP/QUIC `POST /v1/attest`).
+- New `std` crate: `tools/attest-verifier/`.
+- New CI job: `attest-verifier-smoke` — boots SmallAIOS with `tpm-attest` (under QEMU+swtpm), runs the verifier against it, asserts PASS. Advisory initially.
+- New docs: `docs/remote-attestation-protocol.md`, `docs/attest-verifier-usage.md`, `docs/release-attestation-records.md`.
+
+## What this change explicitly does NOT do
+
+- Does not change the inference data plane. Attestation is its own endpoint, separate from `/v1/inference`.
+- Does not modify the existing audit log. Attestation records are a separate artifact type emitted by the verifier, not the server.
+- Does not require continuous attestation. One-shot request/response only.
+- Does not require any particular key-distribution infrastructure. Trust anchors are flat-file in this change; PKI integration is a follow-up.
+- Does not implement Veraison / IETF-RATS conformance testing. Wire format follows EAT conventions but isn't certified against RATS reference suites; that's a future activity.

--- a/openspec/changes/remote-attestation-v1/proposal.md
+++ b/openspec/changes/remote-attestation-v1/proposal.md
@@ -1,0 +1,131 @@
+# remote-attestation-v1
+
+## Summary
+
+A SmallAIOS deployment today cannot answer the question "**is the kernel and model bundle that's serving my inference traffic the one I signed?**" to a remote verifier. The local `BootMeasurementLog` is a debug artifact; there is no protocol for a remote client to request a freshness-bound, signature-bound proof of what's running. This change adds a remote attestation surface: a verifier (e.g. an inference-API client, a fleet operator, an auditor) sends a nonce and an attestation policy; the SmallAIOS instance responds with a signed quote covering the kernel hash, the loaded ONNX models, the SmallAIOS configuration, and the verifier-supplied nonce.
+
+Two attestation backends are specified, selected at build time:
+
+- **x86-64 TPM 2.0 backend**, depending on `boot-root-of-trust-v1` Phase 1. The hardware quote is produced via `TPM2_Quote` over PCRs 11-14; the wire format is the `HybridQuote` CBOR defined in that change (TPM-AK-signed bundle + ML-DSA-65 + Ed25519 SmallAIOS counter-signature).
+- **AArch64 PSA Initial Attestation backend**, depending on `op-tee-bridge-v1`. The Arm PSA Initial Attestation API (PSA-IA, PSA-AT 1.0) is implemented as an OP-TEE Trusted Application called via the bridge. The PSA-IA report is a CBOR Web Token (CWT) signed in Secure World with a Hardware-Unique Key derived ECDSA-P256 key; SmallAIOS counter-signs the CWT with ML-DSA-65 + Ed25519 in Normal World to match the PQC-default stance.
+
+Both backends share a **single Normal-World protocol surface** (`AttestRequest` / `AttestResponse` CBOR over the kernel's existing IPC / HTTP / QUIC transports — caller's choice) and a **single verifier library shape** so an off-host verifier accepts either backend's output through one API. The capability `security-attestation` (new) defines the protocol, the report format, the policy semantics, and the verifier-side interfaces.
+
+A reference verifier crate (`smallaios-attest-verifier`, in `tools/attest-verifier/`) ships with the change. It is build-host-side (`std`-using, runs on any developer workstation), produces a human-readable verification result, and integrates with the existing `cargo-vet`-style audit trail story by emitting a signed `attest-record.cbor` per verification (useful for fleet-operator audit logs).
+
+## Why
+
+- **Without remote attestation, "verified boot" is unverifiable in production.** A SmallAIOS instance can know it booted with the expected kernel hash (via `boot-root-of-trust-v1`'s measurement log), but only the instance itself knows. The inference client three hops away on the network has no way to confirm. Remote attestation closes that loop — verifier sends nonce, instance returns signed quote, verifier checks quote against the expected kernel+model+config hash bundle from the release record. This is the standard cloud / fleet pattern (Google's Project Borg, Microsoft's Azure Attestation Service, AWS Nitro Enclaves) that SmallAIOS lacks.
+- **AI inference is a "confidential by intent" workload.** Customers running inference against a model they paid to license, or feeding sensitive inputs to a SmallAIOS-served model, need attestation as a precondition to trusting either the model output or the input handling. The `confidential-compute-v1` change (separate) addresses *memory* confidentiality; this change addresses *identity* confidentiality — even before any hardware confidential-compute is enabled, a customer can verify the inference endpoint is running a known SmallAIOS + known model bundle.
+- **PQC-default is structurally enforced via hybrid signing.** Both backends produce a TPM-side or PSA-side hardware classical signature (RSA-2048 or ECDSA-P256 — whatever the hardware supports) AND a SmallAIOS-counter-signed ML-DSA-65 + Ed25519 hybrid. A verifier can require the PQC half, the classical half, or both, depending on policy. Today's hardware mandates the classical half; tomorrow's deployment can mandate PQC-only without re-spec.
+- **DO-178C DAL A claim: "Field instances are running certified artifacts."** Remote attestation is the cryptographic primitive an auditor uses to *check* that claim across a fleet. The verifier emits a verifiable audit record per-instance per-time-window; the records are themselves signed and storable for compliance retention.
+- **The two backends share 90% of the wire format.** The differentiator is the inner hardware signature (TPM AK vs. PSA HUK-derived key). Both go inside the same outer CBOR envelope with the same SmallAIOS counter-signature, so verifier code is mostly shared. Designing this from the start means the AArch64 backend lands without re-doing the protocol design — only the inner signature changes.
+- **Aligned with industry standards.** The wire format follows IETF RATS (Remote ATtestation procedureS) WG conventions: EAT (Entity Attestation Token, draft-ietf-rats-eat) for the report shape, COSE_Sign1 / COSE_Sign for signature encoding, CBOR throughout. SmallAIOS gets ecosystem-compatible output by default. A standard EAT verifier (e.g. the Veraison project's tooling) can consume the classical half of our reports unmodified.
+
+## What ships
+
+### Protocol surface
+
+```
+AttestRequest := CBOR-Map {
+  1: Nonce ([u8; 32]),                   // verifier-supplied freshness nonce
+  2: PolicyId (string),                   // identifies the expected hash bundle (e.g. "release-0.3.0")
+  3: ReportFormat ("HybridQuote" | "EAT"), // selects wire format
+  4: PqcMode ("hybrid" | "classical-only" | "pqc-only"), // signature requirement
+  5: Extensions (optional CBOR map),      // policy-specific extensions (e.g. session-binding nonce for QUIC)
+}
+
+AttestResponse := CBOR-Map {
+  1: Backend ("tpm2" | "psa-ia"),
+  2: Report (HybridQuote per boot-root-of-trust-v1 OR EAT-CWT per PSA-IA),
+  3: SignatureMode (echoes PqcMode if honored, or error code if request rejected),
+  4: ServerTime (uint),
+  5: SmallAiosVersion (string),
+}
+```
+
+### x86-64 backend (depends on `boot-root-of-trust-v1` Phase 1)
+
+`security/src/attest/tpm2_backend.rs` (new). On request: gather the current `BootMeasurementLog` snapshot, call `produce_hybrid_quote(nonce)` from the dependency change, wrap in `AttestResponse`, return. Latency target: < 50 ms (TPM2_Quote takes ~10-30 ms on modern fTPMs; SmallAIOS counter-signing adds <5 ms for ML-DSA-65).
+
+### AArch64 backend (depends on `op-tee-bridge-v1`)
+
+`security/src/attest/psa_ia_backend.rs` (new). The PSA-IA Trusted Application UUID is `f0b13b9b-8b8a-4f57-9b95-79c83e3b09cd` (defined by Arm's PSA test suite reference TA, ships with upstream OP-TEE OS). On request:
+
+1. Compute the SmallAIOS-side measurement bundle (kernel hash + model hashes + config hash, all SHA-3-256) — same shape as the TPM-backend bundle, just without PCR encoding.
+2. Open a session to the PSA-IA TA via the OP-TEE bridge.
+3. Invoke `PSA_INITIAL_ATTEST_GET_TOKEN` with the verifier-supplied nonce and the SmallAIOS-side measurement bundle as the `psa_arg_t` payload.
+4. Receive the PSA EAT-CWT (a CBOR Web Token signed in Secure World by an HUK-derived ECDSA-P256 key).
+5. ML-DSA-65 + Ed25519 counter-sign the CWT bundle.
+6. Wrap and return as `AttestResponse` with `Backend = "psa-ia"`.
+
+Latency target: < 100 ms (OP-TEE round-trip + PSA-IA TA work + SmallAIOS counter-sign). The TA-side work is the dominant term.
+
+### Wire transports
+
+The attestation surface is transport-agnostic. SmallAIOS exposes it over:
+
+- **HTTP**: `POST /v1/attest` with `Content-Type: application/cbor` (existing HTTP server in `container/`).
+- **QUIC / HTTP3**: same endpoint, leveraging the existing QUIC stack in `net/quic/`.
+- **IPC**: an `Attest` capability call for in-host verifiers (e.g. a sidecar workload audit agent).
+
+Each transport carries the same `AttestRequest` / `AttestResponse` CBOR. The transport layer enforces TLS / QUIC PQC-hybrid where it's already enforced for other endpoints — no new transport security work.
+
+### Reference verifier
+
+`tools/attest-verifier/` (new crate, `std`-using, build-host-only — not part of the kernel workspace). Capabilities:
+
+- `attest-verifier verify --release-record release-0.3.0.json --endpoint https://host:8080/v1/attest --pqc-mode hybrid` — issues an attestation request, verifies the response, prints human-readable pass/fail, emits `attest-record-<timestamp>.cbor` as the audit trail entry.
+- `attest-verifier inspect <attest-record.cbor>` — pretty-prints a previously-saved record for offline audit.
+- Verifier-side trust anchor management: keeps a directory of TPM EK CA roots (Intel/AMD/Infineon/STM…), PSA HUK-derivation public keys, and SmallAIOS counter-signing public keys. Verifies each layer.
+
+### Documentation
+
+- `docs/remote-attestation-protocol.md` — wire format spec, policy semantics, verifier integration guide.
+- `docs/attest-verifier-usage.md` — operator-side how-to.
+- `docs/release-attestation-records.md` — release-engineering side: how to publish a `release-X.Y.Z.json` hash bundle, how it ties to `boot-root-of-trust-v1` Phase 4 signing.
+
+## Out of scope
+
+- **RISC-V backend.** Defer — no widely-deployed RISC-V hardware attestation primitive exists (Keystone / Penglai are research-stage, not production). RISC-V instances can opt into the *software-counter-signature half* of the protocol only; classical-half is `null`. Documented as a known limitation in the matrix doc update.
+- **Continuous / streaming attestation.** Each `AttestRequest` is one-shot, request/response. Streaming "attestation events" (per-cap-flip, per-model-load) is a future enhancement; the existing audit log handles this surface for now.
+- **Attestation-bound key release.** Some confidential-compute models bind decryption keys to attestation results (verifier checks attest, then unwraps a workload-supplied key). That's `confidential-compute-v1` territory. This change ships the verifier-side primitive; the key-release flow is built on top.
+- **Decentralized / on-chain attestation records.** Audit records are local files; bridging to Sigstore / on-chain transparency logs is out of scope.
+- **Vendor-specific attestation services (e.g. AWS Nitro NSM, Azure HSM).** SmallAIOS supports the *standard* TPM 2.0 and PSA-IA interfaces; cloud-vendor wrappers can adapt by speaking those standards through their own glue layers.
+
+## Sequencing
+
+This change has two phases internally, mapped to the dependencies:
+
+- **Sub-phase A: protocol design + x86-64 TPM backend + reference verifier** — lands once `boot-root-of-trust-v1` Phase 1 is merged. ~2-3 weeks.
+- **Sub-phase B: AArch64 PSA-IA backend** — lands once `op-tee-bridge-v1` is merged. ~2 weeks.
+
+A and B can land as separate PRs against this single OpenSpec change, or as a single PR if the dependencies are sequenced tightly. The protocol surface is defined in A; B is a backend addition with no protocol design surface.
+
+If schedule pressure forces a split, Sub-phase A alone is a complete, useful deliverable for x86-64 deployments — it covers the largest production deployment surface (cloud / datacenter x86-64). Sub-phase B is the followup that extends coverage to ARM datacenter and embedded.
+
+## Effort estimate
+
+| Sub-phase | Scope | Estimate |
+|-----------|-------|----------|
+| A | Protocol + CBOR + TPM2 backend wiring + transport bindings + verifier | ~2-3 weeks |
+| B | PSA-IA TA invocation + CWT counter-signing + backend wiring | ~2 weeks |
+| **Total** | | **~4-5 weeks** (after dependencies merge) |
+
+## Dependencies
+
+- `boot-root-of-trust-v1` Phase 1 (TPM 2.0 driver + `HybridQuote` format) — hard dependency for sub-phase A.
+- `op-tee-bridge-v1` — hard dependency for sub-phase B.
+- No dependency between A and B; they can land in either order once their respective dependencies are in.
+
+## DO-178C alignment
+
+Remote attestation gives DAL A its **field verification primitive**: the auditor's standing question "are the instances in the field running the certified binary?" gets a cryptographic answer per-instance per-poll, with a signed audit record for retention. The verifier-emitted `attest-record-<timestamp>.cbor` is the artifact that fits into the certification evidence chain.
+
+Specifically, the certification claim **"the kernel binary serving inference for tenant T at time T1 is artifact X.Y.Z signed by SmallAIOS Engineering"** is provable by combining:
+
+1. The hybrid quote covering PCR 11 (kernel hash) signed by the TPM AK + SmallAIOS counter-sig.
+2. The release record mapping kernel hash → release version X.Y.Z + Engineering signature.
+3. The freshness nonce in (1) proving the quote was produced at time T1.
+
+All three are CBOR documents, all three are signed, all three are storable for the certification retention period (10+ years for DAL A). The verifier crate emits them in a single bundle per verification.

--- a/openspec/changes/remote-attestation-v1/specs/security-attestation/spec.md
+++ b/openspec/changes/remote-attestation-v1/specs/security-attestation/spec.md
@@ -1,0 +1,146 @@
+## ADDED Requirements
+
+### Requirement: Remote attestation protocol surface
+
+The `smallaios-security` crate SHALL provide a remote attestation protocol producing hybrid-signed, nonce-bound, measurement-bundle reports verifiable by an off-host verifier. The protocol SHALL be transport-agnostic and SHALL be exposed over HTTP, QUIC/HTTP3, and capability-gated IPC.
+
+#### Scenario: AttestRequest / AttestResponse CBOR shape
+
+- **GIVEN** a verifier posting `application/cbor` to `POST /v1/attest`
+- **WHEN** the request body is a CBOR map matching the documented `AttestRequest` shape (Nonce, PolicyId, ReportFormat, PqcMode, optional Extensions)
+- **THEN** the server SHALL respond with a CBOR map matching the documented `AttestResponse` shape (Backend, Report, SignatureMode, ServerTime, SmallAiosVersion)
+- **AND** the response Content-Type SHALL be `application/cbor`
+- **AND** both shapes SHALL be documented in `docs/remote-attestation-protocol.md` with their full CBOR schema
+
+#### Scenario: Three transports carry the same payload
+
+- **GIVEN** a verifier with HTTP, QUIC/HTTP3, and IPC clients
+- **WHEN** the same `AttestRequest` bytes are sent over each transport
+- **THEN** the resulting `AttestResponse` bytes SHALL be byte-identical (the wire payload is transport-independent)
+- **AND** the IPC variant SHALL require the caller to hold an `Attest` capability granted via `security::capability`
+
+#### Scenario: Anti-replay bloom filter rejects nonce reuse within the window
+
+- **GIVEN** a server that has handled an attestation request with nonce N within the last 60 seconds
+- **WHEN** a second request arrives with the same nonce N
+- **THEN** the server SHALL respond with `AttestResponse { Backend: …, Report: null, SignatureMode: "error", error: "ReplayedNonce" }` (or an equivalent CBOR error envelope)
+- **AND** the server SHALL log the rejection with the source transport (HTTP/QUIC/IPC) and timestamp for audit
+
+### Requirement: x86-64 TPM 2.0 backend
+
+When built with `--features tpm-attest` on x86-64, the attestation server SHALL produce a hardware-rooted report using the `HybridQuote` format defined in `boot-root-of-trust-v1`.
+
+#### Scenario: Round-trip with hybrid mode
+
+- **GIVEN** an x86-64 SmallAIOS instance with `tpm-attest` enabled, a TPM 2.0 device present, and PCRs 11-14 extended per `boot-root-of-trust-v1`
+- **WHEN** a verifier sends `AttestRequest { Nonce: N, PolicyId: "release-0.3.0", ReportFormat: "HybridQuote", PqcMode: "hybrid" }`
+- **THEN** the server SHALL produce a `HybridQuote` containing the TPM2_Quote over PCRs 11-14 (with N as the qualifying nonce), the BootMeasurementLog entries, the ML-DSA-65 + Ed25519 counter-signature, the counter-public-key digest, the nonce, and the server timestamp
+- **AND** the response SHALL be wrapped in `AttestResponse { Backend: "tpm2", Report: <HybridQuote>, SignatureMode: "hybrid", ServerTime: <t>, SmallAiosVersion: <ver> }`
+- **AND** end-to-end latency from request receipt to response send SHALL be < 50 ms p99 under nominal load
+
+#### Scenario: PqcMode mode selection honored
+
+- **GIVEN** the same instance
+- **WHEN** the verifier requests `PqcMode: "classical-only"`
+- **THEN** the response SHALL include the TPM-side signature but SHALL omit the ML-DSA-65 + Ed25519 counter-signature (or include it as `null`)
+- **AND** `SignatureMode` SHALL echo `"classical-only"` so the verifier knows the omission was honored
+
+- **GIVEN** the same instance
+- **WHEN** the verifier requests `PqcMode: "pqc-only"`
+- **THEN** the response SHALL include the counter-signature but SHALL omit the TPM-side raw signature bytes (still including the PCR digest the TPM signed, since that's the measurement, not the signature)
+- **AND** `SignatureMode` SHALL echo `"pqc-only"`
+
+#### Scenario: Verifier validates all four layers
+
+- **GIVEN** a captured `AttestResponse` from the TPM2 backend
+- **WHEN** `attest-verifier verify --release-record release-0.3.0.json --pqc-mode hybrid` validates the response
+- **THEN** the verifier SHALL check (a) the TPM AK signature against the TPM EK CA root, (b) the SmallAIOS counter-signature against the configured counter-public-key, (c) the nonce matches the originally-sent nonce, (d) the measurement bundle matches the release record's expected hashes
+- **AND** all four checks SHALL succeed for a valid response
+- **AND** any one failing check SHALL cause the verifier to report FAIL with a documented error code
+
+### Requirement: AArch64 PSA-IA backend
+
+When built with `--features op-tee` on AArch64 and the PSA-IA Trusted Application is loadable, the attestation server SHALL produce a hardware-rooted report using the PSA Initial Attestation API (EAT-CWT format) wrapped with a SmallAIOS counter-signature.
+
+#### Scenario: PSA-IA TA invocation via OP-TEE bridge
+
+- **GIVEN** an AArch64 SmallAIOS instance with the OP-TEE bridge available and the PSA-IA TA (UUID `f0b13b9b-8b8a-4f57-9b95-79c83e3b09cd`) loaded
+- **WHEN** the attestation server initializes
+- **THEN** the server SHALL open a long-lived OP-TEE session to the PSA-IA TA
+- **AND** the boot measurement log SHALL record `AttestBackend::PsaIa { ta_uuid: …, op_tee_version: … }`
+
+#### Scenario: EAT-CWT round-trip with hybrid counter-signature
+
+- **GIVEN** an active PSA-IA session and a verifier-supplied nonce N
+- **WHEN** the server invokes `PSA_INITIAL_ATTEST_GET_TOKEN` with N + the SmallAIOS measurement bundle
+- **THEN** the server SHALL receive an EAT-CWT signed by an HUK-derived ECDSA-P256 key in Secure World
+- **AND** the server SHALL ML-DSA-65 + Ed25519 counter-sign (CWT || measurement_bundle || nonce || timestamp)
+- **AND** the response SHALL be wrapped in `AttestResponse { Backend: "psa-ia", Report: <EAT-CWT-with-counter-sig-envelope>, SignatureMode: "hybrid", … }`
+- **AND** end-to-end latency from request receipt to response send SHALL be < 100 ms p99 under nominal load
+
+#### Scenario: TA failure causes session re-open, not server crash
+
+- **GIVEN** a long-lived PSA-IA session that returns an error mid-request (e.g. OP-TEE-side reset)
+- **WHEN** the server detects the failure
+- **THEN** the server SHALL close and re-open the session
+- **AND** the affected request SHALL fail with `AttestError::BackendUnavailable` (the verifier retries with a fresh nonce)
+- **AND** subsequent requests SHALL succeed against the new session
+
+### Requirement: SoftwareOnly fallback backend
+
+When no hardware backend is available (no TPM on x86-64, no PSA-IA TA on AArch64, RISC-V build), the attestation server SHALL produce a report with the ML-DSA-65 + Ed25519 counter-signature only, with the hardware-quote field set to null.
+
+#### Scenario: SoftwareOnly response is valid but weakest tier
+
+- **GIVEN** a SmallAIOS instance with no hardware attestation backend
+- **WHEN** a verifier sends an `AttestRequest`
+- **THEN** the response SHALL be `AttestResponse { Backend: "software-only", Report: { HardwareQuote: null, … }, SignatureMode: "pqc-only-fallback", … }`
+- **AND** the verifier SHALL accept the response only if it is configured with `--allow-software-only` or `PqcMode: "pqc-only"`
+- **AND** the verifier SHALL emit an audit record explicitly marking the verification as "software-only — weakest tier" so downstream auditors see the policy decision
+
+### Requirement: Reference verifier crate
+
+The repository SHALL provide a `tools/attest-verifier/` crate (std + tokio) implementing the verifier side of the protocol, with `verify`, `inspect`, and `verify-batch` subcommands.
+
+#### Scenario: Verify subcommand emits an audit record per verification
+
+- **GIVEN** a developer running `attest-verifier verify --release-record release-0.3.0.json --endpoint https://target:8080/v1/attest --pqc-mode hybrid`
+- **WHEN** the verification succeeds
+- **THEN** the tool SHALL print human-readable PASS output
+- **AND** the tool SHALL write `attest-record-<rfc3339-timestamp>.cbor` to the current working directory (or a `--output-dir`-specified location)
+- **AND** the audit record SHALL contain the request, the response, the verification trace (which checks passed/failed), the verifier's local time, and the verifier's own signature over the record
+
+#### Scenario: Verify-batch handles a fleet
+
+- **GIVEN** a fleet manifest listing N endpoints with their expected policy IDs
+- **WHEN** `attest-verifier verify-batch --manifest fleet.toml` runs
+- **THEN** the tool SHALL attempt to verify each endpoint in parallel (bounded by a `--concurrency` flag, default 8)
+- **AND** the tool SHALL emit one audit record per endpoint into `--output-dir/`
+- **AND** the tool SHALL exit with code 0 if all endpoints verify, or 1 if any fails (with a summary line listing failures)
+
+#### Scenario: Trust anchor layout is documented
+
+- **THEN** the verifier SHALL read trust anchors from `~/.config/smallaios-attest/trust-anchors/`:
+  - `tpm-ek-roots/` for TPM EK CA certificates
+  - `psa-ia-pub-keys/` for PSA-IA HUK-derived public keys
+  - `smallaios-counter-pub-keys/` for SmallAIOS Engineering's PQC counter-signing pub keys
+- **AND** the layout SHALL be documented in `docs/attest-verifier-usage.md`
+- **AND** the `--trust-anchor-dir` flag SHALL allow overriding the default location
+
+### Requirement: Release records as verifier ground truth
+
+A SmallAIOS release SHALL publish a signed `release-X.Y.Z.json` record listing the canonical kernel hash, boot-config hash, model hashes, and config hash for that release. The verifier consults the record to determine the expected measurement bundle for a `PolicyId`.
+
+#### Scenario: Release record JSON shape
+
+- **THEN** a release record SHALL contain `version`, `kernel_hash_sha3_256`, `boot_config_hash_sha3_256`, `model_hashes_sha3_256` (array), `config_hash_sha3_256`, `counter_pub_digest_sha3_256`, `released_at` (RFC 3339), `vendor_signature_ml_dsa_65` (the SmallAIOS Engineering release-signing key's signature over the preceding fields)
+- **AND** the shape SHALL be documented in `docs/release-attestation-records.md`
+- **AND** the release pipeline (`just release` plus `boot-root-of-trust-v1` Phase 4 signing) SHALL produce one record per tagged release
+
+#### Scenario: Verifier validates the record's own signature
+
+- **GIVEN** a release record loaded by `attest-verifier verify`
+- **WHEN** the verifier reads the file
+- **THEN** the verifier SHALL first validate `vendor_signature_ml_dsa_65` against the SmallAIOS Engineering release-signing pub key
+- **AND** if the record's own signature fails, the verifier SHALL print "Record signature invalid; refusing to trust as ground truth" and exit with code 3 (record-untrusted)
+- **AND** only after the record's signature passes SHALL the verifier compare the measurement bundle from the attest response against the record's hashes

--- a/openspec/changes/remote-attestation-v1/tasks.md
+++ b/openspec/changes/remote-attestation-v1/tasks.md
@@ -1,0 +1,109 @@
+# Tasks — remote-attestation-v1
+
+## 0. Prerequisites
+
+- [ ] 0.1 Confirm `boot-root-of-trust-v1` Phase 1 has merged and the `HybridQuote` CBOR format is stable. Pin to the develop SHA at the start of Sub-phase A; rebase if the format moves.
+- [ ] 0.2 Confirm `op-tee-bridge-v1` has merged and the GP TEE Client API surface is stable. Pin to develop SHA at start of Sub-phase B.
+- [ ] 0.3 Confirm the upstream OP-TEE PSA-IA TA UUID (`f0b13b9b-8b8a-4f57-9b95-79c83e3b09cd`) is loadable on the Tegra Orin reference firmware. If not, document the alternative (custom-built PSA-IA TA per the Trusted Firmware-M reference) in design.md.
+- [ ] 0.4 Pin the EAT (Entity Attestation Token) draft version we target — currently `draft-ietf-rats-eat-25`. Re-pin if a newer draft alters wire format incompatibly.
+
+## 1. Sub-phase A — Protocol + x86-64 TPM backend
+
+### 1a. Protocol module
+
+- [ ] 1.1 Create `security/src/attest/mod.rs` exposing `AttestBackend`, `AttestRequest`, `AttestResponse`, `AttestError`. Public types are `no_std`-friendly CBOR-derive structs.
+- [ ] 1.2 Define `NormalizedReport` CBOR structure per design.md.
+- [ ] 1.3 Implement `AttestBackend::select()` probe: try TPM2 first, then PSA-IA, then SoftwareOnly fallback.
+- [ ] 1.4 Log the selected backend into `BootMeasurementLog` so the choice is itself attested.
+
+### 1b. TPM 2.0 backend wiring
+
+- [ ] 1.5 Create `security/src/attest/tpm2_backend.rs` gated `cfg(feature = "tpm-attest")`. Initialization: probe `boot-root-of-trust-v1`'s TPM driver, fail with `AttestError::TpmAbsent` if not available.
+- [ ] 1.6 Implement `Tpm2Backend::handle_request(req: &AttestRequest) -> Result<AttestResponse>`:
+  - validate nonce length;
+  - call `produce_hybrid_quote(req.nonce)` from `boot-root-of-trust-v1`;
+  - wrap in `NormalizedReport` shape, emit as `AttestResponse`.
+- [ ] 1.7 Honor `PqcMode`: if `classical-only`, omit the ML-DSA-65 + Ed25519 counter-sig from the response (still compute it but mark omitted); if `pqc-only`, omit the TPM quote (but include its measurement). If `hybrid`, include both.
+- [ ] 1.8 Enforce server-side anti-replay bloom filter (1-minute window, sized for 10k req/min).
+
+### 1c. SoftwareOnly backend
+
+- [ ] 1.9 Create `security/src/attest/sw_backend.rs` (no feature gate — always available as a fallback).
+- [ ] 1.10 Implement `SwBackend::handle_request`: assembles the measurement bundle from `BootMeasurementLog`, signs with ML-DSA-65 + Ed25519 counter-sig only, emits with `HardwareQuote: null`.
+- [ ] 1.11 Document this is the weakest tier — verifier policies should explicitly opt-in to accept SoftwareOnly responses.
+
+### 1d. Transport adapters
+
+- [ ] 1.12 Add `POST /v1/attest` route to the existing container HTTP server (`container/src/main.rs` or equivalent). Content-Type `application/cbor`, body is `AttestRequest`, response is `AttestResponse`.
+- [ ] 1.13 Add the same route on the QUIC/HTTP3 side (existing `net/quic/` server).
+- [ ] 1.14 Add an `Attest` capability call for in-host IPC verifiers. Defined in `security/src/capability.rs`, requires explicit cap-grant.
+- [ ] 1.15 Document the three transports in `docs/remote-attestation-protocol.md`.
+
+### 1e. Reference verifier crate
+
+- [ ] 1.16 Create `tools/attest-verifier/Cargo.toml` and `tools/attest-verifier/src/main.rs`. `std` + `tokio` based, build-host-only.
+- [ ] 1.17 Implement `verify` subcommand: load release record, generate nonce, build request, POST to endpoint, parse response, verify all four layers (hardware sig, counter-sig, nonce, measurement match), emit audit record.
+- [ ] 1.18 Implement `inspect` subcommand: pretty-print a saved `attest-record-*.cbor`.
+- [ ] 1.19 Implement `verify-batch` subcommand: take a fleet manifest (list of endpoints), verify each, emit per-instance records.
+- [ ] 1.20 Define trust-anchor directory layout (`~/.config/smallaios-attest/`), implement loader.
+- [ ] 1.21 Document the release-record JSON shape and how it's produced/signed in `docs/release-attestation-records.md`.
+
+### 1f. CI smoke (x86-64 + swtpm)
+
+- [ ] 1.22 Add `attest-tpm2-swtpm-smoke` CI job: boots kernel under QEMU + swtpm (re-uses the fixture from `boot-root-of-trust-v1`'s Phase 1 CI), runs `attest-verifier verify` against the booted instance, asserts PASS.
+- [ ] 1.23 Same job tests `PqcMode: "classical-only"` and `PqcMode: "hybrid"` separately. `pqc-only` returns ECDSA-AK signature omitted but PCR digest still bound via the counter-sig — verify the verifier accepts it.
+- [ ] 1.24 Advisory at land. Promote to gate after one stable week.
+
+### 1g. Sub-phase A close-out
+
+- [ ] 1.25 Update `docs/boot-security-matrix.md`: add a new row "Remote attestation" with **Yes (TPM2 + counter-sig)** for x86-64, **Yes (PSA-IA + counter-sig)** for AArch64 (pending Sub-phase B), **Software-only counter-sig** for RISC-V.
+- [ ] 1.26 Update `CLAUDE.md` "Current state" with the attestation capability.
+- [ ] 1.27 PR title: `feat(security/attest): remote-attestation-v1 sub-phase A — protocol + x86-64 TPM backend`. Target `develop`.
+
+## 2. Sub-phase B — AArch64 PSA-IA backend
+
+### 2a. PSA-IA TA invocation
+
+- [ ] 2.1 Create `security/src/attest/psa_ia_backend.rs` gated `cfg(feature = "op-tee")`. Initialization: open a session to the PSA-IA TA via the `op-tee-bridge-v1` bridge.
+- [ ] 2.2 Implement `PsaIaBackend::handle_request`:
+  - assemble the SmallAIOS-side measurement bundle (SHA-3-256 of kernel + boot config + each model + config);
+  - open session to PSA-IA TA UUID `f0b13b9b-8b8a-4f57-9b95-79c83e3b09cd`;
+  - invoke `PSA_INITIAL_ATTEST_GET_TOKEN` with the verifier nonce + measurement bundle as the `psa_arg_t`;
+  - receive the EAT-CWT;
+  - ML-DSA-65 + Ed25519 counter-sign the CWT and the measurement bundle;
+  - wrap as `AttestResponse` with `Backend = "psa-ia"`.
+- [ ] 2.3 Cache the session across requests (avoid the ~10ms open-session cost per request); reopen on TA-side errors.
+- [ ] 2.4 Honor `PqcMode` (same semantics as TPM2 backend).
+- [ ] 2.5 Enforce server-side anti-replay bloom filter (shared with the TPM2 backend, one bloom per server).
+
+### 2b. Verifier crate updates
+
+- [ ] 2.6 Extend verifier to accept `Backend: "psa-ia"` responses. Verify the inner EAT-CWT signature against the PSA-IA HUK-derived public key (loaded from `~/.config/smallaios-attest/trust-anchors/psa-ia-pub-keys/`).
+- [ ] 2.7 Add PSA-IA HUK-derived public-key loading documentation to `docs/attest-verifier-usage.md`. The keys come from Arm's PSA test suite reference TA or from per-SoC Arm-provided publications.
+- [ ] 2.8 Add `--backend-hint psa-ia` flag for verifier-side testing against AArch64 endpoints.
+
+### 2c. CI smoke (AArch64 + OP-TEE + PSA-IA)
+
+- [ ] 2.9 Add `attest-psa-ia-qemu-smoke` CI job: re-uses the `op-tee-qemu-smoke` fixture from `op-tee-bridge-v1`, boots SmallAIOS with `--features op-tee` as BL33, runs `attest-verifier verify` against the booted AArch64 instance, asserts PASS.
+- [ ] 2.10 Verify the PSA-IA TA UUID resolves and the CWT round-trip works against the upstream OP-TEE PSA-IA TA.
+- [ ] 2.11 Advisory at land; promote with the same one-stable-week rule.
+
+### 2d. Sub-phase B close-out
+
+- [ ] 2.12 Update `docs/boot-security-matrix.md` AArch64 row: "Remote attestation" cell drops "(pending Sub-phase B)" and is finalized.
+- [ ] 2.13 PR title: `feat(security/attest): remote-attestation-v1 sub-phase B — AArch64 PSA-IA backend`. Target `develop`.
+
+## 3. Cross-phase verification
+
+- [ ] 3.1 Cross-platform: verifier runs against a fleet manifest with mixed x86-64-TPM, AArch64-PSA-IA, and RISC-V-software-only endpoints, emits per-instance records, all valid per their respective policy modes.
+- [ ] 3.2 Negative test: tamper with the kernel hash on the server, verifier reports FAIL with `MeasurementMismatch`.
+- [ ] 3.3 Negative test: send a stale nonce (re-use one), verifier reports FAIL with `NonceMismatch` (when checking client-side) AND server reports `ReplayedNonce` (when re-issued within the window).
+- [ ] 3.4 Negative test: `PqcMode: "pqc-only"` against a verifier configured for `PqcMode: "classical-only"` (mode mismatch on the verifier side, not the server). Verifier reports FAIL with `SignatureModeMismatch`.
+- [ ] 3.5 `openspec validate remote-attestation-v1` returns valid.
+
+## 4. Docs
+
+- [ ] 4.1 `docs/remote-attestation-protocol.md`: wire format spec (CBOR schema for `AttestRequest`, `AttestResponse`, `NormalizedReport`), policy semantics, transport bindings, error codes.
+- [ ] 4.2 `docs/attest-verifier-usage.md`: operator-side how-to, trust anchor management, fleet-manifest format, audit record retention guidance.
+- [ ] 4.3 `docs/release-attestation-records.md`: release-engineering side, how to publish a `release-X.Y.Z.json`, how it ties to `boot-root-of-trust-v1` Phase 4 signing.
+- [ ] 4.4 Update `CLAUDE.md` "Container Environment Variables" section if any attestation-related env vars are added (e.g. `SMALLAIOS_ATTEST_PORT`).


### PR DESCRIPTION
## Summary

Documentation-only proposal of four sequenced OpenSpec changes that close the platform-side gaps in [`docs/boot-security-matrix.md`](../blob/develop/docs/boot-security-matrix.md) — TPM 2.0 / TF-A / PMP, OP-TEE bridging, remote attestation, and hardware-rooted confidential compute. No Rust code changes.

## Changes

- **[`boot-root-of-trust-v1`](openspec/changes/boot-root-of-trust-v1/proposal.md)** — 6-8 weeks across 4 phases. Phase 1: clean-room TPM 2.0 driver (TIS + CRB) extending today's software-only `BootMeasurementLog` into hardware PCRs 11-14 on x86-64. Phase 2: TF-A BL31 event-log consumption on AArch64 (Tegra Orin first, via DTB `/reserved-memory/tf-a-event-log` — also closes the DTB-parser gap from `unikernel-orin-bringup-v1` task 2.12). Phase 3: best-effort RISC-V PMP request via SBI vendor extension. Phase 4: signed UEFI kernel image with ML-DSA-65 + Ed25519 PQC counter-signature.
- **[`op-tee-bridge-v1`](openspec/changes/op-tee-bridge-v1/proposal.md)** — 3-4 weeks. Normal-World OP-TEE client implementing the GP TEE Client API subset SmallAIOS needs, on top of a small `arch/aarch64/src/smc.rs` Arm DEN 0028C dispatcher. New `op-tee` Cargo feature defaulting OFF so non-AArch64 / non-OP-TEE builds carry zero cost. Speaks the standard OP-TEE SMC ABI against unmodified upstream OP-TEE OS — no Secure World code ships.
- **[`remote-attestation-v1`](openspec/changes/remote-attestation-v1/proposal.md)** — 4-5 weeks across 2 sub-phases. Unified transport-agnostic (HTTP / QUIC / IPC) CBOR protocol with three backends: x86-64 TPM 2.0 (Sub-phase A, depends on `boot-root-of-trust-v1` Phase 1), AArch64 PSA Initial Attestation TA via OP-TEE (Sub-phase B, depends on `op-tee-bridge-v1`), and a SoftwareOnly counter-sig-only fallback for RISC-V. Hybrid PQC mode is the default; `classical-only` / `pqc-only` modes are selectable per-policy. Ships a reference `tools/attest-verifier/` crate emitting signed per-verification audit records.
- **[`confidential-compute-v1`](openspec/changes/confidential-compute-v1/proposal.md)** — 12-16 weeks for Phase 1; 28-36 weeks total. Phase 1: ARM CCA Realm bring-up using `tf-rmm` (production silicon 2026 on Neoverse). Phase 2: Intel TDX. Phase 3: AMD SEV-SNP. Cross-platform abstraction layer (`SealedRegion`, `AttestableEnclave`, `SharedWindow`) designed in Phase 1 transfers to Phases 2/3. Threat model (`docs/confidential-compute-threat-model.md`) is a required Phase 1 design output, independently reviewed.

## Sequencing

```
boot-root-of-trust-v1 Phase 1 (TPM 2.0, x86-64)
    │
    ├─► remote-attestation-v1 Sub-phase A (x86-64 TPM backend)
    │
op-tee-bridge-v1
    │
    ├─► remote-attestation-v1 Sub-phase B (AArch64 PSA-IA backend)
    │
    ├─► boot-root-of-trust-v1 Phase 2 (TF-A event log, AArch64)
    │
    └─► confidential-compute-v1 Phase 1 (ARM CCA, reuses SMC infrastructure)
            │
            └─► Phase 2 (Intel TDX) + Phase 3 (AMD SEV-SNP), independent
```

- `boot-root-of-trust-v1` Phase 1 lands first (no dependencies).
- `op-tee-bridge-v1` lands in parallel with Phase 1 (no shared code surface).
- `remote-attestation-v1` Sub-phase A lands after Phase 1; Sub-phase B lands after `op-tee-bridge-v1`.
- `boot-root-of-trust-v1` Phase 2 (TF-A on AArch64) lands in parallel with `remote-attestation-v1` Sub-phase B.
- `confidential-compute-v1` Phase 1 (CCA) lands after `op-tee-bridge-v1` + `remote-attestation-v1` Sub-phase A. Phases 2 (TDX) and 3 (SEV-SNP) run independently after Phase 1's abstractions land.

## Cross-cutting design decisions

1. **PQC-default through hybrid signing.** Every attestation report has a hardware classical signature (TPM AK / PSA-IA HUK-derived / CCA RAT / TDX TD Report / SNP report) PLUS an ML-DSA-65 + Ed25519 SmallAIOS counter-signature. Verifier policy selects required signature mode. Today's hardware mandates the classical half; tomorrow's PQC-only deployment is supported without protocol re-spec.
2. **Single verifier crate across all backends.** `tools/attest-verifier/` accepts CCA / TDX / SNP / TPM2 / PSA-IA / software-only responses transparently via the `AttestResponse::Backend` tag and a per-backend trust-anchor directory layout.
3. **Cross-platform abstraction in confidential-compute.** `SealedRegion` / `AttestableEnclave` / `SharedWindow` traits designed in `confidential-compute-v1` Phase 1 (CCA) are reused by Phases 2 (TDX) and 3 (SNP) — porting is platform-glue work, not redesign.
4. **DO-178C DAL A traceability.** Each proposal calls out the specific certification claim it supports — boot integrity, field verification, isolation — with the cryptographic artifact (signed quote, attestation token, audit record) that serves as the evidence.
5. **Graceful fallbacks everywhere.** Missing TPM, missing OP-TEE, missing CCA hardware → typed `Err(...NotPresent)` returns, not panics. Builds without the relevant feature flag are byte-identical to today's behavior — every change is purely additive.
6. **Clean-room implementations.** No `tpm2-tss`, no Linux `optee_armtz` port, no GPL bring-in. `cargo-vet` audit surface stays clean.

## Test plan

- [ ] `openspec validate boot-root-of-trust-v1` — passes (confirmed locally).
- [ ] `openspec validate op-tee-bridge-v1` — passes (confirmed locally).
- [ ] `openspec validate remote-attestation-v1` — passes (confirmed locally).
- [ ] `openspec validate confidential-compute-v1` — passes (confirmed locally).
- [ ] `openspec list` shows all four new changes alongside the existing `unikernel-orin-bringup-v1`.
- [ ] Reviewer-sign-off per change on proposal narrative + design rationale + task breakdown + spec scenarios.
- [ ] Confirm the PQC-hybrid stance is consistent across the four changes.
- [ ] Confirm the dependency arrows match the documented sequencing.
- [ ] Confirm DO-178C DAL A claim coverage is plausible per proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)