### PR TITLE
fix(ci): cover auth/mgmt/fs/xtask in CI and fix mgmt toml oracle features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,10 @@ jobs:
           -p smallaios-usb
           -p smallaios-sdr
           -p smallaios-bench
+          -p smallaios-auth
+          -p smallaios-mgmt
+          -p smallaios-fs
+          -p xtask
           -- -D warnings
 
   build-x86_64:
@@ -147,6 +151,10 @@ jobs:
           -p smallaios-usb
           -p smallaios-sdr
           -p smallaios-bench
+          -p smallaios-auth
+          -p smallaios-mgmt
+          -p smallaios-fs
+          -p xtask
 
   cuda-check:
     name: CUDA Feature Check (cargo check --features cuda)
@@ -622,7 +630,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate per-crate coverage reports
         run: |
-          CRATES=(kernel security onnx-rt ipc net posix container bus peripheral usb sdr)
+          CRATES=(kernel security onnx-rt ipc net posix container bus peripheral usb sdr auth mgmt fs)
           EXTRA_FLAGS=""
           for crate in "${CRATES[@]}"; do
             pkg="smallaios-${crate}"
@@ -1370,6 +1378,9 @@ jobs:
             -p smallaios-container \
             -p smallaios-bus \
             -p smallaios-bench \
+            -p smallaios-auth \
+            -p smallaios-mgmt \
+            -p smallaios-fs \
             2>&1 | tee coverage-threshold.txt
       - name: Upload coverage report
         if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,6 +1066,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
  "toml_parser",

--- a/mgmt/Cargo.toml
+++ b/mgmt/Cargo.toml
@@ -18,8 +18,10 @@ smallaios-kernel = { path = "../kernel" }
 # Dev-only "oracle" used by mgmt/tests/toml_oracle.rs to cross-check
 # our clean-room TOML parser against the upstream `toml` crate. Only
 # pulled in for `cargo test` — production builds (kernel + container)
-# do NOT depend on this crate.
-toml = { version = "1.1", default-features = false, features = ["parse"] }
+# do NOT depend on this crate. toml 1.x gates `from_str`/`Table`
+# behind the `serde` feature (split out of `parse` in the 0.8 -> 1.x
+# bump), so both features are required.
+toml = { version = "1.1", default-features = false, features = ["parse", "serde"] }
 
 [features]
 default = []


### PR DESCRIPTION
## Summary

`smallaios-auth`, `smallaios-mgmt`, `smallaios-fs`, and `xtask` appear **nowhere in ci.yml** — the curated package lists in Unit Tests, Clippy, Code Coverage, and Coverage Threshold were never extended when those crates landed. That gap had a concrete casualty: Dependabot's toml 0.8 → 1.x bump (#178) silently broke `mgmt`'s `toml_oracle` cross-check test (toml 1.x moved `from_str`/`Table` behind the `serde` feature), which CI never noticed and which breaks `just test` on every dev machine.

## Changes
- `mgmt/Cargo.toml`: add `serde` to the toml dev-dependency features (with a comment explaining the 1.x feature split)
- **Unit Tests + Clippy jobs**: add the four crates — verified locally (701 tests pass, `clippy --all-targets -D warnings` clean)
- **Code Coverage + Coverage Threshold jobs**: add `auth`/`mgmt`/`fs` — measured locally at **94.16% lines** combined, comfortably above the 80% gate (`xtask` excluded: dev tooling, not `smallaios-` prefixed)

## Follow-up (not here)
- Weekly Miri job: `auth` exercises Argon2id paths that need the same `cfg(miri)` parameter treatment as kernel `syscall::auth` got in #218 before it can join the Miri package list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded CI pipeline to include additional Rust crates in linting, testing, and code coverage verification.
  * Updated development dependency configuration to enable additional required features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->