### PR TITLE
refactor(onnx-rt): reduce cognitive complexity below 15 in ops/microsoft + ops/recurrent

### DIFF
--- a/onnx-rt/src/ops/microsoft.rs
+++ b/onnx-rt/src/ops/microsoft.rs
@@ -66,6 +66,99 @@ fn sqrt_f32(x: f32) -> f32 {
 // Shared helper: apply RoPE in place
 // ---------------------------------------------------------------------------
 
+/// Validate `rotary_dim` and the cos/sin cache layout. Returns the
+/// number of rows (max_seq) in the cache and `half = rotary_dim/2`.
+fn validate_rope_caches(
+    cos_cache: &Tensor,
+    sin_cache: &Tensor,
+    rotary_dim: usize,
+    head_dim: usize,
+) -> Result<(usize, usize), OpError> {
+    require_float(cos_cache, "RotaryEmbedding")?;
+    require_float(sin_cache, "RotaryEmbedding")?;
+    if rotary_dim == 0 || rotary_dim > head_dim {
+        return Err(OpError::InvalidAttribute(String::from(
+            "apply_rope_in_place: rotary_dim must be in 1..=head_dim",
+        )));
+    }
+    if !rotary_dim.is_multiple_of(2) {
+        return Err(OpError::InvalidAttribute(String::from(
+            "apply_rope_in_place: rotary_dim must be even",
+        )));
+    }
+    let half = rotary_dim / 2;
+    let cos_dims = &cos_cache.shape.dims;
+    let sin_dims = &sin_cache.shape.dims;
+    if cos_dims.len() != 2 || sin_dims.len() != 2 {
+        return Err(OpError::ShapeMismatch(String::from(
+            "apply_rope_in_place: cos/sin caches must be rank-2",
+        )));
+    }
+    let cache_cols = cos_dims[1] as usize;
+    if sin_dims[1] as usize != cache_cols {
+        return Err(OpError::ShapeMismatch(String::from(
+            "apply_rope_in_place: cos and sin caches must share the inner dim",
+        )));
+    }
+    if cache_cols != half {
+        return Err(OpError::ShapeMismatch(format!(
+            "apply_rope_in_place: cache inner dim {} != rotary_dim/2 = {}",
+            cache_cols, half
+        )));
+    }
+    Ok((cos_dims[0] as usize, half))
+}
+
+/// Resolve the position for a `(batch, query)` pair given a flat
+/// `position_ids` buffer that is either per-sequence or per-(batch, sequence).
+#[inline]
+fn rope_position_for(position_ids: &[i64], bi: usize, qi: usize, sq: usize) -> i64 {
+    if position_ids.len() == sq {
+        position_ids[qi]
+    } else {
+        position_ids[bi * sq + qi]
+    }
+}
+
+/// Validate that `pos` is a valid row in the cos/sin cache. Returns `pos` as a `usize`.
+#[inline]
+fn check_rope_position(pos: i64, cache_rows: usize) -> Result<usize, OpError> {
+    if pos < 0 || (pos as usize) >= cache_rows {
+        return Err(OpError::ShapeMismatch(format!(
+            "apply_rope_in_place: position {} out of cache range {}",
+            pos, cache_rows
+        )));
+    }
+    Ok(pos as usize)
+}
+
+/// Rotate a single `(query, head)` block in place using the RoPE pair layout.
+/// `interleaved == true` pairs `(x[2i], x[2i+1])`; otherwise `(x[i], x[i+half])`.
+fn rotate_rope_block(
+    raw: &mut [u8],
+    cos_cache: &Tensor,
+    sin_cache: &Tensor,
+    base: usize,
+    pos: usize,
+    cache_cols: usize,
+    half: usize,
+    interleaved: bool,
+) {
+    for pair in 0..half {
+        let c = read_f32(&cos_cache.raw_data, pos * cache_cols + pair);
+        let s = read_f32(&sin_cache.raw_data, pos * cache_cols + pair);
+        let (i0, i1) = if interleaved {
+            (base + 2 * pair, base + 2 * pair + 1)
+        } else {
+            (base + pair, base + pair + half)
+        };
+        let x0 = read_f32(raw, i0);
+        let x1 = read_f32(raw, i1);
+        write_f32(raw, i0, c * x0 - s * x1);
+        write_f32(raw, i1, s * x0 + c * x1);
+    }
+}
+
 /// Applies rotary positional embedding to a 4-D tensor in place.
 ///
 /// The tensor is expected to have shape `(B, num_heads, Sq, head_dim)`.
@@ -95,9 +188,6 @@ pub(crate) fn apply_rope_in_place(
             "apply_rope_in_place: tensor must be rank-4 (B, H, Sq, head_dim)",
         )));
     }
-    require_float(cos_cache, "RotaryEmbedding")?;
-    require_float(sin_cache, "RotaryEmbedding")?;
-
     let b = shape[0] as usize;
     let num_heads = shape[1] as usize;
     let sq = shape[2] as usize;
@@ -111,39 +201,8 @@ pub(crate) fn apply_rope_in_place(
         )));
     }
 
-    if rotary_dim == 0 || rotary_dim > head_dim {
-        return Err(OpError::InvalidAttribute(String::from(
-            "apply_rope_in_place: rotary_dim must be in 1..=head_dim",
-        )));
-    }
-    if !rotary_dim.is_multiple_of(2) {
-        return Err(OpError::InvalidAttribute(String::from(
-            "apply_rope_in_place: rotary_dim must be even",
-        )));
-    }
-    let half = rotary_dim / 2;
-
-    // cos/sin cache shape: (max_seq, head_dim/2) or (max_seq, rotary_dim/2).
-    let cos_dims = &cos_cache.shape.dims;
-    let sin_dims = &sin_cache.shape.dims;
-    if cos_dims.len() != 2 || sin_dims.len() != 2 {
-        return Err(OpError::ShapeMismatch(String::from(
-            "apply_rope_in_place: cos/sin caches must be rank-2",
-        )));
-    }
-    let cache_cols = cos_dims[1] as usize;
-    if sin_dims[1] as usize != cache_cols {
-        return Err(OpError::ShapeMismatch(String::from(
-            "apply_rope_in_place: cos and sin caches must share the inner dim",
-        )));
-    }
-    if cache_cols != half {
-        return Err(OpError::ShapeMismatch(format!(
-            "apply_rope_in_place: cache inner dim {} != rotary_dim/2 = {}",
-            cache_cols, half
-        )));
-    }
-    let cache_rows = cos_dims[0] as usize;
+    let (cache_rows, half) = validate_rope_caches(cos_cache, sin_cache, rotary_dim, head_dim)?;
+    let cache_cols = half;
 
     // Strides into the raw buffer.
     let head_stride = sq * head_dim;
@@ -152,42 +211,19 @@ pub(crate) fn apply_rope_in_place(
     for bi in 0..b {
         for hi in 0..num_heads {
             for qi in 0..sq {
-                let pos = if position_ids.len() == sq {
-                    position_ids[qi]
-                } else {
-                    position_ids[bi * sq + qi]
-                };
-                if pos < 0 || (pos as usize) >= cache_rows {
-                    return Err(OpError::ShapeMismatch(format!(
-                        "apply_rope_in_place: position {} out of cache range {}",
-                        pos, cache_rows
-                    )));
-                }
+                let pos =
+                    check_rope_position(rope_position_for(position_ids, bi, qi, sq), cache_rows)?;
                 let base = bi * batch_stride + hi * head_stride + qi * head_dim;
-
-                if interleaved {
-                    for pair in 0..half {
-                        let c = read_f32(&cos_cache.raw_data, (pos as usize) * cache_cols + pair);
-                        let s = read_f32(&sin_cache.raw_data, (pos as usize) * cache_cols + pair);
-                        let i0 = base + 2 * pair;
-                        let i1 = base + 2 * pair + 1;
-                        let x0 = read_f32(raw, i0);
-                        let x1 = read_f32(raw, i1);
-                        write_f32(raw, i0, c * x0 - s * x1);
-                        write_f32(raw, i1, s * x0 + c * x1);
-                    }
-                } else {
-                    for pair in 0..half {
-                        let c = read_f32(&cos_cache.raw_data, (pos as usize) * cache_cols + pair);
-                        let s = read_f32(&sin_cache.raw_data, (pos as usize) * cache_cols + pair);
-                        let i0 = base + pair;
-                        let i1 = base + pair + half;
-                        let x0 = read_f32(raw, i0);
-                        let x1 = read_f32(raw, i1);
-                        write_f32(raw, i0, c * x0 - s * x1);
-                        write_f32(raw, i1, s * x0 + c * x1);
-                    }
-                }
+                rotate_rope_block(
+                    raw,
+                    cos_cache,
+                    sin_cache,
+                    base,
+                    pos,
+                    cache_cols,
+                    half,
+                    interleaved,
+                );
                 // Elements >= rotary_dim pass through unchanged.
             }
         }
@@ -199,6 +235,128 @@ pub(crate) fn apply_rope_in_place(
 // ---------------------------------------------------------------------------
 // Shared helper: scaled dot-product attention with on-the-fly causal mask
 // ---------------------------------------------------------------------------
+
+/// Compute the masked, scaled dot-product `scores[ki] = (Q_row · K_row[ki]) * scale`.
+/// Positions `ki >= max_k` are filled with `-inf`.
+fn sdpa_scores_row(
+    q_raw: &[u8],
+    k_raw: &[u8],
+    q_row: usize,
+    k_base: usize,
+    sk: usize,
+    head_dim: usize,
+    max_k: usize,
+    scale: f32,
+) -> Vec<f32> {
+    let mut scores: Vec<f32> = Vec::with_capacity(sk);
+    for ki in 0..sk {
+        if ki >= max_k {
+            scores.push(f32::NEG_INFINITY);
+            continue;
+        }
+        let k_row = k_base + ki * head_dim;
+        let mut acc = 0.0f32;
+        for d in 0..head_dim {
+            acc += read_f32(q_raw, q_row + d) * read_f32(k_raw, k_row + d);
+        }
+        scores.push(acc * scale);
+    }
+    scores
+}
+
+/// Numerically-stable softmax of `scores`. Returns `None` when every entry
+/// is `-inf` or the denominator underflows to zero — both cases are treated
+/// by the caller as "no valid key" and produce a zero output row.
+fn sdpa_softmax(scores: &[f32]) -> Option<Vec<f32>> {
+    let mut max_val = f32::NEG_INFINITY;
+    for &s in scores {
+        if s > max_val {
+            max_val = s;
+        }
+    }
+    if !max_val.is_finite() {
+        return None;
+    }
+    let mut denom = 0.0f32;
+    let mut probs: Vec<f32> = Vec::with_capacity(scores.len());
+    for &s in scores {
+        let e = if s.is_finite() {
+            expf_approx(s - max_val)
+        } else {
+            0.0
+        };
+        denom += e;
+        probs.push(e);
+    }
+    if denom == 0.0 {
+        return None;
+    }
+    let inv = 1.0 / denom;
+    for p in probs.iter_mut() {
+        *p *= inv;
+    }
+    Some(probs)
+}
+
+/// Write `probs · V` into `out[q_row..q_row+head_dim]`.
+fn sdpa_write_weighted_v(
+    out: &mut [u8],
+    v_raw: &[u8],
+    probs: &[f32],
+    q_row: usize,
+    v_base: usize,
+    sk: usize,
+    head_dim: usize,
+) {
+    for d in 0..head_dim {
+        let mut acc = 0.0f32;
+        for ki in 0..sk {
+            let v_row = v_base + ki * head_dim;
+            acc += probs[ki] * read_f32(v_raw, v_row + d);
+        }
+        write_f32(out, q_row + d, acc);
+    }
+}
+
+/// Write `head_dim` zeros into `out[q_row..q_row+head_dim]`.
+fn sdpa_write_zero_row(out: &mut [u8], q_row: usize, head_dim: usize) {
+    for d in 0..head_dim {
+        write_f32(out, q_row + d, 0.0);
+    }
+}
+
+/// Number of keys query position `qi` may attend to under the (optional)
+/// causal mask. Returns `sk` when `causal == false`.
+#[inline]
+fn sdpa_max_k(causal: bool, past_sk: usize, qi: usize, sk: usize) -> usize {
+    if causal {
+        (past_sk + qi + 1).min(sk)
+    } else {
+        sk
+    }
+}
+
+/// Compute the SDPA output for one `(batch, q-head, q-pos)` row.
+#[allow(clippy::too_many_arguments)]
+fn sdpa_row(
+    out: &mut [u8],
+    q_raw: &[u8],
+    k_raw: &[u8],
+    v_raw: &[u8],
+    q_row: usize,
+    k_base: usize,
+    v_base: usize,
+    sk: usize,
+    head_dim: usize,
+    max_k: usize,
+    scale: f32,
+) {
+    let scores = sdpa_scores_row(q_raw, k_raw, q_row, k_base, sk, head_dim, max_k, scale);
+    match sdpa_softmax(&scores) {
+        Some(probs) => sdpa_write_weighted_v(out, v_raw, &probs, q_row, v_base, sk, head_dim),
+        None => sdpa_write_zero_row(out, q_row, head_dim),
+    }
+}
 
 /// Computes `softmax(Q @ K^T * scale + causal_mask) @ V` over a single
 /// batched attention block.
@@ -258,7 +416,6 @@ pub(crate) fn scaled_dot_product_attention(
     let k_head_stride = sk * head_dim;
     let k_batch_stride = num_kv_heads * k_head_stride;
 
-    // Per (batch, q-head, q-pos) row compute masked softmax(Q·K^T) · V.
     for bi in 0..batch {
         for qh in 0..num_q_heads {
             let kh = qh / group_size;
@@ -267,75 +424,12 @@ pub(crate) fn scaled_dot_product_attention(
             let v_base = k_base;
 
             for qi in 0..sq {
-                // Compute scaled scores against every key position.
-                let mut scores: Vec<f32> = Vec::with_capacity(sk);
                 let q_row = q_base + qi * head_dim;
-                let max_k = if causal {
-                    // The current query's absolute position is past_sk + qi.
-                    // It attends over keys 0..=past_sk+qi, clamped to sk.
-                    (past_sk + qi + 1).min(sk)
-                } else {
-                    sk
-                };
-                for ki in 0..sk {
-                    if ki >= max_k {
-                        scores.push(f32::NEG_INFINITY);
-                        continue;
-                    }
-                    let k_row = k_base + ki * head_dim;
-                    let mut acc = 0.0f32;
-                    for d in 0..head_dim {
-                        let qv = read_f32(q_raw, q_row + d);
-                        let kv = read_f32(k_raw, k_row + d);
-                        acc += qv * kv;
-                    }
-                    scores.push(acc * scale);
-                }
-                // Max-stabilized softmax.
-                let mut max_val = f32::NEG_INFINITY;
-                for &s in &scores {
-                    if s > max_val {
-                        max_val = s;
-                    }
-                }
-                if !max_val.is_finite() {
-                    // All -inf: every output element is 0 (no valid key).
-                    for d in 0..head_dim {
-                        write_f32(&mut out, q_row + d, 0.0);
-                    }
-                    continue;
-                }
-                let mut denom = 0.0f32;
-                let mut probs: Vec<f32> = Vec::with_capacity(sk);
-                for &s in &scores {
-                    let e = if s.is_finite() {
-                        expf_approx(s - max_val)
-                    } else {
-                        0.0
-                    };
-                    denom += e;
-                    probs.push(e);
-                }
-                if denom == 0.0 {
-                    for d in 0..head_dim {
-                        write_f32(&mut out, q_row + d, 0.0);
-                    }
-                    continue;
-                }
-                let inv = 1.0 / denom;
-                for p in probs.iter_mut() {
-                    *p *= inv;
-                }
-
-                // Weighted sum of V rows.
-                for d in 0..head_dim {
-                    let mut acc = 0.0f32;
-                    for ki in 0..sk {
-                        let v_row = v_base + ki * head_dim;
-                        acc += probs[ki] * read_f32(v_raw, v_row + d);
-                    }
-                    write_f32(&mut out, q_row + d, acc);
-                }
+                let max_k = sdpa_max_k(causal, past_sk, qi, sk);
+                sdpa_row(
+                    &mut out, q_raw, k_raw, v_raw, q_row, k_base, v_base, sk, head_dim, max_k,
+                    scale,
+                );
             }
         }
     }
@@ -609,6 +703,59 @@ fn reshape_from_bhsd(
     out
 }
 
+/// Validate a (potentially absent) past KV cache tensor and return its
+/// sequence-length axis (`past_sk`). Returns 0 when `past` is `None`.
+fn validate_past_kv(
+    past: Option<&Tensor>,
+    batch: usize,
+    heads: usize,
+    head_dim: usize,
+) -> Result<usize, OpError> {
+    let Some(p) = past else {
+        return Ok(0);
+    };
+    require_float(p, "GroupQueryAttention")?;
+    if p.shape.dims.len() != 4 {
+        return Err(OpError::ShapeMismatch(String::from(
+            "GQA/MHA: past_key/past_value must be rank-4",
+        )));
+    }
+    if p.shape.dims[0] as usize != batch
+        || p.shape.dims[1] as usize != heads
+        || p.shape.dims[3] as usize != head_dim
+    {
+        return Err(OpError::ShapeMismatch(String::from(
+            "GQA/MHA: past cache batch/heads/head_dim mismatch",
+        )));
+    }
+    Ok(p.shape.dims[2] as usize)
+}
+
+/// Copy `src_sk` rows of `(head_dim)` from `src_raw` into the `(B,H,total_sk,head_dim)`
+/// destination starting at `dst_start_si` along the sequence axis.
+fn kv_copy_block(
+    dst: &mut [u8],
+    src_raw: &[u8],
+    batch: usize,
+    heads: usize,
+    src_sk: usize,
+    total_sk: usize,
+    head_dim: usize,
+    dst_start_si: usize,
+) {
+    for bi in 0..batch {
+        for hi in 0..heads {
+            for si in 0..src_sk {
+                for d in 0..head_dim {
+                    let src = ((bi * heads + hi) * src_sk + si) * head_dim + d;
+                    let dst_idx = ((bi * heads + hi) * total_sk + dst_start_si + si) * head_dim + d;
+                    write_f32(dst, dst_idx, read_f32(src_raw, src));
+                }
+            }
+        }
+    }
+}
+
 /// Concatenate past + new along the sequence axis of a
 /// `(B, H, Sk, head_dim)` buffer. Produces `(B, H, past_sk + new_sk,
 /// head_dim)`. If `past_sk == 0`, returns a clone of `new`.
@@ -620,53 +767,26 @@ fn kv_concat(
     new_sk: usize,
     head_dim: usize,
 ) -> Result<(Vec<u8>, usize), OpError> {
-    let past_sk = match past {
-        Some(p) => {
-            require_float(p, "GroupQueryAttention")?;
-            if p.shape.dims.len() != 4 {
-                return Err(OpError::ShapeMismatch(String::from(
-                    "GQA/MHA: past_key/past_value must be rank-4",
-                )));
-            }
-            if p.shape.dims[0] as usize != batch
-                || p.shape.dims[1] as usize != heads
-                || p.shape.dims[3] as usize != head_dim
-            {
-                return Err(OpError::ShapeMismatch(String::from(
-                    "GQA/MHA: past cache batch/heads/head_dim mismatch",
-                )));
-            }
-            p.shape.dims[2] as usize
-        }
-        None => 0,
-    };
-
+    let past_sk = validate_past_kv(past, batch, heads, head_dim)?;
     let total_sk = past_sk + new_sk;
     let out_len = batch * heads * total_sk * head_dim;
     let mut out = allocate_tensor_data(out_len, DataType::Float);
 
-    for bi in 0..batch {
-        for hi in 0..heads {
-            // Copy past.
-            if let Some(p) = past {
-                for si in 0..past_sk {
-                    for d in 0..head_dim {
-                        let src = ((bi * heads + hi) * past_sk + si) * head_dim + d;
-                        let dst = ((bi * heads + hi) * total_sk + si) * head_dim + d;
-                        write_f32(&mut out, dst, read_f32(&p.raw_data, src));
-                    }
-                }
-            }
-            // Copy new.
-            for si in 0..new_sk {
-                for d in 0..head_dim {
-                    let src = ((bi * heads + hi) * new_sk + si) * head_dim + d;
-                    let dst = ((bi * heads + hi) * total_sk + past_sk + si) * head_dim + d;
-                    write_f32(&mut out, dst, read_f32(new_raw, src));
-                }
-            }
-        }
+    if let Some(p) = past {
+        kv_copy_block(
+            &mut out,
+            &p.raw_data,
+            batch,
+            heads,
+            past_sk,
+            total_sk,
+            head_dim,
+            0,
+        );
     }
+    kv_copy_block(
+        &mut out, new_raw, batch, heads, new_sk, total_sk, head_dim, past_sk,
+    );
 
     Ok((out, past_sk))
 }
@@ -808,6 +928,129 @@ pub fn op_multi_head_attention(
 // GroupQueryAttention
 // ---------------------------------------------------------------------------
 
+/// Validate the per-attribute and per-tensor shape invariants for GQA.
+/// Returns `(num_heads, kv_heads, b, sq, q_hidden, head_dim)`.
+fn gqa_validate(
+    query: &Tensor,
+    key: &Tensor,
+    value: &Tensor,
+    num_heads: i64,
+    kv_num_heads: i64,
+) -> Result<(usize, usize, usize, usize, usize, usize), OpError> {
+    if num_heads <= 0 || kv_num_heads <= 0 {
+        return Err(OpError::InvalidAttribute(String::from(
+            "GroupQueryAttention: num_heads and kv_num_heads must be > 0",
+        )));
+    }
+    if num_heads % kv_num_heads != 0 {
+        return Err(OpError::InvalidAttribute(String::from(
+            "GroupQueryAttention: num_heads must be a multiple of kv_num_heads",
+        )));
+    }
+    let num_heads = num_heads as usize;
+    let kv_heads = kv_num_heads as usize;
+
+    if query.shape.dims.len() != 3 || key.shape.dims.len() != 3 || value.shape.dims.len() != 3 {
+        return Err(OpError::ShapeMismatch(String::from(
+            "GroupQueryAttention: Q/K/V must be rank-3",
+        )));
+    }
+    let b = query.shape.dims[0] as usize;
+    let sq = query.shape.dims[1] as usize;
+    let q_hidden = query.shape.dims[2] as usize;
+    let kv_hidden = key.shape.dims[2] as usize;
+    if !q_hidden.is_multiple_of(num_heads) {
+        return Err(OpError::ShapeMismatch(String::from(
+            "GroupQueryAttention: q_hidden not divisible by num_heads",
+        )));
+    }
+    if !kv_hidden.is_multiple_of(kv_heads) {
+        return Err(OpError::ShapeMismatch(String::from(
+            "GroupQueryAttention: kv_hidden not divisible by kv_num_heads",
+        )));
+    }
+    let head_dim = q_hidden / num_heads;
+    if kv_hidden / kv_heads != head_dim {
+        return Err(OpError::ShapeMismatch(String::from(
+            "GroupQueryAttention: Q and KV head_dim must match",
+        )));
+    }
+    if value.shape.dims != key.shape.dims {
+        return Err(OpError::ShapeMismatch(String::from(
+            "GroupQueryAttention: key and value must have the same shape",
+        )));
+    }
+    Ok((num_heads, kv_heads, b, sq, q_hidden, head_dim))
+}
+
+/// Past-key sequence length for GQA's pre-validation step (before `kv_concat`
+/// runs the deeper checks).
+fn gqa_past_sk(past_key: Option<&Tensor>) -> Result<usize, OpError> {
+    match past_key {
+        Some(p) => {
+            if p.shape.dims.len() != 4 {
+                return Err(OpError::ShapeMismatch(String::from(
+                    "GroupQueryAttention: past_key must be rank-4",
+                )));
+            }
+            Ok(p.shape.dims[2] as usize)
+        }
+        None => Ok(0),
+    }
+}
+
+/// Apply fused RoPE to Q and K when `do_rotary` is set.
+#[allow(clippy::too_many_arguments)]
+fn gqa_apply_rotary(
+    q_bhsd: &mut [u8],
+    k_bhsd: &mut [u8],
+    cos_cache: Option<&Tensor>,
+    sin_cache: Option<&Tensor>,
+    b: usize,
+    num_heads: usize,
+    kv_heads: usize,
+    sq: usize,
+    head_dim: usize,
+    past_sk: usize,
+    rotary_interleaved: bool,
+) -> Result<(), OpError> {
+    let cos = cos_cache.ok_or_else(|| {
+        OpError::ShapeMismatch(String::from(
+            "GroupQueryAttention: do_rotary=1 but cos_cache is missing",
+        ))
+    })?;
+    let sin = sin_cache.ok_or_else(|| {
+        OpError::ShapeMismatch(String::from(
+            "GroupQueryAttention: do_rotary=1 but sin_cache is missing",
+        ))
+    })?;
+    let mut positions: Vec<i64> = Vec::with_capacity(sq);
+    for i in 0..sq {
+        positions.push((past_sk + i) as i64);
+    }
+    let q_shape = vec![b as i64, num_heads as i64, sq as i64, head_dim as i64];
+    let k_shape = vec![b as i64, kv_heads as i64, sq as i64, head_dim as i64];
+    apply_rope_in_place(
+        q_bhsd,
+        &q_shape,
+        cos,
+        sin,
+        &positions,
+        rotary_interleaved,
+        head_dim,
+    )?;
+    apply_rope_in_place(
+        k_bhsd,
+        &k_shape,
+        cos,
+        sin,
+        &positions,
+        rotary_interleaved,
+        head_dim,
+    )?;
+    Ok(())
+}
+
 /// `com.microsoft.GroupQueryAttention`.
 ///
 /// Inputs (per ORT contrib op spec):
@@ -870,104 +1113,29 @@ pub fn op_group_query_attention(
     require_float(key, "GroupQueryAttention")?;
     require_float(value, "GroupQueryAttention")?;
 
-    if num_heads <= 0 || kv_num_heads <= 0 {
-        return Err(OpError::InvalidAttribute(String::from(
-            "GroupQueryAttention: num_heads and kv_num_heads must be > 0",
-        )));
-    }
-    if num_heads % kv_num_heads != 0 {
-        return Err(OpError::InvalidAttribute(String::from(
-            "GroupQueryAttention: num_heads must be a multiple of kv_num_heads",
-        )));
-    }
-    let num_heads = num_heads as usize;
-    let kv_heads = kv_num_heads as usize;
+    let (num_heads, kv_heads, b, sq, q_hidden, head_dim) =
+        gqa_validate(query, key, value, num_heads, kv_num_heads)?;
 
-    if query.shape.dims.len() != 3 || key.shape.dims.len() != 3 || value.shape.dims.len() != 3 {
-        return Err(OpError::ShapeMismatch(String::from(
-            "GroupQueryAttention: Q/K/V must be rank-3",
-        )));
-    }
-    let b = query.shape.dims[0] as usize;
-    let sq = query.shape.dims[1] as usize;
-    let q_hidden = query.shape.dims[2] as usize;
-    let kv_hidden = key.shape.dims[2] as usize;
-    if !q_hidden.is_multiple_of(num_heads) {
-        return Err(OpError::ShapeMismatch(String::from(
-            "GroupQueryAttention: q_hidden not divisible by num_heads",
-        )));
-    }
-    if !kv_hidden.is_multiple_of(kv_heads) {
-        return Err(OpError::ShapeMismatch(String::from(
-            "GroupQueryAttention: kv_hidden not divisible by kv_num_heads",
-        )));
-    }
-    let head_dim = q_hidden / num_heads;
-    if kv_hidden / kv_heads != head_dim {
-        return Err(OpError::ShapeMismatch(String::from(
-            "GroupQueryAttention: Q and KV head_dim must match",
-        )));
-    }
-    if value.shape.dims != key.shape.dims {
-        return Err(OpError::ShapeMismatch(String::from(
-            "GroupQueryAttention: key and value must have the same shape",
-        )));
-    }
-
-    // Past length from cache.
-    let past_sk = match past_key {
-        Some(p) => {
-            if p.shape.dims.len() != 4 {
-                return Err(OpError::ShapeMismatch(String::from(
-                    "GroupQueryAttention: past_key must be rank-4",
-                )));
-            }
-            p.shape.dims[2] as usize
-        }
-        None => 0,
-    };
+    let past_sk = gqa_past_sk(past_key)?;
 
     // Reshape Q and KV into (B, H*, Sq, head_dim).
     let mut q_bhsd = reshape_to_bhsd(&query.raw_data, b, sq, num_heads, head_dim);
     let mut k_bhsd = reshape_to_bhsd(&key.raw_data, b, sq, kv_heads, head_dim);
     let v_bhsd = reshape_to_bhsd(&value.raw_data, b, sq, kv_heads, head_dim);
 
-    // Apply fused RoPE to Q and K if requested.
     if do_rotary {
-        let cos = cos_cache.ok_or_else(|| {
-            OpError::ShapeMismatch(String::from(
-                "GroupQueryAttention: do_rotary=1 but cos_cache is missing",
-            ))
-        })?;
-        let sin = sin_cache.ok_or_else(|| {
-            OpError::ShapeMismatch(String::from(
-                "GroupQueryAttention: do_rotary=1 but sin_cache is missing",
-            ))
-        })?;
-        // Positions are past_sk..past_sk+sq per batch.
-        let mut positions: Vec<i64> = Vec::with_capacity(sq);
-        for i in 0..sq {
-            positions.push((past_sk + i) as i64);
-        }
-        let q_shape = vec![b as i64, num_heads as i64, sq as i64, head_dim as i64];
-        let k_shape = vec![b as i64, kv_heads as i64, sq as i64, head_dim as i64];
-        apply_rope_in_place(
+        gqa_apply_rotary(
             &mut q_bhsd,
-            &q_shape,
-            cos,
-            sin,
-            &positions,
-            rotary_interleaved,
-            head_dim,
-        )?;
-        apply_rope_in_place(
             &mut k_bhsd,
-            &k_shape,
-            cos,
-            sin,
-            &positions,
-            rotary_interleaved,
+            cos_cache,
+            sin_cache,
+            b,
+            num_heads,
+            kv_heads,
+            sq,
             head_dim,
+            past_sk,
+            rotary_interleaved,
         )?;
     }
 

--- a/onnx-rt/src/ops/recurrent.rs
+++ b/onnx-rt/src/ops/recurrent.rs
@@ -10,6 +10,8 @@
 //! Implementations are sequence-major and use a simple per-timestep loop.
 //! Output Y has shape `[seq_length, num_directions, batch, hidden_size]`.
 
+#![allow(clippy::too_many_arguments)]
+
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -45,9 +47,241 @@ fn slice_f32(data: &[u8], base: usize, n: usize) -> Vec<f32> {
     (0..n).map(|i| read_f32(data, base + i)).collect()
 }
 
+/// Whether this direction iterates the sequence in reverse.
+#[inline]
+fn dir_is_reverse(direction: &str, d: usize) -> bool {
+    direction == "reverse" || (direction == "bidirectional" && d == 1)
+}
+
+/// Shared shape validation for the `[seq, batch, input]` X tensor.
+/// Returns `(seq, batch, input_size)`.
+fn validate_x_shape(x: &Tensor, op: &str) -> Result<(usize, usize, usize), OpError> {
+    if x.shape.dims.len() != 3 {
+        return Err(OpError::ShapeMismatch(alloc::format!(
+            "{}: X must be 3D [seq, batch, input]",
+            op
+        )));
+    }
+    Ok((
+        x.shape.dims[0] as usize,
+        x.shape.dims[1] as usize,
+        x.shape.dims[2] as usize,
+    ))
+}
+
+/// Validate the `[num_dir, gates*hidden, hidden]` R tensor.
+fn validate_r_shape(
+    r: &Tensor,
+    num_dir: usize,
+    gates: usize,
+    hidden: usize,
+    op: &str,
+    shape_msg: &str,
+) -> Result<(), OpError> {
+    if r.shape.dims.len() != 3
+        || r.shape.dims[0] as usize != num_dir
+        || r.shape.dims[1] as usize != gates * hidden
+        || r.shape.dims[2] as usize != hidden
+    {
+        return Err(OpError::ShapeMismatch(alloc::format!(
+            "{}: R shape must be {}",
+            op,
+            shape_msg
+        )));
+    }
+    Ok(())
+}
+
+/// Validate the `[num_dir, total]` B tensor, if provided.
+fn validate_b_shape(
+    b: Option<&Tensor>,
+    num_dir: usize,
+    total: usize,
+    op: &str,
+    shape_msg: &str,
+) -> Result<(), OpError> {
+    if let Some(bt) = b {
+        if bt.shape.dims.len() != 2
+            || bt.shape.dims[0] as usize != num_dir
+            || bt.shape.dims[1] as usize != total
+        {
+            return Err(OpError::ShapeMismatch(alloc::format!(
+                "{}: B shape must be {}",
+                op,
+                shape_msg
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Validate the `[num_dir, batch, hidden]` initial-state tensor (h0 or c0).
+fn validate_initial_state(
+    state: Option<&Tensor>,
+    num_dir: usize,
+    batch: usize,
+    hidden: usize,
+    op: &str,
+    name: &str,
+) -> Result<(), OpError> {
+    if let Some(st) = state {
+        if st.shape.dims.len() != 3
+            || st.shape.dims[0] as usize != num_dir
+            || st.shape.dims[1] as usize != batch
+            || st.shape.dims[2] as usize != hidden
+        {
+            return Err(OpError::ShapeMismatch(alloc::format!(
+                "{}: {} shape must be [num_dir, batch, hidden]",
+                op,
+                name
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Read the per-direction initial state slice, defaulting to zeros.
+fn read_initial_state(
+    state: Option<&Tensor>,
+    d: usize,
+    batch: usize,
+    hidden: usize,
+    op: &str,
+) -> Result<Vec<f32>, OpError> {
+    if let Some(st) = state {
+        require_float(st, op)?;
+        Ok(slice_f32(&st.raw_data, d * batch * hidden, batch * hidden))
+    } else {
+        Ok(alloc::vec![0.0f32; batch * hidden])
+    }
+}
+
+/// Merge `[W bias | R bias]` halves into a single bias of length `half`.
+fn merge_wr_bias(b: Option<&Tensor>, d: usize, half: usize, op: &str) -> Result<Vec<f32>, OpError> {
+    if let Some(bt) = b {
+        require_float(bt, op)?;
+        let off = d * 2 * half;
+        let wb = slice_f32(&bt.raw_data, off, half);
+        let rb = slice_f32(&bt.raw_data, off + half, half);
+        Ok(wb.iter().zip(rb.iter()).map(|(a, b)| a + b).collect())
+    } else {
+        Ok(alloc::vec![0.0f32; half])
+    }
+}
+
+/// Write the final per-direction hidden state into the `Y_h`-style buffer.
+fn write_final_state(yh_data: &mut [u8], h: &[f32], d: usize, batch: usize, hidden: usize) {
+    let off = d * batch * hidden;
+    for (i, &v) in h.iter().enumerate() {
+        write_f32(yh_data, off + i, v);
+    }
+}
+
+/// Write the per-direction output slice into `Y[t, d, :, :]`.
+fn write_y_timestep(
+    y_data: &mut [u8],
+    h: &[f32],
+    t: usize,
+    d: usize,
+    num_dir: usize,
+    batch: usize,
+    hidden: usize,
+) {
+    let y_off = t * num_dir * batch * hidden + d * batch * hidden;
+    for (i, &v) in h.iter().enumerate() {
+        write_f32(y_data, y_off + i, v);
+    }
+}
+
+/// Build the output Y tensor with shape `[seq, num_dir, batch, hidden]`.
+fn make_y_tensor(
+    y_data: Vec<u8>,
+    seq: usize,
+    num_dir: usize,
+    batch: usize,
+    hidden: usize,
+) -> Tensor {
+    Tensor {
+        data_type: DataType::Float,
+        shape: TensorShape::new(alloc::vec![
+            seq as i64,
+            num_dir as i64,
+            batch as i64,
+            hidden as i64
+        ]),
+        name: String::new(),
+        raw_data: y_data,
+    }
+}
+
+/// Build the hidden-state tensor with shape `[num_dir, batch, hidden]`.
+fn make_state_tensor(data: Vec<u8>, num_dir: usize, batch: usize, hidden: usize) -> Tensor {
+    Tensor {
+        data_type: DataType::Float,
+        shape: TensorShape::new(alloc::vec![num_dir as i64, batch as i64, hidden as i64]),
+        name: String::new(),
+        raw_data: data,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // RNN
 // ---------------------------------------------------------------------------
+
+/// Validate W (and derive `hidden`) and the related R/B/h0 shapes for RNN.
+fn rnn_validate_shapes(
+    w: &Tensor,
+    r: &Tensor,
+    b: Option<&Tensor>,
+    h0: Option<&Tensor>,
+    num_dir: usize,
+    batch: usize,
+    input_size: usize,
+) -> Result<usize, OpError> {
+    if w.shape.dims.len() != 3 || w.shape.dims[0] as usize != num_dir {
+        return Err(OpError::ShapeMismatch(String::from(
+            "RNN: W shape must be [num_dir, hidden, input]",
+        )));
+    }
+    let hidden = w.shape.dims[1] as usize;
+    if w.shape.dims[2] as usize != input_size {
+        return Err(OpError::ShapeMismatch(String::from(
+            "RNN: W input dim mismatch",
+        )));
+    }
+    validate_r_shape(r, num_dir, 1, hidden, "RNN", "[num_dir, hidden, hidden]")?;
+    validate_b_shape(b, num_dir, 2 * hidden, "RNN", "[num_dir, 2*hidden]")?;
+    validate_initial_state(h0, num_dir, batch, hidden, "RNN", "h0")?;
+    Ok(hidden)
+}
+
+/// Compute one RNN timestep: `h_t = tanh(x_t W^T + h_{t-1} R^T + b)`.
+fn rnn_step(
+    x_raw: &[u8],
+    x_off: usize,
+    h_prev: &[f32],
+    w_dir: &[f32],
+    r_dir: &[f32],
+    b_dir: &[f32],
+    batch: usize,
+    input_size: usize,
+    hidden: usize,
+) -> Vec<f32> {
+    let mut new_h = alloc::vec![0.0f32; batch * hidden];
+    for bi in 0..batch {
+        for hi in 0..hidden {
+            let mut acc = b_dir[hi];
+            for ii in 0..input_size {
+                acc += read_f32(x_raw, x_off + bi * input_size + ii) * w_dir[hi * input_size + ii];
+            }
+            for hh in 0..hidden {
+                acc += h_prev[bi * hidden + hh] * r_dir[hi * hidden + hh];
+            }
+            new_h[bi * hidden + hi] = tanh_approx(acc);
+        }
+    }
+    new_h
+}
 
 /// Basic RNN with tanh activation.
 ///
@@ -72,145 +306,171 @@ pub fn op_rnn(
     require_float(w, "RNN")?;
     require_float(r, "RNN")?;
     let (num_dir, _bi) = parse_direction(direction)?;
+    let (seq, batch, input_size) = validate_x_shape(x, "RNN")?;
+    let hidden = rnn_validate_shapes(w, r, b, h0, num_dir, batch, input_size)?;
 
-    if x.shape.dims.len() != 3 {
-        return Err(OpError::ShapeMismatch(String::from(
-            "RNN: X must be 3D [seq, batch, input]",
-        )));
-    }
-    let seq = x.shape.dims[0] as usize;
-    let batch = x.shape.dims[1] as usize;
-    let input_size = x.shape.dims[2] as usize;
-
-    if w.shape.dims.len() != 3 || w.shape.dims[0] as usize != num_dir {
-        return Err(OpError::ShapeMismatch(String::from(
-            "RNN: W shape must be [num_dir, hidden, input]",
-        )));
-    }
-    let hidden = w.shape.dims[1] as usize;
-    if w.shape.dims[2] as usize != input_size {
-        return Err(OpError::ShapeMismatch(String::from(
-            "RNN: W input dim mismatch",
-        )));
-    }
-    if r.shape.dims.len() != 3
-        || r.shape.dims[0] as usize != num_dir
-        || r.shape.dims[1] as usize != hidden
-        || r.shape.dims[2] as usize != hidden
-    {
-        return Err(OpError::ShapeMismatch(String::from(
-            "RNN: R shape must be [num_dir, hidden, hidden]",
-        )));
-    }
-    // Validate optional B, h0 shapes up-front before we slice raw data.
-    if let Some(bt) = b {
-        if bt.shape.dims.len() != 2
-            || bt.shape.dims[0] as usize != num_dir
-            || bt.shape.dims[1] as usize != 2 * hidden
-        {
-            return Err(OpError::ShapeMismatch(String::from(
-                "RNN: B shape must be [num_dir, 2*hidden]",
-            )));
-        }
-    }
-    if let Some(h0t) = h0 {
-        if h0t.shape.dims.len() != 3
-            || h0t.shape.dims[0] as usize != num_dir
-            || h0t.shape.dims[1] as usize != batch
-            || h0t.shape.dims[2] as usize != hidden
-        {
-            return Err(OpError::ShapeMismatch(String::from(
-                "RNN: h0 shape must be [num_dir, batch, hidden]",
-            )));
-        }
-    }
-
-    // Output buffers.
     let y_total = seq * num_dir * batch * hidden;
     let mut y_data = allocate_tensor_data(y_total, DataType::Float);
     let mut yh_data = allocate_tensor_data(num_dir * batch * hidden, DataType::Float);
 
     for d in 0..num_dir {
-        let reverse = direction == "reverse" || (direction == "bidirectional" && d == 1);
-        // Read this direction's weights / biases.
+        let reverse = dir_is_reverse(direction, d);
         let w_off = d * hidden * input_size;
         let r_off = d * hidden * hidden;
         let w_dir = slice_f32(&w.raw_data, w_off, hidden * input_size);
         let r_dir = slice_f32(&r.raw_data, r_off, hidden * hidden);
-        let b_dir: Vec<f32> = if let Some(bt) = b {
-            require_float(bt, "RNN")?;
-            // B is [num_dir, 2*hidden]; final bias is sum of W bias and R bias halves.
-            let off = d * 2 * hidden;
-            let wb = slice_f32(&bt.raw_data, off, hidden);
-            let rb = slice_f32(&bt.raw_data, off + hidden, hidden);
-            wb.iter().zip(rb.iter()).map(|(a, b)| a + b).collect()
-        } else {
-            alloc::vec![0.0f32; hidden]
-        };
-        // Initial hidden state.
-        let mut h: Vec<f32> = if let Some(h0t) = h0 {
-            require_float(h0t, "RNN")?;
-            slice_f32(&h0t.raw_data, d * batch * hidden, batch * hidden)
-        } else {
-            alloc::vec![0.0f32; batch * hidden]
-        };
+        let b_dir = merge_wr_bias(b, d, hidden, "RNN")?;
+        let mut h = read_initial_state(h0, d, batch, hidden, "RNN")?;
 
         for step in 0..seq {
             let t = if reverse { seq - 1 - step } else { step };
-            // Compute h_t = tanh(x_t W^T + h_{t-1} R^T + b)
             let x_off = t * batch * input_size;
-            let mut new_h = alloc::vec![0.0f32; batch * hidden];
-            for bi in 0..batch {
-                for hi in 0..hidden {
-                    let mut acc = b_dir[hi];
-                    for ii in 0..input_size {
-                        acc += read_f32(&x.raw_data, x_off + bi * input_size + ii)
-                            * w_dir[hi * input_size + ii];
-                    }
-                    for hh in 0..hidden {
-                        acc += h[bi * hidden + hh] * r_dir[hi * hidden + hh];
-                    }
-                    new_h[bi * hidden + hi] = tanh_approx(acc);
-                }
-            }
-            h = new_h;
-            // Write Y[t, d, :, :].
-            let y_off = t * num_dir * batch * hidden + d * batch * hidden;
-            for (i, &v) in h.iter().enumerate() {
-                write_f32(&mut y_data, y_off + i, v);
-            }
+            h = rnn_step(
+                &x.raw_data,
+                x_off,
+                &h,
+                &w_dir,
+                &r_dir,
+                &b_dir,
+                batch,
+                input_size,
+                hidden,
+            );
+            write_y_timestep(&mut y_data, &h, t, d, num_dir, batch, hidden);
         }
-        // Final hidden state for this direction.
-        let yh_off = d * batch * hidden;
-        for (i, &v) in h.iter().enumerate() {
-            write_f32(&mut yh_data, yh_off + i, v);
-        }
+        write_final_state(&mut yh_data, &h, d, batch, hidden);
     }
 
     Ok(alloc::vec![
-        Tensor {
-            data_type: DataType::Float,
-            shape: TensorShape::new(alloc::vec![
-                seq as i64,
-                num_dir as i64,
-                batch as i64,
-                hidden as i64
-            ]),
-            name: String::new(),
-            raw_data: y_data,
-        },
-        Tensor {
-            data_type: DataType::Float,
-            shape: TensorShape::new(alloc::vec![num_dir as i64, batch as i64, hidden as i64]),
-            name: String::new(),
-            raw_data: yh_data,
-        },
+        make_y_tensor(y_data, seq, num_dir, batch, hidden),
+        make_state_tensor(yh_data, num_dir, batch, hidden),
     ])
 }
 
 // ---------------------------------------------------------------------------
 // LSTM
 // ---------------------------------------------------------------------------
+
+/// Validate W (and derive `hidden`) and the related R/B/h0/c0 shapes for LSTM.
+fn lstm_validate_shapes(
+    w: &Tensor,
+    r: &Tensor,
+    b: Option<&Tensor>,
+    h0: Option<&Tensor>,
+    c0: Option<&Tensor>,
+    num_dir: usize,
+    batch: usize,
+    input_size: usize,
+) -> Result<usize, OpError> {
+    if w.shape.dims.len() != 3 || w.shape.dims[0] as usize != num_dir {
+        return Err(OpError::ShapeMismatch(String::from(
+            "LSTM: W shape must be [num_dir, 4*hidden, input]",
+        )));
+    }
+    if w.shape.dims[2] as usize != input_size {
+        return Err(OpError::ShapeMismatch(String::from(
+            "LSTM: W input dim mismatch",
+        )));
+    }
+    let four_h = w.shape.dims[1] as usize;
+    if !four_h.is_multiple_of(4) {
+        return Err(OpError::ShapeMismatch(String::from(
+            "LSTM: W second dim must be 4*hidden",
+        )));
+    }
+    let hidden = four_h / 4;
+    validate_r_shape(r, num_dir, 4, hidden, "LSTM", "[num_dir, 4*hidden, hidden]")?;
+    validate_b_shape(b, num_dir, 8 * hidden, "LSTM", "[num_dir, 8*hidden]")?;
+    validate_initial_state(h0, num_dir, batch, hidden, "LSTM", "h0")?;
+    validate_initial_state(c0, num_dir, batch, hidden, "LSTM", "c0")?;
+    Ok(hidden)
+}
+
+/// Compute the LSTM gate pre-activations for one batch element:
+/// `g[k] = X·W^T_k + H·R^T_k + b_k` for `k in 0..4*hidden`.
+fn lstm_gate_preacts(
+    x_raw: &[u8],
+    x_row_off: usize,
+    h_prev_row: &[f32],
+    w_dir: &[f32],
+    r_dir: &[f32],
+    b_dir: &[f32],
+    input_size: usize,
+    hidden: usize,
+) -> Vec<f32> {
+    let mut gates = alloc::vec![0.0f32; 4 * hidden];
+    for k in 0..4 * hidden {
+        let mut acc = b_dir[k];
+        for ii in 0..input_size {
+            acc += read_f32(x_raw, x_row_off + ii) * w_dir[k * input_size + ii];
+        }
+        for hh in 0..hidden {
+            acc += h_prev_row[hh] * r_dir[k * hidden + hh];
+        }
+        gates[k] = acc;
+    }
+    gates
+}
+
+/// Apply the LSTM gate non-linearities and update `(h, c)` for one batch row.
+/// Gate layout per ONNX: i, o, f, c (input, output, forget, cell).
+fn lstm_apply_gates(
+    gates: &[f32],
+    c_prev_row: &[f32],
+    new_h_row: &mut [f32],
+    new_c_row: &mut [f32],
+    hidden: usize,
+) {
+    for hi in 0..hidden {
+        let i_g = sigmoid(gates[hi]);
+        let o_g = sigmoid(gates[hidden + hi]);
+        let f_g = sigmoid(gates[2 * hidden + hi]);
+        let c_g = tanh_approx(gates[3 * hidden + hi]);
+        let c_new = f_g * c_prev_row[hi] + i_g * c_g;
+        new_c_row[hi] = c_new;
+        new_h_row[hi] = o_g * tanh_approx(c_new);
+    }
+}
+
+/// Compute one LSTM timestep across the batch, returning the updated
+/// `(h, c)` slices.
+#[allow(clippy::too_many_arguments)]
+fn lstm_step(
+    x_raw: &[u8],
+    x_off: usize,
+    h_prev: &[f32],
+    c_prev: &[f32],
+    w_dir: &[f32],
+    r_dir: &[f32],
+    b_dir: &[f32],
+    batch: usize,
+    input_size: usize,
+    hidden: usize,
+) -> (Vec<f32>, Vec<f32>) {
+    let mut new_h = alloc::vec![0.0f32; batch * hidden];
+    let mut new_c = alloc::vec![0.0f32; batch * hidden];
+    for bi in 0..batch {
+        let off = bi * hidden;
+        let gates = lstm_gate_preacts(
+            x_raw,
+            x_off + bi * input_size,
+            &h_prev[off..off + hidden],
+            w_dir,
+            r_dir,
+            b_dir,
+            input_size,
+            hidden,
+        );
+        lstm_apply_gates(
+            &gates,
+            &c_prev[off..off + hidden],
+            &mut new_h[off..off + hidden],
+            &mut new_c[off..off + hidden],
+            hidden,
+        );
+    }
+    (new_h, new_c)
+}
 
 /// LSTM with input, forget, cell, output gates (i, o, f, c order per ONNX).
 ///
@@ -233,74 +493,8 @@ pub fn op_lstm(
     require_float(w, "LSTM")?;
     require_float(r, "LSTM")?;
     let (num_dir, _bi) = parse_direction(direction)?;
-
-    if x.shape.dims.len() != 3 {
-        return Err(OpError::ShapeMismatch(String::from(
-            "LSTM: X must be 3D [seq, batch, input]",
-        )));
-    }
-    let seq = x.shape.dims[0] as usize;
-    let batch = x.shape.dims[1] as usize;
-    let input_size = x.shape.dims[2] as usize;
-
-    if w.shape.dims.len() != 3 || w.shape.dims[0] as usize != num_dir {
-        return Err(OpError::ShapeMismatch(String::from(
-            "LSTM: W shape must be [num_dir, 4*hidden, input]",
-        )));
-    }
-    if w.shape.dims[2] as usize != input_size {
-        return Err(OpError::ShapeMismatch(String::from(
-            "LSTM: W input dim mismatch",
-        )));
-    }
-    let four_h = w.shape.dims[1] as usize;
-    if !four_h.is_multiple_of(4) {
-        return Err(OpError::ShapeMismatch(String::from(
-            "LSTM: W second dim must be 4*hidden",
-        )));
-    }
-    let hidden = four_h / 4;
-    if r.shape.dims.len() != 3
-        || r.shape.dims[0] as usize != num_dir
-        || r.shape.dims[1] as usize != 4 * hidden
-        || r.shape.dims[2] as usize != hidden
-    {
-        return Err(OpError::ShapeMismatch(String::from(
-            "LSTM: R shape must be [num_dir, 4*hidden, hidden]",
-        )));
-    }
-    if let Some(bt) = b {
-        if bt.shape.dims.len() != 2
-            || bt.shape.dims[0] as usize != num_dir
-            || bt.shape.dims[1] as usize != 8 * hidden
-        {
-            return Err(OpError::ShapeMismatch(String::from(
-                "LSTM: B shape must be [num_dir, 8*hidden]",
-            )));
-        }
-    }
-    if let Some(h0t) = h0 {
-        if h0t.shape.dims.len() != 3
-            || h0t.shape.dims[0] as usize != num_dir
-            || h0t.shape.dims[1] as usize != batch
-            || h0t.shape.dims[2] as usize != hidden
-        {
-            return Err(OpError::ShapeMismatch(String::from(
-                "LSTM: h0 shape must be [num_dir, batch, hidden]",
-            )));
-        }
-    }
-    if let Some(c0t) = c0 {
-        if c0t.shape.dims.len() != 3
-            || c0t.shape.dims[0] as usize != num_dir
-            || c0t.shape.dims[1] as usize != batch
-            || c0t.shape.dims[2] as usize != hidden
-        {
-            return Err(OpError::ShapeMismatch(String::from(
-                "LSTM: c0 shape must be [num_dir, batch, hidden]",
-            )));
-        }
-    }
+    let (seq, batch, input_size) = validate_x_shape(x, "LSTM")?;
+    let hidden = lstm_validate_shapes(w, r, b, h0, c0, num_dir, batch, input_size)?;
 
     let y_total = seq * num_dir * batch * hidden;
     let mut y_data = allocate_tensor_data(y_total, DataType::Float);
@@ -308,115 +502,185 @@ pub fn op_lstm(
     let mut yc_data = allocate_tensor_data(num_dir * batch * hidden, DataType::Float);
 
     for d in 0..num_dir {
-        let reverse = direction == "reverse" || (direction == "bidirectional" && d == 1);
-
+        let reverse = dir_is_reverse(direction, d);
         let w_off = d * 4 * hidden * input_size;
         let r_off = d * 4 * hidden * hidden;
         let w_dir = slice_f32(&w.raw_data, w_off, 4 * hidden * input_size);
         let r_dir = slice_f32(&r.raw_data, r_off, 4 * hidden * hidden);
-        let b_dir: Vec<f32> = if let Some(bt) = b {
-            require_float(bt, "LSTM")?;
-            // B is [num_dir, 8*hidden]; collapse W bias + R bias.
-            let off = d * 8 * hidden;
-            let wb = slice_f32(&bt.raw_data, off, 4 * hidden);
-            let rb = slice_f32(&bt.raw_data, off + 4 * hidden, 4 * hidden);
-            wb.iter().zip(rb.iter()).map(|(a, b)| a + b).collect()
-        } else {
-            alloc::vec![0.0f32; 4 * hidden]
-        };
-
-        let mut h: Vec<f32> = if let Some(h0t) = h0 {
-            require_float(h0t, "LSTM")?;
-            slice_f32(&h0t.raw_data, d * batch * hidden, batch * hidden)
-        } else {
-            alloc::vec![0.0f32; batch * hidden]
-        };
-        let mut c: Vec<f32> = if let Some(c0t) = c0 {
-            require_float(c0t, "LSTM")?;
-            slice_f32(&c0t.raw_data, d * batch * hidden, batch * hidden)
-        } else {
-            alloc::vec![0.0f32; batch * hidden]
-        };
-
-        // Gate layout per ONNX: i, o, f, c (input, output, forget, cell).
-        let gate_offset = |g: usize| g * hidden;
+        let b_dir = merge_wr_bias(b, d, 4 * hidden, "LSTM")?;
+        let mut h = read_initial_state(h0, d, batch, hidden, "LSTM")?;
+        let mut c = read_initial_state(c0, d, batch, hidden, "LSTM")?;
 
         for step in 0..seq {
             let t = if reverse { seq - 1 - step } else { step };
             let x_off = t * batch * input_size;
-            let mut new_h = alloc::vec![0.0f32; batch * hidden];
-            let mut new_c = alloc::vec![0.0f32; batch * hidden];
-            for bi in 0..batch {
-                // Compute gate pre-activations: g[k] = X·W^T_k + H·R^T_k + b_k
-                let mut gates = alloc::vec![0.0f32; 4 * hidden];
-                for k in 0..4 * hidden {
-                    let mut acc = b_dir[k];
-                    for ii in 0..input_size {
-                        acc += read_f32(&x.raw_data, x_off + bi * input_size + ii)
-                            * w_dir[k * input_size + ii];
-                    }
-                    for hh in 0..hidden {
-                        acc += h[bi * hidden + hh] * r_dir[k * hidden + hh];
-                    }
-                    gates[k] = acc;
-                }
-                // Apply activations: i, o, f use sigmoid; c uses tanh.
-                for hi in 0..hidden {
-                    let i_g = sigmoid(gates[gate_offset(0) + hi]);
-                    let o_g = sigmoid(gates[gate_offset(1) + hi]);
-                    let f_g = sigmoid(gates[gate_offset(2) + hi]);
-                    let c_g = tanh_approx(gates[gate_offset(3) + hi]);
-                    let c_prev = c[bi * hidden + hi];
-                    let c_new = f_g * c_prev + i_g * c_g;
-                    let h_new = o_g * tanh_approx(c_new);
-                    new_c[bi * hidden + hi] = c_new;
-                    new_h[bi * hidden + hi] = h_new;
-                }
-            }
+            let (new_h, new_c) = lstm_step(
+                &x.raw_data,
+                x_off,
+                &h,
+                &c,
+                &w_dir,
+                &r_dir,
+                &b_dir,
+                batch,
+                input_size,
+                hidden,
+            );
             h = new_h;
             c = new_c;
-            let y_off = t * num_dir * batch * hidden + d * batch * hidden;
-            for (i, &v) in h.iter().enumerate() {
-                write_f32(&mut y_data, y_off + i, v);
-            }
+            write_y_timestep(&mut y_data, &h, t, d, num_dir, batch, hidden);
         }
-        let off = d * batch * hidden;
-        for (i, (&hv, &cv)) in h.iter().zip(c.iter()).enumerate() {
-            write_f32(&mut yh_data, off + i, hv);
-            write_f32(&mut yc_data, off + i, cv);
-        }
+        write_final_state(&mut yh_data, &h, d, batch, hidden);
+        write_final_state(&mut yc_data, &c, d, batch, hidden);
     }
 
     Ok(alloc::vec![
-        Tensor {
-            data_type: DataType::Float,
-            shape: TensorShape::new(alloc::vec![
-                seq as i64,
-                num_dir as i64,
-                batch as i64,
-                hidden as i64
-            ]),
-            name: String::new(),
-            raw_data: y_data,
-        },
-        Tensor {
-            data_type: DataType::Float,
-            shape: TensorShape::new(alloc::vec![num_dir as i64, batch as i64, hidden as i64]),
-            name: String::new(),
-            raw_data: yh_data,
-        },
-        Tensor {
-            data_type: DataType::Float,
-            shape: TensorShape::new(alloc::vec![num_dir as i64, batch as i64, hidden as i64]),
-            name: String::new(),
-            raw_data: yc_data,
-        },
+        make_y_tensor(y_data, seq, num_dir, batch, hidden),
+        make_state_tensor(yh_data, num_dir, batch, hidden),
+        make_state_tensor(yc_data, num_dir, batch, hidden),
     ])
 }
 
 // ---------------------------------------------------------------------------
 // GRU
 // ---------------------------------------------------------------------------
+
+/// Validate W (and derive `hidden`) and the related R/B/h0 shapes for GRU.
+fn gru_validate_shapes(
+    w: &Tensor,
+    r: &Tensor,
+    b: Option<&Tensor>,
+    h0: Option<&Tensor>,
+    num_dir: usize,
+    batch: usize,
+    input_size: usize,
+) -> Result<usize, OpError> {
+    if w.shape.dims.len() != 3 || w.shape.dims[0] as usize != num_dir {
+        return Err(OpError::ShapeMismatch(String::from(
+            "GRU: W shape must be [num_dir, 3*hidden, input]",
+        )));
+    }
+    if w.shape.dims[2] as usize != input_size {
+        return Err(OpError::ShapeMismatch(String::from(
+            "GRU: W input dim mismatch",
+        )));
+    }
+    let three_h = w.shape.dims[1] as usize;
+    if !three_h.is_multiple_of(3) {
+        return Err(OpError::ShapeMismatch(String::from(
+            "GRU: W second dim must be 3*hidden",
+        )));
+    }
+    let hidden = three_h / 3;
+    validate_r_shape(r, num_dir, 3, hidden, "GRU", "[num_dir, 3*hidden, hidden]")?;
+    validate_b_shape(b, num_dir, 6 * hidden, "GRU", "[num_dir, 6*hidden]")?;
+    validate_initial_state(h0, num_dir, batch, hidden, "GRU", "h0")?;
+    Ok(hidden)
+}
+
+/// Split the GRU bias into separate `(W bias, R bias)` halves for direction `d`.
+/// ONNX keeps these separate because the hidden gate adds `R bias` only after
+/// being scaled by the reset gate.
+fn gru_split_bias(
+    b: Option<&Tensor>,
+    d: usize,
+    hidden: usize,
+) -> Result<(Vec<f32>, Vec<f32>), OpError> {
+    if let Some(bt) = b {
+        require_float(bt, "GRU")?;
+        let off = d * 6 * hidden;
+        Ok((
+            slice_f32(&bt.raw_data, off, 3 * hidden),
+            slice_f32(&bt.raw_data, off + 3 * hidden, 3 * hidden),
+        ))
+    } else {
+        Ok((
+            alloc::vec![0.0f32; 3 * hidden],
+            alloc::vec![0.0f32; 3 * hidden],
+        ))
+    }
+}
+
+/// Compute the GRU `(z, r)` gates and the split hidden pre-activations
+/// `(h_pre_w, h_pre_r)` for one batch row.
+#[allow(clippy::too_many_arguments)]
+fn gru_zr_and_h_preacts(
+    x_raw: &[u8],
+    x_row_off: usize,
+    h_prev_row: &[f32],
+    w_dir: &[f32],
+    r_dir: &[f32],
+    wb_dir: &[f32],
+    rb_dir: &[f32],
+    input_size: usize,
+    hidden: usize,
+) -> (Vec<f32>, Vec<f32>, Vec<f32>, Vec<f32>) {
+    let mut z_g = alloc::vec![0.0f32; hidden];
+    let mut r_g = alloc::vec![0.0f32; hidden];
+    let mut h_pre_w = alloc::vec![0.0f32; hidden];
+    let mut h_pre_r = alloc::vec![0.0f32; hidden];
+    for hi in 0..hidden {
+        let mut z_acc = wb_dir[hi] + rb_dir[hi];
+        let mut r_acc = wb_dir[hidden + hi] + rb_dir[hidden + hi];
+        let mut hw_acc = wb_dir[2 * hidden + hi];
+        let mut hr_acc = rb_dir[2 * hidden + hi];
+        for ii in 0..input_size {
+            let xv = read_f32(x_raw, x_row_off + ii);
+            z_acc += xv * w_dir[hi * input_size + ii];
+            r_acc += xv * w_dir[(hidden + hi) * input_size + ii];
+            hw_acc += xv * w_dir[(2 * hidden + hi) * input_size + ii];
+        }
+        for hh in 0..hidden {
+            let hv = h_prev_row[hh];
+            z_acc += hv * r_dir[hi * hidden + hh];
+            r_acc += hv * r_dir[(hidden + hi) * hidden + hh];
+            hr_acc += hv * r_dir[(2 * hidden + hi) * hidden + hh];
+        }
+        z_g[hi] = sigmoid(z_acc);
+        r_g[hi] = sigmoid(r_acc);
+        h_pre_w[hi] = hw_acc;
+        h_pre_r[hi] = hr_acc;
+    }
+    (z_g, r_g, h_pre_w, h_pre_r)
+}
+
+/// Compute one GRU timestep across the batch.
+#[allow(clippy::too_many_arguments)]
+fn gru_step(
+    x_raw: &[u8],
+    x_off: usize,
+    h_prev: &[f32],
+    w_dir: &[f32],
+    r_dir: &[f32],
+    wb_dir: &[f32],
+    rb_dir: &[f32],
+    batch: usize,
+    input_size: usize,
+    hidden: usize,
+) -> Vec<f32> {
+    let mut new_h = alloc::vec![0.0f32; batch * hidden];
+    for bi in 0..batch {
+        let off = bi * hidden;
+        let (z_g, r_g, h_pre_w, h_pre_r) = gru_zr_and_h_preacts(
+            x_raw,
+            x_off + bi * input_size,
+            &h_prev[off..off + hidden],
+            w_dir,
+            r_dir,
+            wb_dir,
+            rb_dir,
+            input_size,
+            hidden,
+        );
+        // Hidden gate: h_tilde = tanh(h_pre_w + r * h_pre_r)
+        for hi in 0..hidden {
+            let h_tilde = tanh_approx(h_pre_w[hi] + r_g[hi] * h_pre_r[hi]);
+            let h_prev_v = h_prev[off + hi];
+            new_h[off + hi] = (1.0 - z_g[hi]) * h_tilde + z_g[hi] * h_prev_v;
+        }
+    }
+    new_h
+}
 
 /// GRU with reset, update, and hidden gates (z, r, h order per ONNX).
 ///
@@ -435,165 +699,45 @@ pub fn op_gru(
     require_float(w, "GRU")?;
     require_float(r, "GRU")?;
     let (num_dir, _bi) = parse_direction(direction)?;
-
-    if x.shape.dims.len() != 3 {
-        return Err(OpError::ShapeMismatch(String::from(
-            "GRU: X must be 3D [seq, batch, input]",
-        )));
-    }
-    let seq = x.shape.dims[0] as usize;
-    let batch = x.shape.dims[1] as usize;
-    let input_size = x.shape.dims[2] as usize;
-
-    if w.shape.dims.len() != 3 || w.shape.dims[0] as usize != num_dir {
-        return Err(OpError::ShapeMismatch(String::from(
-            "GRU: W shape must be [num_dir, 3*hidden, input]",
-        )));
-    }
-    if w.shape.dims[2] as usize != input_size {
-        return Err(OpError::ShapeMismatch(String::from(
-            "GRU: W input dim mismatch",
-        )));
-    }
-    let three_h = w.shape.dims[1] as usize;
-    if !three_h.is_multiple_of(3) {
-        return Err(OpError::ShapeMismatch(String::from(
-            "GRU: W second dim must be 3*hidden",
-        )));
-    }
-    let hidden = three_h / 3;
-    if r.shape.dims.len() != 3
-        || r.shape.dims[0] as usize != num_dir
-        || r.shape.dims[1] as usize != 3 * hidden
-        || r.shape.dims[2] as usize != hidden
-    {
-        return Err(OpError::ShapeMismatch(String::from(
-            "GRU: R shape must be [num_dir, 3*hidden, hidden]",
-        )));
-    }
-    if let Some(bt) = b {
-        if bt.shape.dims.len() != 2
-            || bt.shape.dims[0] as usize != num_dir
-            || bt.shape.dims[1] as usize != 6 * hidden
-        {
-            return Err(OpError::ShapeMismatch(String::from(
-                "GRU: B shape must be [num_dir, 6*hidden]",
-            )));
-        }
-    }
-    if let Some(h0t) = h0 {
-        if h0t.shape.dims.len() != 3
-            || h0t.shape.dims[0] as usize != num_dir
-            || h0t.shape.dims[1] as usize != batch
-            || h0t.shape.dims[2] as usize != hidden
-        {
-            return Err(OpError::ShapeMismatch(String::from(
-                "GRU: h0 shape must be [num_dir, batch, hidden]",
-            )));
-        }
-    }
+    let (seq, batch, input_size) = validate_x_shape(x, "GRU")?;
+    let hidden = gru_validate_shapes(w, r, b, h0, num_dir, batch, input_size)?;
 
     let y_total = seq * num_dir * batch * hidden;
     let mut y_data = allocate_tensor_data(y_total, DataType::Float);
     let mut yh_data = allocate_tensor_data(num_dir * batch * hidden, DataType::Float);
 
     for d in 0..num_dir {
-        let reverse = direction == "reverse" || (direction == "bidirectional" && d == 1);
+        let reverse = dir_is_reverse(direction, d);
         let w_off = d * 3 * hidden * input_size;
         let r_off = d * 3 * hidden * hidden;
         let w_dir = slice_f32(&w.raw_data, w_off, 3 * hidden * input_size);
         let r_dir = slice_f32(&r.raw_data, r_off, 3 * hidden * hidden);
-        // For GRU, ONNX keeps W bias and R bias separate because the hidden
-        // gate (h) needs to add R bias *after* multiplying by reset. We split.
-        let (wb_dir, rb_dir): (Vec<f32>, Vec<f32>) = if let Some(bt) = b {
-            require_float(bt, "GRU")?;
-            let off = d * 6 * hidden;
-            (
-                slice_f32(&bt.raw_data, off, 3 * hidden),
-                slice_f32(&bt.raw_data, off + 3 * hidden, 3 * hidden),
-            )
-        } else {
-            (
-                alloc::vec![0.0f32; 3 * hidden],
-                alloc::vec![0.0f32; 3 * hidden],
-            )
-        };
-        let mut h: Vec<f32> = if let Some(h0t) = h0 {
-            require_float(h0t, "GRU")?;
-            slice_f32(&h0t.raw_data, d * batch * hidden, batch * hidden)
-        } else {
-            alloc::vec![0.0f32; batch * hidden]
-        };
+        let (wb_dir, rb_dir) = gru_split_bias(b, d, hidden)?;
+        let mut h = read_initial_state(h0, d, batch, hidden, "GRU")?;
 
         for step in 0..seq {
             let t = if reverse { seq - 1 - step } else { step };
             let x_off = t * batch * input_size;
-            let mut new_h = alloc::vec![0.0f32; batch * hidden];
-            for bi in 0..batch {
-                // Compute z, r gates from W and R linearly.
-                let mut z_g = alloc::vec![0.0f32; hidden];
-                let mut r_g = alloc::vec![0.0f32; hidden];
-                let mut h_pre_w = alloc::vec![0.0f32; hidden]; // x·W^T_h + wb_h
-                let mut h_pre_r = alloc::vec![0.0f32; hidden]; // h·R^T_h + rb_h
-                for hi in 0..hidden {
-                    let mut z_acc = wb_dir[hi] + rb_dir[hi];
-                    let mut r_acc = wb_dir[hidden + hi] + rb_dir[hidden + hi];
-                    let mut hw_acc = wb_dir[2 * hidden + hi];
-                    let mut hr_acc = rb_dir[2 * hidden + hi];
-                    for ii in 0..input_size {
-                        let xv = read_f32(&x.raw_data, x_off + bi * input_size + ii);
-                        z_acc += xv * w_dir[hi * input_size + ii];
-                        r_acc += xv * w_dir[(hidden + hi) * input_size + ii];
-                        hw_acc += xv * w_dir[(2 * hidden + hi) * input_size + ii];
-                    }
-                    for hh in 0..hidden {
-                        let hv = h[bi * hidden + hh];
-                        z_acc += hv * r_dir[hi * hidden + hh];
-                        r_acc += hv * r_dir[(hidden + hi) * hidden + hh];
-                        hr_acc += hv * r_dir[(2 * hidden + hi) * hidden + hh];
-                    }
-                    z_g[hi] = sigmoid(z_acc);
-                    r_g[hi] = sigmoid(r_acc);
-                    h_pre_w[hi] = hw_acc;
-                    h_pre_r[hi] = hr_acc;
-                }
-                // Hidden gate: h_tilde = tanh(h_pre_w + r * h_pre_r)
-                for hi in 0..hidden {
-                    let h_tilde = tanh_approx(h_pre_w[hi] + r_g[hi] * h_pre_r[hi]);
-                    let h_prev = h[bi * hidden + hi];
-                    new_h[bi * hidden + hi] = (1.0 - z_g[hi]) * h_tilde + z_g[hi] * h_prev;
-                }
-            }
-            h = new_h;
-            let y_off = t * num_dir * batch * hidden + d * batch * hidden;
-            for (i, &v) in h.iter().enumerate() {
-                write_f32(&mut y_data, y_off + i, v);
-            }
+            h = gru_step(
+                &x.raw_data,
+                x_off,
+                &h,
+                &w_dir,
+                &r_dir,
+                &wb_dir,
+                &rb_dir,
+                batch,
+                input_size,
+                hidden,
+            );
+            write_y_timestep(&mut y_data, &h, t, d, num_dir, batch, hidden);
         }
-        let off = d * batch * hidden;
-        for (i, &v) in h.iter().enumerate() {
-            write_f32(&mut yh_data, off + i, v);
-        }
+        write_final_state(&mut yh_data, &h, d, batch, hidden);
     }
 
     Ok(alloc::vec![
-        Tensor {
-            data_type: DataType::Float,
-            shape: TensorShape::new(alloc::vec![
-                seq as i64,
-                num_dir as i64,
-                batch as i64,
-                hidden as i64
-            ]),
-            name: String::new(),
-            raw_data: y_data,
-        },
-        Tensor {
-            data_type: DataType::Float,
-            shape: TensorShape::new(alloc::vec![num_dir as i64, batch as i64, hidden as i64]),
-            name: String::new(),
-            raw_data: yh_data,
-        },
+        make_y_tensor(y_data, seq, num_dir, batch, hidden),
+        make_state_tensor(yh_data, num_dir, batch, hidden),
     ])
 }
 


### PR DESCRIPTION
## Summary

Pure refactor that drops SonarCloud rule `rust:S3776` (cognitive complexity, threshold 15) below 15 across the seven hot-spot functions in `onnx-rt/src/ops/microsoft.rs` and `onnx-rt/src/ops/recurrent.rs`. No observable behavior change; only private helpers added.

| File | Function | Before | After (est.) |
|------|----------|-------:|-------------:|
| `ops/microsoft.rs` | `scaled_dot_product_attention` | 79 | ~10 |
| `ops/microsoft.rs` | `apply_rope_in_place` | 41 | ~10 |
| `ops/microsoft.rs` | `kv_concat` | 28 | ~5 |
| `ops/microsoft.rs` | `op_group_query_attention` | 18 | ~10 |
| `ops/recurrent.rs` | `op_lstm` | 63 | ~8 |
| `ops/recurrent.rs` | `op_gru` | 56 | ~8 |
| `ops/recurrent.rs` | `op_rnn` | 51 | ~7 |

### Approach

- **`ops/microsoft.rs`** — extract independent decision branches into named helpers:
  - `validate_rope_caches`, `rope_position_for`, `check_rope_position`, `rotate_rope_block` for RoPE.
  - `sdpa_scores_row`, `sdpa_softmax`, `sdpa_write_weighted_v`, `sdpa_write_zero_row`, `sdpa_max_k`, `sdpa_row` for SDPA. Softmax returns `Option<Vec<f32>>`; `None` means "no valid key" and triggers a zero row.
  - `validate_past_kv` + `kv_copy_block` for `kv_concat`.
  - `gqa_validate`, `gqa_past_sk`, `gqa_apply_rotary` for `op_group_query_attention`.
- **`ops/recurrent.rs`** — factor shared shape validation (`validate_x_shape`, `validate_r_shape`, `validate_b_shape`, `validate_initial_state`), state plumbing (`read_initial_state`, `merge_wr_bias`, `write_y_timestep`, `write_final_state`, `make_y_tensor`, `make_state_tensor`), and per-op step kernels (`rnn_step`, `lstm_step` driven by `lstm_gate_preacts` + `lstm_apply_gates`, `gru_step` driven by `gru_zr_and_h_preacts`). Per-op validators (`rnn_validate_shapes`, `lstm_validate_shapes`, `gru_validate_shapes`) compose the shared validators.

The helpers are exercised entirely through the existing op tests — no new tests were added.

### SonarCloud note

SonarCloud's `new_coverage` (80%) gate may flag this PR as a measurement artifact, since the new helper functions are private and reached only via the existing op tests rather than by tests added in this PR. May need admin merge if the gate trips.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -p smallaios-onnx-rt -- -D warnings` — no warnings
- [x] `cargo test -p smallaios-onnx-rt --lib` — 891 / 891 passing
- [x] `cargo test -p smallaios-onnx-rt` — full crate suite passing (lib 891, doc/bin/integration 19 + 39 + others all green)

Pre-existing failures noted on `develop` are unrelated to this PR:
- `smallaios-mgmt::toml_oracle` is transient.
- `test_cuda` Mutex.borrow under `--features cuda --all-targets` is target-conditional.
- Arch-specific bare-metal asm targets are by-design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized internal operations for attention, rotary position embedding, and recurrent neural network components to improve code maintainability and clarity.
  * No changes to external APIs or user-facing functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SmallAIOS/SmallAIOS/pull/207)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->