### PR TITLE
feat(tls-client): TLS 1.3 handshake state machine + real RFC 8446 key schedule

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -54,17 +54,6 @@ paths-ignore:
 #     or as fresh-CSPRNG-source buffers (salt: filled by the kernel
 #     CSPRNG immediately after declaration). Neither is a secret.
 #
-# - `tls-client/src/handshake/key_schedule.rs`
-#     The TLS 1.3 key schedule (RFC 8446 §7.1) zero-initialises
-#     fixed-size output buffers that HKDF-Expand-Label fills before any
-#     use (`Secret::new`'s `[0u8; MAX_HASH_LEN]`, `traffic_keys`'
-#     `key`/`iv` arrays — flagged as "salt"/"nonce"), and §7.1 itself
-#     mandates literal zero inputs at two schedule points (zero IKM for
-#     the Early Secret and Master Secret extracts). Same
-#     filled-immediately-after-declaration pattern as the
-#     `kernel/src/syscall/auth.rs` salt buffers above. Production code,
-#     so the `_test_vectors.rs` convention does not apply.
-#
 # Adding a new entry MUST cite (a) the file, (b) the spec/RFC section that
 # governs the constant, and (c) why moving to a `_test_vectors.rs` sibling
 # is not applicable.
@@ -74,4 +63,3 @@ query-filters:
       paths:
         - security/src/argon2id.rs
         - kernel/src/syscall/auth.rs
-        - tls-client/src/handshake/key_schedule.rs

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -54,6 +54,17 @@ paths-ignore:
 #     or as fresh-CSPRNG-source buffers (salt: filled by the kernel
 #     CSPRNG immediately after declaration). Neither is a secret.
 #
+# - `tls-client/src/handshake/key_schedule.rs`
+#     The TLS 1.3 key schedule (RFC 8446 §7.1) zero-initialises
+#     fixed-size output buffers that HKDF-Expand-Label fills before any
+#     use (`Secret::new`'s `[0u8; MAX_HASH_LEN]`, `traffic_keys`'
+#     `key`/`iv` arrays — flagged as "salt"/"nonce"), and §7.1 itself
+#     mandates literal zero inputs at two schedule points (zero IKM for
+#     the Early Secret and Master Secret extracts). Same
+#     filled-immediately-after-declaration pattern as the
+#     `kernel/src/syscall/auth.rs` salt buffers above. Production code,
+#     so the `_test_vectors.rs` convention does not apply.
+#
 # Adding a new entry MUST cite (a) the file, (b) the spec/RFC section that
 # governs the constant, and (c) why moving to a `_test_vectors.rs` sibling
 # is not applicable.
@@ -63,3 +74,4 @@ query-filters:
       paths:
         - security/src/argon2id.rs
         - kernel/src/syscall/auth.rs
+        - tls-client/src/handshake/key_schedule.rs

--- a/openspec/changes/tls-tcp-client-v1/design.md
+++ b/openspec/changes/tls-tcp-client-v1/design.md
@@ -364,6 +364,57 @@ flag already covers the "zero overhead when off" rule.
 If future code wants TLS without audit-export, the
 feature graph can be revisited.
 
+### D12. Real RFC 8446 key schedule in `tls-client`; the QUIC stub stays out
+
+**Decision:** Implement the TLS 1.3 key schedule (RFC 8446
+§7.1), transcript hash, HKDF-Expand-Label, traffic-key and
+Finished-key derivations in
+`tls-client/src/handshake/key_schedule.rs`, suite-generic
+over SHA-256/SHA-384. Add the missing primitives to
+`security/`: `Sha384` (in `sha2`), `hmac_sha2`
+(HMAC-SHA-256/384), and `hkdf` (RFC 5869 Extract/Expand over
+both hashes). Do **not** route through
+`net::quic::tls::TlsKeySchedule`.
+
+**Why:** The Context section above (and task 4.4 as
+originally written) assumed `net::quic::tls` shipped real
+HKDF derivations. Implementation found it is an XOR-based
+placeholder — `net/src/quic/tls.rs` says "Simplified:
+XOR-based derivation for stub" — with QUIC-specific labels
+("quic key") and a fake transcript hash. Keys derived from it
+cannot interoperate with any RFC 8446 peer, which would
+defeat this change's headline goal ("one real working
+chain"). The SHA-384 path is not optional either:
+`TLS_AES_256_GCM_SHA384` is the client's first-preference
+suite per D2 and its schedule mathematically requires
+HMAC/HKDF-SHA-384, which existed nowhere in the workspace.
+
+**Validation:** every key-schedule vector checked in is
+cross-validated against two independent oracles — OpenSSL
+3.0's `TLS13-KDF` (EXTRACT_ONLY/EXPAND_ONLY modes, which
+encode the "tls13 " label prefix and the internal
+Derive-Secret-on-extract semantics) and a Python-stdlib
+HMAC/HKDF reference — plus published RFC 4231 / RFC 5869 /
+FIPS 180-4 vectors for the primitives.
+
+**Alternative considered:** Fix `net::quic::tls` and share
+it. Rejected for this change: the QUIC module's stub is
+load-bearing for the QUIC test suite's deterministic
+expectations, its `PacketProtectionKeys` carry QUIC header
+protection with no TLS counterpart (same reasoning as D1),
+and rewriting QUIC key derivation is its own change with its
+own interop test surface. A follow-on can migrate `quic::tls`
+onto `security::hkdf`.
+
+**Hybrid-group wire format note:** the handshake driver
+follows draft-ietf-tls-ecdhe-mlkem for `X25519MLKEM768`
+(codepoint 0x11ec): client share = ML-KEM-768 encapsulation
+key ‖ X25519 key; server share = ML-KEM-768 ciphertext ‖
+X25519 key; shared secret = ML-KEM ss ‖ X25519 ss fed raw to
+HKDF-Extract. This deviates from `quic::tls`'s internal
+SHA-3 combiner — required for interop with standard hybrid
+deployments (OpenSSL 3.5+, BoringSSL).
+
 ## Risks / Trade-offs
 
 - **[X.509 parser CVEs]** Even minimal X.509 parsers

--- a/openspec/changes/tls-tcp-client-v1/tasks.md
+++ b/openspec/changes/tls-tcp-client-v1/tasks.md
@@ -15,6 +15,12 @@
 - [x] 2.4 NIST + RFC 8439 KAT tests (≥4 vectors) including the canonical RFC 8439 § 2.8 example *(11 tests pass: § 2.3.2, § 2.4.2, § 2.5.2, § 2.8.2 + tamper-rejection variants + empty round-trips)*
 - [ ] 2.5 `cargo-fuzz` target on `Aead::open` against arbitrary bytes *(deferred — added with the rest of the tls-client fuzz targets in Phase 10)*
 
+## 2b. `security` hash/KDF primitives (scope discovered during Phase 4 — see design.md D12)
+
+- [x] 2b.1 `security/src/sha2.rs` — add `Sha384` (SHA-512 core, FIPS 180-4) alongside the existing `Sha256`; required by `TLS_AES_256_GCM_SHA384`'s transcript/HKDF hash *(KATs: FIPS examples incl. empty/abc/two-block/1M-a + block-boundary padding sweep)*
+- [x] 2b.2 `security/src/hmac_sha2.rs` — streaming HMAC-SHA-256 + HMAC-SHA-384 (RFC 2104), mirroring the existing `hmac_sha1` shape *(RFC 4231 vectors tc1/tc2/tc3/tc6/tc7 for both hashes)*
+- [x] 2b.3 `security/src/hkdf.rs` — HKDF-Extract/Expand (RFC 5869) over both hashes, alloc-free API, 255×HashLen cap enforced *(RFC 5869 A.1 vectors; SHA-384 variants cross-validated against Python stdlib + OpenSSL 3.0 `openssl kdf HKDF`)*
+
 ## 3. Record layer
 
 - [x] 3.1 `tls-client/src/record.rs` — `ContentType`, `TLSPlaintext`, `TLSCiphertext` encoders + decoders
@@ -29,12 +35,12 @@
 - [x] 4.1 `tls-client/src/handshake/` — message types: HandshakeType (ClientHello/ServerHello/EncryptedExtensions/Certificate/CertificateRequest/CertificateVerify/Finished/NewSessionTicket/KeyUpdate); 4-byte HandshakeHeader (type + 24-bit length); extension encoders/parsers for supported_versions, supported_groups, signature_algorithms, key_share, server_name
 - [x] 4.2 Build ClientHello: legacy_version=0x0303, supported_versions=[0x0304], supported_groups configurable (PQC hybrid first when `require_pqc`), key_share matching primary supported_group, signature_algorithms allow-list per spec, server_name when DNS endpoint
 - [x] 4.3 Parse ServerHello: pin `supported_versions = 0x0304`; pin `legacy_version = 0x0303`; pin `legacy_compression_method = 0`; refuse unsupported cipher_suite; surface (cipher_suite, group, public_key, selected_version)
-- [ ] 4.4 Derive handshake-traffic keys via `net::quic::tls::TlsKeySchedule::derive_handshake_secrets` *(state-machine driver — follow-on commit; the message layer it consumes is ready)*
-- [ ] 4.5 Parse EncryptedExtensions; check SNI ack *(state-machine driver follow-on)*
-- [ ] 4.6 Parse Certificate; pass each cert to the cert-chain verifier *(needs Phase 5)*
-- [ ] 4.7 Parse CertificateVerify; verify signature against the leaf's pubkey + transcript hash; enforce the signature-suite allow-list *(needs Phase 5)*
-- [ ] 4.8 Parse server Finished; verify HMAC over transcript *(state-machine driver follow-on)*
-- [ ] 4.9 Send client Finished; derive application-traffic keys; transition to data phase *(state-machine driver follow-on)*
+- [x] 4.4 Derive handshake-traffic keys per RFC 8446 §7.1 — **task text deviation**: the original task said to reuse `net::quic::tls::TlsKeySchedule::derive_handshake_secrets`, but that type turned out to be an XOR-based placeholder ("Simplified: XOR-based derivation for stub" in `net/src/quic/tls.rs`) that cannot interoperate with any real TLS 1.3 peer. A real HKDF key schedule landed instead in `tls-client/src/handshake/key_schedule.rs` (suite-generic over SHA-256/SHA-384, incl. transcript hash, Expand-Label, traffic keys, Finished keys), on the new `security` primitives of section 2b. Every schedule vector is cross-validated against two independent oracles (OpenSSL 3.0 `TLS13-KDF` + Python stdlib HMAC construction). See design.md D12.
+- [x] 4.5 Parse EncryptedExtensions; check SNI ack *(`handshake/encrypted_extensions.rs`; also refuses key_share/supported_versions/pre_shared_key in EE per RFC 8446 §4.2)*
+- [x] 4.6 Parse Certificate; pass each cert to the cert-chain verifier *(`handshake/certificate_msg.rs` wire parsing + the `cert::ServerCertVerifier` seam the driver calls; the production trust-store verifier behind that trait is Phase 5 — tracked by 5.4/5.5)*
+- [x] 4.7 Parse CertificateVerify; verify signature against the leaf's pubkey + transcript hash; enforce the signature-suite allow-list *(allow-list per spec incl. SHA-1 refusal; Ed25519 verification over the §4.4.3 content is live; the leaf pubkey arrives via `ServerCertVerifier` — X.509 SPKI extraction is Phase 5; ECDSA-P256/RSA-PSS verification deferred with their primitives per 5.5)*
+- [x] 4.8 Parse server Finished; verify HMAC over transcript *(constant-time compare via `security::crypto::constant_time::ct_eq`)*
+- [x] 4.9 Send client Finished; derive application-traffic keys; transition to data phase *(`handshake/driver.rs` `ClientHandshake` — synchronous step-machine per design D7; refuses HRR, CertificateRequest, TLS 1.2 selection; tolerates CCS + coalesced/fragmented records; e2e-tested against an in-test TLS 1.3 server for both suites + PQC hybrid, incl. tampered-Finished, wrong-CV-signature, downgrade and byte-at-a-time cases)*
 - [x] 4.10 Unit tests for the message layer: ServerHello selecting TLS 1.2 → `Version` error; missing supported_versions → `Version`; unsupported cipher_suite → `BadHandshake`; non-zero compression method → reject; wrong legacy_version → `Version`; truncated → reject. (PqcDowngrade and SHA-1 CertificateVerify cases land with their respective phases.)
 
 ## 5. X.509v3 parser + chain verifier

--- a/security/src/hkdf.rs
+++ b/security/src/hkdf.rs
@@ -1,0 +1,200 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! HKDF (RFC 5869) over SHA-256 and SHA-384 — clean-room
+//! `#![no_std]` implementation.
+//!
+//! HKDF is the extract-then-expand key-derivation function TLS 1.3
+//! (RFC 8446 §7.1) builds its entire key schedule on. The hash is
+//! the negotiated cipher suite's: SHA-256 for
+//! `TLS_CHACHA20_POLY1305_SHA256`, SHA-384 for
+//! `TLS_AES_256_GCM_SHA384`.
+//!
+//! ```text
+//! HKDF-Extract(salt, IKM)       -> PRK   (one HMAC)
+//! HKDF-Expand(PRK, info, L)     -> OKM   (ceil(L/HashLen) HMACs)
+//! ```
+//!
+//! The API is alloc-free: `expand` writes into a caller-supplied
+//! buffer. Per RFC 5869 §2.3, `L ≤ 255 * HashLen`; longer requests
+//! are refused.
+
+use crate::hmac_sha2::{HmacSha256, HmacSha384};
+use crate::sha2::{DIGEST_LEN, SHA384_DIGEST_LEN};
+
+/// Error returned when an `expand` request exceeds the RFC 5869
+/// §2.3 output cap of `255 * HashLen` bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HkdfLengthError;
+
+/// HKDF-Extract with HMAC-SHA-256. An empty `salt` is treated as
+/// `HashLen` zero bytes per RFC 5869 §2.2.
+pub fn hkdf_extract_sha256(salt: &[u8], ikm: &[u8]) -> [u8; DIGEST_LEN] {
+    let zero = [0u8; DIGEST_LEN];
+    let salt = if salt.is_empty() { &zero[..] } else { salt };
+    let mut mac = HmacSha256::new(salt);
+    mac.update(ikm);
+    mac.finalize()
+}
+
+/// HKDF-Expand with HMAC-SHA-256, filling all of `okm`.
+pub fn hkdf_expand_sha256(
+    prk: &[u8; DIGEST_LEN],
+    info: &[u8],
+    okm: &mut [u8],
+) -> Result<(), HkdfLengthError> {
+    if okm.len() > 255 * DIGEST_LEN {
+        return Err(HkdfLengthError);
+    }
+    let mut t = [0u8; DIGEST_LEN];
+    let mut t_len = 0usize;
+    let mut counter = 1u8;
+    let mut written = 0usize;
+    while written < okm.len() {
+        let mut mac = HmacSha256::new(prk);
+        mac.update(&t[..t_len]);
+        mac.update(info);
+        mac.update(&[counter]);
+        t = mac.finalize();
+        t_len = DIGEST_LEN;
+        let take = (okm.len() - written).min(DIGEST_LEN);
+        okm[written..written + take].copy_from_slice(&t[..take]);
+        written += take;
+        counter = counter.wrapping_add(1);
+    }
+    Ok(())
+}
+
+/// HKDF-Extract with HMAC-SHA-384. An empty `salt` is treated as
+/// `HashLen` zero bytes per RFC 5869 §2.2.
+pub fn hkdf_extract_sha384(salt: &[u8], ikm: &[u8]) -> [u8; SHA384_DIGEST_LEN] {
+    let zero = [0u8; SHA384_DIGEST_LEN];
+    let salt = if salt.is_empty() { &zero[..] } else { salt };
+    let mut mac = HmacSha384::new(salt);
+    mac.update(ikm);
+    mac.finalize()
+}
+
+/// HKDF-Expand with HMAC-SHA-384, filling all of `okm`.
+pub fn hkdf_expand_sha384(
+    prk: &[u8; SHA384_DIGEST_LEN],
+    info: &[u8],
+    okm: &mut [u8],
+) -> Result<(), HkdfLengthError> {
+    if okm.len() > 255 * SHA384_DIGEST_LEN {
+        return Err(HkdfLengthError);
+    }
+    let mut t = [0u8; SHA384_DIGEST_LEN];
+    let mut t_len = 0usize;
+    let mut counter = 1u8;
+    let mut written = 0usize;
+    while written < okm.len() {
+        let mut mac = HmacSha384::new(prk);
+        mac.update(&t[..t_len]);
+        mac.update(info);
+        mac.update(&[counter]);
+        t = mac.finalize();
+        t_len = SHA384_DIGEST_LEN;
+        let take = (okm.len() - written).min(SHA384_DIGEST_LEN);
+        okm[written..written + take].copy_from_slice(&t[..take]);
+        written += take;
+        counter = counter.wrapping_add(1);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hex(bytes: &[u8]) -> alloc::string::String {
+        use alloc::string::String;
+        let mut s = String::with_capacity(bytes.len() * 2);
+        for b in bytes {
+            s.push(char::from_digit((b >> 4) as u32, 16).unwrap());
+            s.push(char::from_digit((b & 0xf) as u32, 16).unwrap());
+        }
+        s
+    }
+
+    // RFC 5869 A.1 (test case 1) inputs. SHA-256 expected values are
+    // the RFC's published vectors; SHA-384 values were generated from
+    // the same inputs and cross-validated against two independent
+    // oracles (Python stdlib HKDF construction and OpenSSL 3.0
+    // `openssl kdf ... HKDF`).
+    const IKM: [u8; 22] = [0x0b; 22];
+    const SALT: [u8; 13] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0x0a, 0x0b, 0x0c];
+    const INFO: [u8; 10] = [0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9];
+
+    #[test]
+    fn rfc5869_tc1_sha256() {
+        let prk = hkdf_extract_sha256(&SALT, &IKM);
+        assert_eq!(
+            hex(&prk),
+            "077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5"
+        );
+        let mut okm = [0u8; 42];
+        hkdf_expand_sha256(&prk, &INFO, &mut okm).unwrap();
+        assert_eq!(
+            hex(&okm),
+            "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf\
+             34007208d5b887185865"
+        );
+    }
+
+    #[test]
+    fn rfc5869_tc1_inputs_sha384() {
+        let prk = hkdf_extract_sha384(&SALT, &IKM);
+        assert_eq!(
+            hex(&prk),
+            "704b39990779ce1dc548052c7dc39f303570dd13fb39f7acc564680bef80e8de\
+             c70ee9a7e1f3e293ef68eceb072a5ade"
+        );
+        let mut okm = [0u8; 42];
+        hkdf_expand_sha384(&prk, &INFO, &mut okm).unwrap();
+        assert_eq!(
+            hex(&okm),
+            "9b5097a86038b805309076a44b3a9f38063e25b516dcbf369f394cfab43685f7\
+             48b6457763e4f0204fc5"
+        );
+    }
+
+    #[test]
+    fn empty_salt_means_zero_block() {
+        // RFC 5869 §2.2: salt defaults to HashLen zero bytes.
+        let explicit256 = hkdf_extract_sha256(&[0u8; DIGEST_LEN], b"ikm");
+        assert_eq!(hkdf_extract_sha256(&[], b"ikm"), explicit256);
+        let explicit384 = hkdf_extract_sha384(&[0u8; SHA384_DIGEST_LEN], b"ikm");
+        assert_eq!(hkdf_extract_sha384(&[], b"ikm"), explicit384);
+    }
+
+    #[test]
+    fn expand_multi_block_and_caps() {
+        // 100-byte OKM spans 4 SHA-256 blocks; check the chained-T
+        // path by comparing a prefix-read with a full read.
+        let prk = hkdf_extract_sha256(&SALT, &IKM);
+        let mut long = [0u8; 100];
+        hkdf_expand_sha256(&prk, &INFO, &mut long).unwrap();
+        let mut short = [0u8; 42];
+        hkdf_expand_sha256(&prk, &INFO, &mut short).unwrap();
+        assert_eq!(&long[..42], &short[..]);
+
+        // RFC 5869 §2.3 cap: 255 * HashLen.
+        let mut too_big = alloc::vec![0u8; 255 * DIGEST_LEN + 1];
+        assert_eq!(
+            hkdf_expand_sha256(&prk, &INFO, &mut too_big),
+            Err(HkdfLengthError)
+        );
+        let mut max_ok = alloc::vec![0u8; 255 * DIGEST_LEN];
+        hkdf_expand_sha256(&prk, &INFO, &mut max_ok).unwrap();
+    }
+
+    #[test]
+    fn zero_length_okm_is_noop() {
+        let prk = hkdf_extract_sha256(&SALT, &IKM);
+        let mut empty: [u8; 0] = [];
+        hkdf_expand_sha256(&prk, &INFO, &mut empty).unwrap();
+        let prk384 = hkdf_extract_sha384(&SALT, &IKM);
+        hkdf_expand_sha384(&prk384, &INFO, &mut empty).unwrap();
+    }
+}

--- a/security/src/hkdf.rs
+++ b/security/src/hkdf.rs
@@ -187,6 +187,14 @@ mod tests {
         );
         let mut max_ok = alloc::vec![0u8; 255 * DIGEST_LEN];
         hkdf_expand_sha256(&prk, &INFO, &mut max_ok).unwrap();
+
+        // Same cap on the SHA-384 path.
+        let prk384 = hkdf_extract_sha384(&SALT, &IKM);
+        let mut too_big = alloc::vec![0u8; 255 * SHA384_DIGEST_LEN + 1];
+        assert_eq!(
+            hkdf_expand_sha384(&prk384, &INFO, &mut too_big),
+            Err(HkdfLengthError)
+        );
     }
 
     #[test]

--- a/security/src/hkdf.rs
+++ b/security/src/hkdf.rs
@@ -15,9 +15,11 @@
 //! HKDF-Expand(PRK, info, L)     -> OKM   (ceil(L/HashLen) HMACs)
 //! ```
 //!
-//! The API is alloc-free: `expand` writes into a caller-supplied
-//! buffer. Per RFC 5869 §2.3, `L ≤ 255 * HashLen`; longer requests
-//! are refused.
+//! Both hash variants are generated from one `define_hkdf!`
+//! template so the extract/expand logic is written (and audited)
+//! exactly once. The API is alloc-free: `expand` writes into a
+//! caller-supplied buffer. Per RFC 5869 §2.3, `L ≤ 255 * HashLen`;
+//! longer requests are refused.
 
 use crate::hmac_sha2::{HmacSha256, HmacSha384};
 use crate::sha2::{DIGEST_LEN, SHA384_DIGEST_LEN};
@@ -27,81 +29,76 @@ use crate::sha2::{DIGEST_LEN, SHA384_DIGEST_LEN};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HkdfLengthError;
 
-/// HKDF-Extract with HMAC-SHA-256. An empty `salt` is treated as
-/// `HashLen` zero bytes per RFC 5869 §2.2.
-pub fn hkdf_extract_sha256(salt: &[u8], ikm: &[u8]) -> [u8; DIGEST_LEN] {
-    let zero = [0u8; DIGEST_LEN];
-    let salt = if salt.is_empty() { &zero[..] } else { salt };
-    let mut mac = HmacSha256::new(salt);
-    mac.update(ikm);
-    mac.finalize()
+/// Generate the HKDF-Extract/Expand pair for one HMAC. `$mac` is
+/// the streaming HMAC type, `$digest` its output length.
+macro_rules! define_hkdf {
+    (
+        $(#[$extract_doc:meta])* $extract:ident,
+        $(#[$expand_doc:meta])* $expand:ident,
+        $mac:ident, $digest:expr
+    ) => {
+        $(#[$extract_doc])*
+        ///
+        /// An empty `salt` is treated as `HashLen` zero bytes per
+        /// RFC 5869 §2.2.
+        pub fn $extract(salt: &[u8], ikm: &[u8]) -> [u8; $digest] {
+            let zero = [0u8; $digest];
+            let salt = if salt.is_empty() { &zero[..] } else { salt };
+            let mut mac = $mac::new(salt);
+            mac.update(ikm);
+            mac.finalize()
+        }
+
+        $(#[$expand_doc])*
+        ///
+        /// Fills all of `okm`; requests beyond the RFC 5869 §2.3
+        /// cap return [`HkdfLengthError`].
+        pub fn $expand(
+            prk: &[u8; $digest],
+            info: &[u8],
+            okm: &mut [u8],
+        ) -> Result<(), HkdfLengthError> {
+            if okm.len() > 255 * $digest {
+                return Err(HkdfLengthError);
+            }
+            let mut t = [0u8; $digest];
+            let mut t_len = 0usize;
+            let mut counter = 1u8;
+            let mut written = 0usize;
+            while written < okm.len() {
+                let mut mac = $mac::new(prk);
+                mac.update(&t[..t_len]);
+                mac.update(info);
+                mac.update(&[counter]);
+                t = mac.finalize();
+                t_len = $digest;
+                let take = (okm.len() - written).min($digest);
+                okm[written..written + take].copy_from_slice(&t[..take]);
+                written += take;
+                counter = counter.wrapping_add(1);
+            }
+            Ok(())
+        }
+    };
 }
 
-/// HKDF-Expand with HMAC-SHA-256, filling all of `okm`.
-pub fn hkdf_expand_sha256(
-    prk: &[u8; DIGEST_LEN],
-    info: &[u8],
-    okm: &mut [u8],
-) -> Result<(), HkdfLengthError> {
-    if okm.len() > 255 * DIGEST_LEN {
-        return Err(HkdfLengthError);
-    }
-    let mut t = [0u8; DIGEST_LEN];
-    let mut t_len = 0usize;
-    let mut counter = 1u8;
-    let mut written = 0usize;
-    while written < okm.len() {
-        let mut mac = HmacSha256::new(prk);
-        mac.update(&t[..t_len]);
-        mac.update(info);
-        mac.update(&[counter]);
-        t = mac.finalize();
-        t_len = DIGEST_LEN;
-        let take = (okm.len() - written).min(DIGEST_LEN);
-        okm[written..written + take].copy_from_slice(&t[..take]);
-        written += take;
-        counter = counter.wrapping_add(1);
-    }
-    Ok(())
-}
+define_hkdf!(
+    /// HKDF-Extract with HMAC-SHA-256.
+    hkdf_extract_sha256,
+    /// HKDF-Expand with HMAC-SHA-256.
+    hkdf_expand_sha256,
+    HmacSha256,
+    DIGEST_LEN
+);
 
-/// HKDF-Extract with HMAC-SHA-384. An empty `salt` is treated as
-/// `HashLen` zero bytes per RFC 5869 §2.2.
-pub fn hkdf_extract_sha384(salt: &[u8], ikm: &[u8]) -> [u8; SHA384_DIGEST_LEN] {
-    let zero = [0u8; SHA384_DIGEST_LEN];
-    let salt = if salt.is_empty() { &zero[..] } else { salt };
-    let mut mac = HmacSha384::new(salt);
-    mac.update(ikm);
-    mac.finalize()
-}
-
-/// HKDF-Expand with HMAC-SHA-384, filling all of `okm`.
-pub fn hkdf_expand_sha384(
-    prk: &[u8; SHA384_DIGEST_LEN],
-    info: &[u8],
-    okm: &mut [u8],
-) -> Result<(), HkdfLengthError> {
-    if okm.len() > 255 * SHA384_DIGEST_LEN {
-        return Err(HkdfLengthError);
-    }
-    let mut t = [0u8; SHA384_DIGEST_LEN];
-    let mut t_len = 0usize;
-    let mut counter = 1u8;
-    let mut written = 0usize;
-    while written < okm.len() {
-        let mut mac = HmacSha384::new(prk);
-        mac.update(&t[..t_len]);
-        mac.update(info);
-        mac.update(&[counter]);
-        t = mac.finalize();
-        t_len = SHA384_DIGEST_LEN;
-        let take = (okm.len() - written).min(SHA384_DIGEST_LEN);
-        okm[written..written + take].copy_from_slice(&t[..take]);
-        written += take;
-        counter = counter.wrapping_add(1);
-    }
-    Ok(())
-}
+define_hkdf!(
+    /// HKDF-Extract with HMAC-SHA-384.
+    hkdf_extract_sha384,
+    /// HKDF-Expand with HMAC-SHA-384.
+    hkdf_expand_sha384,
+    HmacSha384,
+    SHA384_DIGEST_LEN
+);
 
 #[cfg(test)]
 mod tests {

--- a/security/src/hkdf.rs
+++ b/security/src/hkdf.rs
@@ -109,15 +109,7 @@ mod tests {
     use super::test_vectors::*;
     use super::*;
 
-    fn hex(bytes: &[u8]) -> alloc::string::String {
-        use alloc::string::String;
-        let mut s = String::with_capacity(bytes.len() * 2);
-        for b in bytes {
-            s.push(char::from_digit((b >> 4) as u32, 16).unwrap());
-            s.push(char::from_digit((b & 0xf) as u32, 16).unwrap());
-        }
-        s
-    }
+    use crate::test_util::hex;
 
     // RFC 5869 A.1 (test case 1) inputs live in `test_vectors`.
     // SHA-256 expected values are the RFC's published vectors;

--- a/security/src/hkdf.rs
+++ b/security/src/hkdf.rs
@@ -101,7 +101,12 @@ define_hkdf!(
 );
 
 #[cfg(test)]
+#[path = "hkdf_test_vectors.rs"]
+mod test_vectors;
+
+#[cfg(test)]
 mod tests {
+    use super::test_vectors::*;
     use super::*;
 
     fn hex(bytes: &[u8]) -> alloc::string::String {
@@ -114,14 +119,11 @@ mod tests {
         s
     }
 
-    // RFC 5869 A.1 (test case 1) inputs. SHA-256 expected values are
-    // the RFC's published vectors; SHA-384 values were generated from
-    // the same inputs and cross-validated against two independent
-    // oracles (Python stdlib HKDF construction and OpenSSL 3.0
-    // `openssl kdf ... HKDF`).
-    const IKM: [u8; 22] = [0x0b; 22];
-    const SALT: [u8; 13] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0x0a, 0x0b, 0x0c];
-    const INFO: [u8; 10] = [0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9];
+    // RFC 5869 A.1 (test case 1) inputs live in `test_vectors`.
+    // SHA-256 expected values are the RFC's published vectors;
+    // SHA-384 values were generated from the same inputs and
+    // cross-validated against two independent oracles (Python
+    // stdlib HKDF construction and OpenSSL 3.0 `openssl kdf HKDF`).
 
     #[test]
     fn rfc5869_tc1_sha256() {
@@ -159,9 +161,9 @@ mod tests {
     #[test]
     fn empty_salt_means_zero_block() {
         // RFC 5869 §2.2: salt defaults to HashLen zero bytes.
-        let explicit256 = hkdf_extract_sha256(&[0u8; DIGEST_LEN], b"ikm");
+        let explicit256 = hkdf_extract_sha256(&ZERO_SALT_SHA256, b"ikm");
         assert_eq!(hkdf_extract_sha256(&[], b"ikm"), explicit256);
-        let explicit384 = hkdf_extract_sha384(&[0u8; SHA384_DIGEST_LEN], b"ikm");
+        let explicit384 = hkdf_extract_sha384(&ZERO_SALT_SHA384, b"ikm");
         assert_eq!(hkdf_extract_sha384(&[], b"ikm"), explicit384);
     }
 

--- a/security/src/hkdf_test_vectors.rs
+++ b/security/src/hkdf_test_vectors.rs
@@ -1,0 +1,38 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Deterministic fixtures for `hkdf` unit tests.
+//!
+//! These constants are extracted from inline `#[cfg(test)]` literals in
+//! `hkdf.rs` so GitHub CodeQL's `rust/hard-coded-cryptographic-value`
+//! heuristic does not re-fire on every scan. They are NOT loaded by any
+//! production code path; the module is gated behind `#[cfg(test)]`.
+//!
+//! The corresponding `paths-ignore` entry lives in
+//! `.github/codeql/codeql-config.yml` (`**/*_test_vectors.rs`). See the
+//! `codeql-suppression-policy` spec (archived change
+//! `2026-05-10-codeql-quality-cleanup-v1`) for the policy and
+//! `security/src/argon2id_test_vectors.rs` for the canonical pattern.
+//!
+//! `IKM`/`SALT`/`INFO` are the RFC 5869 A.1 test-case-1 inputs; the
+//! zero salts exercise the §2.2 empty-salt default. None is real key
+//! material.
+
+#![cfg(test)]
+
+use crate::sha2::{DIGEST_LEN, SHA384_DIGEST_LEN};
+
+/// RFC 5869 A.1 test case 1 input keying material (`0x0b` × 22).
+pub(super) const IKM: [u8; 22] = [0x0b; 22];
+
+/// RFC 5869 A.1 test case 1 salt (`0x00..0x0c`).
+pub(super) const SALT: [u8; 13] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0x0a, 0x0b, 0x0c];
+
+/// RFC 5869 A.1 test case 1 info (`0xf0..0xf9`).
+pub(super) const INFO: [u8; 10] = [0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9];
+
+/// Explicit all-zero SHA-256-length salt — RFC 5869 §2.2's default.
+pub(super) const ZERO_SALT_SHA256: [u8; DIGEST_LEN] = [0u8; DIGEST_LEN];
+
+/// Explicit all-zero SHA-384-length salt — RFC 5869 §2.2's default.
+pub(super) const ZERO_SALT_SHA384: [u8; SHA384_DIGEST_LEN] = [0u8; SHA384_DIGEST_LEN];

--- a/security/src/hmac_sha2.rs
+++ b/security/src/hmac_sha2.rs
@@ -1,0 +1,268 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! HMAC-SHA-256 and HMAC-SHA-384 (RFC 2104 / FIPS 198-1) —
+//! clean-room `#![no_std]` implementations.
+//!
+//! The construction is exactly as RFC 2104 §2:
+//!
+//! ```text
+//! HMAC(K, m) = H((K' XOR opad) || H((K' XOR ipad) || m))
+//! ```
+//!
+//! where
+//! - `K'` is the working key: `H(K)` if `len(K) > B`, else `K` zero-padded
+//!   to `B` bytes;
+//! - `B` is the hash block length (64 bytes for SHA-256, 128 for SHA-384);
+//! - `ipad = 0x36 * B` and `opad = 0x5C * B`.
+//!
+//! ## Why HMAC-SHA-2?
+//!
+//! TLS 1.3 (RFC 8446) keys its entire key schedule with HKDF
+//! (RFC 5869), which is built on HMAC over the cipher suite's hash:
+//! HMAC-SHA-256 for `TLS_CHACHA20_POLY1305_SHA256`, HMAC-SHA-384 for
+//! `TLS_AES_256_GCM_SHA384`. The Finished message verify_data is a
+//! bare HMAC over the transcript hash. See
+//! [tls-tcp-client-v1](../../openspec/changes/tls-tcp-client-v1) for
+//! the consuming change. Like [`crate::sha2`], this is an interop
+//! primitive, not a first-party SmallAIOS construction.
+
+use crate::sha2::{Sha256, Sha384, BLOCK_LEN, DIGEST_LEN, SHA384_BLOCK_LEN, SHA384_DIGEST_LEN};
+
+/// HMAC inner-padding byte (RFC 2104 §2).
+//
+// lgtm[rust/hard-coded-cryptographic-value] — RFC 2104 §2 ipad, public constant
+const IPAD: u8 = 0x36;
+
+/// HMAC outer-padding byte (RFC 2104 §2).
+//
+// lgtm[rust/hard-coded-cryptographic-value] — RFC 2104 §2 opad, public constant
+const OPAD: u8 = 0x5C;
+
+/// Streaming HMAC-SHA-256 context.
+///
+/// Construct with [`HmacSha256::new`]; absorb message bytes via
+/// [`HmacSha256::update`]; finalise with [`HmacSha256::finalize`].
+#[derive(Clone)]
+pub struct HmacSha256 {
+    /// Inner SHA-256, primed with `K' XOR ipad`.
+    inner: Sha256,
+    /// Outer key (`K' XOR opad`), kept for finalise.
+    outer_key: [u8; BLOCK_LEN],
+}
+
+impl HmacSha256 {
+    /// Construct a fresh HMAC-SHA-256 instance for the given key.
+    pub fn new(key: &[u8]) -> Self {
+        let mut working = [0u8; BLOCK_LEN];
+        if key.len() > BLOCK_LEN {
+            let mut h = Sha256::new();
+            h.update(key);
+            working[..DIGEST_LEN].copy_from_slice(&h.finalize());
+        } else {
+            working[..key.len()].copy_from_slice(key);
+        }
+        let mut inner = Sha256::new();
+        let mut ipad_block = [0u8; BLOCK_LEN];
+        let mut outer_key = [0u8; BLOCK_LEN];
+        for i in 0..BLOCK_LEN {
+            ipad_block[i] = working[i] ^ IPAD;
+            outer_key[i] = working[i] ^ OPAD;
+        }
+        inner.update(&ipad_block);
+        Self { inner, outer_key }
+    }
+
+    /// Absorb message bytes.
+    pub fn update(&mut self, data: &[u8]) {
+        self.inner.update(data);
+    }
+
+    /// Finalise and return the 32-byte MAC.
+    pub fn finalize(self) -> [u8; DIGEST_LEN] {
+        let inner_digest = self.inner.finalize();
+        let mut outer = Sha256::new();
+        outer.update(&self.outer_key);
+        outer.update(&inner_digest);
+        outer.finalize()
+    }
+}
+
+/// One-shot HMAC-SHA-256.
+pub fn hmac_sha256(key: &[u8], message: &[u8]) -> [u8; DIGEST_LEN] {
+    let mut mac = HmacSha256::new(key);
+    mac.update(message);
+    mac.finalize()
+}
+
+/// Streaming HMAC-SHA-384 context.
+///
+/// Construct with [`HmacSha384::new`]; absorb message bytes via
+/// [`HmacSha384::update`]; finalise with [`HmacSha384::finalize`].
+#[derive(Clone)]
+pub struct HmacSha384 {
+    /// Inner SHA-384, primed with `K' XOR ipad`.
+    inner: Sha384,
+    /// Outer key (`K' XOR opad`), kept for finalise.
+    outer_key: [u8; SHA384_BLOCK_LEN],
+}
+
+impl HmacSha384 {
+    /// Construct a fresh HMAC-SHA-384 instance for the given key.
+    pub fn new(key: &[u8]) -> Self {
+        let mut working = [0u8; SHA384_BLOCK_LEN];
+        if key.len() > SHA384_BLOCK_LEN {
+            let mut h = Sha384::new();
+            h.update(key);
+            working[..SHA384_DIGEST_LEN].copy_from_slice(&h.finalize());
+        } else {
+            working[..key.len()].copy_from_slice(key);
+        }
+        let mut inner = Sha384::new();
+        let mut ipad_block = [0u8; SHA384_BLOCK_LEN];
+        let mut outer_key = [0u8; SHA384_BLOCK_LEN];
+        for i in 0..SHA384_BLOCK_LEN {
+            ipad_block[i] = working[i] ^ IPAD;
+            outer_key[i] = working[i] ^ OPAD;
+        }
+        inner.update(&ipad_block);
+        Self { inner, outer_key }
+    }
+
+    /// Absorb message bytes.
+    pub fn update(&mut self, data: &[u8]) {
+        self.inner.update(data);
+    }
+
+    /// Finalise and return the 48-byte MAC.
+    pub fn finalize(self) -> [u8; SHA384_DIGEST_LEN] {
+        let inner_digest = self.inner.finalize();
+        let mut outer = Sha384::new();
+        outer.update(&self.outer_key);
+        outer.update(&inner_digest);
+        outer.finalize()
+    }
+}
+
+/// One-shot HMAC-SHA-384.
+pub fn hmac_sha384(key: &[u8], message: &[u8]) -> [u8; SHA384_DIGEST_LEN] {
+    let mut mac = HmacSha384::new(key);
+    mac.update(message);
+    mac.finalize()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hex(bytes: &[u8]) -> alloc::string::String {
+        use alloc::string::String;
+        let mut s = String::with_capacity(bytes.len() * 2);
+        for b in bytes {
+            s.push(char::from_digit((b >> 4) as u32, 16).unwrap());
+            s.push(char::from_digit((b & 0xf) as u32, 16).unwrap());
+        }
+        s
+    }
+
+    // RFC 4231 test-case inputs. Expected outputs cross-validated
+    // against two independent oracles (Python `hmac` stdlib and
+    // OpenSSL 3.0) and the RFC 4231 published values.
+
+    #[test]
+    fn rfc4231_tc1() {
+        let key = [0x0bu8; 20];
+        assert_eq!(
+            hex(&hmac_sha256(&key, b"Hi There")),
+            "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"
+        );
+        assert_eq!(
+            hex(&hmac_sha384(&key, b"Hi There")),
+            "afd03944d84895626b0825f4ab46907f15f9dadbe4101ec682aa034c7cebc59c\
+             faea9ea9076ede7f4af152e8b2fa9cb6"
+        );
+    }
+
+    #[test]
+    fn rfc4231_tc2_short_key() {
+        let key = b"Jefe";
+        let msg = b"what do ya want for nothing?";
+        assert_eq!(
+            hex(&hmac_sha256(key, msg)),
+            "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843"
+        );
+        assert_eq!(
+            hex(&hmac_sha384(key, msg)),
+            "af45d2e376484031617f78d2b58a6b1b9c7ef464f5a01b47e42ec3736322445e\
+             8e2240ca5e69e2c78b3239ecfab21649"
+        );
+    }
+
+    #[test]
+    fn rfc4231_tc3_binary() {
+        let key = [0xaau8; 20];
+        let msg = [0xddu8; 50];
+        assert_eq!(
+            hex(&hmac_sha256(&key, &msg)),
+            "773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe"
+        );
+        assert_eq!(
+            hex(&hmac_sha384(&key, &msg)),
+            "88062608d3e6ad8a0aa2ace014c8a86f0aa635d947ac9febe83ef4e55966144b\
+             2a5ab39dc13814b94e3ab6e101a34f27"
+        );
+    }
+
+    #[test]
+    fn rfc4231_tc6_key_longer_than_block() {
+        // 131-byte key exceeds both the SHA-256 (64) and SHA-384
+        // (128) block lengths, exercising the H(K) reduction path.
+        let key = [0xaau8; 131];
+        let msg = b"Test Using Larger Than Block-Size Key - Hash Key First";
+        assert_eq!(
+            hex(&hmac_sha256(&key, msg)),
+            "60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54"
+        );
+        assert_eq!(
+            hex(&hmac_sha384(&key, msg)),
+            "4ece084485813e9088d2c63a041bc5b44f9ef1012a2b588f3cd11f05033ac4c6\
+             0c2ef6ab4030fe8296248df163f44952"
+        );
+    }
+
+    #[test]
+    fn rfc4231_tc7_key_and_data_longer_than_block() {
+        let key = [0xaau8; 131];
+        let msg: &[u8] = b"This is a test using a larger than block-size key and a \
+larger than block-size data. The key needs to be hashed before being used by \
+the HMAC algorithm.";
+        assert_eq!(
+            hex(&hmac_sha256(&key, msg)),
+            "9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f51535c3a35e2"
+        );
+        assert_eq!(
+            hex(&hmac_sha384(&key, msg)),
+            "6617178e941f020d351e2f254e8fd32c602420feb0b8fb9adccebb82461e99c5\
+             a678cc31e799176d3860e6110c46523e"
+        );
+    }
+
+    #[test]
+    fn streaming_equals_oneshot() {
+        let key = b"a moderately sized hmac key";
+        let msg = b"The quick brown fox jumps over the lazy dog, repeatedly.";
+        let oneshot256 = hmac_sha256(key, msg);
+        let mut mac = HmacSha256::new(key);
+        for chunk in msg.chunks(5) {
+            mac.update(chunk);
+        }
+        assert_eq!(oneshot256, mac.finalize());
+
+        let oneshot384 = hmac_sha384(key, msg);
+        let mut mac = HmacSha384::new(key);
+        for chunk in msg.chunks(5) {
+            mac.update(chunk);
+        }
+        assert_eq!(oneshot384, mac.finalize());
+    }
+}

--- a/security/src/hmac_sha2.rs
+++ b/security/src/hmac_sha2.rs
@@ -16,6 +16,9 @@
 //! - `B` is the hash block length (64 bytes for SHA-256, 128 for SHA-384);
 //! - `ipad = 0x36 * B` and `opad = 0x5C * B`.
 //!
+//! Both variants are generated from one `define_hmac!` template so
+//! the construction is written (and audited) exactly once.
+//!
 //! ## Why HMAC-SHA-2?
 //!
 //! TLS 1.3 (RFC 8446) keys its entire key schedule with HKDF
@@ -39,117 +42,92 @@ const IPAD: u8 = 0x36;
 // lgtm[rust/hard-coded-cryptographic-value] — RFC 2104 §2 opad, public constant
 const OPAD: u8 = 0x5C;
 
-/// Streaming HMAC-SHA-256 context.
-///
-/// Construct with [`HmacSha256::new`]; absorb message bytes via
-/// [`HmacSha256::update`]; finalise with [`HmacSha256::finalize`].
-#[derive(Clone)]
-pub struct HmacSha256 {
-    /// Inner SHA-256, primed with `K' XOR ipad`.
-    inner: Sha256,
-    /// Outer key (`K' XOR opad`), kept for finalise.
-    outer_key: [u8; BLOCK_LEN],
-}
-
-impl HmacSha256 {
-    /// Construct a fresh HMAC-SHA-256 instance for the given key.
-    pub fn new(key: &[u8]) -> Self {
-        let mut working = [0u8; BLOCK_LEN];
-        if key.len() > BLOCK_LEN {
-            let mut h = Sha256::new();
-            h.update(key);
-            working[..DIGEST_LEN].copy_from_slice(&h.finalize());
-        } else {
-            working[..key.len()].copy_from_slice(key);
+/// Generate a streaming HMAC context + one-shot helper for one
+/// SHA-2 hash. `$hash` is the hasher type, `$block`/`$digest` its
+/// block and digest lengths.
+macro_rules! define_hmac {
+    (
+        $(#[$ctx_doc:meta])* $name:ident,
+        $(#[$fn_doc:meta])* $oneshot:ident,
+        $hash:ident, $block:expr, $digest:expr
+    ) => {
+        $(#[$ctx_doc])*
+        ///
+        /// Construct with `new`; absorb message bytes via `update`;
+        /// finalise with `finalize`.
+        #[derive(Clone)]
+        pub struct $name {
+            /// Inner hash, primed with `K' XOR ipad`.
+            inner: $hash,
+            /// Outer key (`K' XOR opad`), kept for finalise.
+            outer_key: [u8; $block],
         }
-        let mut inner = Sha256::new();
-        let mut ipad_block = [0u8; BLOCK_LEN];
-        let mut outer_key = [0u8; BLOCK_LEN];
-        for i in 0..BLOCK_LEN {
-            ipad_block[i] = working[i] ^ IPAD;
-            outer_key[i] = working[i] ^ OPAD;
+
+        impl $name {
+            /// Construct a fresh instance for the given key.
+            pub fn new(key: &[u8]) -> Self {
+                let mut working = [0u8; $block];
+                if key.len() > $block {
+                    let mut h = $hash::new();
+                    h.update(key);
+                    working[..$digest].copy_from_slice(&h.finalize());
+                } else {
+                    working[..key.len()].copy_from_slice(key);
+                }
+                let mut inner = $hash::new();
+                let mut ipad_block = [0u8; $block];
+                let mut outer_key = [0u8; $block];
+                for i in 0..$block {
+                    ipad_block[i] = working[i] ^ IPAD;
+                    outer_key[i] = working[i] ^ OPAD;
+                }
+                inner.update(&ipad_block);
+                Self { inner, outer_key }
+            }
+
+            /// Absorb message bytes.
+            pub fn update(&mut self, data: &[u8]) {
+                self.inner.update(data);
+            }
+
+            /// Finalise and return the MAC.
+            pub fn finalize(self) -> [u8; $digest] {
+                let inner_digest = self.inner.finalize();
+                let mut outer = $hash::new();
+                outer.update(&self.outer_key);
+                outer.update(&inner_digest);
+                outer.finalize()
+            }
         }
-        inner.update(&ipad_block);
-        Self { inner, outer_key }
-    }
 
-    /// Absorb message bytes.
-    pub fn update(&mut self, data: &[u8]) {
-        self.inner.update(data);
-    }
-
-    /// Finalise and return the 32-byte MAC.
-    pub fn finalize(self) -> [u8; DIGEST_LEN] {
-        let inner_digest = self.inner.finalize();
-        let mut outer = Sha256::new();
-        outer.update(&self.outer_key);
-        outer.update(&inner_digest);
-        outer.finalize()
-    }
-}
-
-/// One-shot HMAC-SHA-256.
-pub fn hmac_sha256(key: &[u8], message: &[u8]) -> [u8; DIGEST_LEN] {
-    let mut mac = HmacSha256::new(key);
-    mac.update(message);
-    mac.finalize()
-}
-
-/// Streaming HMAC-SHA-384 context.
-///
-/// Construct with [`HmacSha384::new`]; absorb message bytes via
-/// [`HmacSha384::update`]; finalise with [`HmacSha384::finalize`].
-#[derive(Clone)]
-pub struct HmacSha384 {
-    /// Inner SHA-384, primed with `K' XOR ipad`.
-    inner: Sha384,
-    /// Outer key (`K' XOR opad`), kept for finalise.
-    outer_key: [u8; SHA384_BLOCK_LEN],
-}
-
-impl HmacSha384 {
-    /// Construct a fresh HMAC-SHA-384 instance for the given key.
-    pub fn new(key: &[u8]) -> Self {
-        let mut working = [0u8; SHA384_BLOCK_LEN];
-        if key.len() > SHA384_BLOCK_LEN {
-            let mut h = Sha384::new();
-            h.update(key);
-            working[..SHA384_DIGEST_LEN].copy_from_slice(&h.finalize());
-        } else {
-            working[..key.len()].copy_from_slice(key);
+        $(#[$fn_doc])*
+        pub fn $oneshot(key: &[u8], message: &[u8]) -> [u8; $digest] {
+            let mut mac = $name::new(key);
+            mac.update(message);
+            mac.finalize()
         }
-        let mut inner = Sha384::new();
-        let mut ipad_block = [0u8; SHA384_BLOCK_LEN];
-        let mut outer_key = [0u8; SHA384_BLOCK_LEN];
-        for i in 0..SHA384_BLOCK_LEN {
-            ipad_block[i] = working[i] ^ IPAD;
-            outer_key[i] = working[i] ^ OPAD;
-        }
-        inner.update(&ipad_block);
-        Self { inner, outer_key }
-    }
-
-    /// Absorb message bytes.
-    pub fn update(&mut self, data: &[u8]) {
-        self.inner.update(data);
-    }
-
-    /// Finalise and return the 48-byte MAC.
-    pub fn finalize(self) -> [u8; SHA384_DIGEST_LEN] {
-        let inner_digest = self.inner.finalize();
-        let mut outer = Sha384::new();
-        outer.update(&self.outer_key);
-        outer.update(&inner_digest);
-        outer.finalize()
-    }
+    };
 }
 
-/// One-shot HMAC-SHA-384.
-pub fn hmac_sha384(key: &[u8], message: &[u8]) -> [u8; SHA384_DIGEST_LEN] {
-    let mut mac = HmacSha384::new(key);
-    mac.update(message);
-    mac.finalize()
-}
+define_hmac!(
+    /// Streaming HMAC-SHA-256 context.
+    HmacSha256,
+    /// One-shot HMAC-SHA-256.
+    hmac_sha256,
+    Sha256,
+    BLOCK_LEN,
+    DIGEST_LEN
+);
+
+define_hmac!(
+    /// Streaming HMAC-SHA-384 context.
+    HmacSha384,
+    /// One-shot HMAC-SHA-384.
+    hmac_sha384,
+    Sha384,
+    SHA384_BLOCK_LEN,
+    SHA384_DIGEST_LEN
+);
 
 #[cfg(test)]
 mod tests {

--- a/security/src/hmac_sha2.rs
+++ b/security/src/hmac_sha2.rs
@@ -133,15 +133,7 @@ define_hmac!(
 mod tests {
     use super::*;
 
-    fn hex(bytes: &[u8]) -> alloc::string::String {
-        use alloc::string::String;
-        let mut s = String::with_capacity(bytes.len() * 2);
-        for b in bytes {
-            s.push(char::from_digit((b >> 4) as u32, 16).unwrap());
-            s.push(char::from_digit((b & 0xf) as u32, 16).unwrap());
-        }
-        s
-    }
+    use crate::test_util::hex;
 
     // RFC 4231 test-case inputs. Expected outputs cross-validated
     // against two independent oracles (Python `hmac` stdlib and

--- a/security/src/lib.rs
+++ b/security/src/lib.rs
@@ -34,7 +34,9 @@ pub mod enforcement;
 pub mod gate;
 #[cfg(not(feature = "formal-gate"))]
 pub mod gate_noop;
+pub mod hkdf;
 pub mod hmac_sha1;
+pub mod hmac_sha2;
 pub mod incident;
 #[cfg(feature = "formal-gate")]
 pub mod labels;

--- a/security/src/lib.rs
+++ b/security/src/lib.rs
@@ -49,4 +49,6 @@ pub mod policy;
 pub mod sha1;
 pub mod sha2;
 pub mod supply_chain;
+#[cfg(test)]
+pub(crate) mod test_util;
 pub mod totp;

--- a/security/src/sha2.rs
+++ b/security/src/sha2.rs
@@ -516,15 +516,7 @@ pub fn sha384(data: &[u8]) -> [u8; SHA384_DIGEST_LEN] {
 mod tests {
     use super::*;
 
-    fn hex(bytes: &[u8]) -> alloc::string::String {
-        use alloc::string::String;
-        let mut s = String::with_capacity(bytes.len() * 2);
-        for b in bytes {
-            s.push(char::from_digit((b >> 4) as u32, 16).unwrap());
-            s.push(char::from_digit((b & 0xf) as u32, 16).unwrap());
-        }
-        s
-    }
+    use crate::test_util::hex;
 
     // NIST FIPS 180-4 published test vectors.
     #[test]

--- a/security/src/sha2.rs
+++ b/security/src/sha2.rs
@@ -650,6 +650,18 @@ hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu";
     }
 
     #[test]
+    fn sha384_default_equals_new() {
+        let mut a = Sha384::default();
+        let mut b = Sha384::new();
+        a.update(b"abc");
+        b.update(b"abc");
+        assert_eq!(a.finalize(), b.finalize());
+        let mut c = Sha256::default();
+        c.update(b"abc");
+        assert_eq!(c.finalize(), sha256(b"abc"));
+    }
+
+    #[test]
     fn sha384_block_boundary_lengths() {
         // Exercise the padding paths around the 128-byte block
         // boundary (111/112/127/128/129 bytes) against the

--- a/security/src/sha2.rs
+++ b/security/src/sha2.rs
@@ -547,9 +547,9 @@ mod tests {
     #[test]
     fn nist_kat_one_million_a() {
         let mut h = Sha256::new();
-        let chunk = alloc::vec![b'a'; 1024];
+        let chunk = alloc::vec![b'a'; 1000];
         for _ in 0..1000 {
-            h.update(&chunk[..1000.min(1024)]);
+            h.update(&chunk);
         }
         // 1000 iterations × 1000 bytes = 1,000,000.
         assert_eq!(

--- a/security/src/sha2.rs
+++ b/security/src/sha2.rs
@@ -1,12 +1,13 @@
 // Copyright 2026 SmallAIOS Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! SHA-256 (FIPS 180-4) — clean-room `#![no_std]` implementation.
+//! SHA-256 and SHA-384 (FIPS 180-4) — clean-room `#![no_std]`
+//! implementations.
 //!
-//! ## Why ship SHA-256?
+//! ## Why ship SHA-2?
 //!
 //! SmallAIOS's native crypto stack is PQ-aligned (SHA-3-256, ML-DSA-65,
-//! ML-KEM-768). SHA-256 is *not* used for any first-party SmallAIOS
+//! ML-KEM-768). SHA-2 is *not* used for any first-party SmallAIOS
 //! primitive. It is required strictly for **interop** with external
 //! systems whose wire format the SmallAIOS image must speak verbatim:
 //!
@@ -16,6 +17,9 @@
 //!   hashes use SHA-256.
 //! - Transparency-log ecosystems (Sigstore Rekor, RFC 6962 CT) all hash
 //!   with SHA-256.
+//! - The TLS 1.3 cipher suite `TLS_AES_256_GCM_SHA384`
+//!   ([tls-tcp-client-v1](../../../openspec/changes/tls-tcp-client-v1))
+//!   keys its HKDF transcript schedule with SHA-384.
 //!
 //! ## Threat model
 //!
@@ -265,6 +269,249 @@ pub fn sha256(data: &[u8]) -> [u8; DIGEST_LEN] {
     h.finalize()
 }
 
+// ─── SHA-384 ─────────────────────────────────────────────────────────────────
+
+/// SHA-384 digest length in bytes.
+pub const SHA384_DIGEST_LEN: usize = 48;
+
+/// SHA-384 block length in bytes (the SHA-512 core block).
+pub const SHA384_BLOCK_LEN: usize = 128;
+
+// FIPS 180-4 §5.3.4 initial hash value H(0) for SHA-384.
+// lgtm[rust/hard-coded-cryptographic-value] — FIPS 180-4 IV, public constant.
+const H0_384: [u64; 8] = [
+    0xcbbb_9d5d_c105_9ed8,
+    0x629a_292a_367c_d507,
+    0x9159_015a_3070_dd17,
+    0x152f_ecd8_f70e_5939,
+    0x6733_2667_ffc0_0b31,
+    0x8eb4_4a87_6858_1511,
+    0xdb0c_2e0d_64f9_8fa7,
+    0x47b5_481d_befa_4fa4,
+];
+
+// FIPS 180-4 §4.2.3 round constants K[0..79] (shared SHA-512 core).
+// lgtm[rust/hard-coded-cryptographic-value] — FIPS 180-4 constants, public.
+const K512: [u64; 80] = [
+    0x428a_2f98_d728_ae22,
+    0x7137_4491_23ef_65cd,
+    0xb5c0_fbcf_ec4d_3b2f,
+    0xe9b5_dba5_8189_dbbc,
+    0x3956_c25b_f348_b538,
+    0x59f1_11f1_b605_d019,
+    0x923f_82a4_af19_4f9b,
+    0xab1c_5ed5_da6d_8118,
+    0xd807_aa98_a303_0242,
+    0x1283_5b01_4570_6fbe,
+    0x2431_85be_4ee4_b28c,
+    0x550c_7dc3_d5ff_b4e2,
+    0x72be_5d74_f27b_896f,
+    0x80de_b1fe_3b16_96b1,
+    0x9bdc_06a7_25c7_1235,
+    0xc19b_f174_cf69_2694,
+    0xe49b_69c1_9ef1_4ad2,
+    0xefbe_4786_384f_25e3,
+    0x0fc1_9dc6_8b8c_d5b5,
+    0x240c_a1cc_77ac_9c65,
+    0x2de9_2c6f_592b_0275,
+    0x4a74_84aa_6ea6_e483,
+    0x5cb0_a9dc_bd41_fbd4,
+    0x76f9_88da_8311_53b5,
+    0x983e_5152_ee66_dfab,
+    0xa831_c66d_2db4_3210,
+    0xb003_27c8_98fb_213f,
+    0xbf59_7fc7_beef_0ee4,
+    0xc6e0_0bf3_3da8_8fc2,
+    0xd5a7_9147_930a_a725,
+    0x06ca_6351_e003_826f,
+    0x1429_2967_0a0e_6e70,
+    0x27b7_0a85_46d2_2ffc,
+    0x2e1b_2138_5c26_c926,
+    0x4d2c_6dfc_5ac4_2aed,
+    0x5338_0d13_9d95_b3df,
+    0x650a_7354_8baf_63de,
+    0x766a_0abb_3c77_b2a8,
+    0x81c2_c92e_47ed_aee6,
+    0x9272_2c85_1482_353b,
+    0xa2bf_e8a1_4cf1_0364,
+    0xa81a_664b_bc42_3001,
+    0xc24b_8b70_d0f8_9791,
+    0xc76c_51a3_0654_be30,
+    0xd192_e819_d6ef_5218,
+    0xd699_0624_5565_a910,
+    0xf40e_3585_5771_202a,
+    0x106a_a070_32bb_d1b8,
+    0x19a4_c116_b8d2_d0c8,
+    0x1e37_6c08_5141_ab53,
+    0x2748_774c_df8e_eb99,
+    0x34b0_bcb5_e19b_48a8,
+    0x391c_0cb3_c5c9_5a63,
+    0x4ed8_aa4a_e341_8acb,
+    0x5b9c_ca4f_7763_e373,
+    0x682e_6ff3_d6b2_b8a3,
+    0x748f_82ee_5def_b2fc,
+    0x78a5_636f_4317_2f60,
+    0x84c8_7814_a1f0_ab72,
+    0x8cc7_0208_1a64_39ec,
+    0x90be_fffa_2363_1e28,
+    0xa450_6ceb_de82_bde9,
+    0xbef9_a3f7_b2c6_7915,
+    0xc671_78f2_e372_532b,
+    0xca27_3ece_ea26_619c,
+    0xd186_b8c7_21c0_c207,
+    0xeada_7dd6_cde0_eb1e,
+    0xf57d_4f7f_ee6e_d178,
+    0x06f0_67aa_7217_6fba,
+    0x0a63_7dc5_a2c8_98a6,
+    0x113f_9804_bef9_0dae,
+    0x1b71_0b35_131c_471b,
+    0x28db_77f5_2304_7d84,
+    0x32ca_ab7b_40c7_2493,
+    0x3c9e_be0a_15c9_bebc,
+    0x431d_67c4_9c10_0d4c,
+    0x4cc5_d4be_cb3e_42b6,
+    0x597f_299c_fc65_7e2a,
+    0x5fcb_6fab_3ad6_faec,
+    0x6c44_198c_4a47_5817,
+];
+
+/// Incremental SHA-384 hasher (SHA-512 core, truncated output).
+#[derive(Clone, Debug)]
+pub struct Sha384 {
+    state: [u64; 8],
+    buffer: [u8; SHA384_BLOCK_LEN],
+    buffered: usize,
+    total_bits: u128,
+}
+
+impl Default for Sha384 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Sha384 {
+    /// Create a fresh hasher.
+    pub const fn new() -> Self {
+        Self {
+            state: H0_384,
+            buffer: [0u8; SHA384_BLOCK_LEN],
+            buffered: 0,
+            total_bits: 0,
+        }
+    }
+
+    /// Absorb bytes into the hasher.
+    pub fn update(&mut self, mut data: &[u8]) {
+        self.total_bits = self
+            .total_bits
+            .wrapping_add((data.len() as u128).wrapping_mul(8));
+        if self.buffered > 0 {
+            let take = (SHA384_BLOCK_LEN - self.buffered).min(data.len());
+            self.buffer[self.buffered..self.buffered + take].copy_from_slice(&data[..take]);
+            self.buffered += take;
+            data = &data[take..];
+            if self.buffered == SHA384_BLOCK_LEN {
+                let block = self.buffer;
+                self.compress(&block);
+                self.buffered = 0;
+            }
+        }
+        while data.len() >= SHA384_BLOCK_LEN {
+            let mut block = [0u8; SHA384_BLOCK_LEN];
+            block.copy_from_slice(&data[..SHA384_BLOCK_LEN]);
+            self.compress(&block);
+            data = &data[SHA384_BLOCK_LEN..];
+        }
+        if !data.is_empty() {
+            self.buffer[..data.len()].copy_from_slice(data);
+            self.buffered = data.len();
+        }
+    }
+
+    /// Finalize the hash and return the 48-byte digest.
+    pub fn finalize(mut self) -> [u8; SHA384_DIGEST_LEN] {
+        // Pad: 0x80 byte, zeros to ≡ 112 (mod 128), then 16-byte BE length.
+        let bits = self.total_bits;
+        self.buffer[self.buffered] = 0x80;
+        self.buffered += 1;
+        if self.buffered > SHA384_BLOCK_LEN - 16 {
+            for b in &mut self.buffer[self.buffered..] {
+                *b = 0;
+            }
+            let block = self.buffer;
+            self.compress(&block);
+            self.buffered = 0;
+        }
+        for b in &mut self.buffer[self.buffered..SHA384_BLOCK_LEN - 16] {
+            *b = 0;
+        }
+        self.buffer[SHA384_BLOCK_LEN - 16..].copy_from_slice(&bits.to_be_bytes());
+        let block = self.buffer;
+        self.compress(&block);
+
+        // SHA-384 truncates the 512-bit state to the first 6 words.
+        let mut out = [0u8; SHA384_DIGEST_LEN];
+        for (i, w) in self.state.iter().take(6).enumerate() {
+            out[i * 8..i * 8 + 8].copy_from_slice(&w.to_be_bytes());
+        }
+        out
+    }
+
+    fn compress(&mut self, block: &[u8; SHA384_BLOCK_LEN]) {
+        let mut w = [0u64; 80];
+        for i in 0..16 {
+            let mut bytes = [0u8; 8];
+            bytes.copy_from_slice(&block[i * 8..i * 8 + 8]);
+            w[i] = u64::from_be_bytes(bytes);
+        }
+        for i in 16..80 {
+            let s0 = w[i - 15].rotate_right(1) ^ w[i - 15].rotate_right(8) ^ (w[i - 15] >> 7);
+            let s1 = w[i - 2].rotate_right(19) ^ w[i - 2].rotate_right(61) ^ (w[i - 2] >> 6);
+            w[i] = w[i - 16]
+                .wrapping_add(s0)
+                .wrapping_add(w[i - 7])
+                .wrapping_add(s1);
+        }
+        let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h] = self.state;
+        for i in 0..80 {
+            let s1 = e.rotate_right(14) ^ e.rotate_right(18) ^ e.rotate_right(41);
+            let ch = (e & f) ^ ((!e) & g);
+            let t1 = h
+                .wrapping_add(s1)
+                .wrapping_add(ch)
+                .wrapping_add(K512[i])
+                .wrapping_add(w[i]);
+            let s0 = a.rotate_right(28) ^ a.rotate_right(34) ^ a.rotate_right(39);
+            let maj = (a & b) ^ (a & c) ^ (b & c);
+            let t2 = s0.wrapping_add(maj);
+            h = g;
+            g = f;
+            f = e;
+            e = d.wrapping_add(t1);
+            d = c;
+            c = b;
+            b = a;
+            a = t1.wrapping_add(t2);
+        }
+        self.state[0] = self.state[0].wrapping_add(a);
+        self.state[1] = self.state[1].wrapping_add(b);
+        self.state[2] = self.state[2].wrapping_add(c);
+        self.state[3] = self.state[3].wrapping_add(d);
+        self.state[4] = self.state[4].wrapping_add(e);
+        self.state[5] = self.state[5].wrapping_add(f);
+        self.state[6] = self.state[6].wrapping_add(g);
+        self.state[7] = self.state[7].wrapping_add(h);
+    }
+}
+
+/// One-shot SHA-384 over `data`.
+pub fn sha384(data: &[u8]) -> [u8; SHA384_DIGEST_LEN] {
+    let mut h = Sha384::new();
+    h.update(data);
+    h.finalize()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -340,5 +587,81 @@ mod tests {
             hex(&h.finalize()),
             "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
         );
+    }
+
+    // NIST FIPS 180-4 published SHA-384 test vectors.
+    #[test]
+    fn sha384_kat_empty() {
+        assert_eq!(
+            hex(&sha384(b"")),
+            "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da\
+             274edebfe76f65fbd51ad2f14898b95b"
+        );
+    }
+
+    #[test]
+    fn sha384_kat_abc() {
+        assert_eq!(
+            hex(&sha384(b"abc")),
+            "cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed\
+             8086072ba1e7cc2358baeca134c825a7"
+        );
+    }
+
+    #[test]
+    fn sha384_kat_two_block_message() {
+        let msg = b"abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn\
+hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu";
+        assert_eq!(
+            hex(&sha384(msg)),
+            "09330c33f71147e83d192fc782cd1b4753111b173b3b05d22fa08086e3b0f712\
+             fcc7c71a557e2db966c3e9fa91746039"
+        );
+    }
+
+    #[test]
+    fn sha384_kat_one_million_a() {
+        let mut h = Sha384::new();
+        let chunk = alloc::vec![b'a'; 1000];
+        for _ in 0..1000 {
+            h.update(&chunk);
+        }
+        assert_eq!(
+            hex(&h.finalize()),
+            "9d0e1809716474cb086e834e310a4a1ced149e9c00f248527972cec5704c2a5b\
+             07b8b3dc38ecc4ebae97ddd87f3d8985"
+        );
+    }
+
+    #[test]
+    fn sha384_incremental_equals_oneshot() {
+        let msg = b"The quick brown fox jumps over the lazy dog";
+        let oneshot = sha384(msg);
+        assert_eq!(
+            hex(&oneshot),
+            "ca737f1014a48f4c0b6dd43cb177b0afd9e5169367544c494011e3317dbf9a50\
+             9cb1e5dc1e85a941bbee3d7f2afbc9b1"
+        );
+        let mut h = Sha384::new();
+        for chunk in msg.chunks(13) {
+            h.update(chunk);
+        }
+        assert_eq!(oneshot, h.finalize());
+    }
+
+    #[test]
+    fn sha384_block_boundary_lengths() {
+        // Exercise the padding paths around the 128-byte block
+        // boundary (111/112/127/128/129 bytes) against the
+        // incremental path.
+        for len in [111usize, 112, 127, 128, 129, 240, 256] {
+            let msg = alloc::vec![0x5au8; len];
+            let oneshot = sha384(&msg);
+            let mut h = Sha384::new();
+            for chunk in msg.chunks(7) {
+                h.update(chunk);
+            }
+            assert_eq!(oneshot, h.finalize(), "len={len}");
+        }
     }
 }

--- a/security/src/test_util.rs
+++ b/security/src/test_util.rs
@@ -1,0 +1,18 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared helpers for `security` unit tests.
+
+#![cfg(test)]
+
+use alloc::string::String;
+
+/// Lowercase hex of `bytes`.
+pub(crate) fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push(char::from_digit((b >> 4) as u32, 16).unwrap());
+        s.push(char::from_digit((b & 0xf) as u32, 16).unwrap());
+    }
+    s
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -29,4 +29,13 @@ sonar.coverageReportPaths=sonar-coverage.xml
 #   - tools/coverage-probe/**: walker/report code mirrors the
 #                      structure of the ONNX node enumeration; same
 #                      argument as the ops files.
-sonar.cpd.exclusions=onnx-rt/src/operators.rs,onnx-rt/src/executor.rs,onnx-rt/src/ops/**,tools/coverage-probe/**
+#   - security/src/sha2.rs: the SHA-256 and SHA-384 compress cores
+#                      are intentionally parallel clean-room
+#                      implementations of two FIPS 180-4 algorithms
+#                      that share round structure but differ in word
+#                      size (u32 vs u64), constants, and round
+#                      counts. Folding them into one generic core
+#                      would obscure each algorithm's auditability
+#                      against its spec — same rationale as the
+#                      per-op ONNX files above.
+sonar.cpd.exclusions=onnx-rt/src/operators.rs,onnx-rt/src/executor.rs,onnx-rt/src/ops/**,tools/coverage-probe/**,security/src/sha2.rs

--- a/tls-client/src/cert/mod.rs
+++ b/tls-client/src/cert/mod.rs
@@ -21,3 +21,29 @@
 
 pub mod der;
 pub mod hostname;
+
+use crate::Result;
+use alloc::vec::Vec;
+
+/// The leaf certificate's SubjectPublicKeyInfo key, in the
+/// algorithms the workspace can verify CertificateVerify with
+/// today. ECDSA-P256 and RSA-PSS variants join when their
+/// `security/` primitives land (tasks 5.5 note).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LeafPublicKey {
+    Ed25519([u8; 32]),
+}
+
+/// Chain verification seam between the handshake driver (Phase 4)
+/// and the X.509 chain verifier (Phase 5).
+///
+/// `certs` is the server's chain exactly as received — leaf
+/// first, raw DER. Implementations MUST verify the chain anchors
+/// in the operator trust store, the validity windows, and that
+/// the leaf's SAN matches `server_name`, returning the leaf's
+/// public key for CertificateVerify checking. The production
+/// implementation lands with Phase 5's structure parser; until
+/// then the only impls are test doubles inside this crate.
+pub trait ServerCertVerifier {
+    fn verify_chain(&self, certs: &[Vec<u8>], server_name: Option<&str>) -> Result<LeafPublicKey>;
+}

--- a/tls-client/src/handshake/certificate_msg.rs
+++ b/tls-client/src/handshake/certificate_msg.rs
@@ -269,9 +269,13 @@ mod tests {
 
     #[test]
     fn certificate_truncated_rejected() {
+        // No format message on the asserts: CodeQL's
+        // rust/cleartext-logging taints the message via
+        // `bytes.len()` because `bytes` derives from certificate
+        // material (synthetic here, but the query can't know that).
         let bytes = build_certificate(&[b"leaf-der-bytes"]);
         for cut in [5, 8, 12, bytes.len() - 1] {
-            assert!(parse_certificate(&bytes[..cut]).is_err(), "cut={cut}");
+            assert!(parse_certificate(&bytes[..cut]).is_err());
         }
     }
 

--- a/tls-client/src/handshake/certificate_msg.rs
+++ b/tls-client/src/handshake/certificate_msg.rs
@@ -201,45 +201,10 @@ pub fn verify_certificate_verify(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::handshake::test_util::{
+        build_certificate, build_certificate_verify as build_cert_verify,
+    };
     use smallaios_security::crypto::ed25519::{ed25519_keygen, ed25519_sign};
-
-    pub(crate) fn build_certificate(certs: &[&[u8]]) -> Vec<u8> {
-        let mut list = Vec::new();
-        for c in certs {
-            list.extend_from_slice(&(*c).len().to_be_bytes()[5..]); // u24
-            list.extend_from_slice(c);
-            list.extend_from_slice(&[0, 0]); // no per-entry extensions
-        }
-        let mut body = Vec::new();
-        body.push(0); // empty certificate_request_context
-        body.extend_from_slice(&list.len().to_be_bytes()[5..]); // u24
-        body.extend_from_slice(&list);
-        let mut out = Vec::new();
-        HandshakeHeader {
-            msg_type: HandshakeType::Certificate,
-            length: body.len() as u32,
-        }
-        .encode(&mut out)
-        .unwrap();
-        out.extend_from_slice(&body);
-        out
-    }
-
-    fn build_cert_verify(scheme: u16, sig: &[u8]) -> Vec<u8> {
-        let mut body = Vec::new();
-        body.extend_from_slice(&scheme.to_be_bytes());
-        body.extend_from_slice(&(sig.len() as u16).to_be_bytes());
-        body.extend_from_slice(sig);
-        let mut out = Vec::new();
-        HandshakeHeader {
-            msg_type: HandshakeType::CertificateVerify,
-            length: body.len() as u32,
-        }
-        .encode(&mut out)
-        .unwrap();
-        out.extend_from_slice(&body);
-        out
-    }
 
     #[test]
     fn certificate_round_trip() {

--- a/tls-client/src/handshake/certificate_msg.rs
+++ b/tls-client/src/handshake/certificate_msg.rs
@@ -1,0 +1,346 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Certificate and CertificateVerify message wire layer
+//! (RFC 8446 §4.4.2, §4.4.3).
+//!
+//! This module owns the *message* parsing and the
+//! CertificateVerify signature check. Chain construction and
+//! X.509 validation live behind the [`crate::cert`] verifier
+//! (Phase 5 of `tls-tcp-client-v1`); the handshake driver hands
+//! the raw DER blobs parsed here to that verifier.
+//!
+//! ```text
+//! struct {
+//!     opaque certificate_request_context<0..2^8-1>;
+//!     CertificateEntry certificate_list<0..2^24-1>;
+//! } Certificate;
+//!
+//! struct {
+//!     opaque cert_data<1..2^24-1>;
+//!     Extension extensions<0..2^16-1>;
+//! } CertificateEntry;
+//!
+//! struct {
+//!     SignatureScheme algorithm;
+//!     opaque signature<0..2^16-1>;
+//! } CertificateVerify;
+//! ```
+
+use super::extensions::sig_scheme;
+use super::{HandshakeHeader, HandshakeType};
+use crate::{Result, TlsClientError};
+use alloc::vec::Vec;
+use smallaios_security::crypto::ed25519::{ed25519_verify, Ed25519PublicKey, Ed25519Signature};
+
+/// Parsed Certificate message: the server's chain, leaf first,
+/// as raw DER blobs.
+#[derive(Debug, Clone)]
+pub struct CertificateMsg {
+    pub certs: Vec<Vec<u8>>,
+}
+
+/// Parse a Certificate message starting at its handshake header.
+///
+/// The `certificate_request_context` MUST be empty for
+/// server-initiated authentication (RFC 8446 §4.4.2) — we never
+/// send post-handshake CertificateRequest, so any non-empty
+/// context is refused.
+pub fn parse_certificate(buf: &[u8]) -> Result<CertificateMsg> {
+    let header = HandshakeHeader::parse(buf)?;
+    if header.msg_type != HandshakeType::Certificate {
+        return Err(TlsClientError::BadHandshake);
+    }
+    let body_start = HandshakeHeader::LEN;
+    let body_end = body_start + header.length as usize;
+    if buf.len() < body_end {
+        return Err(TlsClientError::BadHandshake);
+    }
+    let body = &buf[body_start..body_end];
+
+    if body.is_empty() {
+        return Err(TlsClientError::BadHandshake);
+    }
+    let ctx_len = body[0] as usize;
+    if ctx_len != 0 {
+        return Err(TlsClientError::BadHandshake);
+    }
+    let mut cur = 1;
+
+    if cur + 3 > body.len() {
+        return Err(TlsClientError::BadHandshake);
+    }
+    let list_len = u32::from_be_bytes([0, body[cur], body[cur + 1], body[cur + 2]]) as usize;
+    cur += 3;
+    if cur + list_len != body.len() {
+        return Err(TlsClientError::BadHandshake);
+    }
+
+    let mut certs = Vec::new();
+    let list_end = cur + list_len;
+    while cur < list_end {
+        if cur + 3 > list_end {
+            return Err(TlsClientError::BadHandshake);
+        }
+        let cert_len = u32::from_be_bytes([0, body[cur], body[cur + 1], body[cur + 2]]) as usize;
+        cur += 3;
+        if cert_len == 0 || cur + cert_len > list_end {
+            return Err(TlsClientError::BadHandshake);
+        }
+        certs.push(body[cur..cur + cert_len].to_vec());
+        cur += cert_len;
+        // Per-entry extensions (e.g. OCSP staple) — length-check
+        // and skip; v1 consumes none of them.
+        if cur + 2 > list_end {
+            return Err(TlsClientError::BadHandshake);
+        }
+        let ext_len = u16::from_be_bytes([body[cur], body[cur + 1]]) as usize;
+        cur += 2;
+        if cur + ext_len > list_end {
+            return Err(TlsClientError::BadHandshake);
+        }
+        cur += ext_len;
+    }
+    if certs.is_empty() {
+        // An empty certificate_list from the server means it has
+        // no certificate — fatal for server auth.
+        return Err(TlsClientError::BadCertificate);
+    }
+    Ok(CertificateMsg { certs })
+}
+
+/// Parsed CertificateVerify message.
+#[derive(Debug, Clone)]
+pub struct CertificateVerifyMsg {
+    pub scheme: u16,
+    pub signature: Vec<u8>,
+}
+
+/// Signature schemes the client accepts in CertificateVerify, per
+/// the `tls-client-handshake` spec allow-list. Everything else —
+/// in particular every SHA-1 suite (`rsa_pkcs1_sha1` 0x0201,
+/// `ecdsa_sha1` 0x0203) and `dsa_*` — is refused with
+/// `BadCertificate`.
+pub const CERT_VERIFY_ALLOW_LIST: [u16; 5] = [
+    sig_scheme::ED25519,
+    sig_scheme::ECDSA_SECP256R1_SHA256,
+    sig_scheme::RSA_PSS_RSAE_SHA256,
+    sig_scheme::RSA_PSS_RSAE_SHA384,
+    sig_scheme::RSA_PSS_RSAE_SHA512,
+];
+
+/// Parse a CertificateVerify message starting at its handshake
+/// header, enforcing the signature-scheme allow-list.
+pub fn parse_certificate_verify(buf: &[u8]) -> Result<CertificateVerifyMsg> {
+    let header = HandshakeHeader::parse(buf)?;
+    if header.msg_type != HandshakeType::CertificateVerify {
+        return Err(TlsClientError::BadHandshake);
+    }
+    let body_start = HandshakeHeader::LEN;
+    let body_end = body_start + header.length as usize;
+    if buf.len() < body_end {
+        return Err(TlsClientError::BadHandshake);
+    }
+    let body = &buf[body_start..body_end];
+    if body.len() < 4 {
+        return Err(TlsClientError::BadHandshake);
+    }
+    let scheme = u16::from_be_bytes([body[0], body[1]]);
+    if !CERT_VERIFY_ALLOW_LIST.contains(&scheme) {
+        return Err(TlsClientError::BadCertificate);
+    }
+    let sig_len = u16::from_be_bytes([body[2], body[3]]) as usize;
+    if 4 + sig_len != body.len() {
+        return Err(TlsClientError::BadHandshake);
+    }
+    Ok(CertificateVerifyMsg {
+        scheme,
+        signature: body[4..].to_vec(),
+    })
+}
+
+/// Build the content the server signs in CertificateVerify
+/// (RFC 8446 §4.4.3): 64 spaces, the context string, one zero
+/// byte, then Transcript-Hash(CH..Certificate).
+pub fn certificate_verify_content(transcript_hash: &[u8]) -> Vec<u8> {
+    let mut content = Vec::with_capacity(64 + 33 + 1 + transcript_hash.len());
+    content.extend_from_slice(&[0x20u8; 64]);
+    content.extend_from_slice(b"TLS 1.3, server CertificateVerify");
+    content.push(0);
+    content.extend_from_slice(transcript_hash);
+    content
+}
+
+/// Verify a CertificateVerify signature against the leaf's
+/// public key and the transcript hash at the Certificate message
+/// (task 4.7's signature step).
+///
+/// Only `ed25519` is verifiable today — ECDSA-P256 and RSA-PSS
+/// primitives are deferred to their own `security/` sub-adds
+/// (tasks 5.5 note). A chain whose leaf needs one of those
+/// surfaces `BadCertificate` rather than silently passing.
+pub fn verify_certificate_verify(
+    msg: &CertificateVerifyMsg,
+    leaf_pubkey_ed25519: &[u8; 32],
+    transcript_hash: &[u8],
+) -> Result<()> {
+    if msg.scheme != sig_scheme::ED25519 {
+        return Err(TlsClientError::BadCertificate);
+    }
+    if msg.signature.len() != 64 {
+        return Err(TlsClientError::BadCertificate);
+    }
+    let content = certificate_verify_content(transcript_hash);
+    let pk = Ed25519PublicKey::from_bytes(*leaf_pubkey_ed25519);
+    let mut sig = [0u8; 64];
+    sig.copy_from_slice(&msg.signature);
+    ed25519_verify(&pk, &content, &Ed25519Signature::from_bytes(sig))
+        .map_err(|_| TlsClientError::BadCertificate)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use smallaios_security::crypto::ed25519::{ed25519_keygen, ed25519_sign};
+
+    pub(crate) fn build_certificate(certs: &[&[u8]]) -> Vec<u8> {
+        let mut list = Vec::new();
+        for c in certs {
+            list.extend_from_slice(&(*c).len().to_be_bytes()[5..]); // u24
+            list.extend_from_slice(c);
+            list.extend_from_slice(&[0, 0]); // no per-entry extensions
+        }
+        let mut body = Vec::new();
+        body.push(0); // empty certificate_request_context
+        body.extend_from_slice(&list.len().to_be_bytes()[5..]); // u24
+        body.extend_from_slice(&list);
+        let mut out = Vec::new();
+        HandshakeHeader {
+            msg_type: HandshakeType::Certificate,
+            length: body.len() as u32,
+        }
+        .encode(&mut out)
+        .unwrap();
+        out.extend_from_slice(&body);
+        out
+    }
+
+    fn build_cert_verify(scheme: u16, sig: &[u8]) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(&scheme.to_be_bytes());
+        body.extend_from_slice(&(sig.len() as u16).to_be_bytes());
+        body.extend_from_slice(sig);
+        let mut out = Vec::new();
+        HandshakeHeader {
+            msg_type: HandshakeType::CertificateVerify,
+            length: body.len() as u32,
+        }
+        .encode(&mut out)
+        .unwrap();
+        out.extend_from_slice(&body);
+        out
+    }
+
+    #[test]
+    fn certificate_round_trip() {
+        let bytes = build_certificate(&[b"leaf-der-bytes", b"intermediate-der"]);
+        let msg = parse_certificate(&bytes).unwrap();
+        assert_eq!(msg.certs.len(), 2);
+        assert_eq!(msg.certs[0], b"leaf-der-bytes");
+        assert_eq!(msg.certs[1], b"intermediate-der");
+    }
+
+    #[test]
+    fn certificate_empty_list_rejected() {
+        assert_eq!(
+            parse_certificate(&build_certificate(&[])).unwrap_err(),
+            TlsClientError::BadCertificate
+        );
+    }
+
+    #[test]
+    fn certificate_nonempty_context_rejected() {
+        let mut bytes = build_certificate(&[b"leaf"]);
+        // context length byte sits right after the 4-byte header;
+        // claim 1 byte of context.
+        bytes[4] = 1;
+        assert!(parse_certificate(&bytes).is_err());
+    }
+
+    #[test]
+    fn certificate_truncated_rejected() {
+        let bytes = build_certificate(&[b"leaf-der-bytes"]);
+        for cut in [5, 8, 12, bytes.len() - 1] {
+            assert!(parse_certificate(&bytes[..cut]).is_err(), "cut={cut}");
+        }
+    }
+
+    #[test]
+    fn cert_verify_round_trip_ed25519() {
+        let sig = [0xabu8; 64];
+        let msg = parse_certificate_verify(&build_cert_verify(sig_scheme::ED25519, &sig)).unwrap();
+        assert_eq!(msg.scheme, sig_scheme::ED25519);
+        assert_eq!(msg.signature, sig);
+    }
+
+    #[test]
+    fn cert_verify_sha1_schemes_rejected() {
+        // rsa_pkcs1_sha1 (0x0201), ecdsa_sha1 (0x0203) — the spec's
+        // "SHA-1 signature refused" scenario.
+        for scheme in [0x0201u16, 0x0203, 0x0202 /* dsa_sha1 */] {
+            assert_eq!(
+                parse_certificate_verify(&build_cert_verify(scheme, &[0u8; 64])).unwrap_err(),
+                TlsClientError::BadCertificate,
+                "scheme {scheme:#06x}"
+            );
+        }
+    }
+
+    #[test]
+    fn cert_verify_rsa_pss_parses() {
+        // Allow-listed schemes parse fine (verification of non-Ed25519
+        // schemes is a Phase 5 follow-on).
+        for scheme in [
+            sig_scheme::RSA_PSS_RSAE_SHA256,
+            sig_scheme::RSA_PSS_RSAE_SHA384,
+            sig_scheme::RSA_PSS_RSAE_SHA512,
+            sig_scheme::ECDSA_SECP256R1_SHA256,
+        ] {
+            assert!(parse_certificate_verify(&build_cert_verify(scheme, &[0u8; 96])).is_ok());
+        }
+    }
+
+    #[test]
+    fn cert_verify_signature_verifies() {
+        let kp = ed25519_keygen(&[7u8; 32]);
+        let transcript_hash = [0x44u8; 32];
+        let content = certificate_verify_content(&transcript_hash);
+        let sig = ed25519_sign(&kp.secret_key, &content);
+        let msg = parse_certificate_verify(&build_cert_verify(sig_scheme::ED25519, sig.as_bytes()))
+            .unwrap();
+        verify_certificate_verify(&msg, kp.public_key.as_bytes(), &transcript_hash).unwrap();
+    }
+
+    #[test]
+    fn cert_verify_wrong_transcript_rejected() {
+        let kp = ed25519_keygen(&[7u8; 32]);
+        let content = certificate_verify_content(&[0x44u8; 32]);
+        let sig = ed25519_sign(&kp.secret_key, &content);
+        let msg = parse_certificate_verify(&build_cert_verify(sig_scheme::ED25519, sig.as_bytes()))
+            .unwrap();
+        assert_eq!(
+            verify_certificate_verify(&msg, kp.public_key.as_bytes(), &[0x45u8; 32]).unwrap_err(),
+            TlsClientError::BadCertificate
+        );
+    }
+
+    #[test]
+    fn cert_verify_content_layout() {
+        let content = certificate_verify_content(&[0xaa; 32]);
+        assert_eq!(content.len(), 64 + 33 + 1 + 32);
+        assert!(content[..64].iter().all(|&b| b == 0x20));
+        assert_eq!(&content[64..97], b"TLS 1.3, server CertificateVerify");
+        assert_eq!(content[97], 0);
+        assert_eq!(&content[98..], &[0xaa; 32]);
+    }
+}

--- a/tls-client/src/handshake/driver.rs
+++ b/tls-client/src/handshake/driver.rs
@@ -627,100 +627,23 @@ mod tests {
         build_server_hello_custom(suite.wire_value(), Some(TLS_1_3), group, share, [0xaa; 32])
     }
 
-    fn build_server_hello_custom(
-        suite_code: u16,
-        version: Option<u16>,
-        group: u16,
-        share: &[u8],
-        random: [u8; 32],
-    ) -> Vec<u8> {
-        let mut body = Vec::new();
-        body.extend_from_slice(&[0x03, 0x03]);
-        body.extend_from_slice(&random);
-        body.push(0); // empty session_id_echo
-        body.extend_from_slice(&suite_code.to_be_bytes());
-        body.push(0); // compression
-        let mut exts = Vec::new();
-        if let Some(v) = version {
-            exts.extend_from_slice(&ext_type::SUPPORTED_VERSIONS.to_be_bytes());
-            exts.extend_from_slice(&2u16.to_be_bytes());
-            exts.extend_from_slice(&v.to_be_bytes());
-        }
-        let mut ks = Vec::new();
-        ks.extend_from_slice(&group.to_be_bytes());
-        ks.extend_from_slice(&(share.len() as u16).to_be_bytes());
-        ks.extend_from_slice(share);
-        exts.extend_from_slice(&ext_type::KEY_SHARE.to_be_bytes());
-        exts.extend_from_slice(&(ks.len() as u16).to_be_bytes());
-        exts.extend_from_slice(&ks);
-        body.extend_from_slice(&(exts.len() as u16).to_be_bytes());
-        body.extend_from_slice(&exts);
-        let mut out = Vec::new();
-        HandshakeHeader {
-            msg_type: HandshakeType::ServerHello,
-            length: body.len() as u32,
-        }
-        .encode(&mut out)
-        .unwrap();
-        out.extend_from_slice(&body);
-        out
-    }
+    use crate::handshake::test_util::build_certificate as build_certificate_raw;
+    use crate::handshake::test_util::build_server_hello as build_server_hello_custom;
+    use crate::handshake::test_util::{build_certificate_verify, build_encrypted_extensions};
 
     fn build_ee_msg() -> Vec<u8> {
         // EncryptedExtensions with an SNI ack.
-        let mut block = Vec::new();
-        block.extend_from_slice(&ext_type::SERVER_NAME.to_be_bytes());
-        block.extend_from_slice(&0u16.to_be_bytes());
-        let mut body = Vec::new();
-        body.extend_from_slice(&(block.len() as u16).to_be_bytes());
-        body.extend_from_slice(&block);
-        let mut out = Vec::new();
-        HandshakeHeader {
-            msg_type: HandshakeType::EncryptedExtensions,
-            length: body.len() as u32,
-        }
-        .encode(&mut out)
-        .unwrap();
-        out.extend_from_slice(&body);
-        out
+        build_encrypted_extensions(&[(ext_type::SERVER_NAME, &[])])
     }
 
     fn build_certificate_msg(leaf: &[u8]) -> Vec<u8> {
-        let mut list = Vec::new();
-        list.extend_from_slice(&(leaf.len() as u32).to_be_bytes()[1..]);
-        list.extend_from_slice(leaf);
-        list.extend_from_slice(&[0, 0]);
-        let mut body = Vec::new();
-        body.push(0);
-        body.extend_from_slice(&(list.len() as u32).to_be_bytes()[1..]);
-        body.extend_from_slice(&list);
-        let mut out = Vec::new();
-        HandshakeHeader {
-            msg_type: HandshakeType::Certificate,
-            length: body.len() as u32,
-        }
-        .encode(&mut out)
-        .unwrap();
-        out.extend_from_slice(&body);
-        out
+        build_certificate_raw(&[leaf])
     }
 
     fn build_cv_msg(kp: &Ed25519KeyPair, transcript_hash: &[u8]) -> Vec<u8> {
         let content = certificate_verify_content(transcript_hash);
         let sig = ed25519_sign(&kp.secret_key, &content);
-        let mut body = Vec::new();
-        body.extend_from_slice(&sig_scheme::ED25519.to_be_bytes());
-        body.extend_from_slice(&64u16.to_be_bytes());
-        body.extend_from_slice(sig.as_bytes());
-        let mut out = Vec::new();
-        HandshakeHeader {
-            msg_type: HandshakeType::CertificateVerify,
-            length: body.len() as u32,
-        }
-        .encode(&mut out)
-        .unwrap();
-        out.extend_from_slice(&body);
-        out
+        build_certificate_verify(sig_scheme::ED25519, sig.as_bytes())
     }
 
     /// Everything the server produced for its flight, plus the
@@ -1145,14 +1068,10 @@ mod tests {
         // CertificateRequest: context len 0 + empty extensions.
         let mut cr_body = alloc::vec![0u8];
         cr_body.extend_from_slice(&0u16.to_be_bytes());
-        let mut cr = Vec::new();
-        HandshakeHeader {
-            msg_type: HandshakeType::CertificateRequest,
-            length: cr_body.len() as u32,
-        }
-        .encode(&mut cr)
-        .unwrap();
-        cr.extend_from_slice(&cr_body);
+        let cr = crate::handshake::test_util::wrap_handshake(
+            HandshakeType::CertificateRequest,
+            &cr_body,
+        );
         let mut payload = ee;
         payload.extend_from_slice(&cr);
         records.extend_from_slice(

--- a/tls-client/src/handshake/driver.rs
+++ b/tls-client/src/handshake/driver.rs
@@ -59,6 +59,24 @@ pub(crate) const HRR_RANDOM: [u8; 32] = [
     0xc2, 0xa2, 0x11, 0x16, 0x7a, 0xbb, 0x8c, 0x5e, 0x07, 0x9e, 0x09, 0xe2, 0xc8, 0xa8, 0x33, 0x9c,
 ];
 
+/// Maximum number of unencrypted middlebox-compatibility
+/// ChangeCipherSpec records tolerated per handshake (RFC 8446 §5
+/// says drop them; we additionally bound how much of that junk we
+/// tolerate so a peer cannot stream CCS records indefinitely).
+const MAX_CCS_RECORDS: u8 = 2;
+
+/// Cap on the claimed 24-bit length of a Certificate message.
+/// Real chains can be tens of KiB (several certificates plus
+/// per-entry extensions), so this cap is generous.
+const MAX_CERTIFICATE_MSG_LEN: usize = 128 * 1024;
+
+/// Cap on the claimed 24-bit length of every other handshake
+/// message. ServerHello/EncryptedExtensions/CertificateVerify/
+/// Finished are all well under a few KiB in practice; 32 KiB
+/// leaves slack without letting a forged header pin multiple
+/// records' worth of heap (see `drain_messages`).
+const MAX_HANDSHAKE_MSG_LEN: usize = 32 * 1024;
+
 /// Operator-facing handshake policy (subset of the `immudb.toml`
 /// `tls.*` surface that Phase 4 consumes).
 #[derive(Debug, Clone, Copy)]
@@ -145,6 +163,9 @@ pub struct ClientHandshake<'a, V: ServerCertVerifier> {
     /// Server handshake-traffic keys + record sequence number.
     server_keys: Option<TrafficKeys>,
     read_seq: u64,
+    /// Unencrypted CCS records seen so far (bounded by
+    /// [`MAX_CCS_RECORDS`]).
+    ccs_count: u8,
     /// Leaf public key returned by the chain verifier.
     leaf_key: Option<LeafPublicKey>,
     /// Transcript-Hash(CH..Certificate) for CertificateVerify.
@@ -215,6 +236,7 @@ impl<'a, V: ServerCertVerifier> ClientHandshake<'a, V> {
                 schedule: None,
                 server_keys: None,
                 read_seq: 0,
+                ccs_count: 0,
                 leaf_key: None,
                 hash_at_cert: Vec::new(),
                 hash_at_cv: Vec::new(),
@@ -316,8 +338,21 @@ impl<'a, V: ServerCertVerifier> ClientHandshake<'a, V> {
         match header.content_type {
             // Middlebox-compatibility ChangeCipherSpec — RFC 8446
             // §5: drop unencrypted CCS received during the
-            // handshake.
-            ContentType::ChangeCipherSpec => Ok(()),
+            // handshake, but only the genuine compatibility form
+            // (exactly one payload byte, value 0x01); any other
+            // length or value is a protocol violation. Tolerance is
+            // also capped at MAX_CCS_RECORDS so a peer cannot
+            // stream junk CCS records at us indefinitely.
+            ContentType::ChangeCipherSpec => {
+                if record[RECORD_HEADER_LEN..] != [0x01] {
+                    return Err(TlsClientError::BadHandshake);
+                }
+                self.ccs_count += 1;
+                if self.ccs_count > MAX_CCS_RECORDS {
+                    return Err(TlsClientError::BadHandshake);
+                }
+                Ok(())
+            }
             ContentType::Alert if self.server_keys.is_none() => {
                 // Plaintext alert during the first flight (e.g.
                 // handshake_failure). Surface as handshake failure.
@@ -325,6 +360,15 @@ impl<'a, V: ServerCertVerifier> ClientHandshake<'a, V> {
             }
             ContentType::Handshake if self.server_keys.is_none() => {
                 // Plaintext handshake record (ServerHello flight).
+                //
+                // Deliberate deviation, on record: RFC 8446 §5.1
+                // says receivers MUST NOT pay attention to
+                // legacy_record_version ("MUST be ignored for all
+                // purposes"), but no conformant TLS 1.3 peer sends
+                // anything other than 0x0303 here, so we pin it
+                // defensively and reject everything else — it
+                // shrinks the unauthenticated parsing surface at
+                // zero interop cost.
                 header.enforce_legacy_version()?;
                 self.hs_buf.extend_from_slice(&record[RECORD_HEADER_LEN..]);
                 Ok(())
@@ -358,6 +402,21 @@ impl<'a, V: ServerCertVerifier> ClientHandshake<'a, V> {
                 return Ok(());
             }
             let header = HandshakeHeader::parse(&self.hs_buf)?;
+            // DoS bound: cap the claimed 24-bit length BEFORE the
+            // reassembly buffer is allowed to grow toward it. A
+            // forged header can claim up to 16 MiB and would
+            // otherwise make us accumulate records on the no_std
+            // kernel heap during the unauthenticated phase.
+            // Certificate is the only legitimately large message
+            // (a real chain can be tens of KiB), so it gets a
+            // wider cap than everything else.
+            let cap = match header.msg_type {
+                HandshakeType::Certificate => MAX_CERTIFICATE_MSG_LEN,
+                _ => MAX_HANDSHAKE_MSG_LEN,
+            };
+            if header.length as usize > cap {
+                return Err(TlsClientError::BadHandshake);
+            }
             let total = HandshakeHeader::LEN + header.length as usize;
             if self.hs_buf.len() < total {
                 return Ok(());
@@ -423,6 +482,25 @@ impl<'a, V: ServerCertVerifier> ClientHandshake<'a, V> {
 
     fn on_server_hello(&mut self, msg: &[u8]) -> Result<()> {
         let sh = parse_server_hello(msg)?;
+        // RFC 8446 §4.1.3: legacy_session_id_echo MUST echo the
+        // ClientHello's legacy_session_id, and a client MUST abort
+        // on a mismatch. This client always sends an EMPTY
+        // legacy_session_id (see client_hello.rs), so any non-empty
+        // echo is a violation.
+        if !sh.session_id_echo.is_empty() {
+            return Err(TlsClientError::BadHandshake);
+        }
+        // Downgrade-sentinel note: the RFC 8446 §4.1.3 "DOWNGRD"
+        // check on the last 8 bytes of ServerHello.random protects
+        // clients that are willing to negotiate TLS 1.2 or below.
+        // It is deliberately omitted here: this client pins
+        // supported_versions to 0x0304 (parse_server_hello aborts
+        // on anything else) and never offers a lower version, which
+        // structurally subsumes the sentinel check — a downgraded
+        // ServerHello cannot get past the version pinning. Anyone
+        // adding TLS 1.2 fallback later MUST add the sentinel check
+        // here.
+        //
         // HelloRetryRequest is a ServerHello whose random is the
         // fixed SHA-256("HelloRetryRequest") sentinel — refused in
         // v1 (design.md D7).
@@ -487,6 +565,15 @@ impl<'a, V: ServerCertVerifier> ClientHandshake<'a, V> {
         self.suite = Some(sh.cipher_suite);
         self.transcript = Some(transcript);
         self.schedule = Some(schedule);
+        // RFC 8446 §5.1 key-change boundary: ServerHello is the
+        // last plaintext handshake message — everything after it
+        // travels under the handshake keys just installed. Any
+        // bytes still sitting in the reassembly buffer arrived in
+        // plaintext records coalesced past the ServerHello and must
+        // not be processed as if they had been protected.
+        if !self.hs_buf.is_empty() {
+            return Err(TlsClientError::BadHandshake);
+        }
         self.state = State::ExpectEncryptedExtensions;
         Ok(())
     }
@@ -529,6 +616,16 @@ impl<'a, V: ServerCertVerifier> ClientHandshake<'a, V> {
             &fin_msg,
         )?;
         send.extend_from_slice(&sealed);
+        // Same RFC 8446 §5.1 key-change rule at the handshake's
+        // end: the server Finished closes the handshake key epoch.
+        // Leftover bytes in the reassembly buffer (e.g. junk
+        // coalesced into the Finished record) would otherwise be
+        // silently retained across the boundary — post-handshake
+        // messages must arrive in their own records under the
+        // application keys.
+        if !self.hs_buf.is_empty() {
+            return Err(TlsClientError::BadHandshake);
+        }
         self.state = State::Complete;
         Ok(())
     }
@@ -657,11 +754,16 @@ mod tests {
 
     /// Run the server side: consume the ClientHello record, emit
     /// SH + encrypted {EE+Cert} {CV} {Fin} records.
+    ///
+    /// `junk_after_finished` coalesces trailing bytes into the
+    /// Finished record — they land beyond the RFC 8446 §5.1
+    /// key-change boundary and must abort the client.
     fn server_respond(
         ch_record: &[u8],
         suite: CipherSuite,
         cert_kp: &Ed25519KeyPair,
         tamper_finished: bool,
+        junk_after_finished: bool,
     ) -> ServerFlight {
         let ch_msg = &ch_record[RECORD_HEADER_LEN..];
         let (group, client_share) = parse_ch_key_share(ch_msg);
@@ -748,7 +850,11 @@ mod tests {
         }
         let fin_msg = build_finished(&vd).unwrap();
         transcript.update(&fin_msg);
-        records.extend_from_slice(&seal_hs(&fin_msg, &mut seq));
+        let mut fin_payload = fin_msg;
+        if junk_after_finished {
+            fin_payload.extend_from_slice(&[0u8; 7]);
+        }
+        records.extend_from_slice(&seal_hs(&fin_payload, &mut seq));
 
         ServerFlight {
             records,
@@ -782,7 +888,7 @@ mod tests {
         )
         .unwrap();
 
-        let mut server = server_respond(&flight, suite, &cert_kp, false);
+        let mut server = server_respond(&flight, suite, &cert_kp, false, false);
 
         // Feed the server flight to the client — all at once, or
         // byte-by-byte to exercise the reassembly paths.
@@ -962,6 +1068,7 @@ mod tests {
             CipherSuite::ChaCha20Poly1305Sha256,
             &cert_kp,
             true, // tamper the Finished verify_data
+            false,
         );
         assert_eq!(
             client.push(&server.records).unwrap_err(),
@@ -986,6 +1093,7 @@ mod tests {
             &flight,
             CipherSuite::ChaCha20Poly1305Sha256,
             &cert_kp,
+            false,
             false,
         );
         assert_eq!(
@@ -1017,6 +1125,7 @@ mod tests {
             &flight,
             CipherSuite::ChaCha20Poly1305Sha256,
             &cert_kp,
+            false,
             false,
         );
         assert_eq!(
@@ -1112,6 +1221,7 @@ mod tests {
             CipherSuite::ChaCha20Poly1305Sha256,
             &cert_kp,
             false,
+            false,
         );
         // Inject a middlebox-compat CCS record between the
         // ServerHello and the encrypted flight.
@@ -1128,5 +1238,147 @@ mod tests {
     fn app_keys_gated_until_complete() {
         let (client, _flight) = start_classical();
         assert!(client.app_keys().is_err());
+    }
+
+    /// A valid classical ServerHello message answering
+    /// `start_classical`'s ClientHello (any well-formed x25519
+    /// public key works — the client just runs DH with it).
+    fn classical_server_hello_msg() -> Vec<u8> {
+        let x = x25519_keygen(&[0x55u8; 32]);
+        build_server_hello_msg(
+            CipherSuite::ChaCha20Poly1305Sha256,
+            named_group::X25519,
+            x.public_key.as_bytes(),
+        )
+    }
+
+    #[test]
+    fn plaintext_bytes_coalesced_after_server_hello_abort() {
+        // RFC 8446 §5.1 key-change boundary: one PLAINTEXT record
+        // carrying ServerHello || EncryptedExtensions. The EE bytes
+        // sit on the wrong side of the key change and must not be
+        // processed as if they had been encrypted.
+        let (mut client, _flight) = start_classical();
+        let mut payload = classical_server_hello_msg();
+        payload.extend_from_slice(&build_ee_msg());
+        let rec = build_plaintext_record(ContentType::Handshake, &payload).unwrap();
+        assert_eq!(client.push(&rec).unwrap_err(), TlsClientError::BadHandshake);
+    }
+
+    #[test]
+    fn leftover_bytes_at_server_finished_abort() {
+        // Junk coalesced into the (encrypted) server Finished
+        // record must abort instead of being silently retained
+        // across the handshake-end key boundary.
+        let cert_kp = ed25519_keygen(&[9u8; 32]);
+        let verifier = TestVerifier {
+            expected_leaf: LEAF_DER,
+            pubkey: *cert_kp.public_key.as_bytes(),
+        };
+        let (mut client, flight) = ClientHandshake::new(
+            ClientConfig {
+                server_name: Some("immudb.example.com"),
+                require_pqc: false,
+            },
+            &entropy(),
+            &verifier,
+        )
+        .unwrap();
+        let server = server_respond(
+            &flight,
+            CipherSuite::ChaCha20Poly1305Sha256,
+            &cert_kp,
+            false,
+            true, // coalesce junk bytes after Finished
+        );
+        assert_eq!(
+            client.push(&server.records).unwrap_err(),
+            TlsClientError::BadHandshake
+        );
+    }
+
+    #[test]
+    fn non_empty_session_id_echo_aborts() {
+        // RFC 8446 §4.1.3: the echo must match our (always empty)
+        // legacy_session_id.
+        let (mut client, _flight) = start_classical();
+        let x = x25519_keygen(&[0x55u8; 32]);
+        let sh = crate::handshake::test_util::build_server_hello_with_session_id(
+            CipherSuite::ChaCha20Poly1305Sha256.wire_value(),
+            Some(TLS_1_3),
+            named_group::X25519,
+            x.public_key.as_bytes(),
+            [0xaa; 32],
+            &[0xde, 0xad, 0xbe, 0xef],
+        );
+        let rec = build_plaintext_record(ContentType::Handshake, &sh).unwrap();
+        assert_eq!(client.push(&rec).unwrap_err(), TlsClientError::BadHandshake);
+    }
+
+    #[test]
+    fn ccs_with_wrong_payload_byte_aborts() {
+        // RFC 8446 §5: the compat CCS is exactly one 0x01 byte.
+        let (mut client, _flight) = start_classical();
+        assert_eq!(
+            client.push(&[20, 0x03, 0x03, 0, 1, 2]).unwrap_err(),
+            TlsClientError::BadHandshake
+        );
+    }
+
+    #[test]
+    fn ccs_with_wrong_length_aborts() {
+        let (mut client, _flight) = start_classical();
+        assert_eq!(
+            client.push(&[20, 0x03, 0x03, 0, 2, 1, 1]).unwrap_err(),
+            TlsClientError::BadHandshake
+        );
+    }
+
+    #[test]
+    fn ccs_flood_aborts() {
+        let (mut client, _flight) = start_classical();
+        // Up to MAX_CCS_RECORDS well-formed CCS records are
+        // dropped per RFC 8446 §5...
+        for _ in 0..MAX_CCS_RECORDS {
+            client.push(&[20, 0x03, 0x03, 0, 1, 1]).unwrap();
+        }
+        // ...but the junk tolerance is bounded.
+        assert_eq!(
+            client.push(&[20, 0x03, 0x03, 0, 1, 1]).unwrap_err(),
+            TlsClientError::BadHandshake
+        );
+    }
+
+    #[test]
+    fn oversized_handshake_length_claim_aborts() {
+        // A ServerHello header claiming 2^24 - 1 bytes is rejected
+        // from the 4 header bytes alone — the driver never
+        // accumulates records toward the bogus claim.
+        let (mut client, _flight) = start_classical();
+        let rec = build_plaintext_record(ContentType::Handshake, &[2, 0xff, 0xff, 0xff]).unwrap();
+        assert_eq!(client.push(&rec).unwrap_err(), TlsClientError::BadHandshake);
+    }
+
+    #[test]
+    fn certificate_length_cap_wider_but_enforced() {
+        // Certificate (type 11) gets the wider cap; one byte over
+        // it still aborts.
+        let (mut client, _flight) = start_classical();
+        let over = ((MAX_CERTIFICATE_MSG_LEN + 1) as u32).to_be_bytes();
+        let rec = build_plaintext_record(ContentType::Handshake, &[11, over[1], over[2], over[3]])
+            .unwrap();
+        assert_eq!(client.push(&rec).unwrap_err(), TlsClientError::BadHandshake);
+
+        // A claim at the cap is not rejected at the header stage —
+        // the driver just waits for the rest of the message.
+        let (mut client2, _flight2) = start_classical();
+        let at_cap = (MAX_CERTIFICATE_MSG_LEN as u32).to_be_bytes();
+        let rec2 = build_plaintext_record(
+            ContentType::Handshake,
+            &[11, at_cap[1], at_cap[2], at_cap[3]],
+        )
+        .unwrap();
+        let p = client2.push(&rec2).unwrap();
+        assert_eq!(p.status, HandshakeStatus::InProgress);
     }
 }

--- a/tls-client/src/handshake/driver.rs
+++ b/tls-client/src/handshake/driver.rs
@@ -1,0 +1,1213 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Client handshake state machine (RFC 8446 §4) — Phase 4 of
+//! `tls-tcp-client-v1`, design.md D7.
+//!
+//! The driver is a synchronous, I/O-free state machine. The
+//! integration layer (Phase 7's `TcpTlsStream`) owns the socket:
+//! it sends [`ClientHandshake::new`]'s initial flight, then feeds
+//! every received byte through [`ClientHandshake::push`] and
+//! writes back whatever bytes `push` returns, until the status
+//! turns [`HandshakeStatus::Complete`]. No `async`, no executor.
+//!
+//! ```text
+//! ExpectServerHello ──► ExpectEncryptedExtensions ──►
+//! ExpectCertificate ──► ExpectCertificateVerify ──►
+//! ExpectFinished ──► Complete
+//! ```
+//!
+//! Refused mid-handshake (v1 scope): HelloRetryRequest (D7),
+//! CertificateRequest (no mTLS — see proposal §"No mTLS in v1"),
+//! TLS 1.2 selection anywhere (spec: version pinning).
+//!
+//! Certificate-chain validation is delegated through the
+//! [`ServerCertVerifier`] seam (`crate::cert`) — the wire parsing
+//! and CertificateVerify transcript-signature check happen here;
+//! X.509 structure/chain/hostname checks are Phase 5's
+//! `TrustStoreVerifier`.
+
+use super::certificate_msg::{
+    parse_certificate, parse_certificate_verify, verify_certificate_verify,
+};
+use super::client_hello::{build_client_hello, ClientHelloInput, ClientHelloKeyShare};
+use super::encrypted_extensions::parse_encrypted_extensions;
+use super::finished::{build_finished, check_verify_data, parse_finished};
+use super::key_schedule::{HashAlg, KeySchedule, TrafficKeys, TranscriptHash};
+use super::server_hello::parse_server_hello;
+use super::{extensions::named_group, HandshakeHeader, HandshakeType};
+use crate::cert::{LeafPublicKey, ServerCertVerifier};
+use crate::record::{
+    self, build_plaintext_record, CipherSuite, ContentType, RecordHeader, RECORD_HEADER_LEN,
+};
+use crate::{Result, TlsClientError};
+use alloc::vec::Vec;
+use smallaios_security::crypto::ml_kem::{
+    ml_kem_768_decaps, ml_kem_768_keygen, MlKemCiphertext, MlKemKeyPair, ML_KEM_768_CT_LEN,
+    ML_KEM_768_PK_LEN,
+};
+use smallaios_security::crypto::x25519::{
+    x25519_dh, x25519_keygen, X25519KeyPair, X25519PublicKey,
+};
+
+/// ServerHello.random sentinel that turns the message into a
+/// HelloRetryRequest (RFC 8446 §4.1.3) = SHA-256("HelloRetryRequest").
+/// v1 refuses HRR per design.md D7; a unit test pins this constant
+/// to the live SHA-256 implementation.
+pub(crate) const HRR_RANDOM: [u8; 32] = [
+    0xcf, 0x21, 0xad, 0x74, 0xe5, 0x9a, 0x61, 0x11, 0xbe, 0x1d, 0x8c, 0x02, 0x1e, 0x65, 0xb8, 0x91,
+    0xc2, 0xa2, 0x11, 0x16, 0x7a, 0xbb, 0x8c, 0x5e, 0x07, 0x9e, 0x09, 0xe2, 0xc8, 0xa8, 0x33, 0x9c,
+];
+
+/// Operator-facing handshake policy (subset of the `immudb.toml`
+/// `tls.*` surface that Phase 4 consumes).
+#[derive(Debug, Clone, Copy)]
+pub struct ClientConfig<'a> {
+    /// SNI hostname; `None` for IP-literal endpoints (RFC 6066 §3).
+    pub server_name: Option<&'a str>,
+    /// When true, offer X25519+ML-KEM-768 first and refuse a
+    /// classical reply with `PqcDowngrade` (design.md D3).
+    pub require_pqc: bool,
+}
+
+/// Caller-supplied entropy. The driver is `#![no_std]` and does not
+/// bake in a CSPRNG; the integration layer draws these from
+/// `security::crypto::csprng`.
+pub struct ClientEntropy {
+    /// ClientHello.random.
+    pub client_random: [u8; 32],
+    /// X25519 ephemeral key seed.
+    pub x25519_seed: [u8; 32],
+    /// ML-KEM-768 keypair seed — consumed only when `require_pqc`.
+    pub ml_kem_seed: [u8; 64],
+}
+
+/// Where the handshake stands after a `push` call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HandshakeStatus {
+    /// Keep reading from the peer and calling `push`.
+    InProgress,
+    /// Handshake done — application keys are available.
+    Complete,
+}
+
+/// Output of one `push` call.
+#[derive(Debug)]
+pub struct Push {
+    /// Bytes the integration layer must write to the socket
+    /// before reading further (empty when nothing to send).
+    pub send: Vec<u8>,
+    pub status: HandshakeStatus,
+}
+
+/// Application-traffic keys for the data phase, handed to the
+/// record loop once the handshake completes.
+pub struct AppKeys {
+    pub suite: CipherSuite,
+    pub client: TrafficKeys,
+    pub server: TrafficKeys,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum State {
+    ExpectServerHello,
+    ExpectEncryptedExtensions,
+    ExpectCertificate,
+    ExpectCertificateVerify,
+    ExpectFinished,
+    Complete,
+    Failed,
+}
+
+enum KeyExchange {
+    Classical(X25519KeyPair),
+    // Boxed: an ML-KEM-768 keypair is ~3.6 KiB.
+    Hybrid(X25519KeyPair, alloc::boxed::Box<MlKemKeyPair>),
+}
+
+/// The client-side handshake state machine.
+pub struct ClientHandshake<'a, V: ServerCertVerifier> {
+    state: State,
+    require_pqc: bool,
+    server_name: Option<&'a str>,
+    verifier: &'a V,
+    kx: KeyExchange,
+    /// Raw ClientHello message (transcript seed — the transcript
+    /// hash can only start once the ServerHello fixes the suite).
+    client_hello: Vec<u8>,
+    /// Unconsumed socket bytes.
+    inbuf: Vec<u8>,
+    /// Reassembly buffer for handshake messages spanning records.
+    hs_buf: Vec<u8>,
+    suite: Option<CipherSuite>,
+    transcript: Option<TranscriptHash>,
+    schedule: Option<KeySchedule>,
+    /// Server handshake-traffic keys + record sequence number.
+    server_keys: Option<TrafficKeys>,
+    read_seq: u64,
+    /// Leaf public key returned by the chain verifier.
+    leaf_key: Option<LeafPublicKey>,
+    /// Transcript-Hash(CH..Certificate) for CertificateVerify.
+    hash_at_cert: Vec<u8>,
+    /// Transcript-Hash(CH..CertificateVerify) for server Finished.
+    hash_at_cv: Vec<u8>,
+    sni_acked: bool,
+}
+
+impl<'a, V: ServerCertVerifier> ClientHandshake<'a, V> {
+    /// Start a handshake: returns the driver and the initial
+    /// flight (the ClientHello record) to write to the socket.
+    pub fn new(
+        config: ClientConfig<'a>,
+        entropy: &ClientEntropy,
+        verifier: &'a V,
+    ) -> Result<(Self, Vec<u8>)> {
+        let x25519 = x25519_keygen(&entropy.x25519_seed);
+        let (kx, groups, share): (KeyExchange, &[u16], Vec<u8>) = if config.require_pqc {
+            let ml_kem =
+                ml_kem_768_keygen(&entropy.ml_kem_seed).map_err(|_| TlsClientError::KeyExchange)?;
+            // draft-ietf-tls-ecdhe-mlkem X25519MLKEM768 ordering:
+            // ML-KEM-768 encapsulation key first, then X25519.
+            let mut share = Vec::with_capacity(ML_KEM_768_PK_LEN + 32);
+            share.extend_from_slice(ml_kem.public_key.as_bytes());
+            share.extend_from_slice(x25519.public_key.as_bytes());
+            (
+                KeyExchange::Hybrid(x25519, alloc::boxed::Box::new(ml_kem)),
+                &[named_group::X25519_MLKEM768, named_group::X25519],
+                share,
+            )
+        } else {
+            let share = x25519.public_key.as_bytes().to_vec();
+            (
+                KeyExchange::Classical(x25519),
+                &[named_group::X25519],
+                share,
+            )
+        };
+        let primary_group = groups[0];
+        let suites = [
+            CipherSuite::Aes256GcmSha384,
+            CipherSuite::ChaCha20Poly1305Sha256,
+        ];
+        let client_hello = build_client_hello(&ClientHelloInput {
+            random: entropy.client_random,
+            server_name: config.server_name,
+            cipher_suites: &suites,
+            supported_groups: groups,
+            key_share: ClientHelloKeyShare {
+                group: primary_group,
+                public_key: &share,
+            },
+        })?;
+        let flight = build_plaintext_record(ContentType::Handshake, &client_hello)?;
+        Ok((
+            Self {
+                state: State::ExpectServerHello,
+                require_pqc: config.require_pqc,
+                server_name: config.server_name,
+                verifier,
+                kx,
+                client_hello,
+                inbuf: Vec::new(),
+                hs_buf: Vec::new(),
+                suite: None,
+                transcript: None,
+                schedule: None,
+                server_keys: None,
+                read_seq: 0,
+                leaf_key: None,
+                hash_at_cert: Vec::new(),
+                hash_at_cv: Vec::new(),
+                sni_acked: false,
+            },
+            flight,
+        ))
+    }
+
+    /// Feed bytes received from the peer. Returns bytes to send
+    /// back (the client Finished flight, once the server flight
+    /// verifies) and the handshake status.
+    pub fn push(&mut self, incoming: &[u8]) -> Result<Push> {
+        if self.state == State::Failed {
+            return Err(TlsClientError::BadHandshake);
+        }
+        if self.state == State::Complete {
+            return Ok(Push {
+                send: Vec::new(),
+                status: HandshakeStatus::Complete,
+            });
+        }
+        self.inbuf.extend_from_slice(incoming);
+        let mut send = Vec::new();
+        let result = self.drain_records(&mut send);
+        if let Err(e) = result {
+            self.state = State::Failed;
+            return Err(e);
+        }
+        Ok(Push {
+            send,
+            status: if self.state == State::Complete {
+                HandshakeStatus::Complete
+            } else {
+                HandshakeStatus::InProgress
+            },
+        })
+    }
+
+    /// Negotiated cipher suite (after ServerHello).
+    pub fn suite(&self) -> Option<CipherSuite> {
+        self.suite
+    }
+
+    /// Whether the server acknowledged our SNI in
+    /// EncryptedExtensions.
+    pub fn sni_acked(&self) -> bool {
+        self.sni_acked
+    }
+
+    /// Application-traffic keys; only once `Complete`.
+    pub fn app_keys(&self) -> Result<AppKeys> {
+        if self.state != State::Complete {
+            return Err(TlsClientError::BadHandshake);
+        }
+        let suite = self.suite.ok_or(TlsClientError::BadHandshake)?;
+        let ks = self.schedule.as_ref().ok_or(TlsClientError::BadHandshake)?;
+        Ok(AppKeys {
+            suite,
+            client: ks.traffic_keys(ks.client_ap_traffic_secret()?)?,
+            server: ks.traffic_keys(ks.server_ap_traffic_secret()?)?,
+        })
+    }
+
+    /// Bytes received after the handshake finished (e.g. a
+    /// NewSessionTicket flight coalesced into the same TCP
+    /// segment). The record loop takes ownership of these.
+    pub fn take_residual(&mut self) -> Vec<u8> {
+        core::mem::take(&mut self.inbuf)
+    }
+
+    // ── internals ─────────────────────────────────────────────
+
+    fn drain_records(&mut self, send: &mut Vec<u8>) -> Result<()> {
+        loop {
+            if self.state == State::Complete {
+                return Ok(());
+            }
+            if self.inbuf.len() < RECORD_HEADER_LEN {
+                return Ok(());
+            }
+            let header = RecordHeader::parse(&self.inbuf[..RECORD_HEADER_LEN])?;
+            let total = RECORD_HEADER_LEN + header.length as usize;
+            if self.inbuf.len() < total {
+                return Ok(());
+            }
+            let record: Vec<u8> = self.inbuf.drain(..total).collect();
+            self.process_record(header, &record, send)?;
+            self.drain_messages(send)?;
+        }
+    }
+
+    fn process_record(
+        &mut self,
+        header: RecordHeader,
+        record: &[u8],
+        _send: &mut Vec<u8>,
+    ) -> Result<()> {
+        match header.content_type {
+            // Middlebox-compatibility ChangeCipherSpec — RFC 8446
+            // §5: drop unencrypted CCS received during the
+            // handshake.
+            ContentType::ChangeCipherSpec => Ok(()),
+            ContentType::Alert if self.server_keys.is_none() => {
+                // Plaintext alert during the first flight (e.g.
+                // handshake_failure). Surface as handshake failure.
+                Err(TlsClientError::BadHandshake)
+            }
+            ContentType::Handshake if self.server_keys.is_none() => {
+                // Plaintext handshake record (ServerHello flight).
+                header.enforce_legacy_version()?;
+                self.hs_buf.extend_from_slice(&record[RECORD_HEADER_LEN..]);
+                Ok(())
+            }
+            ContentType::ApplicationData => {
+                // Encrypted record. Keys must exist by now.
+                let keys = self
+                    .server_keys
+                    .as_ref()
+                    .ok_or(TlsClientError::BadHandshake)?;
+                let suite = self.suite.ok_or(TlsClientError::BadHandshake)?;
+                let (inner_type, plaintext) =
+                    record::open(suite, &keys.key, &keys.iv, self.read_seq, record)?;
+                self.read_seq += 1;
+                match inner_type {
+                    ContentType::Handshake => {
+                        self.hs_buf.extend_from_slice(&plaintext);
+                        Ok(())
+                    }
+                    ContentType::Alert => Err(TlsClientError::BadHandshake),
+                    _ => Err(TlsClientError::BadHandshake),
+                }
+            }
+            _ => Err(TlsClientError::BadHandshake),
+        }
+    }
+
+    fn drain_messages(&mut self, send: &mut Vec<u8>) -> Result<()> {
+        loop {
+            if self.hs_buf.len() < HandshakeHeader::LEN {
+                return Ok(());
+            }
+            let header = HandshakeHeader::parse(&self.hs_buf)?;
+            let total = HandshakeHeader::LEN + header.length as usize;
+            if self.hs_buf.len() < total {
+                return Ok(());
+            }
+            let msg: Vec<u8> = self.hs_buf.drain(..total).collect();
+            self.process_message(header.msg_type, &msg, send)?;
+            if self.state == State::Complete {
+                return Ok(());
+            }
+        }
+    }
+
+    fn process_message(
+        &mut self,
+        msg_type: HandshakeType,
+        msg: &[u8],
+        send: &mut Vec<u8>,
+    ) -> Result<()> {
+        match (self.state, msg_type) {
+            (State::ExpectServerHello, HandshakeType::ServerHello) => self.on_server_hello(msg),
+            (State::ExpectEncryptedExtensions, HandshakeType::EncryptedExtensions) => {
+                let ee = parse_encrypted_extensions(msg)?;
+                self.sni_acked = ee.sni_acked;
+                self.transcript_update(msg);
+                self.state = State::ExpectCertificate;
+                Ok(())
+            }
+            (State::ExpectCertificate, HandshakeType::CertificateRequest) => {
+                // v1 ships no client certificate (proposal: "No
+                // mTLS in v1") — refuse rather than answer with an
+                // empty Certificate the operator can't influence.
+                Err(TlsClientError::BadHandshake)
+            }
+            (State::ExpectCertificate, HandshakeType::Certificate) => {
+                let cert_msg = parse_certificate(msg)?;
+                self.leaf_key = Some(
+                    self.verifier
+                        .verify_chain(&cert_msg.certs, self.server_name)?,
+                );
+                self.transcript_update(msg);
+                self.hash_at_cert = self.transcript_current();
+                self.state = State::ExpectCertificateVerify;
+                Ok(())
+            }
+            (State::ExpectCertificateVerify, HandshakeType::CertificateVerify) => {
+                let cv = parse_certificate_verify(msg)?;
+                let LeafPublicKey::Ed25519(pk) =
+                    self.leaf_key.as_ref().ok_or(TlsClientError::BadHandshake)?;
+                verify_certificate_verify(&cv, pk, &self.hash_at_cert)?;
+                self.transcript_update(msg);
+                self.hash_at_cv = self.transcript_current();
+                self.state = State::ExpectFinished;
+                Ok(())
+            }
+            (State::ExpectFinished, HandshakeType::Finished) => self.on_server_finished(msg, send),
+            // Anything else is out of order for this state machine
+            // (incl. HelloRetryRequest-triggered second ServerHello,
+            // NewSessionTicket before Finished, KeyUpdate during
+            // handshake).
+            _ => Err(TlsClientError::BadHandshake),
+        }
+    }
+
+    fn on_server_hello(&mut self, msg: &[u8]) -> Result<()> {
+        let sh = parse_server_hello(msg)?;
+        // HelloRetryRequest is a ServerHello whose random is the
+        // fixed SHA-256("HelloRetryRequest") sentinel — refused in
+        // v1 (design.md D7).
+        if sh.random == HRR_RANDOM {
+            return Err(TlsClientError::BadHandshake);
+        }
+        // Group policy (design.md D3 + spec scenario "Hybrid
+        // required and server picks classical → reject").
+        let ecdhe: Vec<u8> = match (&self.kx, sh.key_share_group) {
+            (KeyExchange::Hybrid(x, mlkem), g) if g == named_group::X25519_MLKEM768 => {
+                // Server share: ML-KEM-768 ciphertext || X25519 pk
+                // (draft-ietf-tls-ecdhe-mlkem ordering). Shared
+                // secret: ML-KEM ss || X25519 ss.
+                if sh.key_share_public.len() != ML_KEM_768_CT_LEN + 32 {
+                    return Err(TlsClientError::KeyExchange);
+                }
+                let mut ct = [0u8; ML_KEM_768_CT_LEN];
+                ct.copy_from_slice(&sh.key_share_public[..ML_KEM_768_CT_LEN]);
+                let ml_kem_ss =
+                    ml_kem_768_decaps(&mlkem.secret_key, &MlKemCiphertext::from_bytes(ct))
+                        .map_err(|_| TlsClientError::KeyExchange)?;
+                let mut server_x = [0u8; 32];
+                server_x.copy_from_slice(&sh.key_share_public[ML_KEM_768_CT_LEN..]);
+                let x_ss = x25519_dh(&x.secret_key, &X25519PublicKey::from_bytes(server_x))
+                    .map_err(|_| TlsClientError::KeyExchange)?;
+                let mut ss = Vec::with_capacity(64);
+                ss.extend_from_slice(ml_kem_ss.as_bytes());
+                ss.extend_from_slice(&x_ss);
+                ss
+            }
+            (KeyExchange::Hybrid(..), _) => {
+                // Operator demanded PQC; server picked a classical
+                // group.
+                return Err(TlsClientError::PqcDowngrade);
+            }
+            (KeyExchange::Classical(x), g) if g == named_group::X25519 => {
+                if sh.key_share_public.len() != 32 {
+                    return Err(TlsClientError::KeyExchange);
+                }
+                let mut server_x = [0u8; 32];
+                server_x.copy_from_slice(&sh.key_share_public);
+                x25519_dh(&x.secret_key, &X25519PublicKey::from_bytes(server_x))
+                    .map_err(|_| TlsClientError::KeyExchange)?
+                    .to_vec()
+            }
+            (KeyExchange::Classical(_), _) => {
+                // We never offered that group.
+                return Err(TlsClientError::BadHandshake);
+            }
+        };
+        debug_assert!(self.require_pqc == matches!(self.kx, KeyExchange::Hybrid(..)));
+
+        // Suite fixed — start the transcript and the schedule.
+        let alg = HashAlg::for_suite(sh.cipher_suite);
+        let mut transcript = TranscriptHash::new(alg);
+        transcript.update(&self.client_hello);
+        transcript.update(msg);
+        let mut schedule = KeySchedule::new(alg);
+        schedule.derive_handshake_secrets(&ecdhe, &transcript.current())?;
+        self.server_keys = Some(schedule.traffic_keys(schedule.server_hs_traffic_secret()?)?);
+        self.read_seq = 0;
+        self.suite = Some(sh.cipher_suite);
+        self.transcript = Some(transcript);
+        self.schedule = Some(schedule);
+        self.state = State::ExpectEncryptedExtensions;
+        Ok(())
+    }
+
+    fn on_server_finished(&mut self, msg: &[u8], send: &mut Vec<u8>) -> Result<()> {
+        let suite = self.suite.ok_or(TlsClientError::BadHandshake)?;
+        let ks = self.schedule.as_mut().ok_or(TlsClientError::BadHandshake)?;
+        let alg = ks.alg();
+
+        // Task 4.8 — verify the server Finished MAC over
+        // Transcript-Hash(CH..CertificateVerify).
+        let received = parse_finished(msg, alg.digest_len())?;
+        let expected = ks.finished_verify_data(ks.server_hs_traffic_secret()?, &self.hash_at_cv)?;
+        check_verify_data(&received, &expected)?;
+
+        // Task 4.9 — application secrets are keyed by the
+        // transcript through the server Finished...
+        let transcript = self
+            .transcript
+            .as_mut()
+            .ok_or(TlsClientError::BadHandshake)?;
+        transcript.update(msg);
+        let hash_through_sfin = transcript.current();
+        ks.derive_application_secrets(&hash_through_sfin)?;
+
+        // ...and the client Finished is the same transcript point,
+        // MAC'd with the *client* handshake-traffic secret and
+        // sealed under the client handshake keys (its sequence
+        // number is 0 — this is our first encrypted record).
+        let client_vd =
+            ks.finished_verify_data(ks.client_hs_traffic_secret()?, &hash_through_sfin)?;
+        let fin_msg = build_finished(&client_vd)?;
+        let client_keys = ks.traffic_keys(ks.client_hs_traffic_secret()?)?;
+        let sealed = record::seal(
+            suite,
+            &client_keys.key,
+            &client_keys.iv,
+            0,
+            ContentType::Handshake,
+            &fin_msg,
+        )?;
+        send.extend_from_slice(&sealed);
+        self.state = State::Complete;
+        Ok(())
+    }
+
+    fn transcript_update(&mut self, msg: &[u8]) {
+        if let Some(t) = self.transcript.as_mut() {
+            t.update(msg);
+        }
+    }
+
+    fn transcript_current(&self) -> Vec<u8> {
+        self.transcript
+            .as_ref()
+            .map(|t| t.current())
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::handshake::certificate_msg::certificate_verify_content;
+    use crate::handshake::extensions::{ext_type, sig_scheme, TLS_1_3};
+    use smallaios_security::crypto::ed25519::{ed25519_keygen, ed25519_sign, Ed25519KeyPair};
+    use smallaios_security::crypto::ml_kem::ml_kem_768_encaps;
+    use smallaios_security::sha2::sha256;
+
+    #[test]
+    fn hrr_sentinel_is_sha256_of_label() {
+        assert_eq!(HRR_RANDOM, sha256(b"HelloRetryRequest"));
+    }
+
+    // ── In-test TLS 1.3 server ────────────────────────────────
+    //
+    // A minimal server built from the same primitives, driving
+    // the client end-to-end: SH, EE+Certificate (coalesced in one
+    // record, exercising multi-message records), CertificateVerify,
+    // Finished, then verification of the client Finished.
+
+    struct TestVerifier {
+        expected_leaf: &'static [u8],
+        pubkey: [u8; 32],
+    }
+
+    impl ServerCertVerifier for TestVerifier {
+        fn verify_chain(
+            &self,
+            certs: &[Vec<u8>],
+            _server_name: Option<&str>,
+        ) -> Result<LeafPublicKey> {
+            assert_eq!(certs[0], self.expected_leaf);
+            Ok(LeafPublicKey::Ed25519(self.pubkey))
+        }
+    }
+
+    struct RejectingVerifier;
+    impl ServerCertVerifier for RejectingVerifier {
+        fn verify_chain(&self, _: &[Vec<u8>], _: Option<&str>) -> Result<LeafPublicKey> {
+            Err(TlsClientError::ChainUntrusted)
+        }
+    }
+
+    const LEAF_DER: &[u8] = b"synthetic-leaf-der-for-driver-tests";
+
+    /// Extract (cipher_suites, key_share group, key_share pubkey)
+    /// from a raw ClientHello message.
+    fn parse_ch_key_share(ch: &[u8]) -> (u16, Vec<u8>) {
+        let body = &ch[4..];
+        let mut cur = 2 + 32; // legacy_version + random
+        let sid = body[cur] as usize;
+        cur += 1 + sid;
+        let cs_len = u16::from_be_bytes([body[cur], body[cur + 1]]) as usize;
+        cur += 2 + cs_len;
+        cur += 1 + body[cur] as usize; // compression methods
+        let ext_len = u16::from_be_bytes([body[cur], body[cur + 1]]) as usize;
+        cur += 2;
+        let ext_end = cur + ext_len;
+        while cur < ext_end {
+            let t = u16::from_be_bytes([body[cur], body[cur + 1]]);
+            let l = u16::from_be_bytes([body[cur + 2], body[cur + 3]]) as usize;
+            cur += 4;
+            if t == ext_type::KEY_SHARE {
+                // client form: u16 list length, then entries.
+                let mut p = cur + 2;
+                let group = u16::from_be_bytes([body[p], body[p + 1]]);
+                let klen = u16::from_be_bytes([body[p + 2], body[p + 3]]) as usize;
+                p += 4;
+                return (group, body[p..p + klen].to_vec());
+            }
+            cur += l;
+        }
+        panic!("no key_share in ClientHello");
+    }
+
+    fn build_server_hello_msg(suite: CipherSuite, group: u16, share: &[u8]) -> Vec<u8> {
+        build_server_hello_custom(suite.wire_value(), Some(TLS_1_3), group, share, [0xaa; 32])
+    }
+
+    fn build_server_hello_custom(
+        suite_code: u16,
+        version: Option<u16>,
+        group: u16,
+        share: &[u8],
+        random: [u8; 32],
+    ) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(&[0x03, 0x03]);
+        body.extend_from_slice(&random);
+        body.push(0); // empty session_id_echo
+        body.extend_from_slice(&suite_code.to_be_bytes());
+        body.push(0); // compression
+        let mut exts = Vec::new();
+        if let Some(v) = version {
+            exts.extend_from_slice(&ext_type::SUPPORTED_VERSIONS.to_be_bytes());
+            exts.extend_from_slice(&2u16.to_be_bytes());
+            exts.extend_from_slice(&v.to_be_bytes());
+        }
+        let mut ks = Vec::new();
+        ks.extend_from_slice(&group.to_be_bytes());
+        ks.extend_from_slice(&(share.len() as u16).to_be_bytes());
+        ks.extend_from_slice(share);
+        exts.extend_from_slice(&ext_type::KEY_SHARE.to_be_bytes());
+        exts.extend_from_slice(&(ks.len() as u16).to_be_bytes());
+        exts.extend_from_slice(&ks);
+        body.extend_from_slice(&(exts.len() as u16).to_be_bytes());
+        body.extend_from_slice(&exts);
+        let mut out = Vec::new();
+        HandshakeHeader {
+            msg_type: HandshakeType::ServerHello,
+            length: body.len() as u32,
+        }
+        .encode(&mut out)
+        .unwrap();
+        out.extend_from_slice(&body);
+        out
+    }
+
+    fn build_ee_msg() -> Vec<u8> {
+        // EncryptedExtensions with an SNI ack.
+        let mut block = Vec::new();
+        block.extend_from_slice(&ext_type::SERVER_NAME.to_be_bytes());
+        block.extend_from_slice(&0u16.to_be_bytes());
+        let mut body = Vec::new();
+        body.extend_from_slice(&(block.len() as u16).to_be_bytes());
+        body.extend_from_slice(&block);
+        let mut out = Vec::new();
+        HandshakeHeader {
+            msg_type: HandshakeType::EncryptedExtensions,
+            length: body.len() as u32,
+        }
+        .encode(&mut out)
+        .unwrap();
+        out.extend_from_slice(&body);
+        out
+    }
+
+    fn build_certificate_msg(leaf: &[u8]) -> Vec<u8> {
+        let mut list = Vec::new();
+        list.extend_from_slice(&(leaf.len() as u32).to_be_bytes()[1..]);
+        list.extend_from_slice(leaf);
+        list.extend_from_slice(&[0, 0]);
+        let mut body = Vec::new();
+        body.push(0);
+        body.extend_from_slice(&(list.len() as u32).to_be_bytes()[1..]);
+        body.extend_from_slice(&list);
+        let mut out = Vec::new();
+        HandshakeHeader {
+            msg_type: HandshakeType::Certificate,
+            length: body.len() as u32,
+        }
+        .encode(&mut out)
+        .unwrap();
+        out.extend_from_slice(&body);
+        out
+    }
+
+    fn build_cv_msg(kp: &Ed25519KeyPair, transcript_hash: &[u8]) -> Vec<u8> {
+        let content = certificate_verify_content(transcript_hash);
+        let sig = ed25519_sign(&kp.secret_key, &content);
+        let mut body = Vec::new();
+        body.extend_from_slice(&sig_scheme::ED25519.to_be_bytes());
+        body.extend_from_slice(&64u16.to_be_bytes());
+        body.extend_from_slice(sig.as_bytes());
+        let mut out = Vec::new();
+        HandshakeHeader {
+            msg_type: HandshakeType::CertificateVerify,
+            length: body.len() as u32,
+        }
+        .encode(&mut out)
+        .unwrap();
+        out.extend_from_slice(&body);
+        out
+    }
+
+    /// Everything the server produced for its flight, plus the
+    /// state needed to check the client Finished.
+    struct ServerFlight {
+        records: Vec<u8>,
+        schedule: KeySchedule,
+        transcript: TranscriptHash,
+        suite: CipherSuite,
+    }
+
+    /// Run the server side: consume the ClientHello record, emit
+    /// SH + encrypted {EE+Cert} {CV} {Fin} records.
+    fn server_respond(
+        ch_record: &[u8],
+        suite: CipherSuite,
+        cert_kp: &Ed25519KeyPair,
+        tamper_finished: bool,
+    ) -> ServerFlight {
+        let ch_msg = &ch_record[RECORD_HEADER_LEN..];
+        let (group, client_share) = parse_ch_key_share(ch_msg);
+
+        // Server key exchange.
+        let server_x = x25519_keygen(&[0x55u8; 32]);
+        let (ecdhe, server_share): (Vec<u8>, Vec<u8>) = if group == named_group::X25519_MLKEM768 {
+            let client_mlkem = smallaios_security::crypto::ml_kem::MlKemPublicKey::from_slice(
+                &client_share[..ML_KEM_768_PK_LEN],
+            )
+            .unwrap();
+            let (ct, mlkem_ss) = ml_kem_768_encaps(&client_mlkem, &[0x66u8; 32]).unwrap();
+            let mut client_x = [0u8; 32];
+            client_x.copy_from_slice(&client_share[ML_KEM_768_PK_LEN..]);
+            let x_ss =
+                x25519_dh(&server_x.secret_key, &X25519PublicKey::from_bytes(client_x)).unwrap();
+            let mut ss = Vec::new();
+            ss.extend_from_slice(mlkem_ss.as_bytes());
+            ss.extend_from_slice(&x_ss);
+            let mut share = Vec::new();
+            share.extend_from_slice(ct.as_bytes());
+            share.extend_from_slice(server_x.public_key.as_bytes());
+            (ss, share)
+        } else {
+            let mut client_x = [0u8; 32];
+            client_x.copy_from_slice(&client_share);
+            let ss =
+                x25519_dh(&server_x.secret_key, &X25519PublicKey::from_bytes(client_x)).unwrap();
+            (ss.to_vec(), server_x.public_key.as_bytes().to_vec())
+        };
+
+        let sh_msg = build_server_hello_msg(suite, group, &server_share);
+        let alg = HashAlg::for_suite(suite);
+        let mut transcript = TranscriptHash::new(alg);
+        transcript.update(ch_msg);
+        transcript.update(&sh_msg);
+        let mut schedule = KeySchedule::new(alg);
+        schedule
+            .derive_handshake_secrets(&ecdhe, &transcript.current())
+            .unwrap();
+        let server_keys = schedule
+            .traffic_keys(schedule.server_hs_traffic_secret().unwrap())
+            .unwrap();
+
+        let mut records = build_plaintext_record(ContentType::Handshake, &sh_msg).unwrap();
+        let mut seq = 0u64;
+        let seal_hs = |payload: &[u8], seq: &mut u64| {
+            let rec = record::seal(
+                suite,
+                &server_keys.key,
+                &server_keys.iv,
+                *seq,
+                ContentType::Handshake,
+                payload,
+            )
+            .unwrap();
+            *seq += 1;
+            rec
+        };
+
+        // EE + Certificate coalesced into ONE record.
+        let ee_msg = build_ee_msg();
+        let cert_msg = build_certificate_msg(LEAF_DER);
+        transcript.update(&ee_msg);
+        transcript.update(&cert_msg);
+        let mut coalesced = ee_msg.clone();
+        coalesced.extend_from_slice(&cert_msg);
+        records.extend_from_slice(&seal_hs(&coalesced, &mut seq));
+
+        // CertificateVerify over Transcript-Hash(CH..Certificate).
+        let cv_msg = build_cv_msg(cert_kp, &transcript.current());
+        transcript.update(&cv_msg);
+        records.extend_from_slice(&seal_hs(&cv_msg, &mut seq));
+
+        // Server Finished over Transcript-Hash(CH..CV).
+        let mut vd = schedule
+            .finished_verify_data(
+                schedule.server_hs_traffic_secret().unwrap(),
+                &transcript.current(),
+            )
+            .unwrap();
+        if tamper_finished {
+            vd[0] ^= 0xff;
+        }
+        let fin_msg = build_finished(&vd).unwrap();
+        transcript.update(&fin_msg);
+        records.extend_from_slice(&seal_hs(&fin_msg, &mut seq));
+
+        ServerFlight {
+            records,
+            schedule,
+            transcript,
+            suite,
+        }
+    }
+
+    fn entropy() -> ClientEntropy {
+        ClientEntropy {
+            client_random: [0x11; 32],
+            x25519_seed: [0x22; 32],
+            ml_kem_seed: [0x33; 64],
+        }
+    }
+
+    fn run_e2e(suite: CipherSuite, require_pqc: bool, fragment: bool) {
+        let cert_kp = ed25519_keygen(&[9u8; 32]);
+        let verifier = TestVerifier {
+            expected_leaf: LEAF_DER,
+            pubkey: *cert_kp.public_key.as_bytes(),
+        };
+        let (mut client, flight) = ClientHandshake::new(
+            ClientConfig {
+                server_name: Some("immudb.example.com"),
+                require_pqc,
+            },
+            &entropy(),
+            &verifier,
+        )
+        .unwrap();
+
+        let mut server = server_respond(&flight, suite, &cert_kp, false);
+
+        // Feed the server flight to the client — all at once, or
+        // byte-by-byte to exercise the reassembly paths.
+        let mut sent = Vec::new();
+        let mut status = HandshakeStatus::InProgress;
+        if fragment {
+            for b in server.records.clone() {
+                let p = client.push(&[b]).unwrap();
+                sent.extend_from_slice(&p.send);
+                status = p.status;
+            }
+        } else {
+            let p = client.push(&server.records.clone()).unwrap();
+            sent.extend_from_slice(&p.send);
+            status = p.status;
+        }
+        assert_eq!(status, HandshakeStatus::Complete);
+        assert_eq!(client.suite(), Some(suite));
+        assert!(client.sni_acked());
+
+        // Server verifies the client Finished (over the transcript
+        // through the server Finished) and compares app keys.
+        let client_keys = server
+            .schedule
+            .traffic_keys(server.schedule.client_hs_traffic_secret().unwrap())
+            .unwrap();
+        let (inner, fin_plain) =
+            record::open(server.suite, &client_keys.key, &client_keys.iv, 0, &sent).unwrap();
+        assert_eq!(inner, ContentType::Handshake);
+        let alg = HashAlg::for_suite(suite);
+        let received = parse_finished(&fin_plain, alg.digest_len()).unwrap();
+        let expected = server
+            .schedule
+            .finished_verify_data(
+                server.schedule.client_hs_traffic_secret().unwrap(),
+                &server.transcript.current(),
+            )
+            .unwrap();
+        check_verify_data(&received, &expected).unwrap();
+
+        server
+            .schedule
+            .derive_application_secrets(&server.transcript.current())
+            .unwrap();
+        let client_app = client.app_keys().unwrap();
+        let server_view_client = server
+            .schedule
+            .traffic_keys(server.schedule.client_ap_traffic_secret().unwrap())
+            .unwrap();
+        let server_view_server = server
+            .schedule
+            .traffic_keys(server.schedule.server_ap_traffic_secret().unwrap())
+            .unwrap();
+        assert_eq!(client_app.client.key, server_view_client.key);
+        assert_eq!(client_app.client.iv, server_view_client.iv);
+        assert_eq!(client_app.server.key, server_view_server.key);
+        assert_eq!(client_app.server.iv, server_view_server.iv);
+    }
+
+    #[test]
+    fn e2e_chacha20_classical() {
+        run_e2e(CipherSuite::ChaCha20Poly1305Sha256, false, false);
+    }
+
+    #[test]
+    fn e2e_aes256_classical() {
+        run_e2e(CipherSuite::Aes256GcmSha384, false, false);
+    }
+
+    #[test]
+    fn e2e_hybrid_pqc() {
+        run_e2e(CipherSuite::ChaCha20Poly1305Sha256, true, false);
+    }
+
+    #[test]
+    fn e2e_byte_at_a_time_fragmentation() {
+        run_e2e(CipherSuite::Aes256GcmSha384, false, true);
+    }
+
+    fn start_classical() -> (ClientHandshake<'static, TestVerifier>, Vec<u8>) {
+        static VERIFIER: TestVerifier = TestVerifier {
+            expected_leaf: LEAF_DER,
+            pubkey: [0u8; 32],
+        };
+        let (client, flight) = ClientHandshake::new(
+            ClientConfig {
+                server_name: Some("immudb.example.com"),
+                require_pqc: false,
+            },
+            &entropy(),
+            &VERIFIER,
+        )
+        .unwrap();
+        (client, flight)
+    }
+
+    #[test]
+    fn server_selecting_tls12_aborts() {
+        let (mut client, _flight) = start_classical();
+        let x = x25519_keygen(&[0x55u8; 32]);
+        let sh = build_server_hello_custom(
+            0x1302,
+            Some(0x0303),
+            named_group::X25519,
+            x.public_key.as_bytes(),
+            [0xaa; 32],
+        );
+        let rec = build_plaintext_record(ContentType::Handshake, &sh).unwrap();
+        assert_eq!(client.push(&rec).unwrap_err(), TlsClientError::Version);
+        // Driver latches Failed.
+        assert_eq!(client.push(&[]).unwrap_err(), TlsClientError::BadHandshake);
+    }
+
+    #[test]
+    fn hello_retry_request_refused() {
+        let (mut client, _flight) = start_classical();
+        let x = x25519_keygen(&[0x55u8; 32]);
+        let sh = build_server_hello_custom(
+            0x1302,
+            Some(TLS_1_3),
+            named_group::X25519,
+            x.public_key.as_bytes(),
+            HRR_RANDOM,
+        );
+        let rec = build_plaintext_record(ContentType::Handshake, &sh).unwrap();
+        assert_eq!(client.push(&rec).unwrap_err(), TlsClientError::BadHandshake);
+    }
+
+    #[test]
+    fn pqc_downgrade_detected() {
+        let cert_kp = ed25519_keygen(&[9u8; 32]);
+        let verifier = TestVerifier {
+            expected_leaf: LEAF_DER,
+            pubkey: *cert_kp.public_key.as_bytes(),
+        };
+        let (mut client, _flight) = ClientHandshake::new(
+            ClientConfig {
+                server_name: None,
+                require_pqc: true,
+            },
+            &entropy(),
+            &verifier,
+        )
+        .unwrap();
+        // Server replies with a classical x25519 share despite the
+        // hybrid offer.
+        let x = x25519_keygen(&[0x55u8; 32]);
+        let sh = build_server_hello_custom(
+            0x1303,
+            Some(TLS_1_3),
+            named_group::X25519,
+            x.public_key.as_bytes(),
+            [0xaa; 32],
+        );
+        let rec = build_plaintext_record(ContentType::Handshake, &sh).unwrap();
+        assert_eq!(client.push(&rec).unwrap_err(), TlsClientError::PqcDowngrade);
+    }
+
+    #[test]
+    fn tampered_server_finished_rejected() {
+        let cert_kp = ed25519_keygen(&[9u8; 32]);
+        let verifier = TestVerifier {
+            expected_leaf: LEAF_DER,
+            pubkey: *cert_kp.public_key.as_bytes(),
+        };
+        let (mut client, flight) = ClientHandshake::new(
+            ClientConfig {
+                server_name: Some("immudb.example.com"),
+                require_pqc: false,
+            },
+            &entropy(),
+            &verifier,
+        )
+        .unwrap();
+        let server = server_respond(
+            &flight,
+            CipherSuite::ChaCha20Poly1305Sha256,
+            &cert_kp,
+            true, // tamper the Finished verify_data
+        );
+        assert_eq!(
+            client.push(&server.records).unwrap_err(),
+            TlsClientError::BadHandshake
+        );
+    }
+
+    #[test]
+    fn untrusted_chain_aborts() {
+        let cert_kp = ed25519_keygen(&[9u8; 32]);
+        let verifier = RejectingVerifier;
+        let (mut client, flight) = ClientHandshake::new(
+            ClientConfig {
+                server_name: Some("immudb.example.com"),
+                require_pqc: false,
+            },
+            &entropy(),
+            &verifier,
+        )
+        .unwrap();
+        let server = server_respond(
+            &flight,
+            CipherSuite::ChaCha20Poly1305Sha256,
+            &cert_kp,
+            false,
+        );
+        assert_eq!(
+            client.push(&server.records).unwrap_err(),
+            TlsClientError::ChainUntrusted
+        );
+    }
+
+    #[test]
+    fn wrong_cert_verify_signature_rejected() {
+        let cert_kp = ed25519_keygen(&[9u8; 32]);
+        let wrong_kp = ed25519_keygen(&[10u8; 32]);
+        // Verifier returns a pubkey that does NOT match the key
+        // the server signed CertificateVerify with.
+        let verifier = TestVerifier {
+            expected_leaf: LEAF_DER,
+            pubkey: *wrong_kp.public_key.as_bytes(),
+        };
+        let (mut client, flight) = ClientHandshake::new(
+            ClientConfig {
+                server_name: Some("immudb.example.com"),
+                require_pqc: false,
+            },
+            &entropy(),
+            &verifier,
+        )
+        .unwrap();
+        let server = server_respond(
+            &flight,
+            CipherSuite::ChaCha20Poly1305Sha256,
+            &cert_kp,
+            false,
+        );
+        assert_eq!(
+            client.push(&server.records).unwrap_err(),
+            TlsClientError::BadCertificate
+        );
+    }
+
+    #[test]
+    fn certificate_request_refused() {
+        let cert_kp = ed25519_keygen(&[9u8; 32]);
+        let verifier = TestVerifier {
+            expected_leaf: LEAF_DER,
+            pubkey: *cert_kp.public_key.as_bytes(),
+        };
+        let (mut client, flight) = ClientHandshake::new(
+            ClientConfig {
+                server_name: Some("immudb.example.com"),
+                require_pqc: false,
+            },
+            &entropy(),
+            &verifier,
+        )
+        .unwrap();
+        // Build a normal flight, then splice a CertificateRequest
+        // where the Certificate would go.
+        let ch_msg = &flight[RECORD_HEADER_LEN..];
+        let (group, client_share) = parse_ch_key_share(ch_msg);
+        let server_x = x25519_keygen(&[0x55u8; 32]);
+        let mut client_x = [0u8; 32];
+        client_x.copy_from_slice(&client_share);
+        let ecdhe =
+            x25519_dh(&server_x.secret_key, &X25519PublicKey::from_bytes(client_x)).unwrap();
+        let suite = CipherSuite::ChaCha20Poly1305Sha256;
+        let sh_msg = build_server_hello_msg(suite, group, server_x.public_key.as_bytes());
+        let alg = HashAlg::for_suite(suite);
+        let mut transcript = TranscriptHash::new(alg);
+        transcript.update(ch_msg);
+        transcript.update(&sh_msg);
+        let mut schedule = KeySchedule::new(alg);
+        schedule
+            .derive_handshake_secrets(&ecdhe, &transcript.current())
+            .unwrap();
+        let server_keys = schedule
+            .traffic_keys(schedule.server_hs_traffic_secret().unwrap())
+            .unwrap();
+        let mut records = build_plaintext_record(ContentType::Handshake, &sh_msg).unwrap();
+        let ee = build_ee_msg();
+        // CertificateRequest: context len 0 + empty extensions.
+        let mut cr_body = alloc::vec![0u8];
+        cr_body.extend_from_slice(&0u16.to_be_bytes());
+        let mut cr = Vec::new();
+        HandshakeHeader {
+            msg_type: HandshakeType::CertificateRequest,
+            length: cr_body.len() as u32,
+        }
+        .encode(&mut cr)
+        .unwrap();
+        cr.extend_from_slice(&cr_body);
+        let mut payload = ee;
+        payload.extend_from_slice(&cr);
+        records.extend_from_slice(
+            &record::seal(
+                suite,
+                &server_keys.key,
+                &server_keys.iv,
+                0,
+                ContentType::Handshake,
+                &payload,
+            )
+            .unwrap(),
+        );
+        assert_eq!(
+            client.push(&records).unwrap_err(),
+            TlsClientError::BadHandshake
+        );
+    }
+
+    #[test]
+    fn ccs_record_ignored_mid_handshake() {
+        let cert_kp = ed25519_keygen(&[9u8; 32]);
+        let verifier = TestVerifier {
+            expected_leaf: LEAF_DER,
+            pubkey: *cert_kp.public_key.as_bytes(),
+        };
+        let (mut client, flight) = ClientHandshake::new(
+            ClientConfig {
+                server_name: Some("immudb.example.com"),
+                require_pqc: false,
+            },
+            &entropy(),
+            &verifier,
+        )
+        .unwrap();
+        let server = server_respond(
+            &flight,
+            CipherSuite::ChaCha20Poly1305Sha256,
+            &cert_kp,
+            false,
+        );
+        // Inject a middlebox-compat CCS record between the
+        // ServerHello and the encrypted flight.
+        let sh_len =
+            RECORD_HEADER_LEN + u16::from_be_bytes([server.records[3], server.records[4]]) as usize;
+        let mut with_ccs = server.records[..sh_len].to_vec();
+        with_ccs.extend_from_slice(&[20, 0x03, 0x03, 0, 1, 1]); // CCS record
+        with_ccs.extend_from_slice(&server.records[sh_len..]);
+        let p = client.push(&with_ccs).unwrap();
+        assert_eq!(p.status, HandshakeStatus::Complete);
+    }
+
+    #[test]
+    fn app_keys_gated_until_complete() {
+        let (client, _flight) = start_classical();
+        assert!(client.app_keys().is_err());
+    }
+}

--- a/tls-client/src/handshake/encrypted_extensions.rs
+++ b/tls-client/src/handshake/encrypted_extensions.rs
@@ -68,28 +68,7 @@ pub fn parse_encrypted_extensions(buf: &[u8]) -> Result<EncryptedExtensions> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloc::vec::Vec;
-
-    fn build_ee(exts: &[(u16, &[u8])]) -> Vec<u8> {
-        let mut block = Vec::new();
-        for (t, data) in exts {
-            block.extend_from_slice(&t.to_be_bytes());
-            block.extend_from_slice(&(data.len() as u16).to_be_bytes());
-            block.extend_from_slice(data);
-        }
-        let mut body = Vec::new();
-        body.extend_from_slice(&(block.len() as u16).to_be_bytes());
-        body.extend_from_slice(&block);
-        let mut out = Vec::new();
-        HandshakeHeader {
-            msg_type: HandshakeType::EncryptedExtensions,
-            length: body.len() as u32,
-        }
-        .encode(&mut out)
-        .unwrap();
-        out.extend_from_slice(&body);
-        out
-    }
+    use crate::handshake::test_util::build_encrypted_extensions as build_ee;
 
     #[test]
     fn empty_ee_parses() {

--- a/tls-client/src/handshake/encrypted_extensions.rs
+++ b/tls-client/src/handshake/encrypted_extensions.rs
@@ -1,0 +1,148 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! EncryptedExtensions parser (RFC 8446 §4.3.1).
+//!
+//! ```text
+//! struct {
+//!     Extension extensions<0..2^16-1>;
+//! } EncryptedExtensions;
+//! ```
+//!
+//! The server uses this message for extensions that are not needed
+//! to establish keys. An empty `server_name` extension here is the
+//! server's acknowledgement that it used our SNI (RFC 6066 §3).
+//! Extensions that RFC 8446 §4.2 pins to other messages
+//! (`key_share`, `supported_versions`, `pre_shared_key`) are
+//! illegal in EncryptedExtensions and refused.
+
+use super::extensions::{ext_type, parse_extensions_block};
+use super::{HandshakeHeader, HandshakeType};
+use crate::{Result, TlsClientError};
+
+/// Extension type codepoints RFC 8446 §4.2 forbids in
+/// EncryptedExtensions (the ones a TLS 1.3 client could otherwise
+/// see): key_share, supported_versions, pre_shared_key.
+const FORBIDDEN_IN_EE: [u16; 3] = [ext_type::KEY_SHARE, ext_type::SUPPORTED_VERSIONS, 0x0029];
+
+/// Parsed EncryptedExtensions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EncryptedExtensions {
+    /// `true` when the server echoed an empty `server_name`
+    /// extension, acknowledging the SNI we sent (task 4.5).
+    pub sni_acked: bool,
+}
+
+/// Parse an EncryptedExtensions message starting at its 4-byte
+/// handshake header.
+pub fn parse_encrypted_extensions(buf: &[u8]) -> Result<EncryptedExtensions> {
+    let header = HandshakeHeader::parse(buf)?;
+    if header.msg_type != HandshakeType::EncryptedExtensions {
+        return Err(TlsClientError::BadHandshake);
+    }
+    let body_start = HandshakeHeader::LEN;
+    let body_end = body_start + header.length as usize;
+    if buf.len() < body_end {
+        return Err(TlsClientError::BadHandshake);
+    }
+    let extensions = parse_extensions_block(&buf[body_start..body_end])?;
+
+    let mut sni_acked = false;
+    for ext in &extensions {
+        if FORBIDDEN_IN_EE.contains(&ext.ext_type) {
+            return Err(TlsClientError::BadHandshake);
+        }
+        if ext.ext_type == ext_type::SERVER_NAME {
+            // The ack form is an empty extension (RFC 6066 §3).
+            if !ext.data.is_empty() {
+                return Err(TlsClientError::BadHandshake);
+            }
+            sni_acked = true;
+        }
+        // Other extensions (max_fragment_length, ALPN,
+        // supported_groups, ...) are tolerated and ignored in v1.
+    }
+    Ok(EncryptedExtensions { sni_acked })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+
+    fn build_ee(exts: &[(u16, &[u8])]) -> Vec<u8> {
+        let mut block = Vec::new();
+        for (t, data) in exts {
+            block.extend_from_slice(&t.to_be_bytes());
+            block.extend_from_slice(&(data.len() as u16).to_be_bytes());
+            block.extend_from_slice(data);
+        }
+        let mut body = Vec::new();
+        body.extend_from_slice(&(block.len() as u16).to_be_bytes());
+        body.extend_from_slice(&block);
+        let mut out = Vec::new();
+        HandshakeHeader {
+            msg_type: HandshakeType::EncryptedExtensions,
+            length: body.len() as u32,
+        }
+        .encode(&mut out)
+        .unwrap();
+        out.extend_from_slice(&body);
+        out
+    }
+
+    #[test]
+    fn empty_ee_parses() {
+        let ee = parse_encrypted_extensions(&build_ee(&[])).unwrap();
+        assert!(!ee.sni_acked);
+    }
+
+    #[test]
+    fn sni_ack_detected() {
+        let ee = parse_encrypted_extensions(&build_ee(&[(ext_type::SERVER_NAME, &[])])).unwrap();
+        assert!(ee.sni_acked);
+    }
+
+    #[test]
+    fn non_empty_server_name_rejected() {
+        assert_eq!(
+            parse_encrypted_extensions(&build_ee(&[(ext_type::SERVER_NAME, b"x")])).unwrap_err(),
+            TlsClientError::BadHandshake
+        );
+    }
+
+    #[test]
+    fn forbidden_extensions_rejected() {
+        for t in [ext_type::KEY_SHARE, ext_type::SUPPORTED_VERSIONS, 0x0029] {
+            assert_eq!(
+                parse_encrypted_extensions(&build_ee(&[(t, &[0, 0])])).unwrap_err(),
+                TlsClientError::BadHandshake,
+                "ext_type {t:#06x} must be refused in EE"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_extensions_tolerated() {
+        // ALPN (16) and max_fragment_length (1) are fine.
+        let ee = parse_encrypted_extensions(&build_ee(&[(16, b"\x00\x05\x04h2-x"), (1, b"\x01")]))
+            .unwrap();
+        assert!(!ee.sni_acked);
+    }
+
+    #[test]
+    fn wrong_message_type_rejected() {
+        let mut bytes = build_ee(&[]);
+        bytes[0] = HandshakeType::Finished as u8;
+        assert_eq!(
+            parse_encrypted_extensions(&bytes).unwrap_err(),
+            TlsClientError::BadHandshake
+        );
+    }
+
+    #[test]
+    fn truncated_rejected() {
+        let bytes = build_ee(&[(ext_type::SERVER_NAME, &[])]);
+        assert!(parse_encrypted_extensions(&bytes[..bytes.len() - 1]).is_err());
+    }
+}

--- a/tls-client/src/handshake/finished.rs
+++ b/tls-client/src/handshake/finished.rs
@@ -1,0 +1,99 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Finished message (RFC 8446 §4.4.4).
+//!
+//! ```text
+//! struct {
+//!     opaque verify_data[Hash.length];
+//! } Finished;
+//! ```
+//!
+//! `verify_data = HMAC(finished_key, Transcript-Hash(...))` where
+//! the finished_key is expanded from the sender's handshake-traffic
+//! secret. The MAC comparison is constant-time
+//! (`security::crypto::constant_time::ct_eq`) — a forged Finished
+//! must not leak how many bytes matched.
+
+use super::{HandshakeHeader, HandshakeType};
+use crate::{Result, TlsClientError};
+use alloc::vec::Vec;
+use smallaios_security::crypto::constant_time::ct_eq;
+
+/// Parse a Finished message starting at its handshake header,
+/// returning the raw verify_data.
+pub fn parse_finished(buf: &[u8], expected_len: usize) -> Result<Vec<u8>> {
+    let header = HandshakeHeader::parse(buf)?;
+    if header.msg_type != HandshakeType::Finished {
+        return Err(TlsClientError::BadHandshake);
+    }
+    let body_start = HandshakeHeader::LEN;
+    let body_end = body_start + header.length as usize;
+    if buf.len() < body_end || header.length as usize != expected_len {
+        return Err(TlsClientError::BadHandshake);
+    }
+    Ok(buf[body_start..body_end].to_vec())
+}
+
+/// Verify a received Finished's verify_data in constant time
+/// (task 4.8).
+pub fn check_verify_data(received: &[u8], expected: &[u8]) -> Result<()> {
+    if received.len() != expected.len() || !ct_eq(received, expected).to_bool() {
+        return Err(TlsClientError::BadHandshake);
+    }
+    Ok(())
+}
+
+/// Build a Finished message (header + verify_data) — the client's
+/// final flight (task 4.9).
+pub fn build_finished(verify_data: &[u8]) -> Result<Vec<u8>> {
+    let mut out = Vec::with_capacity(HandshakeHeader::LEN + verify_data.len());
+    HandshakeHeader {
+        msg_type: HandshakeType::Finished,
+        length: verify_data.len() as u32,
+    }
+    .encode(&mut out)?;
+    out.extend_from_slice(verify_data);
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finished_round_trip() {
+        let vd = [0x5au8; 32];
+        let msg = build_finished(&vd).unwrap();
+        assert_eq!(msg[0], HandshakeType::Finished as u8);
+        let parsed = parse_finished(&msg, 32).unwrap();
+        assert_eq!(parsed, vd);
+        check_verify_data(&parsed, &vd).unwrap();
+    }
+
+    #[test]
+    fn finished_wrong_length_rejected() {
+        let msg = build_finished(&[0x5au8; 32]).unwrap();
+        // SHA-384 suite expects 48 bytes.
+        assert_eq!(
+            parse_finished(&msg, 48).unwrap_err(),
+            TlsClientError::BadHandshake
+        );
+    }
+
+    #[test]
+    fn tampered_verify_data_rejected() {
+        let vd = [0x5au8; 32];
+        let mut bad = vd;
+        bad[31] ^= 1;
+        assert_eq!(
+            check_verify_data(&bad, &vd).unwrap_err(),
+            TlsClientError::BadHandshake
+        );
+    }
+
+    #[test]
+    fn length_mismatch_rejected() {
+        assert!(check_verify_data(&[0u8; 32], &[0u8; 48]).is_err());
+    }
+}

--- a/tls-client/src/handshake/key_schedule.rs
+++ b/tls-client/src/handshake/key_schedule.rs
@@ -613,6 +613,33 @@ f9a41999316e6976c96bf12e533324c925948512b0892b12d121825a216dd3d7",
     }
 
     #[test]
+    fn rfc8448_section3_handshake_traffic_secrets() {
+        // RFC 8448 §3 ("Simple 1-RTT Handshake") known-answer test
+        // — the only published end-to-end TLS 1.3 key-schedule
+        // vectors. The schedule is hash-generic, so we drive it
+        // with SHA-256 directly even though RFC 8448's
+        // TLS_AES_128_GCM_SHA256 suite is outside this client's
+        // suite allow-list.
+        //
+        // Inputs (RFC 8448 §3):
+        //   "{server} extract secret 'handshake'" IKM = the x25519
+        //   shared secret; transcript hash = Transcript-Hash(CH..SH)
+        //   from the "derive secret 'tls13 c hs traffic'" step.
+        let ecdhe = h("8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d");
+        let t_ch_sh = h("860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8");
+        let mut ks = KeySchedule::new(HashAlg::Sha256);
+        ks.derive_handshake_secrets(&ecdhe, &t_ch_sh).unwrap();
+        assert_eq!(
+            hex(ks.client_hs_traffic_secret().unwrap().as_bytes()),
+            "b3eddb126e067f35a780b3abf45e2d8f3b1a950738f52e9600746a0e27a55a21"
+        );
+        assert_eq!(
+            hex(ks.server_hs_traffic_secret().unwrap().as_bytes()),
+            "b67b7d690cc16c4e75e54213cb2d37b4e9c912bcded9105d42befd59d391ad38"
+        );
+    }
+
+    #[test]
     fn early_secret_matches_known_value() {
         // HKDF-Extract(0, 0^32) over SHA-256 — the universal TLS 1.3
         // no-PSK early secret, also OpenSSL-confirmed.

--- a/tls-client/src/handshake/key_schedule.rs
+++ b/tls-client/src/handshake/key_schedule.rs
@@ -424,16 +424,7 @@ impl KeySchedule {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloc::format;
-    use alloc::string::String;
-
-    fn hex(bytes: &[u8]) -> String {
-        let mut s = String::with_capacity(bytes.len() * 2);
-        for b in bytes {
-            s.push_str(&format!("{b:02x}"));
-        }
-        s
-    }
+    use crate::handshake::test_util::hex;
 
     fn h(s: &str) -> Vec<u8> {
         (0..s.len())

--- a/tls-client/src/handshake/key_schedule.rs
+++ b/tls-client/src/handshake/key_schedule.rs
@@ -1,0 +1,646 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! TLS 1.3 key schedule (RFC 8446 §7.1) and transcript hash
+//! (§4.4.1), generic over the negotiated cipher suite's hash.
+//!
+//! ```text
+//!             0
+//!             |
+//!             v
+//!   PSK ->  HKDF-Extract = Early Secret
+//!             |
+//!             +--> Derive-Secret(., "derived", "")
+//!             |
+//!             v
+//! ECDHE -> HKDF-Extract = Handshake Secret
+//!             |
+//!             +--> Derive-Secret(., "c hs traffic", CH..SH)
+//!             +--> Derive-Secret(., "s hs traffic", CH..SH)
+//!             +--> Derive-Secret(., "derived", "")
+//!             |
+//!             v
+//!     0 -> HKDF-Extract = Master Secret
+//!             |
+//!             +--> Derive-Secret(., "c ap traffic", CH..server Fin)
+//!             +--> Derive-Secret(., "s ap traffic", CH..server Fin)
+//! ```
+//!
+//! Per-record traffic keys come from the traffic secrets via
+//! `HKDF-Expand-Label(secret, "key"/"iv", "", len)` (§7.3); the
+//! Finished MAC key via `HKDF-Expand-Label(secret, "finished",
+//! "", Hash.length)` (§4.4.4).
+//!
+//! ## Why not `net::quic::tls::TlsKeySchedule`?
+//!
+//! The change's tasks file originally pointed Phase 4 at the QUIC
+//! module's `TlsKeySchedule`. That type is an XOR-based placeholder
+//! ("Simplified: XOR-based derivation for stub" — see
+//! `net/src/quic/tls.rs`) wired for QUIC's CRYPTO-frame flow; its
+//! output does not interoperate with any RFC 8446 peer. This module
+//! is the real HKDF schedule, keyed by the suite hash, validated
+//! against vectors cross-checked with two independent oracles
+//! (OpenSSL 3.0 `TLS13-KDF` and the Python stdlib HMAC/HKDF
+//! construction). See design.md D12.
+
+use crate::record::{CipherSuite, NONCE_LEN};
+use crate::{Result, TlsClientError};
+use alloc::vec::Vec;
+use smallaios_security::hkdf::{
+    hkdf_expand_sha256, hkdf_expand_sha384, hkdf_extract_sha256, hkdf_extract_sha384,
+};
+use smallaios_security::hmac_sha2::{hmac_sha256, hmac_sha384};
+use smallaios_security::sha2::{Sha256, Sha384};
+
+/// Maximum digest length across supported suites (SHA-384).
+pub const MAX_HASH_LEN: usize = 48;
+
+/// AEAD key length — 32 bytes for both supported suites
+/// (AES-256-GCM and ChaCha20-Poly1305).
+pub const TRAFFIC_KEY_LEN: usize = 32;
+
+/// The hash algorithm a cipher suite keys its schedule with.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HashAlg {
+    Sha256,
+    Sha384,
+}
+
+impl HashAlg {
+    /// The suite's transcript/HKDF hash (RFC 8446 §B.4).
+    pub fn for_suite(suite: CipherSuite) -> Self {
+        match suite {
+            CipherSuite::Aes256GcmSha384 => Self::Sha384,
+            CipherSuite::ChaCha20Poly1305Sha256 => Self::Sha256,
+        }
+    }
+
+    /// Digest length in bytes.
+    pub fn digest_len(self) -> usize {
+        match self {
+            Self::Sha256 => 32,
+            Self::Sha384 => 48,
+        }
+    }
+}
+
+/// A schedule secret: digest-sized bytes in a max-sized buffer.
+#[derive(Clone, Copy)]
+pub struct Secret {
+    bytes: [u8; MAX_HASH_LEN],
+    len: usize,
+}
+
+impl Secret {
+    fn new(alg: HashAlg) -> Self {
+        Self {
+            bytes: [0u8; MAX_HASH_LEN],
+            len: alg.digest_len(),
+        }
+    }
+
+    fn from_slice(s: &[u8]) -> Self {
+        let mut bytes = [0u8; MAX_HASH_LEN];
+        bytes[..s.len()].copy_from_slice(s);
+        Self {
+            bytes,
+            len: s.len(),
+        }
+    }
+
+    /// The secret bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes[..self.len]
+    }
+}
+
+impl core::fmt::Debug for Secret {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // Never print key material.
+        write!(f, "Secret({} bytes)", self.len)
+    }
+}
+
+/// Streaming transcript hash over every handshake message
+/// (header + body), in order (RFC 8446 §4.4.1).
+#[derive(Clone)]
+pub enum TranscriptHash {
+    Sha256(Sha256),
+    Sha384(Sha384),
+}
+
+impl TranscriptHash {
+    /// Fresh transcript for the suite's hash.
+    pub fn new(alg: HashAlg) -> Self {
+        match alg {
+            HashAlg::Sha256 => Self::Sha256(Sha256::new()),
+            HashAlg::Sha384 => Self::Sha384(Sha384::new()),
+        }
+    }
+
+    /// Absorb raw handshake-message bytes (including the 4-byte
+    /// message header).
+    pub fn update(&mut self, data: &[u8]) {
+        match self {
+            Self::Sha256(h) => h.update(data),
+            Self::Sha384(h) => h.update(data),
+        }
+    }
+
+    /// Hash of everything absorbed so far, without consuming the
+    /// running state.
+    pub fn current(&self) -> Vec<u8> {
+        match self {
+            Self::Sha256(h) => h.clone().finalize().to_vec(),
+            Self::Sha384(h) => h.clone().finalize().to_vec(),
+        }
+    }
+}
+
+/// HKDF-Expand-Label (RFC 8446 §7.1):
+///
+/// ```text
+/// struct {
+///     uint16 length;
+///     opaque label<7..255> = "tls13 " + Label;
+///     opaque context<0..255>;
+/// } HkdfLabel;
+/// ```
+fn hkdf_expand_label(
+    alg: HashAlg,
+    secret: &[u8],
+    label: &[u8],
+    context: &[u8],
+    out: &mut [u8],
+) -> Result<()> {
+    debug_assert!(label.len() <= 249 && context.len() <= 255);
+    let mut info = Vec::with_capacity(2 + 1 + 6 + label.len() + 1 + context.len());
+    info.extend_from_slice(&(out.len() as u16).to_be_bytes());
+    info.push((6 + label.len()) as u8);
+    info.extend_from_slice(b"tls13 ");
+    info.extend_from_slice(label);
+    info.push(context.len() as u8);
+    info.extend_from_slice(context);
+    match alg {
+        HashAlg::Sha256 => {
+            let mut prk = [0u8; 32];
+            if secret.len() != 32 {
+                return Err(TlsClientError::KeyExchange);
+            }
+            prk.copy_from_slice(secret);
+            hkdf_expand_sha256(&prk, &info, out).map_err(|_| TlsClientError::KeyExchange)
+        }
+        HashAlg::Sha384 => {
+            let mut prk = [0u8; 48];
+            if secret.len() != 48 {
+                return Err(TlsClientError::KeyExchange);
+            }
+            prk.copy_from_slice(secret);
+            hkdf_expand_sha384(&prk, &info, out).map_err(|_| TlsClientError::KeyExchange)
+        }
+    }
+}
+
+/// Derive-Secret (RFC 8446 §7.1): Expand-Label keyed by an
+/// already-computed transcript hash, at digest length.
+fn derive_secret(
+    alg: HashAlg,
+    secret: &[u8],
+    label: &[u8],
+    transcript_hash: &[u8],
+) -> Result<Secret> {
+    let mut out = Secret::new(alg);
+    let len = out.len;
+    hkdf_expand_label(alg, secret, label, transcript_hash, &mut out.bytes[..len])?;
+    Ok(out)
+}
+
+fn extract(alg: HashAlg, salt: &[u8], ikm: &[u8]) -> Secret {
+    match alg {
+        HashAlg::Sha256 => Secret::from_slice(&hkdf_extract_sha256(salt, ikm)),
+        HashAlg::Sha384 => Secret::from_slice(&hkdf_extract_sha384(salt, ikm)),
+    }
+}
+
+fn hmac(alg: HashAlg, key: &[u8], message: &[u8]) -> Vec<u8> {
+    match alg {
+        HashAlg::Sha256 => hmac_sha256(key, message).to_vec(),
+        HashAlg::Sha384 => hmac_sha384(key, message).to_vec(),
+    }
+}
+
+/// AEAD write/read keys for one direction (RFC 8446 §7.3).
+#[derive(Clone)]
+pub struct TrafficKeys {
+    pub key: [u8; TRAFFIC_KEY_LEN],
+    pub iv: [u8; NONCE_LEN],
+}
+
+impl core::fmt::Debug for TrafficKeys {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "TrafficKeys(redacted)")
+    }
+}
+
+/// Schedule stage marker — secrets only become readable once the
+/// stage that derives them has run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Stage {
+    Early,
+    Handshake,
+    Application,
+}
+
+/// The TLS 1.3 key schedule for one connection (client role,
+/// no PSK — `psk_ke`/resumption is out of scope in v1).
+pub struct KeySchedule {
+    alg: HashAlg,
+    stage: Stage,
+    /// The "current" extract secret for the next stage transition.
+    current: Secret,
+    client_hs_traffic: Secret,
+    server_hs_traffic: Secret,
+    client_ap_traffic: Secret,
+    server_ap_traffic: Secret,
+}
+
+impl core::fmt::Debug for KeySchedule {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "KeySchedule({:?}, {:?})", self.alg, self.stage)
+    }
+}
+
+impl KeySchedule {
+    /// Initialize with the Early Secret: `HKDF-Extract(0, 0)`
+    /// (no PSK).
+    pub fn new(alg: HashAlg) -> Self {
+        let zeros = [0u8; MAX_HASH_LEN];
+        let early = extract(alg, &[], &zeros[..alg.digest_len()]);
+        Self {
+            alg,
+            stage: Stage::Early,
+            current: early,
+            client_hs_traffic: Secret::new(alg),
+            server_hs_traffic: Secret::new(alg),
+            client_ap_traffic: Secret::new(alg),
+            server_ap_traffic: Secret::new(alg),
+        }
+    }
+
+    /// The suite hash this schedule runs on.
+    pub fn alg(&self) -> HashAlg {
+        self.alg
+    }
+
+    /// Derive the handshake-traffic secrets (task 4.4).
+    ///
+    /// `ecdhe` is the raw key-exchange shared secret (32 bytes for
+    /// x25519; 64 bytes — ML-KEM ss || X25519 ss — for the hybrid
+    /// group). `transcript_hash` is Transcript-Hash(CH..SH).
+    pub fn derive_handshake_secrets(&mut self, ecdhe: &[u8], transcript_hash: &[u8]) -> Result<()> {
+        if self.stage != Stage::Early {
+            return Err(TlsClientError::KeyExchange);
+        }
+        let empty_hash = TranscriptHash::new(self.alg).current();
+        let derived = derive_secret(self.alg, self.current.as_bytes(), b"derived", &empty_hash)?;
+        let handshake = extract(self.alg, derived.as_bytes(), ecdhe);
+        self.client_hs_traffic = derive_secret(
+            self.alg,
+            handshake.as_bytes(),
+            b"c hs traffic",
+            transcript_hash,
+        )?;
+        self.server_hs_traffic = derive_secret(
+            self.alg,
+            handshake.as_bytes(),
+            b"s hs traffic",
+            transcript_hash,
+        )?;
+        self.current = handshake;
+        self.stage = Stage::Handshake;
+        Ok(())
+    }
+
+    /// Derive the application-traffic secrets (task 4.9).
+    ///
+    /// `transcript_hash` is Transcript-Hash(CH..server Finished).
+    pub fn derive_application_secrets(&mut self, transcript_hash: &[u8]) -> Result<()> {
+        if self.stage != Stage::Handshake {
+            return Err(TlsClientError::KeyExchange);
+        }
+        let empty_hash = TranscriptHash::new(self.alg).current();
+        let derived = derive_secret(self.alg, self.current.as_bytes(), b"derived", &empty_hash)?;
+        let zeros = [0u8; MAX_HASH_LEN];
+        let master = extract(
+            self.alg,
+            derived.as_bytes(),
+            &zeros[..self.alg.digest_len()],
+        );
+        self.client_ap_traffic = derive_secret(
+            self.alg,
+            master.as_bytes(),
+            b"c ap traffic",
+            transcript_hash,
+        )?;
+        self.server_ap_traffic = derive_secret(
+            self.alg,
+            master.as_bytes(),
+            b"s ap traffic",
+            transcript_hash,
+        )?;
+        self.current = master;
+        self.stage = Stage::Application;
+        Ok(())
+    }
+
+    fn require(&self, stage: Stage) -> Result<()> {
+        // Application stage retains handshake secrets — allow
+        // reading hs secrets at either stage.
+        let ok = match stage {
+            Stage::Early => true,
+            Stage::Handshake => self.stage != Stage::Early,
+            Stage::Application => self.stage == Stage::Application,
+        };
+        if ok {
+            Ok(())
+        } else {
+            Err(TlsClientError::KeyExchange)
+        }
+    }
+
+    /// client_handshake_traffic_secret.
+    pub fn client_hs_traffic_secret(&self) -> Result<&Secret> {
+        self.require(Stage::Handshake)?;
+        Ok(&self.client_hs_traffic)
+    }
+
+    /// server_handshake_traffic_secret.
+    pub fn server_hs_traffic_secret(&self) -> Result<&Secret> {
+        self.require(Stage::Handshake)?;
+        Ok(&self.server_hs_traffic)
+    }
+
+    /// client_application_traffic_secret_0.
+    pub fn client_ap_traffic_secret(&self) -> Result<&Secret> {
+        self.require(Stage::Application)?;
+        Ok(&self.client_ap_traffic)
+    }
+
+    /// server_application_traffic_secret_0.
+    pub fn server_ap_traffic_secret(&self) -> Result<&Secret> {
+        self.require(Stage::Application)?;
+        Ok(&self.server_ap_traffic)
+    }
+
+    /// Per-direction AEAD keys from a traffic secret (§7.3).
+    pub fn traffic_keys(&self, secret: &Secret) -> Result<TrafficKeys> {
+        let mut key = [0u8; TRAFFIC_KEY_LEN];
+        let mut iv = [0u8; NONCE_LEN];
+        hkdf_expand_label(self.alg, secret.as_bytes(), b"key", &[], &mut key)?;
+        hkdf_expand_label(self.alg, secret.as_bytes(), b"iv", &[], &mut iv)?;
+        Ok(TrafficKeys { key, iv })
+    }
+
+    /// Finished verify_data for the given traffic secret (§4.4.4):
+    ///
+    /// ```text
+    /// finished_key = HKDF-Expand-Label(BaseKey, "finished", "", Hash.length)
+    /// verify_data = HMAC(finished_key, Transcript-Hash(...))
+    /// ```
+    pub fn finished_verify_data(&self, secret: &Secret, transcript_hash: &[u8]) -> Result<Vec<u8>> {
+        let mut finished_key = [0u8; MAX_HASH_LEN];
+        let len = self.alg.digest_len();
+        hkdf_expand_label(
+            self.alg,
+            secret.as_bytes(),
+            b"finished",
+            &[],
+            &mut finished_key[..len],
+        )?;
+        Ok(hmac(self.alg, &finished_key[..len], transcript_hash))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::format;
+    use alloc::string::String;
+
+    fn hex(bytes: &[u8]) -> String {
+        let mut s = String::with_capacity(bytes.len() * 2);
+        for b in bytes {
+            s.push_str(&format!("{b:02x}"));
+        }
+        s
+    }
+
+    fn h(s: &str) -> Vec<u8> {
+        (0..s.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
+            .collect()
+    }
+
+    // Synthetic-transcript key-schedule vectors. Every value was
+    // generated twice — once with OpenSSL 3.0's `TLS13-KDF`
+    // (EXTRACT_ONLY/EXPAND_ONLY modes) and once with a Python
+    // stdlib HMAC/HKDF reference — and the two oracles agreed on
+    // every intermediate secret.
+    //
+    // Transcript material (raw, unhashed):
+    //   CH  = 01000200 || "synthetic-client-hello-body-for-kat"*3
+    //   SH  = 02000100 || "synthetic-server-hello-body-for-kat"*2
+    //   MID = "synthetic-ee||cert||certverify-bytes"*4
+    //   FIN = "synthetic-server-finished-message"
+    fn ch() -> Vec<u8> {
+        let mut v = h("01000200");
+        for _ in 0..3 {
+            v.extend_from_slice(b"synthetic-client-hello-body-for-kat");
+        }
+        v
+    }
+    fn sh() -> Vec<u8> {
+        let mut v = h("02000100");
+        for _ in 0..2 {
+            v.extend_from_slice(b"synthetic-server-hello-body-for-kat");
+        }
+        v
+    }
+    fn mid() -> Vec<u8> {
+        let mut v = Vec::new();
+        for _ in 0..4 {
+            v.extend_from_slice(b"synthetic-ee||cert||certverify-bytes");
+        }
+        v
+    }
+    const FIN: &[u8] = b"synthetic-server-finished-message";
+
+    struct Expected {
+        alg: HashAlg,
+        ecdhe: &'static str,
+        t_ch_sh: &'static str,
+        c_hs: &'static str,
+        s_hs: &'static str,
+        t_full: &'static str,
+        c_ap: &'static str,
+        s_ap: &'static str,
+        s_hs_key: &'static str,
+        s_hs_iv: &'static str,
+        t_at_sfin_input: &'static str,
+        s_verify_data: &'static str,
+    }
+
+    fn run_scenario(e: &Expected) {
+        let mut ks = KeySchedule::new(e.alg);
+
+        // Handshake secrets are gated until derived.
+        assert!(ks.client_hs_traffic_secret().is_err());
+
+        let mut transcript = TranscriptHash::new(e.alg);
+        transcript.update(&ch());
+        transcript.update(&sh());
+        let t_ch_sh = transcript.current();
+        assert_eq!(hex(&t_ch_sh), e.t_ch_sh);
+
+        ks.derive_handshake_secrets(&h(e.ecdhe), &t_ch_sh).unwrap();
+        assert_eq!(
+            hex(ks.client_hs_traffic_secret().unwrap().as_bytes()),
+            e.c_hs
+        );
+        assert_eq!(
+            hex(ks.server_hs_traffic_secret().unwrap().as_bytes()),
+            e.s_hs
+        );
+
+        // App secrets still gated.
+        assert!(ks.client_ap_traffic_secret().is_err());
+
+        // Server handshake traffic keys.
+        let keys = ks
+            .traffic_keys(ks.server_hs_traffic_secret().unwrap())
+            .unwrap();
+        assert_eq!(hex(&keys.key), e.s_hs_key);
+        assert_eq!(hex(&keys.iv), e.s_hs_iv);
+
+        // Server Finished verify_data over CH..CertificateVerify.
+        transcript.update(&mid());
+        let t_at_fin = transcript.current();
+        assert_eq!(hex(&t_at_fin), e.t_at_sfin_input);
+        let vd = ks
+            .finished_verify_data(ks.server_hs_traffic_secret().unwrap(), &t_at_fin)
+            .unwrap();
+        assert_eq!(hex(&vd), e.s_verify_data);
+
+        // App secrets over CH..server Finished.
+        transcript.update(FIN);
+        let t_full = transcript.current();
+        assert_eq!(hex(&t_full), e.t_full);
+        ks.derive_application_secrets(&t_full).unwrap();
+        assert_eq!(
+            hex(ks.client_ap_traffic_secret().unwrap().as_bytes()),
+            e.c_ap
+        );
+        assert_eq!(
+            hex(ks.server_ap_traffic_secret().unwrap().as_bytes()),
+            e.s_ap
+        );
+
+        // Handshake secrets remain readable post-transition.
+        assert_eq!(
+            hex(ks.server_hs_traffic_secret().unwrap().as_bytes()),
+            e.s_hs
+        );
+
+        // Double-transition refused.
+        assert!(ks.derive_application_secrets(&t_full).is_err());
+    }
+
+    #[test]
+    fn schedule_sha256_suite() {
+        run_scenario(&Expected {
+            alg: HashAlg::Sha256,
+            ecdhe: "0a2643dee2a53e5ac789def7053c1a663e1a38ab87a65db0e93cdb666f08adf4",
+            t_ch_sh: "db7d416283dbac908d50ee5965c3301f61018324927b2d76e2d59e5a48f6c0ca",
+            c_hs: "f36435ad632b9bd79efc425723758ac8d8a9b7d0a414d0c1448bd4d5b6941b32",
+            s_hs: "12b76515d84a0b861604020210fa6bdeca5dc318e5bd338691a0feefdf0261d4",
+            t_full: "7b5d304b7647d6fba59c1aee9f78d03198650b42f3be455ff153ea65a5f13771",
+            c_ap: "7947fd6113b86abdae06b622921c243134b6d75c79f5e858fa022c1c1a400c8d",
+            s_ap: "52ea36e0ea0920079c53105ead6e5de899a1ce2170eb0aebe6b98eb871008b3b",
+            s_hs_key: "d188e0e355f151b682b9732a74745fb0d4ff988eaf6b04716b0484d14923e8eb",
+            s_hs_iv: "f4b6796a9f8a33ab1bf8610b",
+            t_at_sfin_input: "0d925902be67d7ca179467bd7fb117551c970f7da6f21fcc62e817bb3d7523c4",
+            s_verify_data: "7078cb671e7d749bb2061ee5616d0578e306debcbddc9155e2aa98b0562fc85b",
+        });
+    }
+
+    #[test]
+    fn schedule_sha384_suite() {
+        run_scenario(&Expected {
+            alg: HashAlg::Sha384,
+            ecdhe: "0a2643dee2a53e5ac789def7053c1a663e1a38ab87a65db0e93cdb666f08adf4",
+            t_ch_sh: "e803b50e86a7d46f9b2ec4f4c8340a92fcd23bd1a2111ab6c898167ee3c395dc\
+72571378d25e72dd2a27b77e0f6fc7bf",
+            c_hs: "55f8047598e2cea07b08133aba11964462e14415982f5b37b6989702b7e8588d\
+db71929ea9adbd2be371be5640a12553",
+            s_hs: "43ae32fb4edb01b3eaaad9e2c3576eb1a2a22eee2c6fa482dcdc50a7ea9ca4ea\
+f46d0a5902698b2eb6c38f0c6b0caa25",
+            t_full: "e53cfe4f5a7f0956890baa72d1e1f70fc52bb770dbb6322331a541ebcd0fe440\
+dc32aa3f47fa04f4943976e3da706be8",
+            c_ap: "3284fbd06e0fbf2b5c6bea3523723b5799091b5297e008120dbaeeb49e7fbae7\
+414a3a04fa86b039f6d3edd4ce428f10",
+            s_ap: "3c06bf11bb623e481ec4bd2d723fb9db8345ddcbe2bb7c72a3e1523d7f874f3f\
+2153158cc24045228c579cfa81204fe0",
+            s_hs_key: "9bbfd5b8e82b47cb83600f4029aba4e9e54de811889473c51b4124688474ce79",
+            s_hs_iv: "694a44c03f1334da125d42c6",
+            t_at_sfin_input: "883f481e52b466179a65f62cdacade01cf5f2eb79870a0593733247fb195b4b5\
+edfa55339526265164790087b80d22f4",
+            s_verify_data: "de435589fc3dd351b97d5714be5acb9bfb836991fa61b9eada848507b635208e\
+e58af7cef835a568064a710bcb5b4717",
+        });
+    }
+
+    #[test]
+    fn schedule_sha256_hybrid_64_byte_ecdhe() {
+        // The hybrid group's shared secret is 64 bytes
+        // (ML-KEM-768 ss || X25519 ss) — exercise the wider IKM.
+        run_scenario(&Expected {
+            alg: HashAlg::Sha256,
+            ecdhe: "9aa93c43c6959937ee1e467b892abf8d823d999ceda44a8e1f1a8f653ad04789\
+f9a41999316e6976c96bf12e533324c925948512b0892b12d121825a216dd3d7",
+            t_ch_sh: "db7d416283dbac908d50ee5965c3301f61018324927b2d76e2d59e5a48f6c0ca",
+            c_hs: "cdd2c068573f9a404c38ef7779eebabfdac4058097c1a0c952ee5961935e72ec",
+            s_hs: "21d9b6dbb2bb7b509eb7c07354e9fe320254cb21a12319581d6a0ae39d2cfae1",
+            t_full: "7b5d304b7647d6fba59c1aee9f78d03198650b42f3be455ff153ea65a5f13771",
+            c_ap: "61ed2cdf54749124aab58dad6b07b7ab8a0e2b512b0d1b489f28b5a7d27867a4",
+            s_ap: "71cb2aeb7b692f1f90d999365c5d49ae8cb2a821b3a5478fd5eb27dabdecff1b",
+            s_hs_key: "be510923febfcb36abaf7cb84e257278dfe58c18606a0fde28d84bf28f1c71ff",
+            s_hs_iv: "1ded168b19c354965cbca710",
+            t_at_sfin_input: "0d925902be67d7ca179467bd7fb117551c970f7da6f21fcc62e817bb3d7523c4",
+            s_verify_data: "eb7c9e8fda3cc2c65e3f5442b89afcba014fbe38587c968a2881f198c622e268",
+        });
+    }
+
+    #[test]
+    fn early_secret_matches_known_value() {
+        // HKDF-Extract(0, 0^32) over SHA-256 — the universal TLS 1.3
+        // no-PSK early secret, also OpenSSL-confirmed.
+        let ks = KeySchedule::new(HashAlg::Sha256);
+        assert_eq!(
+            hex(ks.current.as_bytes()),
+            "33ad0a1c607ec03b09e6cd9893680ce210adf300aa1f2660e1b22e10f170f92a"
+        );
+    }
+
+    #[test]
+    fn suite_to_hash_mapping() {
+        assert_eq!(
+            HashAlg::for_suite(CipherSuite::Aes256GcmSha384),
+            HashAlg::Sha384
+        );
+        assert_eq!(
+            HashAlg::for_suite(CipherSuite::ChaCha20Poly1305Sha256),
+            HashAlg::Sha256
+        );
+    }
+}

--- a/tls-client/src/handshake/mod.rs
+++ b/tls-client/src/handshake/mod.rs
@@ -28,6 +28,8 @@ pub mod extensions;
 pub mod finished;
 pub mod key_schedule;
 pub mod server_hello;
+#[cfg(test)]
+pub(crate) mod test_util;
 
 use crate::{Result, TlsClientError};
 use alloc::vec::Vec;

--- a/tls-client/src/handshake/mod.rs
+++ b/tls-client/src/handshake/mod.rs
@@ -20,8 +20,13 @@
 //! follow-on commit alongside Phase 5's cert verifier and
 //! Phase 7's `TcpTlsStream`.
 
+pub mod certificate_msg;
 pub mod client_hello;
+pub mod driver;
+pub mod encrypted_extensions;
 pub mod extensions;
+pub mod finished;
+pub mod key_schedule;
 pub mod server_hello;
 
 use crate::{Result, TlsClientError};

--- a/tls-client/src/handshake/server_hello.rs
+++ b/tls-client/src/handshake/server_hello.rs
@@ -152,7 +152,7 @@ pub fn parse_server_hello(buf: &[u8]) -> Result<ServerHello> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::handshake::extensions::{ext_type, named_group};
+    use crate::handshake::extensions::named_group;
 
     /// Build a synthetic ServerHello for testing the parser.
     fn build_server_hello(
@@ -161,46 +161,13 @@ mod tests {
         key_share_group: u16,
         key_share_pk: &[u8],
     ) -> Vec<u8> {
-        let mut body = Vec::new();
-        // legacy_version
-        body.extend_from_slice(&[0x03, 0x03]);
-        // random
-        body.extend_from_slice(&[0xaa; 32]);
-        // session_id_echo: empty
-        body.push(0);
-        // cipher_suite
-        body.extend_from_slice(&cipher_suite_code.to_be_bytes());
-        // legacy_compression_method
-        body.push(0);
-        // extensions block
-        let mut exts = Vec::new();
-        if let Some(v) = selected_version {
-            // supported_versions extension (server form: bare u16)
-            exts.extend_from_slice(&ext_type::SUPPORTED_VERSIONS.to_be_bytes());
-            exts.extend_from_slice(&2u16.to_be_bytes());
-            exts.extend_from_slice(&v.to_be_bytes());
-        }
-        // key_share
-        let mut ks_body = Vec::new();
-        ks_body.extend_from_slice(&key_share_group.to_be_bytes());
-        ks_body.extend_from_slice(&(key_share_pk.len() as u16).to_be_bytes());
-        ks_body.extend_from_slice(key_share_pk);
-        exts.extend_from_slice(&ext_type::KEY_SHARE.to_be_bytes());
-        exts.extend_from_slice(&(ks_body.len() as u16).to_be_bytes());
-        exts.extend_from_slice(&ks_body);
-        // outer length
-        body.extend_from_slice(&(exts.len() as u16).to_be_bytes());
-        body.extend_from_slice(&exts);
-
-        // 4-byte handshake header
-        let mut out = Vec::new();
-        let hdr = HandshakeHeader {
-            msg_type: HandshakeType::ServerHello,
-            length: body.len() as u32,
-        };
-        hdr.encode(&mut out).unwrap();
-        out.extend_from_slice(&body);
-        out
+        crate::handshake::test_util::build_server_hello(
+            cipher_suite_code,
+            selected_version,
+            key_share_group,
+            key_share_pk,
+            [0xaa; 32],
+        )
     }
 
     #[test]

--- a/tls-client/src/handshake/test_util.rs
+++ b/tls-client/src/handshake/test_util.rs
@@ -48,12 +48,35 @@ pub(crate) fn build_server_hello(
     key_share_pk: &[u8],
     random: [u8; 32],
 ) -> Vec<u8> {
+    build_server_hello_with_session_id(
+        cipher_suite_code,
+        selected_version,
+        key_share_group,
+        key_share_pk,
+        random,
+        &[],
+    )
+}
+
+/// [`build_server_hello`] with a caller-chosen
+/// `legacy_session_id_echo`. The client under test always sends an
+/// empty `legacy_session_id`, so tests pass a non-empty echo here
+/// to provoke the RFC 8446 §4.1.3 mismatch abort.
+pub(crate) fn build_server_hello_with_session_id(
+    cipher_suite_code: u16,
+    selected_version: Option<u16>,
+    key_share_group: u16,
+    key_share_pk: &[u8],
+    random: [u8; 32],
+    session_id_echo: &[u8],
+) -> Vec<u8> {
     let mut body = Vec::new();
     // legacy_version
     body.extend_from_slice(&[0x03, 0x03]);
     body.extend_from_slice(&random);
-    // session_id_echo: empty
-    body.push(0);
+    // session_id_echo
+    body.push(session_id_echo.len() as u8);
+    body.extend_from_slice(session_id_echo);
     body.extend_from_slice(&cipher_suite_code.to_be_bytes());
     // legacy_compression_method
     body.push(0);

--- a/tls-client/src/handshake/test_util.rs
+++ b/tls-client/src/handshake/test_util.rs
@@ -1,0 +1,118 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared helpers for `handshake` unit tests.
+//!
+//! One copy of the synthetic server-flight message builders and the
+//! hex formatter, consumed by the `server_hello`,
+//! `encrypted_extensions`, `certificate_msg`, `key_schedule`, and
+//! `driver` test modules — so the wire-building logic under test
+//! exists exactly once and the per-file test harnesses cannot drift.
+
+#![cfg(test)]
+
+use super::extensions::ext_type;
+use super::{HandshakeHeader, HandshakeType};
+use alloc::string::String;
+use alloc::vec::Vec;
+
+/// Lowercase hex of `bytes`.
+pub(crate) fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push(char::from_digit((b >> 4) as u32, 16).unwrap());
+        s.push(char::from_digit((b & 0xf) as u32, 16).unwrap());
+    }
+    s
+}
+
+/// Prepend the 4-byte handshake header to `body`.
+pub(crate) fn wrap_handshake(msg_type: HandshakeType, body: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(HandshakeHeader::LEN + body.len());
+    HandshakeHeader {
+        msg_type,
+        length: body.len() as u32,
+    }
+    .encode(&mut out)
+    .unwrap();
+    out.extend_from_slice(body);
+    out
+}
+
+/// Build a synthetic ServerHello message (header included).
+/// `selected_version = None` omits the supported_versions extension.
+pub(crate) fn build_server_hello(
+    cipher_suite_code: u16,
+    selected_version: Option<u16>,
+    key_share_group: u16,
+    key_share_pk: &[u8],
+    random: [u8; 32],
+) -> Vec<u8> {
+    let mut body = Vec::new();
+    // legacy_version
+    body.extend_from_slice(&[0x03, 0x03]);
+    body.extend_from_slice(&random);
+    // session_id_echo: empty
+    body.push(0);
+    body.extend_from_slice(&cipher_suite_code.to_be_bytes());
+    // legacy_compression_method
+    body.push(0);
+    let mut exts = Vec::new();
+    if let Some(v) = selected_version {
+        // supported_versions extension (server form: bare u16)
+        exts.extend_from_slice(&ext_type::SUPPORTED_VERSIONS.to_be_bytes());
+        exts.extend_from_slice(&2u16.to_be_bytes());
+        exts.extend_from_slice(&v.to_be_bytes());
+    }
+    let mut ks_body = Vec::new();
+    ks_body.extend_from_slice(&key_share_group.to_be_bytes());
+    ks_body.extend_from_slice(&(key_share_pk.len() as u16).to_be_bytes());
+    ks_body.extend_from_slice(key_share_pk);
+    exts.extend_from_slice(&ext_type::KEY_SHARE.to_be_bytes());
+    exts.extend_from_slice(&(ks_body.len() as u16).to_be_bytes());
+    exts.extend_from_slice(&ks_body);
+    body.extend_from_slice(&(exts.len() as u16).to_be_bytes());
+    body.extend_from_slice(&exts);
+    wrap_handshake(HandshakeType::ServerHello, &body)
+}
+
+/// Build an EncryptedExtensions message carrying the given raw
+/// `(ext_type, data)` pairs.
+pub(crate) fn build_encrypted_extensions(exts: &[(u16, &[u8])]) -> Vec<u8> {
+    let mut block = Vec::new();
+    for (t, data) in exts {
+        block.extend_from_slice(&t.to_be_bytes());
+        block.extend_from_slice(&(data.len() as u16).to_be_bytes());
+        block.extend_from_slice(data);
+    }
+    let mut body = Vec::new();
+    body.extend_from_slice(&(block.len() as u16).to_be_bytes());
+    body.extend_from_slice(&block);
+    wrap_handshake(HandshakeType::EncryptedExtensions, &body)
+}
+
+/// Build a Certificate message from raw DER blobs (no per-entry
+/// extensions, empty certificate_request_context).
+pub(crate) fn build_certificate(certs: &[&[u8]]) -> Vec<u8> {
+    let mut list = Vec::new();
+    for c in certs {
+        list.extend_from_slice(&(c.len() as u32).to_be_bytes()[1..]); // u24
+        list.extend_from_slice(c);
+        list.extend_from_slice(&[0, 0]); // no per-entry extensions
+    }
+    let mut body = Vec::new();
+    body.push(0); // empty certificate_request_context
+    body.extend_from_slice(&(list.len() as u32).to_be_bytes()[1..]); // u24
+    body.extend_from_slice(&list);
+    wrap_handshake(HandshakeType::Certificate, &body)
+}
+
+/// Build a CertificateVerify message from a scheme code and raw
+/// signature bytes.
+pub(crate) fn build_certificate_verify(scheme: u16, sig: &[u8]) -> Vec<u8> {
+    let mut body = Vec::new();
+    body.extend_from_slice(&scheme.to_be_bytes());
+    body.extend_from_slice(&(sig.len() as u16).to_be_bytes());
+    body.extend_from_slice(sig);
+    wrap_handshake(HandshakeType::CertificateVerify, &body)
+}


### PR DESCRIPTION
## Summary

Phase 4 of the `tls-tcp-client-v1` OpenSpec change (tasks 4.4–4.9): the client handshake state machine and the cryptographic key schedule that backs it.

### Key design call — design.md D12

Task 4.4 originally said to reuse `net::quic::tls::TlsKeySchedule::derive_handshake_secrets`. Implementation found that type is an **XOR-based placeholder** (`"Simplified: XOR-based derivation for stub"` in `net/src/quic/tls.rs`) whose output cannot interoperate with any RFC 8446 peer. This PR instead lands a real RFC 8446 §7.1 HKDF key schedule in `tls-client/src/handshake/key_schedule.rs`, recorded as decision **D12** in the change's design.md. The QUIC module is untouched.

That also surfaced missing primitives: the spec-mandated `TLS_AES_256_GCM_SHA384` suite requires HMAC/HKDF-SHA-384, which existed nowhere in the workspace. Added to `security/` (section 2b of tasks.md): `Sha384` (FIPS 180-4), `hmac_sha2` (RFC 2104), `hkdf` (RFC 5869).

### What's in the driver (`handshake/driver.rs`)

- Synchronous, I/O-free `ClientHandshake` step machine per design D7 — Phase 7's `TcpTlsStream` will drive it over a socket.
- Version pinning (TLS 1.2 selection → `Version`), HelloRetryRequest refusal, `require_pqc` downgrade detection (→ `PqcDowngrade`) per design D3.
- X25519 and draft-ietf-tls-ecdhe-mlkem `X25519MLKEM768` hybrid key exchange (ML-KEM material first, concatenated shared secret — the standard interop ordering, not QUIC's internal SHA-3 combiner).
- EncryptedExtensions (SNI ack; refuses extensions illegal in EE), Certificate / CertificateVerify wire parsing with the spec's signature-scheme allow-list (SHA-1 refused), Ed25519 CertificateVerify verification, constant-time server-Finished check, client Finished + application-traffic keys.
- Chain validation is delegated through a new `cert::ServerCertVerifier` seam — the production trust-store verifier is Phase 5 (tasks 5.4/5.5); CertificateRequest is refused (no mTLS in v1, per proposal).

### Test/validation strategy

- Every key-schedule vector cross-validated against **two independent oracles**: OpenSSL 3.0 `TLS13-KDF` and a Python-stdlib HMAC/HKDF reference; primitives KAT'd against published RFC 4231 / RFC 5869 / FIPS 180-4 vectors.
- End-to-end driver tests against an in-test TLS 1.3 server built from the same primitives: both cipher suites, the PQC hybrid group, coalesced and byte-at-a-time fragmented records, tampered Finished, wrong CertificateVerify signature, untrusted chain, TLS 1.2 reply, HRR, CertificateRequest, mid-handshake CCS.
- `cargo test`: 120 tests in `smallaios-tls-client`, 950 in `smallaios-security`; host suite green (5,475 passed / 0 failed — `smallaios-mgmt` excluded, its `toml_oracle` test fails to compile on the clean baseline too, unrelated to this PR).
- `cargo clippy -D warnings` and `cargo fmt --check` clean on both touched crates.

### OpenSpec progress

`tls-tcp-client-v1`: 21/63 → 30/66 tasks (sections 2b + 4 updated; deviation recorded in tasks.md 4.4 and design.md D12).

https://claude.ai/code/session_01V8CYR19HgR4QDdEWNmspyZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01V8CYR19HgR4QDdEWNmspyZ)_