### PR TITLE
refactor(onnx-rt): reduce cognitive complexity below 15 in ops/vision + ops/data_select

### DIFF
--- a/onnx-rt/src/ops/data_select.rs
+++ b/onnx-rt/src/ops/data_select.rs
@@ -74,16 +74,8 @@ pub fn op_top_k(
         )));
     }
     let k_us = k as usize;
-    let outer: usize = input.shape.dims[..ax]
-        .iter()
-        .map(|&d| d as usize)
-        .product::<usize>()
-        .max(1);
-    let inner: usize = input.shape.dims[ax + 1..]
-        .iter()
-        .map(|&d| d as usize)
-        .product::<usize>()
-        .max(1);
+    let outer = product_dims(&input.shape.dims[..ax]);
+    let inner = product_dims(&input.shape.dims[ax + 1..]);
 
     let mut out_dims = input.shape.dims.clone();
     out_dims[ax] = k;
@@ -94,25 +86,12 @@ pub fn op_top_k(
     let mut scratch: Vec<(f32, usize)> = Vec::with_capacity(axis_dim);
     for o in 0..outer {
         for i in 0..inner {
-            scratch.clear();
-            for a in 0..axis_dim {
-                let src = o * axis_dim * inner + a * inner + i;
-                scratch.push((read_f32(&input.raw_data, src), a));
-            }
-            // Sort descending (largest=true) or ascending.
-            if largest {
-                scratch.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(core::cmp::Ordering::Equal));
-            } else {
-                scratch.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(core::cmp::Ordering::Equal));
-            }
-            // scratch[..k_us] is the top-k. If not sorted, the spec allows
-            // any order — we still return the selection order from sort.
+            fill_top_k_scratch(&input.raw_data, &mut scratch, o, i, axis_dim, inner);
+            sort_top_k(&mut scratch, largest);
+            // If not sorted, the spec allows any order — we still
+            // return the selection order from sort.
             let _ = sorted;
-            for (rank_idx, &(v, idx)) in scratch.iter().take(k_us).enumerate() {
-                let dst = o * k_us * inner + rank_idx * inner + i;
-                write_f32(&mut val_data, dst, v);
-                write_i64(&mut idx_data, dst, idx as i64);
-            }
+            write_top_k_slot(&scratch, &mut val_data, &mut idx_data, o, i, k_us, inner);
         }
     }
     let values = Tensor {
@@ -130,6 +109,49 @@ pub fn op_top_k(
     Ok(alloc::vec![values, indices])
 }
 
+fn product_dims(dims: &[i64]) -> usize {
+    dims.iter().map(|&d| d as usize).product::<usize>().max(1)
+}
+
+fn fill_top_k_scratch(
+    raw: &[u8],
+    scratch: &mut Vec<(f32, usize)>,
+    o: usize,
+    i: usize,
+    axis_dim: usize,
+    inner: usize,
+) {
+    scratch.clear();
+    for a in 0..axis_dim {
+        let src = o * axis_dim * inner + a * inner + i;
+        scratch.push((read_f32(raw, src), a));
+    }
+}
+
+fn sort_top_k(scratch: &mut [(f32, usize)], largest: bool) {
+    if largest {
+        scratch.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(core::cmp::Ordering::Equal));
+    } else {
+        scratch.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(core::cmp::Ordering::Equal));
+    }
+}
+
+fn write_top_k_slot(
+    scratch: &[(f32, usize)],
+    val_data: &mut [u8],
+    idx_data: &mut [u8],
+    o: usize,
+    i: usize,
+    k_us: usize,
+    inner: usize,
+) {
+    for (rank_idx, &(v, idx)) in scratch.iter().take(k_us).enumerate() {
+        let dst = o * k_us * inner + rank_idx * inner + i;
+        write_f32(val_data, dst, v);
+        write_i64(idx_data, dst, idx as i64);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Compress
 // ---------------------------------------------------------------------------
@@ -144,81 +166,78 @@ pub fn op_compress(
     axis: Option<i64>,
 ) -> Result<Tensor, OpError> {
     require_float(input, "Compress")?;
-    let cond: Vec<bool> = {
-        // Condition may be Bool/Int8 but we store as raw bytes: treat any
-        // non-zero byte in a length-aligned stream as true.
-        let n = condition.shape.total_elements();
-        (0..n)
-            .map(|i| {
-                if i < condition.raw_data.len() {
-                    condition.raw_data[i] != 0
-                } else {
-                    false
-                }
-            })
-            .collect()
-    };
+    let cond = decode_compress_condition(condition);
     match axis {
-        None => {
-            // Flatten and filter.
-            let total = input.shape.total_elements();
-            let mut kept: Vec<f32> = Vec::new();
-            for i in 0..total {
-                if i < cond.len() && cond[i] {
-                    kept.push(read_f32(&input.raw_data, i));
-                }
+        None => Ok(compress_flat(input, &cond)),
+        Some(ax) => compress_along_axis(input, &cond, ax),
+    }
+}
+
+fn decode_compress_condition(condition: &Tensor) -> Vec<bool> {
+    // Condition may be Bool/Int8 but we store as raw bytes: treat any
+    // non-zero byte in a length-aligned stream as true.
+    let n = condition.shape.total_elements();
+    (0..n)
+        .map(|i| {
+            if i < condition.raw_data.len() {
+                condition.raw_data[i] != 0
+            } else {
+                false
             }
-            let len = kept.len();
-            let mut data = allocate_tensor_data(len, DataType::Float);
-            for (i, v) in kept.iter().enumerate() {
-                write_f32(&mut data, i, *v);
-            }
-            Ok(Tensor {
-                data_type: DataType::Float,
-                shape: TensorShape::new(alloc::vec![len as i64]),
-                name: String::new(),
-                raw_data: data,
-            })
-        }
-        Some(ax) => {
-            let rank = input.shape.dims.len();
-            let ax = normalize_axis(ax, rank)?;
-            let axis_dim = input.shape.dims[ax] as usize;
-            let outer: usize = input.shape.dims[..ax]
-                .iter()
-                .map(|&d| d as usize)
-                .product::<usize>()
-                .max(1);
-            let inner: usize = input.shape.dims[ax + 1..]
-                .iter()
-                .map(|&d| d as usize)
-                .product::<usize>()
-                .max(1);
-            let keep: Vec<usize> = (0..axis_dim)
-                .filter(|&i| i < cond.len() && cond[i])
-                .collect();
-            let k_len = keep.len();
-            let mut out_dims = input.shape.dims.clone();
-            out_dims[ax] = k_len as i64;
-            let total = outer * k_len * inner;
-            let mut data = allocate_tensor_data(total, DataType::Float);
-            for o in 0..outer {
-                for (ki, &src_a) in keep.iter().enumerate() {
-                    for i in 0..inner {
-                        let src = o * axis_dim * inner + src_a * inner + i;
-                        let dst = o * k_len * inner + ki * inner + i;
-                        write_f32(&mut data, dst, read_f32(&input.raw_data, src));
-                    }
-                }
-            }
-            Ok(Tensor {
-                data_type: DataType::Float,
-                shape: TensorShape::new(out_dims),
-                name: String::new(),
-                raw_data: data,
-            })
+        })
+        .collect()
+}
+
+fn compress_flat(input: &Tensor, cond: &[bool]) -> Tensor {
+    let total = input.shape.total_elements();
+    let mut kept: Vec<f32> = Vec::new();
+    for i in 0..total {
+        if i < cond.len() && cond[i] {
+            kept.push(read_f32(&input.raw_data, i));
         }
     }
+    let len = kept.len();
+    let mut data = allocate_tensor_data(len, DataType::Float);
+    for (i, v) in kept.iter().enumerate() {
+        write_f32(&mut data, i, *v);
+    }
+    Tensor {
+        data_type: DataType::Float,
+        shape: TensorShape::new(alloc::vec![len as i64]),
+        name: String::new(),
+        raw_data: data,
+    }
+}
+
+fn compress_along_axis(input: &Tensor, cond: &[bool], ax: i64) -> Result<Tensor, OpError> {
+    let rank = input.shape.dims.len();
+    let ax = normalize_axis(ax, rank)?;
+    let axis_dim = input.shape.dims[ax] as usize;
+    let outer = product_dims(&input.shape.dims[..ax]);
+    let inner = product_dims(&input.shape.dims[ax + 1..]);
+    let keep: Vec<usize> = (0..axis_dim)
+        .filter(|&i| i < cond.len() && cond[i])
+        .collect();
+    let k_len = keep.len();
+    let mut out_dims = input.shape.dims.clone();
+    out_dims[ax] = k_len as i64;
+    let total = outer * k_len * inner;
+    let mut data = allocate_tensor_data(total, DataType::Float);
+    for o in 0..outer {
+        for (ki, &src_a) in keep.iter().enumerate() {
+            for i in 0..inner {
+                let src = o * axis_dim * inner + src_a * inner + i;
+                let dst = o * k_len * inner + ki * inner + i;
+                write_f32(&mut data, dst, read_f32(&input.raw_data, src));
+            }
+        }
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: TensorShape::new(out_dims),
+        name: String::new(),
+        raw_data: data,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -233,31 +252,12 @@ pub fn op_non_zero(input: &Tensor) -> Result<Tensor, OpError> {
     let mut coord = alloc::vec![0usize; rank];
     let mut rows: Vec<Vec<i64>> = (0..rank).map(|_| Vec::new()).collect();
     for flat in 0..total {
-        let nonzero = match input.data_type {
-            DataType::Float => read_f32(&input.raw_data, flat) != 0.0,
-            DataType::Int64 => read_i64(&input.raw_data, flat) != 0,
-            DataType::Int32 => crate::byte_io::read_i32(&input.raw_data, flat) != 0,
-            _ => {
-                if flat < input.raw_data.len() {
-                    input.raw_data[flat] != 0
-                } else {
-                    false
-                }
-            }
-        };
-        if nonzero {
-            for d in 0..rank {
-                rows[d].push(coord[d] as i64);
+        if is_nonzero_element(input, flat) {
+            for (d, row) in rows.iter_mut().enumerate() {
+                row.push(coord[d] as i64);
             }
         }
-        // Increment coord
-        for d in (0..rank).rev() {
-            coord[d] += 1;
-            if (coord[d] as i64) < input.shape.dims[d] {
-                break;
-            }
-            coord[d] = 0;
-        }
+        increment_shape_coord(&mut coord, &input.shape.dims, rank);
     }
     let count = rows.first().map(|r| r.len()).unwrap_or(0);
     let mut data = allocate_tensor_data(rank * count, DataType::Int64);
@@ -272,6 +272,25 @@ pub fn op_non_zero(input: &Tensor) -> Result<Tensor, OpError> {
         name: String::new(),
         raw_data: data,
     })
+}
+
+fn is_nonzero_element(input: &Tensor, flat: usize) -> bool {
+    match input.data_type {
+        DataType::Float => read_f32(&input.raw_data, flat) != 0.0,
+        DataType::Int64 => read_i64(&input.raw_data, flat) != 0,
+        DataType::Int32 => crate::byte_io::read_i32(&input.raw_data, flat) != 0,
+        _ => flat < input.raw_data.len() && input.raw_data[flat] != 0,
+    }
+}
+
+fn increment_shape_coord(coord: &mut [usize], dims: &[i64], rank: usize) {
+    for d in (0..rank).rev() {
+        coord[d] += 1;
+        if (coord[d] as i64) < dims[d] {
+            break;
+        }
+        coord[d] = 0;
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -350,40 +369,13 @@ pub fn op_gather_elements(input: &Tensor, indices: &Tensor, axis: i64) -> Result
         )));
     }
     let mut data = allocate_tensor_data(total, DataType::Float);
-    // Compute strides.
-    let mut strides = alloc::vec![1usize; rank];
-    for i in (0..rank.saturating_sub(1)).rev() {
-        strides[i] = strides[i + 1] * input.shape.dims[i + 1] as usize;
-    }
+    let strides = element_strides(&input.shape.dims, rank);
     let mut coord = alloc::vec![0usize; rank];
     for (flat, &raw_idx) in idx.iter().enumerate().take(total) {
-        let mut src_idx_val = raw_idx;
-        if src_idx_val < 0 {
-            src_idx_val += axis_dim as i64;
-        }
-        if src_idx_val < 0 || (src_idx_val as usize) >= axis_dim {
-            return Err(OpError::ShapeMismatch(String::from(
-                "GatherElements: index out of range",
-            )));
-        }
-        let mut src = 0usize;
-        for d in 0..rank {
-            let c = if d == ax {
-                src_idx_val as usize
-            } else {
-                coord[d]
-            };
-            src += c * strides[d];
-        }
+        let src_idx_val = normalize_index(raw_idx, axis_dim, "GatherElements")?;
+        let src = src_offset(&coord, &strides, rank, ax, src_idx_val);
         write_f32(&mut data, flat, read_f32(&input.raw_data, src));
-        // Increment coord.
-        for d in (0..rank).rev() {
-            coord[d] += 1;
-            if (coord[d] as i64) < input.shape.dims[d] {
-                break;
-            }
-            coord[d] = 0;
-        }
+        increment_shape_coord(&mut coord, &input.shape.dims, rank);
     }
     Ok(Tensor {
         data_type: DataType::Float,
@@ -391,6 +383,43 @@ pub fn op_gather_elements(input: &Tensor, indices: &Tensor, axis: i64) -> Result
         name: String::new(),
         raw_data: data,
     })
+}
+
+fn element_strides(dims: &[i64], rank: usize) -> Vec<usize> {
+    let mut strides = alloc::vec![1usize; rank];
+    for i in (0..rank.saturating_sub(1)).rev() {
+        strides[i] = strides[i + 1] * dims[i + 1] as usize;
+    }
+    strides
+}
+
+fn normalize_index(raw_idx: i64, axis_dim: usize, op: &str) -> Result<usize, OpError> {
+    let mut v = raw_idx;
+    if v < 0 {
+        v += axis_dim as i64;
+    }
+    if v < 0 || (v as usize) >= axis_dim {
+        return Err(OpError::ShapeMismatch(alloc::format!(
+            "{}: index out of range",
+            op
+        )));
+    }
+    Ok(v as usize)
+}
+
+fn src_offset(
+    coord: &[usize],
+    strides: &[usize],
+    rank: usize,
+    ax: usize,
+    axis_idx: usize,
+) -> usize {
+    let mut src = 0usize;
+    for d in 0..rank {
+        let c = if d == ax { axis_idx } else { coord[d] };
+        src += c * strides[d];
+    }
+    src
 }
 
 /// Element-wise scatter along `axis`. `indices` and `updates` must have
@@ -418,12 +447,47 @@ pub fn op_scatter_elements(
     }
     let ax = normalize_axis(axis, rank)?;
     let axis_dim = input.shape.dims[ax] as usize;
-    // Non-axis dims of indices/updates must not exceed the corresponding
-    // dims of `input`, otherwise the scatter would write past the output
-    // buffer. ONNX additionally allows indices[ax] <= input[ax].
+    validate_scatter_dims(&input.shape.dims, &indices.shape.dims, rank, ax)?;
+    let idx = read_i64_vec(indices);
+    let u_total = updates.shape.total_elements();
+    if idx.len() != u_total {
+        return Err(OpError::ShapeMismatch(String::from(
+            "ScatterElements: indices must be Int32/Int64",
+        )));
+    }
+    // Start with a copy of input.
+    let mut data = input.raw_data.clone();
+    let strides = element_strides(&input.shape.dims, rank);
+    let mut coord = alloc::vec![0usize; rank];
+    for (flat, &raw_idx) in idx.iter().enumerate().take(u_total) {
+        let ax_idx = normalize_index(raw_idx, axis_dim, "ScatterElements")?;
+        let dst = src_offset(&coord, &strides, rank, ax, ax_idx);
+        let upd = read_f32(&updates.raw_data, flat);
+        let cur = read_f32(&data, dst);
+        let new_val = apply_scatter_reduction(reduction, cur, upd)?;
+        write_f32(&mut data, dst, new_val);
+        increment_shape_coord(&mut coord, &updates.shape.dims, rank);
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: input.shape.clone(),
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+/// Non-axis dims of indices/updates must not exceed the corresponding
+/// dims of `input`, otherwise the scatter would write past the output
+/// buffer. ONNX additionally allows indices[ax] <= input[ax].
+fn validate_scatter_dims(
+    input_dims: &[i64],
+    idx_dims: &[i64],
+    rank: usize,
+    ax: usize,
+) -> Result<(), OpError> {
     for d in 0..rank {
-        let in_d = input.shape.dims[d];
-        let idx_d = indices.shape.dims[d];
+        let in_d = input_dims[d];
+        let idx_d = idx_dims[d];
         if idx_d < 0 || in_d < 0 {
             return Err(OpError::ShapeMismatch(String::from(
                 "ScatterElements: negative dimensions are invalid",
@@ -441,64 +505,19 @@ pub fn op_scatter_elements(
             )));
         }
     }
-    let idx = read_i64_vec(indices);
-    let u_total = updates.shape.total_elements();
-    if idx.len() != u_total {
-        return Err(OpError::ShapeMismatch(String::from(
-            "ScatterElements: indices must be Int32/Int64",
-        )));
+    Ok(())
+}
+
+fn apply_scatter_reduction(reduction: &str, cur: f32, upd: f32) -> Result<f32, OpError> {
+    match reduction {
+        "" | "none" => Ok(upd),
+        "add" => Ok(cur + upd),
+        "mul" => Ok(cur * upd),
+        other => Err(OpError::InvalidAttribute(alloc::format!(
+            "ScatterElements reduction '{}' not supported",
+            other
+        ))),
     }
-    // Start with a copy of input.
-    let mut data = input.raw_data.clone();
-    let mut strides = alloc::vec![1usize; rank];
-    for i in (0..rank.saturating_sub(1)).rev() {
-        strides[i] = strides[i + 1] * input.shape.dims[i + 1] as usize;
-    }
-    let mut coord = alloc::vec![0usize; rank];
-    for (flat, &raw_idx) in idx.iter().enumerate().take(u_total) {
-        let mut ax_idx = raw_idx;
-        if ax_idx < 0 {
-            ax_idx += axis_dim as i64;
-        }
-        if ax_idx < 0 || (ax_idx as usize) >= axis_dim {
-            return Err(OpError::ShapeMismatch(String::from(
-                "ScatterElements: index out of range",
-            )));
-        }
-        let mut dst = 0usize;
-        for d in 0..rank {
-            let c = if d == ax { ax_idx as usize } else { coord[d] };
-            dst += c * strides[d];
-        }
-        let upd = read_f32(&updates.raw_data, flat);
-        let cur = read_f32(&data, dst);
-        let new_val = match reduction {
-            "" | "none" => upd,
-            "add" => cur + upd,
-            "mul" => cur * upd,
-            other => {
-                return Err(OpError::InvalidAttribute(alloc::format!(
-                    "ScatterElements reduction '{}' not supported",
-                    other
-                )));
-            }
-        };
-        write_f32(&mut data, dst, new_val);
-        // Increment coord over updates shape.
-        for d in (0..rank).rev() {
-            coord[d] += 1;
-            if (coord[d] as i64) < updates.shape.dims[d] {
-                break;
-            }
-            coord[d] = 0;
-        }
-    }
-    Ok(Tensor {
-        data_type: DataType::Float,
-        shape: input.shape.clone(),
-        name: String::new(),
-        raw_data: data,
-    })
 }
 
 #[cfg(test)]

--- a/onnx-rt/src/ops/vision.rs
+++ b/onnx-rt/src/ops/vision.rs
@@ -85,69 +85,13 @@ pub fn op_resize(
     mode: &str,
 ) -> Result<Tensor, OpError> {
     let (n, c, h, w) = require_4d(input, "Resize")?;
-    let (oh, ow) = if let Some(s) = sizes {
-        if s.len() != 4 {
-            return Err(OpError::InvalidAttribute(String::from(
-                "Resize sizes must have rank 4",
-            )));
-        }
-        if s.iter().any(|&d| d < 0) {
-            return Err(OpError::InvalidAttribute(String::from(
-                "Resize sizes must be non-negative",
-            )));
-        }
-        // Bound the spatial dims so the later `n*c*oh*ow` allocation
-        // cannot overflow usize.
-        let oh_i = s[2];
-        let ow_i = s[3];
-        if oh_i > (i32::MAX as i64) || ow_i > (i32::MAX as i64) {
-            return Err(OpError::InvalidAttribute(String::from(
-                "Resize output dims exceed addressable range",
-            )));
-        }
-        (oh_i as usize, ow_i as usize)
-    } else if let Some(s) = scales {
-        if s.len() != 4 {
-            return Err(OpError::InvalidAttribute(String::from(
-                "Resize scales must have rank 4",
-            )));
-        }
-        if !s.iter().all(|v| v.is_finite() && *v > 0.0) {
-            return Err(OpError::InvalidAttribute(String::from(
-                "Resize scales must be finite and > 0",
-            )));
-        }
-        let oh_f = round_f32((h as f32) * s[2]);
-        let ow_f = round_f32((w as f32) * s[3]);
-        if !oh_f.is_finite() || !ow_f.is_finite() || oh_f < 0.0 || ow_f < 0.0 {
-            return Err(OpError::InvalidAttribute(String::from(
-                "Resize computed output dims are invalid",
-            )));
-        }
-        if oh_f > (i32::MAX as f32) || ow_f > (i32::MAX as f32) {
-            return Err(OpError::InvalidAttribute(String::from(
-                "Resize output dims exceed addressable range",
-            )));
-        }
-        (oh_f as usize, ow_f as usize)
-    } else {
-        return Err(OpError::InvalidAttribute(String::from(
-            "Resize requires scales or sizes",
-        )));
-    };
+    let (oh, ow) = resolve_resize_output_dims(h, w, scales, sizes)?;
     if oh == 0 || ow == 0 {
         return Err(OpError::ShapeMismatch(String::from(
             "Resize output dims must be > 0",
         )));
     }
-    // Checked total-elements to guarantee no overflow before allocation.
-    let total_out = n
-        .checked_mul(c)
-        .and_then(|v| v.checked_mul(oh))
-        .and_then(|v| v.checked_mul(ow))
-        .ok_or_else(|| {
-            OpError::InvalidAttribute(String::from("Resize output tensor size overflows usize"))
-        })?;
+    let total_out = checked_total_elements(n, c, oh, ow)?;
     let out_shape = TensorShape::new(alloc::vec![n as i64, c as i64, oh as i64, ow as i64]);
     let mut data = allocate_tensor_data(total_out, DataType::Float);
     let h_scale = h as f32 / oh as f32;
@@ -156,36 +100,16 @@ pub fn op_resize(
         for ch in 0..c {
             let plane = bn * c * h * w + ch * h * w;
             let out_plane = bn * c * oh * ow + ch * oh * ow;
-            for oy in 0..oh {
-                for ox in 0..ow {
-                    // half_pixel: src = (out + 0.5) * scale - 0.5
-                    let sy = (oy as f32 + 0.5) * h_scale - 0.5;
-                    let sx = (ox as f32 + 0.5) * w_scale - 0.5;
-                    let v = match mode {
-                        "nearest" => {
-                            let iy = round_f32(sy).clamp(0.0, (h - 1) as f32) as usize;
-                            let ix = round_f32(sx).clamp(0.0, (w - 1) as f32) as usize;
-                            read_f32(&input.raw_data, plane + iy * w + ix)
-                        }
-                        "linear" | "bilinear" => bilinear_sample(
-                            &input.raw_data,
-                            plane,
-                            h,
-                            w,
-                            sy,
-                            sx,
-                            /*zero_pad=*/ false,
-                        ),
-                        other => {
-                            return Err(OpError::InvalidAttribute(alloc::format!(
-                                "Resize mode '{}' not supported",
-                                other
-                            )));
-                        }
-                    };
-                    write_f32(&mut data, out_plane + oy * ow + ox, v);
-                }
-            }
+            resize_plane(
+                &input.raw_data,
+                &mut data,
+                plane,
+                out_plane,
+                (h, w),
+                (oh, ow),
+                (h_scale, w_scale),
+                mode,
+            )?;
         }
     }
     Ok(Tensor {
@@ -194,6 +118,131 @@ pub fn op_resize(
         name: String::new(),
         raw_data: data,
     })
+}
+
+/// Resolve the (oh, ow) output spatial dimensions for `Resize` from the
+/// `sizes` (preferred) or `scales` input. Returns an error if the
+/// attribute is malformed or would overflow the output buffer.
+fn resolve_resize_output_dims(
+    h: usize,
+    w: usize,
+    scales: Option<&[f32]>,
+    sizes: Option<&[i64]>,
+) -> Result<(usize, usize), OpError> {
+    if let Some(s) = sizes {
+        return resize_dims_from_sizes(s);
+    }
+    if let Some(s) = scales {
+        return resize_dims_from_scales(h, w, s);
+    }
+    Err(OpError::InvalidAttribute(String::from(
+        "Resize requires scales or sizes",
+    )))
+}
+
+fn resize_dims_from_sizes(s: &[i64]) -> Result<(usize, usize), OpError> {
+    if s.len() != 4 {
+        return Err(OpError::InvalidAttribute(String::from(
+            "Resize sizes must have rank 4",
+        )));
+    }
+    if s.iter().any(|&d| d < 0) {
+        return Err(OpError::InvalidAttribute(String::from(
+            "Resize sizes must be non-negative",
+        )));
+    }
+    let oh_i = s[2];
+    let ow_i = s[3];
+    if oh_i > (i32::MAX as i64) || ow_i > (i32::MAX as i64) {
+        return Err(OpError::InvalidAttribute(String::from(
+            "Resize output dims exceed addressable range",
+        )));
+    }
+    Ok((oh_i as usize, ow_i as usize))
+}
+
+fn resize_dims_from_scales(h: usize, w: usize, s: &[f32]) -> Result<(usize, usize), OpError> {
+    if s.len() != 4 {
+        return Err(OpError::InvalidAttribute(String::from(
+            "Resize scales must have rank 4",
+        )));
+    }
+    if !s.iter().all(|v| v.is_finite() && *v > 0.0) {
+        return Err(OpError::InvalidAttribute(String::from(
+            "Resize scales must be finite and > 0",
+        )));
+    }
+    let oh_f = round_f32((h as f32) * s[2]);
+    let ow_f = round_f32((w as f32) * s[3]);
+    if !oh_f.is_finite() || !ow_f.is_finite() || oh_f < 0.0 || ow_f < 0.0 {
+        return Err(OpError::InvalidAttribute(String::from(
+            "Resize computed output dims are invalid",
+        )));
+    }
+    if oh_f > (i32::MAX as f32) || ow_f > (i32::MAX as f32) {
+        return Err(OpError::InvalidAttribute(String::from(
+            "Resize output dims exceed addressable range",
+        )));
+    }
+    Ok((oh_f as usize, ow_f as usize))
+}
+
+fn checked_total_elements(n: usize, c: usize, oh: usize, ow: usize) -> Result<usize, OpError> {
+    n.checked_mul(c)
+        .and_then(|v| v.checked_mul(oh))
+        .and_then(|v| v.checked_mul(ow))
+        .ok_or_else(|| {
+            OpError::InvalidAttribute(String::from("Resize output tensor size overflows usize"))
+        })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn resize_plane(
+    raw: &[u8],
+    data: &mut [u8],
+    plane: usize,
+    out_plane: usize,
+    in_hw: (usize, usize),
+    out_hw: (usize, usize),
+    scales: (f32, f32),
+    mode: &str,
+) -> Result<(), OpError> {
+    let (h, w) = in_hw;
+    let (oh, ow) = out_hw;
+    let (h_scale, w_scale) = scales;
+    for oy in 0..oh {
+        for ox in 0..ow {
+            // half_pixel: src = (out + 0.5) * scale - 0.5
+            let sy = (oy as f32 + 0.5) * h_scale - 0.5;
+            let sx = (ox as f32 + 0.5) * w_scale - 0.5;
+            let v = sample_resize_pixel(raw, plane, h, w, sy, sx, mode)?;
+            write_f32(data, out_plane + oy * ow + ox, v);
+        }
+    }
+    Ok(())
+}
+
+fn sample_resize_pixel(
+    raw: &[u8],
+    plane: usize,
+    h: usize,
+    w: usize,
+    sy: f32,
+    sx: f32,
+    mode: &str,
+) -> Result<f32, OpError> {
+    match mode {
+        "nearest" => {
+            let iy = round_f32(sy).clamp(0.0, (h - 1) as f32) as usize;
+            let ix = round_f32(sx).clamp(0.0, (w - 1) as f32) as usize;
+            Ok(read_f32(raw, plane + iy * w + ix))
+        }
+        "linear" | "bilinear" => Ok(bilinear_sample(raw, plane, h, w, sy, sx, false)),
+        other => Err(OpError::InvalidAttribute(alloc::format!(
+            "Resize mode '{}' not supported",
+            other
+        ))),
+    }
 }
 
 /// Bilinear sample from a single HxW plane with clamp-to-edge (or
@@ -263,18 +312,8 @@ pub fn op_depth_to_space(input: &Tensor, blocksize: i64, mode: &str) -> Result<T
         for co in 0..c_out {
             for yy in 0..oh {
                 for xx in 0..ow {
+                    let ci = depth_to_space_channel_index(mode, r, c_out, yy, xx, co)?;
                     let (ih, iw) = (yy / r, xx / r);
-                    let (by_, bx_) = (yy % r, xx % r);
-                    let ci = match mode {
-                        "DCR" => (by_ * r + bx_) * c_out + co,
-                        "CRD" => co * r * r + by_ * r + bx_,
-                        other => {
-                            return Err(OpError::InvalidAttribute(alloc::format!(
-                                "DepthToSpace mode '{}' not supported",
-                                other
-                            )));
-                        }
-                    };
                     let src = bn * c_in * h * w + ci * h * w + ih * w + iw;
                     let dst = bn * c_out * oh * ow + co * oh * ow + yy * ow + xx;
                     write_f32(&mut data, dst, read_f32(&input.raw_data, src));
@@ -288,6 +327,30 @@ pub fn op_depth_to_space(input: &Tensor, blocksize: i64, mode: &str) -> Result<T
         name: String::new(),
         raw_data: data,
     })
+}
+
+/// Compute the source channel index for `DepthToSpace` given the mode
+/// (`DCR` or `CRD`), block size `r`, output channel count, and the
+/// current output (yy, xx, co) coordinate. Returns `InvalidAttribute`
+/// for unsupported modes.
+fn depth_to_space_channel_index(
+    mode: &str,
+    r: usize,
+    c_out: usize,
+    yy: usize,
+    xx: usize,
+    co: usize,
+) -> Result<usize, OpError> {
+    let by_ = yy % r;
+    let bx_ = xx % r;
+    match mode {
+        "DCR" => Ok((by_ * r + bx_) * c_out + co),
+        "CRD" => Ok(co * r * r + by_ * r + bx_),
+        other => Err(OpError::InvalidAttribute(alloc::format!(
+            "DepthToSpace mode '{}' not supported",
+            other
+        ))),
+    }
 }
 
 /// SpaceToDepth: [N, C, H*r, W*r] -> [N, C*r*r, H, W] (DCR-style order).
@@ -311,20 +374,16 @@ pub fn op_space_to_depth(input: &Tensor, blocksize: i64) -> Result<Tensor, OpErr
     let mut data = allocate_tensor_data(n * c_out * oh * ow, DataType::Float);
     for bn in 0..n {
         for ci in 0..c_in {
-            for by_ in 0..r {
-                for bx_ in 0..r {
-                    let co = (by_ * r + bx_) * c_in + ci;
-                    for yy in 0..oh {
-                        for xx in 0..ow {
-                            let src_y = yy * r + by_;
-                            let src_x = xx * r + bx_;
-                            let src = bn * c_in * h * w + ci * h * w + src_y * w + src_x;
-                            let dst = bn * c_out * oh * ow + co * oh * ow + yy * ow + xx;
-                            write_f32(&mut data, dst, read_f32(&input.raw_data, src));
-                        }
-                    }
-                }
-            }
+            space_to_depth_channel(
+                &input.raw_data,
+                &mut data,
+                bn,
+                ci,
+                r,
+                (c_in, c_out),
+                (h, w),
+                (oh, ow),
+            );
         }
     }
     Ok(Tensor {
@@ -333,6 +392,69 @@ pub fn op_space_to_depth(input: &Tensor, blocksize: i64) -> Result<Tensor, OpErr
         name: String::new(),
         raw_data: data,
     })
+}
+
+/// Copy one input channel into its `r*r` output sub-channels under the
+/// DCR-style ordering used by `SpaceToDepth`.
+#[allow(clippy::too_many_arguments)]
+fn space_to_depth_channel(
+    raw: &[u8],
+    data: &mut [u8],
+    bn: usize,
+    ci: usize,
+    r: usize,
+    c_in_out: (usize, usize),
+    in_hw: (usize, usize),
+    out_hw: (usize, usize),
+) {
+    let (c_in, c_out) = c_in_out;
+    let (h, w) = in_hw;
+    let (oh, ow) = out_hw;
+    for by_ in 0..r {
+        for bx_ in 0..r {
+            let co = (by_ * r + bx_) * c_in + ci;
+            copy_space_to_depth_block(
+                raw,
+                data,
+                bn,
+                ci,
+                co,
+                (by_, bx_),
+                r,
+                (c_in, c_out),
+                (h, w),
+                (oh, ow),
+            );
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn copy_space_to_depth_block(
+    raw: &[u8],
+    data: &mut [u8],
+    bn: usize,
+    ci: usize,
+    co: usize,
+    block: (usize, usize),
+    r: usize,
+    c_in_out: (usize, usize),
+    in_hw: (usize, usize),
+    out_hw: (usize, usize),
+) {
+    let (by_, bx_) = block;
+    let (c_in, c_out) = c_in_out;
+    let (h, w) = in_hw;
+    let (oh, ow) = out_hw;
+    for yy in 0..oh {
+        for xx in 0..ow {
+            let src_y = yy * r + by_;
+            let src_x = xx * r + bx_;
+            let src = bn * c_in * h * w + ci * h * w + src_y * w + src_x;
+            let dst = bn * c_out * oh * ow + co * oh * ow + yy * ow + xx;
+            write_f32(data, dst, read_f32(raw, src));
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -366,44 +488,13 @@ pub fn op_roi_align(
         )));
     }
     let (n_batch, c, h, w) = require_4d(x, "RoiAlign")?;
-    require_float(rois, "RoiAlign")?;
-    if rois.shape.dims.len() != 2 || rois.shape.dims[1] != 4 {
-        return Err(OpError::ShapeMismatch(String::from(
-            "RoiAlign rois must be [num_rois, 4]",
-        )));
-    }
+    validate_roi_align_rois(rois)?;
     let num_rois = rois.shape.dims[0] as usize;
     let pooled_h = output_height.max(1) as usize;
     let pooled_w = output_width.max(1) as usize;
 
-    // batch_indices must be a 1D tensor of length num_rois.
-    if batch_indices.shape.total_elements() != num_rois {
-        return Err(OpError::ShapeMismatch(String::from(
-            "RoiAlign batch_indices length must equal num_rois",
-        )));
-    }
-
-    // Decode batch indices (Int64 or Int32).
-    let bi: Vec<i64> = match batch_indices.data_type {
-        DataType::Int64 => (0..num_rois)
-            .map(|i| crate::byte_io::read_i64(&batch_indices.raw_data, i))
-            .collect(),
-        DataType::Int32 => (0..num_rois)
-            .map(|i| crate::byte_io::read_i32(&batch_indices.raw_data, i) as i64)
-            .collect(),
-        _ => {
-            return Err(OpError::ShapeMismatch(String::from(
-                "RoiAlign batch_indices must be Int32/Int64",
-            )));
-        }
-    };
-    for &b in &bi {
-        if b < 0 || (b as usize) >= n_batch {
-            return Err(OpError::ShapeMismatch(String::from(
-                "RoiAlign batch_indices value out of range [0, N)",
-            )));
-        }
-    }
+    let bi = decode_roi_batch_indices(batch_indices, num_rois)?;
+    validate_roi_batch_ids(&bi, n_batch)?;
 
     let out_shape = TensorShape::new(alloc::vec![
         num_rois as i64,
@@ -414,54 +505,17 @@ pub fn op_roi_align(
     let mut data = allocate_tensor_data(num_rois * c * pooled_h * pooled_w, DataType::Float);
 
     for (r_idx, &batch_id) in bi.iter().enumerate() {
-        let base = r_idx * 4;
-        let x1 = read_f32(&rois.raw_data, base) * spatial_scale;
-        let y1 = read_f32(&rois.raw_data, base + 1) * spatial_scale;
-        let x2 = read_f32(&rois.raw_data, base + 2) * spatial_scale;
-        let y2 = read_f32(&rois.raw_data, base + 3) * spatial_scale;
-        let roi_w = (x2 - x1).max(1.0);
-        let roi_h = (y2 - y1).max(1.0);
-        let bin_h = roi_h / pooled_h as f32;
-        let bin_w = roi_w / pooled_w as f32;
-        let sr_h = if sampling_ratio > 0 {
-            sampling_ratio as usize
-        } else {
-            ceil_f32(roi_h / pooled_h as f32).max(1.0) as usize
-        };
-        let sr_w = if sampling_ratio > 0 {
-            sampling_ratio as usize
-        } else {
-            ceil_f32(roi_w / pooled_w as f32).max(1.0) as usize
-        };
-        // Bounds already validated above.
-        let bn = batch_id as usize;
-        for ch in 0..c {
-            let plane = bn * c * h * w + ch * h * w;
-            for py in 0..pooled_h {
-                for px in 0..pooled_w {
-                    let mut acc = 0.0f32;
-                    let mut count = 0u32;
-                    for iy in 0..sr_h {
-                        for ix in 0..sr_w {
-                            let sy = y1
-                                + (py as f32) * bin_h
-                                + ((iy as f32) + 0.5) * bin_h / (sr_h as f32);
-                            let sx = x1
-                                + (px as f32) * bin_w
-                                + ((ix as f32) + 0.5) * bin_w / (sr_w as f32);
-                            acc += bilinear_sample(&x.raw_data, plane, h, w, sy, sx, true);
-                            count += 1;
-                        }
-                    }
-                    let v = if count > 0 { acc / count as f32 } else { 0.0 };
-                    let dst = r_idx * c * pooled_h * pooled_w
-                        + ch * pooled_h * pooled_w
-                        + py * pooled_w
-                        + px;
-                    write_f32(&mut data, dst, v);
-                }
-            }
-        }
+        pool_one_roi(
+            x,
+            rois,
+            &mut data,
+            r_idx,
+            batch_id as usize,
+            (c, h, w),
+            (pooled_h, pooled_w),
+            sampling_ratio,
+            spatial_scale,
+        );
     }
     Ok(Tensor {
         data_type: DataType::Float,
@@ -469,6 +523,159 @@ pub fn op_roi_align(
         name: String::new(),
         raw_data: data,
     })
+}
+
+fn validate_roi_align_rois(rois: &Tensor) -> Result<(), OpError> {
+    require_float(rois, "RoiAlign")?;
+    if rois.shape.dims.len() != 2 || rois.shape.dims[1] != 4 {
+        return Err(OpError::ShapeMismatch(String::from(
+            "RoiAlign rois must be [num_rois, 4]",
+        )));
+    }
+    Ok(())
+}
+
+fn decode_roi_batch_indices(batch_indices: &Tensor, num_rois: usize) -> Result<Vec<i64>, OpError> {
+    if batch_indices.shape.total_elements() != num_rois {
+        return Err(OpError::ShapeMismatch(String::from(
+            "RoiAlign batch_indices length must equal num_rois",
+        )));
+    }
+    match batch_indices.data_type {
+        DataType::Int64 => Ok((0..num_rois)
+            .map(|i| crate::byte_io::read_i64(&batch_indices.raw_data, i))
+            .collect()),
+        DataType::Int32 => Ok((0..num_rois)
+            .map(|i| crate::byte_io::read_i32(&batch_indices.raw_data, i) as i64)
+            .collect()),
+        _ => Err(OpError::ShapeMismatch(String::from(
+            "RoiAlign batch_indices must be Int32/Int64",
+        ))),
+    }
+}
+
+fn validate_roi_batch_ids(bi: &[i64], n_batch: usize) -> Result<(), OpError> {
+    for &b in bi {
+        if b < 0 || (b as usize) >= n_batch {
+            return Err(OpError::ShapeMismatch(String::from(
+                "RoiAlign batch_indices value out of range [0, N)",
+            )));
+        }
+    }
+    Ok(())
+}
+
+struct RoiBinGeometry {
+    x1: f32,
+    y1: f32,
+    bin_h: f32,
+    bin_w: f32,
+    sr_h: usize,
+    sr_w: usize,
+}
+
+/// Decode the ROI box for `r_idx` and the sampling lattice (bin sizes,
+/// sub-sample counts) given the global pooling configuration.
+fn roi_bin_geometry(
+    rois: &Tensor,
+    r_idx: usize,
+    pooled_h: usize,
+    pooled_w: usize,
+    sampling_ratio: i64,
+    spatial_scale: f32,
+) -> RoiBinGeometry {
+    let base = r_idx * 4;
+    let x1 = read_f32(&rois.raw_data, base) * spatial_scale;
+    let y1 = read_f32(&rois.raw_data, base + 1) * spatial_scale;
+    let x2 = read_f32(&rois.raw_data, base + 2) * spatial_scale;
+    let y2 = read_f32(&rois.raw_data, base + 3) * spatial_scale;
+    let roi_w = (x2 - x1).max(1.0);
+    let roi_h = (y2 - y1).max(1.0);
+    let bin_h = roi_h / pooled_h as f32;
+    let bin_w = roi_w / pooled_w as f32;
+    let sr_h = sampling_count(sampling_ratio, roi_h, pooled_h);
+    let sr_w = sampling_count(sampling_ratio, roi_w, pooled_w);
+    RoiBinGeometry {
+        x1,
+        y1,
+        bin_h,
+        bin_w,
+        sr_h,
+        sr_w,
+    }
+}
+
+fn sampling_count(sampling_ratio: i64, roi_side: f32, pooled_side: usize) -> usize {
+    if sampling_ratio > 0 {
+        sampling_ratio as usize
+    } else {
+        ceil_f32(roi_side / pooled_side as f32).max(1.0) as usize
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn pool_one_roi(
+    x: &Tensor,
+    rois: &Tensor,
+    data: &mut [u8],
+    r_idx: usize,
+    bn: usize,
+    chw: (usize, usize, usize),
+    pooled_hw: (usize, usize),
+    sampling_ratio: i64,
+    spatial_scale: f32,
+) {
+    let (c, h, w) = chw;
+    let (pooled_h, pooled_w) = pooled_hw;
+    let geom = roi_bin_geometry(
+        rois,
+        r_idx,
+        pooled_h,
+        pooled_w,
+        sampling_ratio,
+        spatial_scale,
+    );
+    for ch in 0..c {
+        let plane = bn * c * h * w + ch * h * w;
+        for py in 0..pooled_h {
+            for px in 0..pooled_w {
+                let v = average_roi_bin(&x.raw_data, plane, h, w, &geom, py, px);
+                let dst =
+                    r_idx * c * pooled_h * pooled_w + ch * pooled_h * pooled_w + py * pooled_w + px;
+                write_f32(data, dst, v);
+            }
+        }
+    }
+}
+
+fn average_roi_bin(
+    raw: &[u8],
+    plane: usize,
+    h: usize,
+    w: usize,
+    geom: &RoiBinGeometry,
+    py: usize,
+    px: usize,
+) -> f32 {
+    let mut acc = 0.0f32;
+    let mut count = 0u32;
+    for iy in 0..geom.sr_h {
+        for ix in 0..geom.sr_w {
+            let sy = geom.y1
+                + (py as f32) * geom.bin_h
+                + ((iy as f32) + 0.5) * geom.bin_h / (geom.sr_h as f32);
+            let sx = geom.x1
+                + (px as f32) * geom.bin_w
+                + ((ix as f32) + 0.5) * geom.bin_w / (geom.sr_w as f32);
+            acc += bilinear_sample(raw, plane, h, w, sy, sx, true);
+            count += 1;
+        }
+    }
+    if count > 0 {
+        acc / count as f32
+    } else {
+        0.0
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -489,6 +696,41 @@ pub fn op_grid_sample(
     align_corners: bool,
 ) -> Result<Tensor, OpError> {
     let (n, c, h, w) = require_4d(input, "GridSample")?;
+    validate_grid_sample_grid(grid, n, padding_mode)?;
+    let oh = grid.shape.dims[1] as usize;
+    let ow = grid.shape.dims[2] as usize;
+    let out_shape = TensorShape::new(alloc::vec![n as i64, c as i64, oh as i64, ow as i64]);
+    let mut data = allocate_tensor_data(n * c * oh * ow, DataType::Float);
+    for bn in 0..n {
+        for yy in 0..oh {
+            for xx in 0..ow {
+                let g_off = bn * oh * ow * 2 + yy * ow * 2 + xx * 2;
+                let gx = read_f32(&grid.raw_data, g_off);
+                let gy = read_f32(&grid.raw_data, g_off + 1);
+                let (sx, sy) = grid_to_pixel(gx, gy, w, h, align_corners);
+                write_grid_sample_pixels(
+                    &input.raw_data,
+                    &mut data,
+                    bn,
+                    yy,
+                    xx,
+                    (n, c, h, w),
+                    (oh, ow),
+                    (sy, sx),
+                    mode,
+                )?;
+            }
+        }
+    }
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: out_shape,
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+fn validate_grid_sample_grid(grid: &Tensor, n: usize, padding_mode: &str) -> Result<(), OpError> {
     require_float(grid, "GridSample")?;
     if padding_mode != "zeros" {
         return Err(OpError::InvalidAttribute(alloc::format!(
@@ -507,62 +749,76 @@ pub fn op_grid_sample(
             "GridSample grid batch must match input batch",
         )));
     }
-    let oh = grid.shape.dims[1] as usize;
-    let ow = grid.shape.dims[2] as usize;
-    let out_shape = TensorShape::new(alloc::vec![n as i64, c as i64, oh as i64, ow as i64]);
-    let mut data = allocate_tensor_data(n * c * oh * ow, DataType::Float);
-    for bn in 0..n {
-        for yy in 0..oh {
-            for xx in 0..ow {
-                let g_off = bn * oh * ow * 2 + yy * ow * 2 + xx * 2;
-                let gx = read_f32(&grid.raw_data, g_off);
-                let gy = read_f32(&grid.raw_data, g_off + 1);
-                // Map from [-1,1] to pixel coordinates.
-                let (sx, sy) = if align_corners {
-                    (
-                        (gx + 1.0) * 0.5 * ((w - 1) as f32),
-                        (gy + 1.0) * 0.5 * ((h - 1) as f32),
-                    )
-                } else {
-                    (
-                        ((gx + 1.0) * (w as f32) - 1.0) * 0.5,
-                        ((gy + 1.0) * (h as f32) - 1.0) * 0.5,
-                    )
-                };
-                for ch in 0..c {
-                    let plane = bn * c * h * w + ch * h * w;
-                    let v = match mode {
-                        "bilinear" | "linear" => {
-                            bilinear_sample(&input.raw_data, plane, h, w, sy, sx, true)
-                        }
-                        "nearest" => {
-                            let iy = round_f32(sy);
-                            let ix = round_f32(sx);
-                            if iy < 0.0 || iy >= h as f32 || ix < 0.0 || ix >= w as f32 {
-                                0.0
-                            } else {
-                                read_f32(&input.raw_data, plane + (iy as usize) * w + (ix as usize))
-                            }
-                        }
-                        other => {
-                            return Err(OpError::InvalidAttribute(alloc::format!(
-                                "GridSample mode '{}' not supported",
-                                other
-                            )));
-                        }
-                    };
-                    let dst = bn * c * oh * ow + ch * oh * ow + yy * ow + xx;
-                    write_f32(&mut data, dst, v);
-                }
-            }
-        }
+    Ok(())
+}
+
+/// Map a `[-1, 1]` grid coordinate `(gx, gy)` to fractional pixel
+/// coordinates given the source image size and `align_corners` flag.
+fn grid_to_pixel(gx: f32, gy: f32, w: usize, h: usize, align_corners: bool) -> (f32, f32) {
+    if align_corners {
+        (
+            (gx + 1.0) * 0.5 * ((w - 1) as f32),
+            (gy + 1.0) * 0.5 * ((h - 1) as f32),
+        )
+    } else {
+        (
+            ((gx + 1.0) * (w as f32) - 1.0) * 0.5,
+            ((gy + 1.0) * (h as f32) - 1.0) * 0.5,
+        )
     }
-    Ok(Tensor {
-        data_type: DataType::Float,
-        shape: out_shape,
-        name: String::new(),
-        raw_data: data,
-    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn write_grid_sample_pixels(
+    raw: &[u8],
+    data: &mut [u8],
+    bn: usize,
+    yy: usize,
+    xx: usize,
+    nchw: (usize, usize, usize, usize),
+    out_hw: (usize, usize),
+    sy_sx: (f32, f32),
+    mode: &str,
+) -> Result<(), OpError> {
+    let (_, c, h, w) = nchw;
+    let (oh, ow) = out_hw;
+    let (sy, sx) = sy_sx;
+    for ch in 0..c {
+        let plane = bn * c * h * w + ch * h * w;
+        let v = sample_grid_pixel(raw, plane, h, w, sy, sx, mode)?;
+        let dst = bn * c * oh * ow + ch * oh * ow + yy * ow + xx;
+        write_f32(data, dst, v);
+    }
+    Ok(())
+}
+
+fn sample_grid_pixel(
+    raw: &[u8],
+    plane: usize,
+    h: usize,
+    w: usize,
+    sy: f32,
+    sx: f32,
+    mode: &str,
+) -> Result<f32, OpError> {
+    match mode {
+        "bilinear" | "linear" => Ok(bilinear_sample(raw, plane, h, w, sy, sx, true)),
+        "nearest" => Ok(grid_nearest_sample(raw, plane, h, w, sy, sx)),
+        other => Err(OpError::InvalidAttribute(alloc::format!(
+            "GridSample mode '{}' not supported",
+            other
+        ))),
+    }
+}
+
+fn grid_nearest_sample(raw: &[u8], plane: usize, h: usize, w: usize, sy: f32, sx: f32) -> f32 {
+    let iy = round_f32(sy);
+    let ix = round_f32(sx);
+    if iy < 0.0 || iy >= h as f32 || ix < 0.0 || ix >= w as f32 {
+        0.0
+    } else {
+        read_f32(raw, plane + (iy as usize) * w + (ix as usize))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -612,14 +868,61 @@ pub fn op_center_crop_pad(
 ) -> Result<Tensor, OpError> {
     require_float(input, "CenterCropPad")?;
     let in_rank = input.shape.dims.len();
+    let axes_vec = resolve_crop_axes(axes, shape, in_rank)?;
     let mut out_dims = input.shape.dims.clone();
-    let axes_vec: Vec<usize> = if let Some(a) = axes {
+    apply_crop_target_dims(&mut out_dims, &axes_vec, shape, in_rank)?;
+
+    // Allocate zero-filled output.
+    let total: usize = out_dims
+        .iter()
+        .map(|&d| d as usize)
+        .product::<usize>()
+        .max(1);
+    let mut data = allocate_tensor_data(total, DataType::Float);
+
+    let (src_starts, dst_starts, copy_dims) = compute_crop_windows(input, &out_dims, in_rank);
+    let total_copy: usize = copy_dims.iter().product();
+    if total_copy == 0 {
+        return Ok(Tensor {
+            data_type: DataType::Float,
+            shape: TensorShape::new(out_dims),
+            name: String::new(),
+            raw_data: data,
+        });
+    }
+    let in_strides = row_major_strides(&input.shape.dims, in_rank);
+    let out_strides = row_major_strides(&out_dims, in_rank);
+    copy_crop_region(
+        &input.raw_data,
+        &mut data,
+        &src_starts,
+        &dst_starts,
+        &copy_dims,
+        &in_strides,
+        &out_strides,
+        total_copy,
+        in_rank,
+    );
+    Ok(Tensor {
+        data_type: DataType::Float,
+        shape: TensorShape::new(out_dims),
+        name: String::new(),
+        raw_data: data,
+    })
+}
+
+fn resolve_crop_axes(
+    axes: Option<&[i64]>,
+    shape: &[i64],
+    in_rank: usize,
+) -> Result<Vec<usize>, OpError> {
+    if let Some(a) = axes {
         if a.len() != shape.len() {
             return Err(OpError::InvalidAttribute(String::from(
                 "CenterCropPad: axes length must match shape length",
             )));
         }
-        a.iter()
+        Ok(a.iter()
             .map(|&ax| {
                 if ax < 0 {
                     (ax + in_rank as i64) as usize
@@ -627,15 +930,23 @@ pub fn op_center_crop_pad(
                     ax as usize
                 }
             })
-            .collect()
+            .collect())
     } else {
         if shape.len() != in_rank {
             return Err(OpError::InvalidAttribute(String::from(
                 "CenterCropPad: shape length must equal input rank when axes omitted",
             )));
         }
-        (0..in_rank).collect()
-    };
+        Ok((0..in_rank).collect())
+    }
+}
+
+fn apply_crop_target_dims(
+    out_dims: &mut [i64],
+    axes_vec: &[usize],
+    shape: &[i64],
+    in_rank: usize,
+) -> Result<(), OpError> {
     for (i, &ax) in axes_vec.iter().enumerate() {
         if ax >= in_rank {
             return Err(OpError::InvalidAttribute(String::from(
@@ -649,14 +960,14 @@ pub fn op_center_crop_pad(
         }
         out_dims[ax] = shape[i];
     }
-    // Allocate zero-filled output.
-    let total: usize = out_dims
-        .iter()
-        .map(|&d| d as usize)
-        .product::<usize>()
-        .max(1);
-    let mut data = allocate_tensor_data(total, DataType::Float);
-    // For each axis, compute source/dest start offsets (symmetric).
+    Ok(())
+}
+
+fn compute_crop_windows(
+    input: &Tensor,
+    out_dims: &[i64],
+    in_rank: usize,
+) -> (Vec<usize>, Vec<usize>, Vec<usize>) {
     let mut src_starts = alloc::vec![0usize; in_rank];
     let mut dst_starts = alloc::vec![0usize; in_rank];
     let mut copy_dims = alloc::vec![0usize; in_rank];
@@ -668,31 +979,30 @@ pub fn op_center_crop_pad(
         src_starts[d] = (id - c) / 2;
         dst_starts[d] = (od - c) / 2;
     }
-    // Iterate the copy region.
-    let total_copy: usize = copy_dims.iter().product();
-    if total_copy == 0 {
-        return Ok(Tensor {
-            data_type: DataType::Float,
-            shape: TensorShape::new(out_dims),
-            name: String::new(),
-            raw_data: data,
-        });
+    (src_starts, dst_starts, copy_dims)
+}
+
+fn row_major_strides(dims: &[i64], rank: usize) -> Vec<usize> {
+    let mut s = alloc::vec![1usize; rank];
+    for i in (0..rank.saturating_sub(1)).rev() {
+        s[i] = s[i + 1] * dims[i + 1] as usize;
     }
+    s
+}
+
+#[allow(clippy::too_many_arguments)]
+fn copy_crop_region(
+    raw: &[u8],
+    data: &mut [u8],
+    src_starts: &[usize],
+    dst_starts: &[usize],
+    copy_dims: &[usize],
+    in_strides: &[usize],
+    out_strides: &[usize],
+    total_copy: usize,
+    in_rank: usize,
+) {
     let mut coord = alloc::vec![0usize; in_rank];
-    let in_strides: Vec<usize> = {
-        let mut s = alloc::vec![1usize; in_rank];
-        for i in (0..in_rank.saturating_sub(1)).rev() {
-            s[i] = s[i + 1] * input.shape.dims[i + 1] as usize;
-        }
-        s
-    };
-    let out_strides: Vec<usize> = {
-        let mut s = alloc::vec![1usize; in_rank];
-        for i in (0..in_rank.saturating_sub(1)).rev() {
-            s[i] = s[i + 1] * out_dims[i + 1] as usize;
-        }
-        s
-    };
     for _ in 0..total_copy {
         let mut src = 0usize;
         let mut dst = 0usize;
@@ -700,22 +1010,19 @@ pub fn op_center_crop_pad(
             src += (src_starts[d] + coord[d]) * in_strides[d];
             dst += (dst_starts[d] + coord[d]) * out_strides[d];
         }
-        write_f32(&mut data, dst, read_f32(&input.raw_data, src));
-        // Increment coord
-        for d in (0..in_rank).rev() {
-            coord[d] += 1;
-            if coord[d] < copy_dims[d] {
-                break;
-            }
-            coord[d] = 0;
-        }
+        write_f32(data, dst, read_f32(raw, src));
+        increment_coord(&mut coord, copy_dims, in_rank);
     }
-    Ok(Tensor {
-        data_type: DataType::Float,
-        shape: TensorShape::new(out_dims),
-        name: String::new(),
-        raw_data: data,
-    })
+}
+
+fn increment_coord(coord: &mut [usize], copy_dims: &[usize], in_rank: usize) {
+    for d in (0..in_rank).rev() {
+        coord[d] += 1;
+        if coord[d] < copy_dims[d] {
+            break;
+        }
+        coord[d] = 0;
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Reduce cognitive complexity (SonarCloud rule `rust:S3776`, threshold 15) on 10 functions across two ONNX op files by extracting independent decision branches and inner-loop bodies into named helpers. Observable behavior is unchanged.

| File | Function | Before | After (est.) |
|------|----------|-------:|-------------:|
| `onnx-rt/src/ops/vision.rs` | `op_resize` (line 81) | 38 | <=10 |
| `onnx-rt/src/ops/vision.rs` | `op_depth_to_space` (line 244) | 17 | <=8 |
| `onnx-rt/src/ops/vision.rs` | `op_space_to_depth` (line 294) | 24 | <=8 |
| `onnx-rt/src/ops/vision.rs` | `op_roi_align` (line 352) | 42 | <=10 |
| `onnx-rt/src/ops/vision.rs` | `op_grid_sample` (line 484) | 32 | <=10 |
| `onnx-rt/src/ops/vision.rs` | `op_center_crop_pad` (line 608) | 27 | <=10 |
| `onnx-rt/src/ops/data_select.rs` | `op_top_k` (line 141) | 22 | <=10 |
| `onnx-rt/src/ops/data_select.rs` | `op_compress` (line 141) | 22 | <=6 |
| `onnx-rt/src/ops/data_select.rs` | `op_non_zero` (line 230) | 20 | <=10 |
| `onnx-rt/src/ops/data_select.rs` | `op_gather_elements` (line 335) | 20 | <=10 |
| `onnx-rt/src/ops/data_select.rs` | `op_scatter_elements` (line 399) | 33 | <=10 |

(`op_compress` and `op_gather_elements` were both originally flagged but a few were close to the threshold. After-counts are estimates pending a fresh SonarCloud scan.)

### Refactor patterns applied

- **Vision ops** — extracted spatial-loop bodies and mode dispatch into helpers:
  `resolve_resize_output_dims`, `resize_dims_from_sizes`, `resize_dims_from_scales`, `checked_total_elements`, `resize_plane`, `sample_resize_pixel`, `depth_to_space_channel_index`, `space_to_depth_channel`, `copy_space_to_depth_block`, `validate_roi_align_rois`, `decode_roi_batch_indices`, `validate_roi_batch_ids`, `roi_bin_geometry` (+ `RoiBinGeometry` struct), `sampling_count`, `pool_one_roi`, `average_roi_bin`, `validate_grid_sample_grid`, `grid_to_pixel`, `write_grid_sample_pixels`, `sample_grid_pixel`, `grid_nearest_sample`, `resolve_crop_axes`, `apply_crop_target_dims`, `compute_crop_windows`, `row_major_strides`, `copy_crop_region`, `increment_coord`.
- **Data-select ops** — extracted index validation and dtype dispatch:
  `product_dims`, `fill_top_k_scratch`, `sort_top_k`, `write_top_k_slot`, `decode_compress_condition`, `compress_flat`, `compress_along_axis`, `is_nonzero_element`, `increment_shape_coord`, `element_strides`, `normalize_index`, `src_offset`, `validate_scatter_dims`, `apply_scatter_reduction`.

## Test plan

- [x] `cargo test -p smallaios-onnx-rt` — all 966 tests pass (matches baseline).
- [x] `cargo clippy -p smallaios-onnx-rt --all-targets -- -D warnings` — clean, no warnings.
- [x] `cargo fmt -- --check` — clean.
- [ ] Fresh SonarCloud scan to confirm each refactored function reports cognitive complexity < 15.

## Notes

- SonarCloud `new_coverage` (80%) may flag this PR because the extracted helpers are private and exercised only through the public ops; the existing tests do cover all paths but the gate may treat new lines as uncovered. May need admin merge.
- A workspace-wide `cargo clippy` currently fails in `smallaios-mgmt` due to a pre-existing toml-edit/closure type-annotation regression on `origin/develop` (`mgmt/tests/toml_oracle.rs`). Unrelated to this PR; verified the same failure on a clean develop checkout.
- No sibling `ops/*.rs` files were modified; other agents may be refactoring those in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)