### PR TITLE
feat(arch/riscv64): spec-exec-mitigations-v1 Phase 4 — fence.i scaffolding + Zicfilp planning

### DIFF
--- a/arch/riscv64/src/lib.rs
+++ b/arch/riscv64/src/lib.rs
@@ -22,6 +22,7 @@ pub mod features;
 pub mod paging;
 pub mod plic;
 pub mod sbi;
+pub mod security;
 pub mod syscall;
 pub mod trap;
 pub mod uart;
@@ -87,6 +88,12 @@ pub extern "C" fn kernel_main(hart_id: u64, dtb_addr: u64) -> ! {
         uart::puts("unknown");
     }
     uart::putc(b'\n');
+
+    // Speculative-execution mitigation scaffolding (Phase 4, RISC-V).
+    // Currently a no-op beyond logging — the relevant extensions
+    // (Zicfilp / Zicfiss) are unratified. See
+    // docs/spec-exec-audit-riscv.md and arch/riscv64/src/security/.
+    security::spec_exec::init();
 
     // Parse physical memory map from DTB
     uart::puts("[SmallAIOS] Parsing DTB memory map...\n");

--- a/arch/riscv64/src/security/mod.rs
+++ b/arch/riscv64/src/security/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! RISC-V security HAL.
+//!
+//! Houses speculative-execution / control-flow-integrity scaffolding for the
+//! RISC-V port. RISC-V is currently a boot-only target (no syscall workloads
+//! exercised yet), and the relevant hardening extensions are mostly
+//! unratified, so this module is deliberately a stub whose *shape* — not yet
+//! its silicon programming — is correct-by-construction.
+//!
+//! See `docs/spec-exec-audit-riscv.md` for the planned mitigation matrix and
+//! the OpenSpec change `spec-exec-mitigations-v1` (Phase 4) for tracking.
+
+pub mod spec_exec;

--- a/arch/riscv64/src/security/spec_exec.rs
+++ b/arch/riscv64/src/security/spec_exec.rs
@@ -1,0 +1,114 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! RISC-V speculative-execution mitigation scaffolding.
+//!
+//! Part of OpenSpec change `spec-exec-mitigations-v1`, Phase 4 (RISC-V).
+//!
+//! # Why this is scaffolding, not a mitigation
+//!
+//! RISC-V is a boot-only target in SmallAIOS today — no U-mode syscall
+//! workloads are exercised yet. More importantly, the hardware extensions
+//! that would let us *actually* mitigate the Spectre-class attacks at the
+//! syscall trust boundary are mostly **not ratified** as of 2026-02:
+//!
+//! - **Zicfilp** (forward-edge CFI / landing pads) — Spectre-v2-class
+//!   (branch-target-injection) mitigation. NOT ratified as of 2026-02.
+//! - **Zicfiss** (backward-edge CFI / shadow stack) — return-address /
+//!   Retbleed-class mitigation. NOT ratified as of 2026-02.
+//! - **Zicbom / Zicbop / Zicboz** (cache-block management: clean / prefetch /
+//!   zero) — used for partial cache-state cleanup at the privileged
+//!   transition. Ratified, but no silicon in our validation matrix exposes
+//!   them yet, so the cleanup path is gated off.
+//!
+//! Until those ratify *and* our silicon advertises them, the only mitigation
+//! the RISC-V port can apply is the architecturally-defined `fence.i`
+//! instruction-fetch barrier at the privileged-transition boundary (see
+//! [`crate::syscall::handle_ecall`]). That is a correctness/coherence barrier,
+//! not a speculation barrier — it does NOT close the Spectre-v1/v2 windows.
+//!
+//! Production RISC-V deployments MUST therefore be flagged
+//! **"speculation mitigations partial"** in the DO-178C safety case. See
+//! `docs/spec-exec-audit-riscv.md`.
+//!
+//! # TODO — CSRs / instructions to program once the extensions ratify
+//!
+//! When Zicfilp / Zicfiss ratify and the target silicon advertises them
+//! (via the DTB `riscv,isa` string and/or a `misa`-adjacent discovery CSR),
+//! [`init`] will be filled in to program, at minimum:
+//!
+//! - **`menvcfg.LPE` / `senvcfg.LPE`** (Zicfilp) — enable landing-pad
+//!   enforcement for the privilege level we run at (S-mode for the kernel,
+//!   U-mode for any future task graph). Forward-edge CFI / Spectre-v2.
+//! - **`menvcfg.SSE` / `senvcfg.SSE`** (Zicfiss) — enable shadow-stack
+//!   enforcement; allocate the shadow stack and point **`ssp`** (the
+//!   shadow-stack pointer CSR) at it. Backward-edge CFI / Retbleed-class.
+//! - **`mseccfg` (machine security configuration)** — sticky bits governing
+//!   landing-pad / shadow-stack lockdown; set once at boot, never cleared.
+//! - **Zicbom cache-block clean** — issue `cbo.clean` / `cbo.flush` over the
+//!   capability-check working set at the privileged transition, to bound the
+//!   cache-state residue an attacker can probe (partial Spectre-v1 cache-
+//!   timing mitigation; not a full fix).
+//! - **`fence.i`** — already emitted unconditionally at the privileged
+//!   transition (see [`crate::syscall::handle_ecall`]); this stays even after
+//!   the CFI extensions land (defense in depth, instruction-fetch coherence).
+//!
+//! None of these CSRs/instructions exist in a ratified form we can rely on
+//! yet, so `init()` only logs that the port is running in partial-mitigation
+//! mode. The shape of this module is fixed now so the ratification follow-up
+//! is a fill-in, not a redesign.
+
+/// The single boot-record line emitted by [`init`].
+///
+/// Pulled out as a `const` so a host unit test can assert the exact wording
+/// (the safety case greps boot logs for this marker) without triggering the
+/// UART MMIO write, which is a wild pointer dereference on a host target.
+pub(crate) const SCAFFOLDING_LOG_LINE: &str =
+    "[spec-exec-riscv] scaffolding — extensions not yet ratified, \
+     software mitigations partial\n";
+
+/// Initialize RISC-V speculative-execution mitigations.
+///
+/// **Scaffolding only.** Currently this does not program any CSR or issue any
+/// cache-management instruction — the extensions that would make that
+/// meaningful are unratified (see module docs). It logs a single line so the
+/// boot record unambiguously shows the RISC-V port is running with only
+/// partial software mitigations, which the safety case must account for.
+///
+/// Once Zicfilp / Zicfiss ratify and silicon support is detected, this
+/// function will program the CSRs enumerated in the module-level TODO. The
+/// call site (boot path) and signature are intentionally fixed now so that
+/// future work is a body fill-in with no churn at the call site.
+///
+/// The UART write is `cfg`-gated off under `test` because `uart::putc`
+/// poll-reads NS16550A MMIO at `0x1000_0005`, which is a wild access on a
+/// host target. The non-test path keeps the real boot-log side effect.
+pub fn init() {
+    #[cfg(not(test))]
+    crate::uart::puts(SCAFFOLDING_LOG_LINE);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `init()` is a side-effect-only logging stub today; the contract under
+    /// test is that it is callable and total (never panics / diverges) so the
+    /// fixed boot call site stays correct-by-construction. The UART write is
+    /// `cfg(not(test))`-gated, so this is a wild-pointer-free host check.
+    #[test]
+    fn test_init_is_callable_and_total() {
+        init();
+        // Reaching here proves `init` returned normally on the host target.
+    }
+
+    /// The safety case greps boot logs for this exact marker; pin its wording
+    /// so a refactor cannot silently weaken the partial-mitigation signal.
+    #[test]
+    fn test_scaffolding_log_line_wording() {
+        assert!(SCAFFOLDING_LOG_LINE.starts_with("[spec-exec-riscv] scaffolding"));
+        assert!(SCAFFOLDING_LOG_LINE.contains("not yet ratified"));
+        assert!(SCAFFOLDING_LOG_LINE.contains("software mitigations partial"));
+        assert!(SCAFFOLDING_LOG_LINE.ends_with('\n'));
+    }
+}

--- a/arch/riscv64/src/syscall.rs
+++ b/arch/riscv64/src/syscall.rs
@@ -12,8 +12,54 @@
 //!   - Return value in a0
 //!
 //! This matches the Linux RISC-V ABI, making future compatibility easier.
+//!
+//! # Privileged-transition instruction-fetch barrier (`fence.i`)
+//!
+//! Part of OpenSpec change `spec-exec-mitigations-v1`, Phase 4 (RISC-V,
+//! scaffolding). The `ecall` path is a privileged transition: U-mode traps
+//! into S-mode, the kernel dispatches, then `sret` (in `trap.rs`) resumes
+//! U-mode. RISC-V does **not** make stores to the instruction stream visible
+//! to subsequent instruction fetches on the same hart without an explicit
+//! [`fence.i`] — the architecturally-defined instruction-fetch / fetch-
+//! coherence barrier.
+//!
+//! We emit `fence.i` **after** [`smallaios_kernel::syscall::dispatch`]
+//! returns and **before** control unwinds toward `sret` back to U-mode. The
+//! *after* side is the load-bearing one: a syscall may legitimately have
+//! mutated the code that the about-to-resume context will fetch (future
+//! code-load / page-remap / module-style syscalls), and the resuming hart
+//! must observe that mutation. Placing it after dispatch also bounds any
+//! stale-instruction window opened during kernel servicing of the call.
+//!
+//! This is a coherence / correctness barrier, **not** a speculation barrier:
+//! it does not by itself close the Spectre-v1/v2 windows. Those need
+//! Zicfilp / Zicfiss (forward/backward-edge CFI), which are **not ratified**
+//! as of 2026-02. RISC-V therefore ships with *partial* mitigations — see
+//! `docs/spec-exec-audit-riscv.md` and `crate::security::spec_exec`. The
+//! barrier is inserted now so the privileged-transition entry shape is
+//! correct-by-construction even though syscall workloads are not yet
+//! exercised on this target.
 
 use super::trap::TrapFrame;
+
+/// Instruction-fetch / fetch-coherence barrier at the privileged-transition
+/// boundary.
+///
+/// Emits a single `fence.i` (Zifencei, part of the RV64GC baseline). On the
+/// host test target this is a no-op so `handle_ecall` stays host-testable.
+///
+/// See the module docs for placement rationale (emitted *after* dispatch,
+/// *before* the return toward `sret` to U-mode).
+#[inline(always)]
+fn fence_i_barrier() {
+    // SAFETY: `fence.i` has no operands, no memory effects beyond ordering
+    // the calling hart's own instruction fetch w.r.t. its prior stores, and
+    // is part of the RV64GC baseline (Zifencei). It cannot trap in S-mode.
+    #[cfg(not(test))]
+    unsafe {
+        core::arch::asm!("fence.i", options(nostack, preserves_flags));
+    }
+}
 
 /// Handle an ecall from U-mode.
 ///
@@ -41,6 +87,14 @@ pub fn handle_ecall(frame: &mut TrapFrame) {
 
     // Write return value to a0 (x10) in the trap frame
     frame.regs[10] = result as u64;
+
+    // Privileged-transition instruction-fetch barrier (Phase 4 scaffolding).
+    // Emitted AFTER dispatch and BEFORE the return that unwinds toward `sret`
+    // (in trap.rs) back to U-mode: a syscall may have mutated code the
+    // resuming context will fetch, and `fence.i` makes that visible to this
+    // hart's subsequent instruction fetch. Coherence barrier, not a
+    // speculation barrier — see module docs and docs/spec-exec-audit-riscv.md.
+    fence_i_barrier();
 }
 
 #[cfg(test)]
@@ -93,5 +147,20 @@ mod tests {
         handle_ecall(&mut frame);
         assert_eq!(frame.regs[1], 0xDEAD);
         assert_eq!(frame.regs[8], 0xBEEF);
+    }
+
+    /// The `fence.i` privileged-transition barrier is on the `handle_ecall`
+    /// path (after dispatch, before return). On the host target the asm is
+    /// `cfg(not(test))`-gated to a no-op; this test pins that the barrier
+    /// helper stays callable and total so the scaffolding can't regress to a
+    /// shape where the barrier is unreachable.
+    #[test]
+    fn test_fence_i_barrier_is_total() {
+        // Direct call: must not panic / diverge on host.
+        fence_i_barrier();
+        // Indirect via the real entry path: handle_ecall reaches the barrier
+        // after dispatch even for an out-of-range syscall.
+        let mut frame = make_frame(0xFF, [0; 6]);
+        handle_ecall(&mut frame);
     }
 }

--- a/docs/spec-exec-audit-riscv.md
+++ b/docs/spec-exec-audit-riscv.md
@@ -1,0 +1,157 @@
+# Speculative-Execution Mitigation Audit — RISC-V (Phase 4, scaffolding)
+
+> **Status: SCAFFOLDING / PARTIAL.** This document covers only the RISC-V
+> (`riscv64gc-unknown-none-elf`) slice of OpenSpec change
+> `spec-exec-mitigations-v1`, Phase 4. It is intentionally a **separate**
+> file from the cross-arch spine document `docs/spec-exec-audit.md`; the
+> RISC-V content here will be folded into / linked from that canonical audit
+> centrally once the spine PR lands. Do not duplicate the cross-arch matrix
+> here.
+>
+> **Production RISC-V deployments MUST be flagged "speculation mitigations
+> partial" in the DO-178C safety case.** See [Safety-case
+> impact](#safety-case-impact).
+
+## Scope and current reality
+
+RISC-V is a **boot-only** target in SmallAIOS today. The kernel boots to the
+halt loop; no U-mode task graph and no syscall workload is exercised yet (the
+syscall path `arch/riscv64/src/syscall.rs::handle_ecall` →
+`smallaios_kernel::syscall::dispatch` exists and is unit-tested on the host,
+but is not driven by a real workload on RISC-V silicon).
+
+Critically, the hardware extensions that would let RISC-V mount a *real*
+defense against the Spectre-class attacks at the syscall trust boundary are
+**mostly unratified as of 2026-02**. We therefore cannot ship the
+silicon-programming half of the mitigation; what we ship is:
+
+1. The architecturally-defined `fence.i` instruction-fetch barrier at the
+   privileged-transition boundary (correct-by-construction now).
+2. A scaffolding module (`arch/riscv64/src/security/spec_exec.rs`) whose
+   *shape* is fixed so the ratification follow-up is a body fill-in, not a
+   redesign.
+3. This audit document, recording the gap explicitly so the safety case can
+   cite it.
+
+## Planned mitigations
+
+### Cache-state cleanup — Zicbom / Zicbop / Zicboz
+
+| Extension | Purpose | Ratification | Use in SmallAIOS |
+|-----------|---------|--------------|------------------|
+| **Zicbom** | Cache-Block Management: `cbo.clean` / `cbo.flush` / `cbo.inval` | Ratified | At the privileged transition, clean/flush the capability-check working set so the cache-state residue an attacker can probe via timing is bounded. **Partial** Spectre-v1 cache-timing mitigation only — does not close the speculation window itself. |
+| **Zicbop** | Cache-Block Prefetch: `prefetch.{i,r,w}` | Ratified | Controlled prefetch to normalize cache state across the boundary (defense-in-depth alongside Zicbom). Hint-only; no architectural guarantee, so it is *adjunct*, never the primary mitigation. |
+| **Zicboz** | Cache-Block Zero: `cbo.zero` | Ratified | Zeroing scratch lines that held attacker-influenced data before returning to U-mode. |
+
+Although Zicbo* is ratified, **no silicon in the SmallAIOS validation matrix
+advertises it yet**, and the cache-block size (`CBOM_BLOCK_SIZE`) must be
+discovered from the DTB before any `cbo.*` may be issued safely. The cleanup
+path is therefore gated off in `security::spec_exec::init()` until both
+(a) the DTB exposes the block size and (b) a validated target advertises the
+extension. Even fully wired, this is a **partial** mitigation: cache-state
+cleanup narrows a side channel; it does not provide branch-target or
+shadow-stack integrity.
+
+### Control-flow integrity — Zicfilp / Zicfiss (NOT ratified)
+
+These are the load-bearing Spectre-v2-class mitigations, and they are the
+ones we **cannot** ship:
+
+| Extension | CFI edge | Attack class addressed | Ratification (2026-02) |
+|-----------|----------|------------------------|------------------------|
+| **Zicfilp** | Forward-edge (landing pads on indirect-branch targets) | Spectre v2 / branch-target-injection (BTI) | **NOT ratified.** No stable encoding for the CSRs (`menvcfg.LPE` / `senvcfg.LPE`, `mseccfg` lockdown bits) we would program. |
+| **Zicfiss** | Backward-edge (hardware shadow stack) | Return-address corruption / Retbleed-class | **NOT ratified.** No stable `ssp` shadow-stack-pointer CSR / `menvcfg.SSE` / `senvcfg.SSE` to rely on. |
+
+Because both are unratified, SmallAIOS:
+
+- Does **not** depend on any Zicfilp/Zicfiss encoding (no speculative use of
+  a CSR that may be renumbered before ratification).
+- Fixes the *call shape* now (`security::spec_exec::init()` is on the boot
+  path with a documented TODO enumerating exactly which CSRs it will program
+  once the extensions ratify and silicon is detected) so the follow-up
+  change is a contained fill-in.
+- Leaves the RISC-V forward/backward-edge CFI posture as **absent** in the
+  cross-arch matrix — contrast aarch64 (BTI via
+  `aarch64-mte-pac-hardening-v1`) and x86_64 (Retpoline + IBRS), which do
+  have shipped mitigations on these edges.
+
+### Instruction-fetch barrier — `fence.i` (shipped now)
+
+`fence.i` (Zifencei) **is** part of the RV64GC baseline and is shipped now.
+
+- **Where:** `arch/riscv64/src/syscall.rs::handle_ecall`, via the
+  `fence_i_barrier()` helper.
+- **Placement:** emitted **after** `smallaios_kernel::syscall::dispatch`
+  returns and **before** `handle_ecall` returns toward the `sret` (in
+  `arch/riscv64/src/trap.rs`) that resumes U-mode.
+- **Why this side:** the *after-dispatch / pre-return* position is the
+  load-bearing one. RISC-V does not make a hart's stores to the instruction
+  stream visible to that hart's *subsequent instruction fetch* without an
+  explicit `fence.i`. A syscall may legitimately mutate code the resuming
+  context will fetch (future code-load / page-remap / module-style calls);
+  the barrier guarantees the resuming hart observes that mutation, and it
+  also bounds any stale-instruction window opened while the kernel serviced
+  the call. A `fence.i` *before* dispatch would order fetches against
+  pre-syscall state, which is not what the privileged-transition boundary
+  needs.
+- **What it is NOT:** `fence.i` is an instruction-fetch / fetch-coherence
+  barrier, **not** a speculation barrier. It does **not** close the
+  Spectre-v1 (bounds-check bypass) or Spectre-v2 (branch-target-injection)
+  windows. It is shipped now purely so the privileged-transition entry
+  *shape* is correct-by-construction before syscall workloads come online;
+  it is retained even after Zicfilp/Zicfiss land (defense in depth +
+  instruction-fetch coherence).
+
+## Trust-boundary posture (RISC-V column)
+
+The canonical trust-boundary × attack-class matrix lives in the spine
+document `docs/spec-exec-audit.md`. The RISC-V column summarizes as:
+
+| Trust boundary | Spectre v1 (BCB) | Spectre v2 (BTI) | Spectre v4 (SSB) | Meltdown | Retbleed | Spectre-BHB |
+|----------------|------------------|------------------|------------------|----------|----------|-------------|
+| Syscall entry (`syscall.rs::handle_ecall`) | Partial — `fence.i` shipped (coherence, not a spec barrier); Zicbo* cache cleanup gated off | **Absent** — needs Zicfilp (unratified) | Absent — no ratified SSB control on RISC-V | **N/A (structural)** — unikernel, single address space, no user/kernel page-table split (same rationale as the spine doc's Meltdown row) | **Absent** — needs Zicfiss shadow stack (unratified) | Absent — no ratified BHB control |
+| Capability check / ONNX op-dispatch / bus receive | Inherits the above; not separately mitigated on RISC-V at this phase | Absent | Absent | N/A (structural) | Absent | Absent |
+
+"Partial" / "Absent" here is **stronger language than the other arches** by
+design — RISC-V genuinely lacks the ratified primitives the spine doc's
+x86_64 / aarch64 columns rely on.
+
+## Safety-case impact
+
+- RISC-V production deployments **MUST** carry the explicit safety-case
+  annotation **"speculation mitigations partial"**. This is not a
+  formality: forward-edge (Spectre v2) and backward-edge (Retbleed-class)
+  CFI are *absent*, not merely degraded.
+- The boot record emits a single grep-able marker line so this is auditable
+  from logs:
+  `[spec-exec-riscv] scaffolding — extensions not yet ratified, software mitigations partial`
+  (emitted by `security::spec_exec::init()` on the boot path).
+- Meltdown is recorded as **N/A (structural)** — the SmallAIOS unikernel has
+  no user/kernel page-table privilege split, so Meltdown structurally does
+  not apply (same evidence kind as the spine document's cross-arch Meltdown
+  rationale). This is an absence-of-applicability claim, not an
+  absence-of-mitigation claim.
+
+## Review trigger
+
+Promote RISC-V from *partial* toward *full* and re-audit when **any** of:
+
+- Zicfilp and/or Zicfiss reach ratified status with stable CSR encodings.
+- A validated SmallAIOS RISC-V target advertises Zicbom (with DTB-discoverable
+  `CBOM_BLOCK_SIZE`) so the cache-cleanup path can be enabled.
+- A syscall workload is brought online on RISC-V silicon (the barrier shape
+  becomes load-bearing in practice, not just by construction).
+- A new CVE lands in the speculation-class space affecting RISC-V silicon in
+  the validation matrix (tracked, per the spine doc's review-trigger policy,
+  as a new OpenSpec change).
+
+## Cross-references
+
+- Spine / cross-arch audit: `docs/spec-exec-audit.md` (owned by the spine PR;
+  this RISC-V file is merged/linked into it centrally).
+- OpenSpec change: `openspec/changes/spec-exec-mitigations-v1/` (Phase 4 =
+  RISC-V scaffolding; tasks tracked on the spine branch).
+- Scaffolding module + ratification TODO:
+  `arch/riscv64/src/security/spec_exec.rs`.
+- Barrier placement + rationale:
+  `arch/riscv64/src/syscall.rs` (`fence_i_barrier`).


### PR DESCRIPTION
## Summary

Phase 4 (RISC-V scaffolding) of OpenSpec change `spec-exec-mitigations-v1`. RISC-V (`riscv64gc-unknown-none-elf`) is boot-only and the load-bearing CFI extensions (Zicfilp/Zicfiss) are **not ratified** as of 2026-02, so this lands the correct *entry shape* now, not a real mitigation.

- **Task 3.1** — `docs/spec-exec-audit-riscv.md` (new, separate from the spine `docs/spec-exec-audit.md`): planned Zicbom/Zicbop/Zicboz cache-state cleanup, Zicfilp/Zicfiss CFI with ratification status (not ratified, 2026-02), `fence.i` after privileged transitions. States the posture is partial and **production RISC-V deployments must be flagged "speculation mitigations partial" in the DO-178C safety case**.
- **Task 3.2** — `arch/riscv64/src/security/spec_exec.rs` (new `security` module, registered in `lib.rs` and wired into the boot path). `pub fn init()` logs `[spec-exec-riscv] scaffolding — extensions not yet ratified, software mitigations partial`. Doc-comment TODO enumerates the exact CSRs (`menvcfg`/`senvcfg` LPE+SSE, `mseccfg`, `ssp`, Zicbom `cbo.*`) to program once Zicfilp/Zicfiss ratify.
- **Task 3.3** — `fence.i` instruction-fetch barrier inserted in `handle_ecall` via a `fence_i_barrier()` helper, emitted **after** `dispatch` returns and **before** the return that unwinds toward `sret` back to U-mode.

## Verification

- `cargo build --release --target riscv64gc-unknown-none-elf -p smallaios-arch-riscv64 -Z build-std=...` — **succeeds** (clean compile of all changed files).
- `cargo fmt -p smallaios-arch-riscv64 -- --check` — clean (exit 0).
- Clippy/host-test: `smallaios-arch-riscv64` is **excluded from CI host clippy and Unit Tests jobs** (documented in `.github/workflows/ci.yml` line ~162) because pre-existing files (`sbi.rs`, `trap.rs`, `paging.rs`) carry unguarded RISC-V `core::arch::asm!`/lints that do not compile on the host. The 8 clippy errors on this crate pre-exist on a clean `origin/develop` checkout; **zero new errors are in the files this PR touches**. UART/`fence.i` side effects are `cfg(not(test))`-gated so the added logic stays host-testable in isolation; authoritative validation is the riscv64 target build, which passes.

## Notes

**Scaffolding rationale:** RISC-V cannot mount a real Spectre-v2/Retbleed-class defense at the syscall boundary because Zicfilp (forward-edge CFI / landing pads) and Zicfiss (backward-edge CFI / shadow stack) are unratified. What *is* shippable now: the RV64GC-baseline `fence.i` instruction-fetch barrier (a coherence barrier, **not** a speculation barrier — it does not close the Spectre windows) and a fixed-shape `security::spec_exec` module so the ratification follow-up is a body fill-in, not a redesign.

**`fence.i` placement:** in `handle_ecall`, *after* `smallaios_kernel::syscall::dispatch` returns and *before* `handle_ecall` returns toward the `sret` (in `trap.rs`) that resumes U-mode. The after-dispatch side is load-bearing: a code-mutating syscall (future code-load / page-remap) must be visible to the resuming hart's subsequent instruction fetch, and the barrier also bounds any stale-instruction window opened while the kernel serviced the call. A `fence.i` *before* dispatch would order fetches against pre-syscall state, which is not what the privileged-transition boundary needs.

**What ratifies later:** when Zicfilp/Zicfiss reach ratified status with stable CSR encodings (and validated silicon advertises them, plus DTB-discoverable `CBOM_BLOCK_SIZE` for Zicbom), `security::spec_exec::init()` will program the CSRs listed in its doc-comment TODO and the audit doc's posture moves from *partial* toward *full*. `fence.i` is retained even then (defense in depth + fetch coherence).

Part of OpenSpec change `spec-exec-mitigations-v1`; `tasks.md` is tracked on the spine branch (not edited here); `docs/spec-exec-audit-riscv.md` will be folded into the main `docs/spec-exec-audit.md` centrally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)