### PR TITLE
refactor(onnx-rt): reduce cognitive complexity below 15 in ops/shape_data + ops/reduction + ops/math + sub_executor

### DIFF
--- a/onnx-rt/src/ops/math.rs
+++ b/onnx-rt/src/ops/math.rs
@@ -73,6 +73,48 @@ pub(crate) fn erf_approx(x: f32) -> f32 {
 // Public operators
 // ---------------------------------------------------------------------------
 
+/// Computes `b ^ e` for the special case where `b == 0`, matching the
+/// behavior expected by ONNX Pow: `0^0 = 1`, `0^neg = +inf`, `0^pos = 0`.
+fn pow_zero_base(e: f32) -> f32 {
+    if e == 0.0 {
+        1.0
+    } else if e < 0.0 {
+        f32::INFINITY
+    } else {
+        0.0
+    }
+}
+
+/// Computes `b ^ e` for negative `b`, supporting only integer exponents.
+/// Non-integer exponents on a negative base return NaN.
+fn pow_negative_base(b: f32, e: f32) -> f32 {
+    let e_int = e as i32;
+    if (e_int as f32 - e).abs() >= 1e-6 {
+        return f32::NAN;
+    }
+    let mut p = 1.0_f32;
+    let n = e_int.unsigned_abs();
+    for _ in 0..n {
+        p *= b;
+    }
+    if e_int < 0 {
+        1.0 / p
+    } else {
+        p
+    }
+}
+
+/// Computes a single element-wise `pow(b, e)` matching ONNX semantics.
+fn pow_one(b: f32, e: f32) -> f32 {
+    if b == 0.0 {
+        pow_zero_base(e)
+    } else if b < 0.0 {
+        pow_negative_base(b, e)
+    } else {
+        expf_approx(e * lnf_approx(b))
+    }
+}
+
 /// Element-wise power with broadcasting: `out[i] = base[i] ^ exp[i]`.
 pub fn op_pow(base: &Tensor, exponent: &Tensor) -> Result<Tensor, OpError> {
     require_float(base, "Pow")?;
@@ -91,36 +133,7 @@ pub fn op_pow(base: &Tensor, exponent: &Tensor) -> Result<Tensor, OpError> {
         let ei = broadcast_index(&coord, &exponent.shape.dims);
         let b = read_f32(&base.raw_data, bi);
         let e = read_f32(&exponent.raw_data, ei);
-        // pow(x, y) = exp(y * ln(x)) for positive x; handle integer y for negatives.
-        let v = if b == 0.0 {
-            if e == 0.0 {
-                1.0
-            } else if e < 0.0 {
-                f32::INFINITY
-            } else {
-                0.0
-            }
-        } else if b < 0.0 {
-            // Only support integer exponents for negative bases.
-            let e_int = e as i32;
-            if (e_int as f32 - e).abs() < 1e-6 {
-                let mut p = 1.0_f32;
-                let n = e_int.unsigned_abs();
-                for _ in 0..n {
-                    p *= b;
-                }
-                if e_int < 0 {
-                    1.0 / p
-                } else {
-                    p
-                }
-            } else {
-                f32::NAN
-            }
-        } else {
-            expf_approx(e * lnf_approx(b))
-        };
-        write_f32(&mut data, flat, v);
+        write_f32(&mut data, flat, pow_one(b, e));
         if flat + 1 < total {
             next_coord(&mut coord, &out_dims);
         }
@@ -450,6 +463,45 @@ pub fn op_or(a: &Tensor, b: &Tensor) -> Result<Tensor, OpError> {
     bool_binary(a, b, "Or", |x, y| x || y)
 }
 
+/// Returns the maximum value along one (outer, inner) lane of `axis_size`
+/// elements with stride `inner` starting at `base`.
+fn lane_max(input: &[u8], base: usize, axis_size: usize, inner: usize) -> f32 {
+    let mut maxv = f32::NEG_INFINITY;
+    for a in 0..axis_size {
+        let v = read_f32(input, base + a * inner);
+        if v > maxv {
+            maxv = v;
+        }
+    }
+    maxv
+}
+
+/// Returns `sum(exp(x - maxv))` along one lane.
+fn lane_exp_sum(input: &[u8], base: usize, axis_size: usize, inner: usize, maxv: f32) -> f32 {
+    let mut sum = 0.0_f32;
+    for a in 0..axis_size {
+        sum += expf_approx(read_f32(input, base + a * inner) - maxv);
+    }
+    sum
+}
+
+/// Writes `x - maxv - log_sum` into `out` along one lane.
+fn lane_write_logsoftmax(
+    input: &[u8],
+    out: &mut [u8],
+    base: usize,
+    axis_size: usize,
+    inner: usize,
+    maxv: f32,
+    log_sum: f32,
+) {
+    for a in 0..axis_size {
+        let idx = base + a * inner;
+        let v = read_f32(input, idx) - maxv - log_sum;
+        write_f32(out, idx, v);
+    }
+}
+
 /// Numerically-stable log-softmax along a single axis.
 ///
 /// Computes `x - max - log(sum(exp(x - max)))` along `axis`.
@@ -464,7 +516,6 @@ pub fn op_log_softmax(input: &Tensor, axis: i64) -> Result<Tensor, OpError> {
     }
     let dims = &input.shape.dims;
     let axis = axis as usize;
-    // Compute outer/axis/inner factor sizes.
     let outer: usize = dims[..axis]
         .iter()
         .map(|&d| d as usize)
@@ -481,27 +532,19 @@ pub fn op_log_softmax(input: &Tensor, axis: i64) -> Result<Tensor, OpError> {
 
     for o in 0..outer {
         for i in 0..inner {
-            // Find max along axis
-            let mut maxv = f32::NEG_INFINITY;
-            for a in 0..axis_size {
-                let idx = (o * axis_size + a) * inner + i;
-                let v = read_f32(&input.raw_data, idx);
-                if v > maxv {
-                    maxv = v;
-                }
-            }
-            // Sum of exp(x - max)
-            let mut sum = 0.0_f32;
-            for a in 0..axis_size {
-                let idx = (o * axis_size + a) * inner + i;
-                sum += expf_approx(read_f32(&input.raw_data, idx) - maxv);
-            }
+            let base = o * axis_size * inner + i;
+            let maxv = lane_max(&input.raw_data, base, axis_size, inner);
+            let sum = lane_exp_sum(&input.raw_data, base, axis_size, inner, maxv);
             let log_sum = lnf_approx(sum);
-            for a in 0..axis_size {
-                let idx = (o * axis_size + a) * inner + i;
-                let v = read_f32(&input.raw_data, idx) - maxv - log_sum;
-                write_f32(&mut out, idx, v);
-            }
+            lane_write_logsoftmax(
+                &input.raw_data,
+                &mut out,
+                base,
+                axis_size,
+                inner,
+                maxv,
+                log_sum,
+            );
         }
     }
     Ok(Tensor {

--- a/onnx-rt/src/ops/reduction.rs
+++ b/onnx-rt/src/ops/reduction.rs
@@ -75,6 +75,31 @@ fn compute_strides(shape: &[i64]) -> Vec<usize> {
     strides
 }
 
+/// Maps an input coordinate to the corresponding flat output index for a
+/// reduction described by `resolved` (axes being reduced) and `keepdims`.
+fn reduce_out_index(
+    in_coord: &[usize],
+    resolved: &[usize],
+    keepdims: bool,
+    out_strides: &[usize],
+) -> usize {
+    let mut out_idx = 0usize;
+    let mut od = 0usize;
+    for (d, &coord) in in_coord.iter().enumerate() {
+        if resolved.contains(&d) {
+            if keepdims {
+                od += 1;
+            }
+        } else {
+            if od < out_strides.len() {
+                out_idx += coord * out_strides[od];
+            }
+            od += 1;
+        }
+    }
+    out_idx
+}
+
 /// Generic reduction helper for f32 reductions with an initial value and a
 /// combine function.
 fn reduce_float<F: Fn(f32, f32) -> f32>(
@@ -92,7 +117,6 @@ fn reduce_float<F: Fn(f32, f32) -> f32>(
     let out_shape = TensorShape::new(out_dims);
     let total_out = out_shape.total_elements();
     let mut raw = allocate_tensor_data(total_out, DataType::Float);
-    // Fill with init.
     for i in 0..total_out {
         write_f32(&mut raw, i, init);
     }
@@ -104,21 +128,7 @@ fn reduce_float<F: Fn(f32, f32) -> f32>(
         if i > 0 {
             next_coord(&mut in_coord, &input.shape.dims);
         }
-        let mut out_idx = 0usize;
-        let mut od = 0usize;
-        #[allow(clippy::needless_range_loop)]
-        for d in 0..ndim {
-            if resolved.contains(&d) {
-                if keepdims {
-                    od += 1;
-                }
-            } else {
-                if od < out_strides.len() {
-                    out_idx += in_coord[d] * out_strides[od];
-                }
-                od += 1;
-            }
-        }
+        let out_idx = reduce_out_index(&in_coord, &resolved, keepdims, &out_strides);
         let prev = read_f32(&raw, out_idx);
         let v = read_f32(&input.raw_data, i);
         write_f32(&mut raw, out_idx, combine(prev, v));
@@ -159,6 +169,68 @@ pub fn op_reduce_prod(input: &Tensor, axes: &[i64], keepdims: bool) -> Result<Te
     reduce_float(input, axes, keepdims, "ReduceProd", 1.0, |a, b| a * b)
 }
 
+/// Normalizes a signed axis for an `ndim`-rank tensor, returning the
+/// non-negative axis or an `InvalidAttribute` error.
+fn normalize_arg_axis(axis: i64, ndim: i64, op: &str) -> Result<usize, OpError> {
+    let axis = if axis < 0 { ndim + axis } else { axis };
+    if axis < 0 || axis >= ndim {
+        return Err(OpError::InvalidAttribute(alloc::format!(
+            "{} axis out of range",
+            op
+        )));
+    }
+    Ok(axis as usize)
+}
+
+/// Builds the output shape for an ArgMax/ArgMin reduction along `axis`.
+/// A fully-collapsed shape becomes `[1]`.
+fn arg_out_shape(dims: &[i64], axis: usize, keepdims: bool) -> TensorShape {
+    let out_dims: Vec<i64> = dims
+        .iter()
+        .enumerate()
+        .filter_map(|(i, &d)| {
+            if i == axis {
+                if keepdims {
+                    Some(1)
+                } else {
+                    None
+                }
+            } else {
+                Some(d)
+            }
+        })
+        .collect();
+    if out_dims.is_empty() {
+        TensorShape::new(alloc::vec![1])
+    } else {
+        TensorShape::new(out_dims)
+    }
+}
+
+/// Scans one (outer, inner) lane of an ArgMax/ArgMin and returns the
+/// winning index into the axis.
+fn argreduce_scan_lane<F: Fn(f32, f32) -> bool>(
+    input: &[u8],
+    o: usize,
+    i: usize,
+    axis_size: usize,
+    inner: usize,
+    select_last_index: bool,
+    better: &F,
+) -> usize {
+    let mut best_idx: usize = 0;
+    let mut best_val = read_f32(input, (o * axis_size) * inner + i);
+    for a in 1..axis_size {
+        let idx = (o * axis_size + a) * inner + i;
+        let v = read_f32(input, idx);
+        if better(v, best_val) || (select_last_index && v == best_val) {
+            best_val = v;
+            best_idx = a;
+        }
+    }
+    best_idx
+}
+
 /// ArgMax/ArgMin core. Operates along a single axis and emits Int64 indices.
 /// `select_last_index` controls whether ties pick the last matching index.
 fn argreduce<F: Fn(f32, f32) -> bool>(
@@ -171,14 +243,7 @@ fn argreduce<F: Fn(f32, f32) -> bool>(
 ) -> Result<Tensor, OpError> {
     require_float(input, op)?;
     let ndim = input.shape.ndim() as i64;
-    let axis = if axis < 0 { ndim + axis } else { axis };
-    if axis < 0 || axis >= ndim {
-        return Err(OpError::InvalidAttribute(alloc::format!(
-            "{} axis out of range",
-            op
-        )));
-    }
-    let axis = axis as usize;
+    let axis = normalize_arg_axis(axis, ndim, op)?;
     let dims = &input.shape.dims;
     let axis_size = dims[axis] as usize;
     if axis_size == 0 {
@@ -198,41 +263,21 @@ fn argreduce<F: Fn(f32, f32) -> bool>(
         .product::<usize>()
         .max(1);
 
-    let out_dims: Vec<i64> = dims
-        .iter()
-        .enumerate()
-        .filter_map(|(i, &d)| {
-            if i == axis {
-                if keepdims {
-                    Some(1)
-                } else {
-                    None
-                }
-            } else {
-                Some(d)
-            }
-        })
-        .collect();
-    let out_shape = TensorShape::new(if out_dims.is_empty() {
-        alloc::vec![1]
-    } else {
-        out_dims
-    });
+    let out_shape = arg_out_shape(dims, axis, keepdims);
     let total_out = outer * inner;
     let mut raw = alloc::vec![0u8; total_out * I64_SIZE];
 
     for o in 0..outer {
         for i in 0..inner {
-            let mut best_idx: usize = 0;
-            let mut best_val = read_f32(&input.raw_data, (o * axis_size) * inner + i);
-            for a in 1..axis_size {
-                let idx = (o * axis_size + a) * inner + i;
-                let v = read_f32(&input.raw_data, idx);
-                if better(v, best_val) || (select_last_index && v == best_val) {
-                    best_val = v;
-                    best_idx = a;
-                }
-            }
+            let best_idx = argreduce_scan_lane(
+                &input.raw_data,
+                o,
+                i,
+                axis_size,
+                inner,
+                select_last_index,
+                &better,
+            );
             write_i64(&mut raw, o * inner + i, best_idx as i64);
         }
     }

--- a/onnx-rt/src/ops/shape_data.rs
+++ b/onnx-rt/src/ops/shape_data.rs
@@ -168,6 +168,42 @@ pub fn op_range(start: f32, limit: f32, delta: f32) -> Result<Tensor, OpError> {
     })
 }
 
+/// Returns `true` when element `(r, c)` is kept by a Trilu mask with
+/// diagonal offset `k`. `upper=true` keeps `col-row >= k`; otherwise keeps
+/// `col-row <= k`.
+fn trilu_keep(r: i64, c: i64, k: i64, upper: bool) -> bool {
+    let diff = c - r;
+    if upper {
+        diff >= k
+    } else {
+        diff <= k
+    }
+}
+
+/// Writes the Trilu mask for one matrix slice (rows × cols) starting at
+/// `base` into the flat output buffer.
+fn trilu_fill_matrix(
+    input: &[u8],
+    out: &mut [u8],
+    base: usize,
+    rows: i64,
+    cols: i64,
+    k: i64,
+    upper: bool,
+) {
+    for r in 0..rows {
+        for c in 0..cols {
+            let flat = base + (r * cols + c) as usize;
+            let v = if trilu_keep(r, c, k, upper) {
+                read_f32(input, flat)
+            } else {
+                0.0
+            };
+            write_f32(out, flat, v);
+        }
+    }
+}
+
 /// Trilu: upper or lower triangular mask for 2D+ tensors.
 ///
 /// For higher-rank inputs, the masking is applied to the last two dims
@@ -195,19 +231,15 @@ pub fn op_trilu(input: &Tensor, k: i64, upper: bool) -> Result<Tensor, OpError> 
     let total = batches * matrix_elems;
     let mut out = allocate_tensor_data(total, DataType::Float);
     for b in 0..batches {
-        for r in 0..rows {
-            for c in 0..cols {
-                let flat = b * matrix_elems + (r * cols + c) as usize;
-                let diff = c - r;
-                let keep = if upper { diff >= k } else { diff <= k };
-                let v = if keep {
-                    read_f32(&input.raw_data, flat)
-                } else {
-                    0.0
-                };
-                write_f32(&mut out, flat, v);
-            }
-        }
+        trilu_fill_matrix(
+            &input.raw_data,
+            &mut out,
+            b * matrix_elems,
+            rows,
+            cols,
+            k,
+            upper,
+        );
     }
     Ok(Tensor {
         data_type: DataType::Float,
@@ -217,24 +249,24 @@ pub fn op_trilu(input: &Tensor, k: i64, upper: bool) -> Result<Tensor, OpError> 
     })
 }
 
-/// CumSum along a single axis. `exclusive=true` omits the current element
-/// from each partial sum; `reverse=true` scans from the end.
-pub fn op_cumsum(
-    input: &Tensor,
-    axis: i64,
-    exclusive: bool,
-    reverse: bool,
-) -> Result<Tensor, OpError> {
-    require_float(input, "CumSum")?;
-    let ndim = input.shape.ndim() as i64;
-    let axis = if axis < 0 { ndim + axis } else { axis };
-    if axis < 0 || axis >= ndim {
-        return Err(OpError::InvalidAttribute(String::from(
-            "CumSum axis out of range",
+/// Normalizes a signed axis index against an `ndim`-rank tensor. Returns
+/// the non-negative axis or an `InvalidAttribute` error when out of range.
+fn normalize_axis(axis: i64, ndim: usize, op: &str) -> Result<usize, OpError> {
+    let nd = ndim as i64;
+    let normalized = if axis < 0 { nd + axis } else { axis };
+    if normalized < 0 || normalized >= nd {
+        return Err(OpError::InvalidAttribute(alloc::format!(
+            "{} axis out of range",
+            op
         )));
     }
-    let axis = axis as usize;
-    let dims = &input.shape.dims;
+    Ok(normalized as usize)
+}
+
+/// Splits a shape into `(outer, axis_size, inner)` factor sizes around
+/// `axis`. Each factor is clamped to `max(1)` so scalar/empty inputs still
+/// step exactly once.
+fn factor_sizes(dims: &[i64], axis: usize) -> (usize, usize, usize) {
     let outer: usize = dims[..axis]
         .iter()
         .map(|&d| d as usize)
@@ -246,37 +278,67 @@ pub fn op_cumsum(
         .map(|&d| d as usize)
         .product::<usize>()
         .max(1);
+    (outer, axis_size, inner)
+}
+
+/// Scans a single (outer, inner) lane of a CumSum along `axis_size`
+/// elements with stride `inner`. `exclusive=true` emits the running total
+/// *before* adding the current element.
+fn cumsum_scan_lane(
+    input: &[u8],
+    out: &mut [u8],
+    base: usize,
+    axis_size: usize,
+    inner: usize,
+    exclusive: bool,
+    reverse: bool,
+) {
+    let mut acc = 0.0_f32;
+    let order: alloc::vec::Vec<usize> = if reverse {
+        (0..axis_size).rev().collect()
+    } else {
+        (0..axis_size).collect()
+    };
+    for a in order {
+        let idx = base + a * inner;
+        let v = read_f32(input, idx);
+        if exclusive {
+            write_f32(out, idx, acc);
+            acc += v;
+        } else {
+            acc += v;
+            write_f32(out, idx, acc);
+        }
+    }
+}
+
+/// CumSum along a single axis. `exclusive=true` omits the current element
+/// from each partial sum; `reverse=true` scans from the end.
+pub fn op_cumsum(
+    input: &Tensor,
+    axis: i64,
+    exclusive: bool,
+    reverse: bool,
+) -> Result<Tensor, OpError> {
+    require_float(input, "CumSum")?;
+    let ndim = input.shape.ndim();
+    let axis = normalize_axis(axis, ndim, "CumSum")?;
+    let (outer, axis_size, inner) = factor_sizes(&input.shape.dims, axis);
     let total = outer * axis_size * inner;
     let mut out = allocate_tensor_data(total, DataType::Float);
 
     for o in 0..outer {
         for i in 0..inner {
-            let mut acc = 0.0_f32;
-            if !reverse {
-                for a in 0..axis_size {
-                    let idx = (o * axis_size + a) * inner + i;
-                    let v = read_f32(&input.raw_data, idx);
-                    if exclusive {
-                        write_f32(&mut out, idx, acc);
-                        acc += v;
-                    } else {
-                        acc += v;
-                        write_f32(&mut out, idx, acc);
-                    }
-                }
-            } else {
-                for a in (0..axis_size).rev() {
-                    let idx = (o * axis_size + a) * inner + i;
-                    let v = read_f32(&input.raw_data, idx);
-                    if exclusive {
-                        write_f32(&mut out, idx, acc);
-                        acc += v;
-                    } else {
-                        acc += v;
-                        write_f32(&mut out, idx, acc);
-                    }
-                }
-            }
+            let base = o * axis_size * inner + i;
+            cumsum_scan_lane(
+                &input.raw_data,
+                &mut out,
+                base,
+                axis_size,
+                inner,
+                exclusive,
+                reverse,
+            );
         }
     }
     Ok(Tensor {
@@ -299,17 +361,77 @@ pub fn op_cumsum(
 /// output has shape `indices.shape[:-1] + input.shape[batch_dims + k:]`.
 ///
 /// Float32 data only. Int64 indices only.
-pub fn op_gather_nd(input: &Tensor, indices: &Tensor, batch_dims: i64) -> Result<Tensor, OpError> {
-    require_float(input, "GatherND")?;
-    require_int64(indices, "GatherND")?;
+/// Folds an index tuple (`k` elements starting at `idx_base` in
+/// `indices`) into a flat input offset using `in_strides`. The tuple
+/// addresses dimensions `[axis_start, axis_start + k)` of `input_dims`.
+/// Negative indices are normalized to the non-negative range; out-of-range
+/// values produce an error tagged with `op`.
+fn gather_index_offset(
+    indices: &[u8],
+    idx_base: usize,
+    k: usize,
+    axis_start: usize,
+    input_dims: &[i64],
+    in_strides: &[usize],
+    op: &str,
+) -> Result<usize, OpError> {
+    let mut off = 0usize;
+    for j in 0..k {
+        let raw = read_i64(indices, idx_base + j);
+        let pos = axis_start + j;
+        let dim = input_dims[pos];
+        let normalized = if raw < 0 { raw + dim } else { raw };
+        if normalized < 0 || normalized >= dim {
+            return Err(OpError::ShapeMismatch(alloc::format!(
+                "{} index {} out of range [0,{})",
+                op,
+                raw,
+                dim
+            )));
+        }
+        off += (normalized as usize) * in_strides[pos];
+    }
+    Ok(off)
+}
+
+/// Returns the flat offset into a tensor with `in_strides` corresponding
+/// to the row-major batch index `batch` over the first `batch_dims` of
+/// `input_dims`.
+fn batch_offset(
+    batch: usize,
+    batch_dims: usize,
+    input_dims: &[i64],
+    in_strides: &[usize],
+) -> usize {
+    let mut off = 0usize;
+    let mut rem = batch;
+    for d in (0..batch_dims).rev() {
+        let dim = input_dims[d] as usize;
+        let c = rem % dim;
+        rem /= dim;
+        off += c * in_strides[d];
+    }
+    off
+}
+
+/// Product of a dim slice, clamped to at least 1.
+fn product_dims(dims: &[i64]) -> usize {
+    dims.iter().map(|&d| d as usize).product::<usize>().max(1)
+}
+
+/// Validates `indices`/`batch_dims` for GatherND and returns the
+/// `(idx_ndim, batch_dims, k)` triple expected by the main loop.
+fn gather_nd_validate(
+    input: &Tensor,
+    indices: &Tensor,
+    batch_dims: i64,
+) -> Result<(usize, usize, usize), OpError> {
     let idx_ndim = indices.shape.ndim();
     if idx_ndim == 0 {
         return Err(OpError::ShapeMismatch(String::from(
             "GatherND indices must have at least 1 dimension",
         )));
     }
-    // ONNX GatherND-13: batch_dims must satisfy
-    // 0 <= batch_dims <= rank(indices) - 1 (the last dim of indices is `k`).
     if batch_dims < 0 || (batch_dims as usize) >= idx_ndim {
         return Err(OpError::InvalidAttribute(alloc::format!(
             "GatherND batch_dims {} out of range [0, {})",
@@ -319,77 +441,48 @@ pub fn op_gather_nd(input: &Tensor, indices: &Tensor, batch_dims: i64) -> Result
     }
     let batch_dims = batch_dims as usize;
     let k = indices.shape.dims[idx_ndim - 1] as usize;
-    let in_ndim = input.shape.ndim();
-    if batch_dims + k > in_ndim {
+    if batch_dims + k > input.shape.ndim() {
         return Err(OpError::ShapeMismatch(String::from(
             "GatherND batch_dims+k exceeds input rank",
         )));
     }
+    Ok((idx_ndim, batch_dims, k))
+}
+
+pub fn op_gather_nd(input: &Tensor, indices: &Tensor, batch_dims: i64) -> Result<Tensor, OpError> {
+    require_float(input, "GatherND")?;
+    require_int64(indices, "GatherND")?;
+    let (idx_ndim, batch_dims, k) = gather_nd_validate(input, indices, batch_dims)?;
 
     // Output shape = indices.shape[:-1] + input.shape[batch_dims+k:]
     let mut out_shape: Vec<i64> = indices.shape.dims[..idx_ndim - 1].to_vec();
     let slice_dims = &input.shape.dims[batch_dims + k..];
     out_shape.extend_from_slice(slice_dims);
-    let slice_size: usize = slice_dims
-        .iter()
-        .map(|&d| d as usize)
-        .product::<usize>()
-        .max(1);
+    let slice_size = product_dims(slice_dims);
 
-    let total_out: usize = out_shape
-        .iter()
-        .map(|&d| d as usize)
-        .product::<usize>()
-        .max(1);
+    let total_out = product_dims(&out_shape);
     let mut out = allocate_tensor_data(total_out, DataType::Float);
 
-    // Total number of index tuples = product of indices.shape[:-1]
-    let tuple_count: usize = indices.shape.dims[..idx_ndim - 1]
-        .iter()
-        .map(|&d| d as usize)
-        .product::<usize>()
-        .max(1);
-    // Number of batch tuples = product of first batch_dims of indices
-    let batch_count: usize = indices.shape.dims[..batch_dims]
-        .iter()
-        .map(|&d| d as usize)
-        .product::<usize>()
-        .max(1);
+    let tuple_count = product_dims(&indices.shape.dims[..idx_ndim - 1]);
+    let batch_count = product_dims(&indices.shape.dims[..batch_dims]);
     let tuples_per_batch = tuple_count / batch_count;
 
     let in_strides = compute_strides(&input.shape.dims);
 
     for batch in 0..batch_count {
-        // Leading batch offset into input (flattened).
-        let in_batch_offset = {
-            let mut off = 0usize;
-            let mut rem = batch;
-            for d in (0..batch_dims).rev() {
-                let dim = input.shape.dims[d] as usize;
-                let c = rem % dim;
-                rem /= dim;
-                off += c * in_strides[d];
-            }
-            off
-        };
+        let in_batch_offset = batch_offset(batch, batch_dims, &input.shape.dims, &in_strides);
         for t in 0..tuples_per_batch {
             let idx_base = (batch * tuples_per_batch + t) * k;
-            // Compute linear offset into input.
-            let mut in_off = in_batch_offset;
-            for (j, idx_pos) in (batch_dims..batch_dims + k).enumerate() {
-                let raw = read_i64(&indices.raw_data, idx_base + j);
-                let dim = input.shape.dims[idx_pos];
-                let normalized = if raw < 0 { raw + dim } else { raw };
-                if normalized < 0 || normalized >= dim {
-                    return Err(OpError::ShapeMismatch(alloc::format!(
-                        "GatherND index {} out of range [0,{})",
-                        raw,
-                        dim
-                    )));
-                }
-                in_off += (normalized as usize) * in_strides[idx_pos];
-            }
-            // Copy slice_size elements.
+            let tuple_off = gather_index_offset(
+                &indices.raw_data,
+                idx_base,
+                k,
+                batch_dims,
+                &input.shape.dims,
+                &in_strides,
+                "GatherND",
+            )?;
+            let in_off = in_batch_offset + tuple_off;
             let out_off = (batch * tuples_per_batch + t) * slice_size;
             for s in 0..slice_size {
                 let v = read_f32(&input.raw_data, in_off + s);
@@ -411,15 +504,13 @@ pub fn op_gather_nd(input: &Tensor, indices: &Tensor, batch_dims: i64) -> Result
 /// Copies `input` and overwrites slices at the positions specified by
 /// `indices` with values from `updates`. `indices.shape[-1] = k` and
 /// `updates.shape == indices.shape[:-1] + input.shape[k:]`.
-pub fn op_scatter_nd(
+/// Validates the ScatterND shape contracts and returns `(idx_ndim, k)`
+/// for the main loop.
+fn scatter_nd_validate(
     input: &Tensor,
     indices: &Tensor,
     updates: &Tensor,
-) -> Result<Tensor, OpError> {
-    require_float(input, "ScatterND")?;
-    require_int64(indices, "ScatterND")?;
-    require_float(updates, "ScatterND")?;
-
+) -> Result<(usize, usize), OpError> {
     let idx_ndim = indices.shape.ndim();
     if idx_ndim == 0 {
         return Err(OpError::ShapeMismatch(String::from(
@@ -433,8 +524,6 @@ pub fn op_scatter_nd(
             "ScatterND index depth exceeds input rank",
         )));
     }
-    // ONNX ScatterND-16 requires
-    //   updates.shape == indices.shape[:-1] + input.shape[k:]
     let expected_updates_rank = (idx_ndim - 1) + (in_ndim - k);
     if updates.shape.ndim() != expected_updates_rank {
         return Err(OpError::ShapeMismatch(alloc::format!(
@@ -443,6 +532,18 @@ pub fn op_scatter_nd(
             expected_updates_rank
         )));
     }
+    scatter_nd_check_updates_dims(input, indices, updates, idx_ndim, k)?;
+    Ok((idx_ndim, k))
+}
+
+/// Verifies `updates.shape == indices.shape[:-1] + input.shape[k:]`.
+fn scatter_nd_check_updates_dims(
+    input: &Tensor,
+    indices: &Tensor,
+    updates: &Tensor,
+    idx_ndim: usize,
+    k: usize,
+) -> Result<(), OpError> {
     for (i, &d) in indices.shape.dims[..idx_ndim - 1].iter().enumerate() {
         if updates.shape.dims[i] != d {
             return Err(OpError::ShapeMismatch(String::from(
@@ -457,46 +558,58 @@ pub fn op_scatter_nd(
             )));
         }
     }
-    let slice_dims = &input.shape.dims[k..];
-    let slice_size: usize = slice_dims
-        .iter()
-        .map(|&d| d as usize)
-        .product::<usize>()
-        .max(1);
+    Ok(())
+}
+
+/// Copies `slice_size` f32 elements from `updates[upd_off..]` into
+/// `out_raw[in_off..]` (element indices).
+fn scatter_nd_write_slice(
+    out_raw: &mut [u8],
+    updates: &[u8],
+    in_off: usize,
+    upd_off: usize,
+    slice_size: usize,
+) {
+    for s in 0..slice_size {
+        let v = read_f32(updates, upd_off + s);
+        let byte_off = (in_off + s) * F32_SIZE;
+        out_raw[byte_off..byte_off + F32_SIZE].copy_from_slice(&v.to_le_bytes());
+    }
+}
+
+pub fn op_scatter_nd(
+    input: &Tensor,
+    indices: &Tensor,
+    updates: &Tensor,
+) -> Result<Tensor, OpError> {
+    require_float(input, "ScatterND")?;
+    require_int64(indices, "ScatterND")?;
+    require_float(updates, "ScatterND")?;
+
+    let (idx_ndim, k) = scatter_nd_validate(input, indices, updates)?;
+    let slice_size = product_dims(&input.shape.dims[k..]);
 
     let mut out_raw = input.raw_data.clone();
     let in_strides = compute_strides(&input.shape.dims);
-
-    let tuple_count: usize = indices.shape.dims[..idx_ndim - 1]
-        .iter()
-        .map(|&d| d as usize)
-        .product::<usize>()
-        .max(1);
+    let tuple_count = product_dims(&indices.shape.dims[..idx_ndim - 1]);
 
     for t in 0..tuple_count {
-        let idx_base = t * k;
-        let mut in_off = 0usize;
-        #[allow(clippy::needless_range_loop)]
-        for j in 0..k {
-            let raw = read_i64(&indices.raw_data, idx_base + j);
-            let dim = input.shape.dims[j];
-            let normalized = if raw < 0 { raw + dim } else { raw };
-            if normalized < 0 || normalized >= dim {
-                return Err(OpError::ShapeMismatch(alloc::format!(
-                    "ScatterND index {} out of range [0,{})",
-                    raw,
-                    dim
-                )));
-            }
-            in_off += (normalized as usize) * in_strides[j];
-        }
-        let upd_off = t * slice_size;
-        for s in 0..slice_size {
-            let v = read_f32(&updates.raw_data, upd_off + s);
-            // Write into out_raw at position in_off + s (in float32 element idx).
-            let byte_off = (in_off + s) * F32_SIZE;
-            out_raw[byte_off..byte_off + F32_SIZE].copy_from_slice(&v.to_le_bytes());
-        }
+        let in_off = gather_index_offset(
+            &indices.raw_data,
+            t * k,
+            k,
+            0,
+            &input.shape.dims,
+            &in_strides,
+            "ScatterND",
+        )?;
+        scatter_nd_write_slice(
+            &mut out_raw,
+            &updates.raw_data,
+            in_off,
+            t * slice_size,
+            slice_size,
+        );
     }
     Ok(Tensor {
         data_type: DataType::Float,

--- a/onnx-rt/src/sub_executor.rs
+++ b/onnx-rt/src/sub_executor.rs
@@ -75,73 +75,86 @@ pub const MAX_LOOP_ITERATIONS: i64 = 1_000_000;
 /// threaded through: per §6 of the design doc, the parent `Loop`/`If`/`Scan`
 /// is the single budget unit. Inner-operator measurement is a follow-up
 /// work-item.
+/// Inserts the body's initializers into `value_map` without overwriting
+/// already-seeded entries (loop-carried values shadow same-named weights).
+fn seed_initializers(value_map: &mut BTreeMap<String, Tensor>, initializers: &[TensorProto]) {
+    for init in initializers {
+        value_map
+            .entry(init.name.clone())
+            .or_insert_with(|| materialize_initializer(init));
+    }
+}
+
+/// Writes a node's positional outputs into `value_map`, skipping empty
+/// output names (the ONNX convention for "ignore this output").
+fn record_outputs(
+    value_map: &mut BTreeMap<String, Tensor>,
+    output_names: &[String],
+    outputs: &[Tensor],
+) {
+    for (i, output_name) in output_names.iter().enumerate() {
+        if !output_name.is_empty() {
+            if let Some(tensor) = outputs.get(i) {
+                value_map.insert(output_name.clone(), tensor.clone());
+            }
+        }
+    }
+}
+
+/// Resolves a node's inputs against `value_map`. Empty names map to `None`,
+/// matching ONNX optional-input semantics.
+fn resolve_inputs<'a>(
+    inputs: &[String],
+    value_map: &'a BTreeMap<String, Tensor>,
+) -> Vec<Option<&'a Tensor>> {
+    inputs
+        .iter()
+        .map(|name| {
+            if name.is_empty() {
+                None
+            } else {
+                value_map.get(name)
+            }
+        })
+        .collect()
+}
+
+/// Executes a single non-control-flow node and returns its outputs.
+fn run_plain_node(
+    node: &crate::graph::ExecutionNode,
+    value_map: &BTreeMap<String, Tensor>,
+) -> Result<Vec<Tensor>, SessionError> {
+    let input_tensors = resolve_inputs(&node.inputs, value_map);
+    dispatch_node(
+        &node.op_type,
+        &input_tensors,
+        &node.attributes,
+        node.outputs.len(),
+        #[cfg(feature = "gpu")]
+        None,
+        #[cfg(feature = "cuda")]
+        None,
+    )
+    .map_err(|e| {
+        SessionError::ExecutionFailed(alloc::format!("sub_executor: {}: {}", node.name, e))
+    })
+}
+
 pub fn run_sub_graph(
     graph: &ExecutionGraph,
     mut value_map: BTreeMap<String, Tensor>,
     initializers: &[TensorProto],
 ) -> Result<BTreeMap<String, Tensor>, SessionError> {
-    // Load any initializers not already present in the seeded map so the
-    // body can reference outer weights by name.
-    for init in initializers {
-        value_map.entry(init.name.clone()).or_insert_with(|| {
-            // Convert TensorProto -> Tensor. For now only raw_data / f32
-            // initializers are supported; string/f16 initializers are
-            // rejected by the main graph builder anyway.
-            materialize_initializer(init)
-        });
-    }
+    seed_initializers(&mut value_map, initializers);
 
     for node_idx in graph.execution_order() {
         let node = &graph.nodes[node_idx.index()];
-
-        // Control-flow ops need the full ExecutionNode + outer value map
-        // and bypass the flat dispatch_node path.
-        if crate::executor::is_control_flow_op(&node.op_type) {
-            let outputs = crate::executor::dispatch_control_flow(node, &value_map, initializers)?;
-            for (i, output_name) in node.outputs.iter().enumerate() {
-                if !output_name.is_empty() {
-                    if let Some(tensor) = outputs.get(i) {
-                        value_map.insert(output_name.clone(), tensor.clone());
-                    }
-                }
-            }
-            continue;
-        }
-
-        // Resolve input tensors from the value map.
-        let input_tensors: Vec<Option<&Tensor>> = node
-            .inputs
-            .iter()
-            .map(|name| {
-                if name.is_empty() {
-                    None
-                } else {
-                    value_map.get(name)
-                }
-            })
-            .collect();
-
-        let outputs = dispatch_node(
-            &node.op_type,
-            &input_tensors,
-            &node.attributes,
-            node.outputs.len(),
-            #[cfg(feature = "gpu")]
-            None,
-            #[cfg(feature = "cuda")]
-            None,
-        )
-        .map_err(|e| {
-            SessionError::ExecutionFailed(alloc::format!("sub_executor: {}: {}", node.name, e))
-        })?;
-
-        for (i, output_name) in node.outputs.iter().enumerate() {
-            if !output_name.is_empty() {
-                if let Some(tensor) = outputs.get(i) {
-                    value_map.insert(output_name.clone(), tensor.clone());
-                }
-            }
-        }
+        let outputs = if crate::executor::is_control_flow_op(&node.op_type) {
+            crate::executor::dispatch_control_flow(node, &value_map, initializers)?
+        } else {
+            run_plain_node(node, &value_map)?
+        };
+        record_outputs(&mut value_map, &node.outputs, &outputs);
     }
 
     Ok(value_map)


### PR DESCRIPTION
## Summary

Reduces SonarCloud `rust:S3776` cognitive complexity below the 15
threshold on nine functions across four `onnx-rt` files. The refactor
extracts independent decision branches into named helper functions; no
observable behavior changes.

| File | Function | Before | After (est.) |
|---|---|---:|---:|
| `onnx-rt/src/ops/shape_data.rs` | `op_cumsum` | 31 | ≤6 |
| `onnx-rt/src/ops/shape_data.rs` | `op_gather_nd` | 25 | ≤8 |
| `onnx-rt/src/ops/shape_data.rs` | `op_scatter_nd` | 22 | ≤5 |
| `onnx-rt/src/ops/shape_data.rs` | `op_trilu` | 17 | ≤4 |
| `onnx-rt/src/ops/reduction.rs` | `argreduce` | 26 | ≤6 |
| `onnx-rt/src/ops/reduction.rs` | `reduce_float` | 18 | ≤6 |
| `onnx-rt/src/ops/math.rs` | `op_pow` | 25 | ≤4 |
| `onnx-rt/src/ops/math.rs` | `op_log_softmax` | 20 | ≤7 |
| `onnx-rt/src/sub_executor.rs` | `run_sub_graph` | 29 | ≤4 |

New helpers (private, `#[cfg(test)]`-tested indirectly via their public
callers):

- `shape_data.rs`: `trilu_keep`, `trilu_fill_matrix`, `normalize_axis`,
  `factor_sizes`, `cumsum_scan_lane`, `gather_nd_validate`,
  `gather_index_offset`, `batch_offset`, `product_dims`,
  `scatter_nd_validate`, `scatter_nd_check_updates_dims`,
  `scatter_nd_write_slice`.
- `reduction.rs`: `reduce_out_index`, `normalize_arg_axis`,
  `arg_out_shape`, `argreduce_scan_lane`.
- `math.rs`: `pow_zero_base`, `pow_negative_base`, `pow_one`,
  `lane_max`, `lane_exp_sum`, `lane_write_logsoftmax`.
- `sub_executor.rs`: `seed_initializers`, `record_outputs`,
  `resolve_inputs`, `run_plain_node`.

## Test plan

- [x] `cargo fmt --all -- --check` (clean)
- [x] `cargo clippy -p smallaios-onnx-rt -- -D warnings` (clean)
- [x] `cargo test -p smallaios-onnx-rt` — all 966 tests pass
  (baseline ~966, unchanged)
- [ ] `just clippy` workspace-wide passes in CI (a pre-existing
  unrelated `smallaios-mgmt` test failure on `develop` may still
  surface here)
- [ ] SonarCloud `new_coverage` check (80%): may flag this PR since
  new helpers are exercised only indirectly through existing tests;
  may need admin merge

## Notes

- Sibling PRs are refactoring other `onnx-rt/src/ops/*.rs` files in
  parallel; this PR touches only the four files listed above plus
  `sub_executor.rs`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal operator implementations for improved code maintainability and clarity.
  * Extracted helper functions to reduce code duplication across mathematical, reduction, and shape-handling operations.
  * Streamlined sub-graph execution logic with shared utility routines.
  * All public APIs remain unchanged; no functional impact on end-users.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SmallAIOS/SmallAIOS/pull/205)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->