### PR TITLE
feat(tls-client): X.509v3 parser, trust store + chain verifier (tls-tcp-client-v1 phase 5/6)

### DIFF
--- a/openspec/changes/tls-tcp-client-v1/tasks.md
+++ b/openspec/changes/tls-tcp-client-v1/tasks.md
@@ -48,20 +48,20 @@
 - [x] 5.1 `tls-client/src/cert/der.rs` — minimal DER TLV decoder. Accepts short-form length (≤127), long-form length (1-4 octets, value ≤ 1 MiB cap); refuses indefinite-length, multi-byte tag forms, non-minimal long forms, length exceeding enclosing structure
 - [x] 5.3 Length-bound every OCTET STRING / SEQUENCE before allocation *(landed with 5.1)*
 - [x] 5.7 RFC 6125 hostname matcher (`tls-client/src/cert/hostname.rs`): DNS-ID with exact + wildcard matching (leftmost-label, ≥3-label cert, no mid-label `*`, no multi-label span); iPAddress SAN (IPv4 + IPv6 with `::` elision); refuses DNS-ID for IP literals and vice versa
-- [ ] 5.2 Refuse `version != v3`, SHA-1 signatures, missing SAN *(follow-on: full X.509v3 structure parser — needs RSA-PSS + ECDSA-P256 primitives in security/, both deferred)*
-- [ ] 5.4 Chain construction: leaf → intermediate(s) → anchor in trust store; each intermediate must have `BasicConstraints.CA = true` + `KeyUsage.keyCertSign` *(follow-on)*
-- [ ] 5.5 Signature verification on every link (Ed25519, ECDSA-P256, RSA-PSS) *(follow-on; Ed25519 ready in security/crypto/ed25519; ECDSA-P256 and RSA-PSS deferred to their own primitive sub-adds)*
-- [ ] 5.6 Validity-window check with `kernel::clock()`; unsynced-clock sentinel handling; audit `audit_export_unsynced_clock` on bypass *(follow-on)*
-- [ ] 5.8 Cross-vector tests in `tls-client/tests/corpus/`: ≥10 known-good cert chains + ≥6 known-bad *(follow-on; requires the full structure parser + a synthetic Ed25519-signed cert generator harness)*
+- [x] 5.2 Refuse `version != v3`, SHA-1 signatures, missing SAN *(`cert/x509.rs` — full X.509v3 structure parser: version/serial/sig-alg/issuer/subject/validity/SPKI + SAN/BasicConstraints/KeyUsage/ExtKeyUsage; v3-only, SHA-1 refused, SAN required by the chain verifier. RSA-PSS/PKCS#1 and ECDSA-P256 OIDs are recognized for precise "unsupported" reporting but their verification is deferred to their primitive sub-adds.)*
+- [x] 5.4 Chain construction: leaf → intermediate(s) → anchor in trust store; each intermediate must have `BasicConstraints.CA = true` + `KeyUsage.keyCertSign` *(`cert/verify.rs` `TrustStoreVerifier`; depth-bounded issuer walk)*
+- [ ] 5.5 Signature verification on every link (Ed25519, ECDSA-P256, RSA-PSS) *(Ed25519 link verification is **live** in `cert/verify.rs`; ECDSA-P256 and RSA-PSS remain blocked on `security-ecdsa-p256-v1` / `security-rsa-pss-v1` — a chain needing one is refused with `ChainUntrusted`, never silently accepted)*
+- [x] 5.6 Validity-window check with `kernel::clock()`; unsynced-clock sentinel handling; audit `audit_export_unsynced_clock` on bypass *(validity window + 2026 unsynced-clock sentinel with `require_synced_clock` policy in `cert/verify.rs`; `now` is injected by the caller to keep `tls-client` decoupled from the kernel allocator — the `kernel::clock()` read + `audit_export_unsynced_clock` record land in the Phase 8 container integration)*
+- [ ] 5.8 Cross-vector tests in `tls-client/tests/corpus/`: ≥10 known-good cert chains + ≥6 known-bad *(synthetic Ed25519 cert generator landed in `cert/test_certs.rs`; in-module good/bad cross-vectors cover direct/two-link chains, tampered sig, unknown anchor, hostname mismatch, expiry, no-SAN, non-CA intermediate, pinning, IP-SAN. The external `tests/corpus/` files + RSA/ECDSA cases remain follow-on)*
 - [ ] 5.9 `cargo-fuzz` target on the X.509 parser *(follow-on; the DER decoder landed in this commit is the largest attacker-controlled surface and is fuzz-ready)*
 
 ## 6. Trust store
 
-- [ ] 6.1 `tls-client/src/trust.rs` — PEM bundle loader (base64-decode each `BEGIN CERTIFICATE` / `END CERTIFICATE` block)
-- [ ] 6.2 Reject empty bundles, non-CA certs, duplicate Subjects
-- [ ] 6.3 Optional pin verification: when `tls.trust_store_pin` is set, refuse chains anchored elsewhere
-- [ ] 6.4 Wire `Config::validate` in `audit-export::config` to enforce: `enabled = true && trust_store_path = ""` → `ConfigError::TrustStoreRequired`
-- [ ] 6.5 Tests: empty bundle, non-CA cert, duplicate Subjects, valid bundle, pinned vs non-pinned chain accept/reject
+- [x] 6.1 `tls-client/src/trust.rs` — PEM bundle loader (base64-decode each `BEGIN CERTIFICATE` / `END CERTIFICATE` block)
+- [x] 6.2 Reject empty bundles, non-CA certs, duplicate Subjects
+- [x] 6.3 Optional pin verification: when `tls.trust_store_pin` is set, refuse chains anchored elsewhere *(per-anchor SHA-256 fingerprint pin enforced in `TrustStoreVerifier`)*
+- [ ] 6.4 Wire `Config::validate` in `audit-export::config` to enforce: `enabled = true && trust_store_path = ""` → `ConfigError::TrustStoreRequired` *(Phase 8 — `audit-export` integration)*
+- [x] 6.5 Tests: empty bundle, non-CA cert, duplicate Subjects, valid bundle, pinned vs non-pinned chain accept/reject
 
 ## 7. `std`-IO adapter (`TcpTlsStream`)
 

--- a/tls-client/src/cert/der.rs
+++ b/tls-client/src/cert/der.rs
@@ -148,6 +148,18 @@ impl<'a> Reader<'a> {
         Ok(Tlv { tag, value })
     }
 
+    /// Decode the next TLV, returning both the parsed view and the
+    /// complete raw encoding (header + value). Needed when an outer
+    /// signature is computed over a nested element's exact DER — e.g.
+    /// a certificate's `signatureValue` covers the full
+    /// `tbsCertificate` TLV, not just its contents.
+    pub fn next_tlv_with_raw(&mut self) -> Result<(Tlv<'a>, &'a [u8])> {
+        let start = self.input;
+        let tlv = self.next_tlv()?;
+        let consumed = start.len() - self.input.len();
+        Ok((tlv, &start[..consumed]))
+    }
+
     /// Decode the next TLV and assert it matches `expected_tag`.
     pub fn expect_tlv(&mut self, expected_tag: u8) -> Result<&'a [u8]> {
         let tlv = self.next_tlv()?;

--- a/tls-client/src/cert/mod.rs
+++ b/tls-client/src/cert/mod.rs
@@ -21,6 +21,10 @@
 
 pub mod der;
 pub mod hostname;
+pub mod x509;
+
+#[cfg(test)]
+pub(crate) mod test_certs;
 
 use crate::Result;
 use alloc::vec::Vec;

--- a/tls-client/src/cert/mod.rs
+++ b/tls-client/src/cert/mod.rs
@@ -21,6 +21,7 @@
 
 pub mod der;
 pub mod hostname;
+pub mod verify;
 pub mod x509;
 
 #[cfg(test)]

--- a/tls-client/src/cert/test_certs.rs
+++ b/tls-client/src/cert/test_certs.rs
@@ -1,0 +1,267 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Synthetic X.509 certificate generator for tests (task 5.8).
+//!
+//! Builds Ed25519-signed DER certificates with configurable
+//! validity, SAN, BasicConstraints, KeyUsage and ExtKeyUsage so the
+//! structure parser ([`super::x509`]) and the chain verifier
+//! ([`super::verify`]) can be exercised end-to-end without any
+//! external fixtures or a real CA. NOT compiled into the shipping
+//! crate — `#[cfg(test)]` only.
+
+#![cfg(test)]
+
+use alloc::vec::Vec;
+use smallaios_security::crypto::ed25519::{ed25519_keygen, ed25519_sign, Ed25519KeyPair};
+
+// ─── DER encoding helpers ──────────────────────────────────────────
+
+/// Encode a DER length (short form < 128, else minimal long form).
+fn der_len(len: usize) -> Vec<u8> {
+    if len < 128 {
+        alloc::vec![len as u8]
+    } else {
+        let mut bytes = Vec::new();
+        let mut n = len;
+        while n > 0 {
+            bytes.insert(0, (n & 0xff) as u8);
+            n >>= 8;
+        }
+        let mut out = alloc::vec![0x80 | bytes.len() as u8];
+        out.extend_from_slice(&bytes);
+        out
+    }
+}
+
+/// Build a TLV from a tag and contents.
+fn tlv(tag: u8, contents: &[u8]) -> Vec<u8> {
+    let mut out = alloc::vec![tag];
+    out.extend_from_slice(&der_len(contents.len()));
+    out.extend_from_slice(contents);
+    out
+}
+
+fn seq(contents: &[u8]) -> Vec<u8> {
+    tlv(0x30, contents)
+}
+fn set(contents: &[u8]) -> Vec<u8> {
+    tlv(0x31, contents)
+}
+fn oid(body: &[u8]) -> Vec<u8> {
+    tlv(0x06, body)
+}
+fn integer(body: &[u8]) -> Vec<u8> {
+    tlv(0x02, body)
+}
+
+/// BIT STRING with zero unused bits.
+fn bit_string(body: &[u8]) -> Vec<u8> {
+    let mut contents = alloc::vec![0x00];
+    contents.extend_from_slice(body);
+    tlv(0x03, &contents)
+}
+
+fn octet_string(body: &[u8]) -> Vec<u8> {
+    tlv(0x04, body)
+}
+
+fn explicit(tag: u8, contents: &[u8]) -> Vec<u8> {
+    tlv(tag, contents)
+}
+
+/// commonName (2.5.4.3) DN with a single CN RDN.
+fn distinguished_name(cn: &str) -> Vec<u8> {
+    let atv = seq(&[oid(&[0x55, 0x04, 0x03]), tlv(0x0c, cn.as_bytes())].concat());
+    seq(&set(&atv))
+}
+
+/// Ed25519 SubjectPublicKeyInfo for a 32-byte public key.
+fn ed25519_spki(pk: &[u8; 32]) -> Vec<u8> {
+    let alg = seq(&oid(&[0x2b, 0x65, 0x70]));
+    seq(&[alg, bit_string(pk)].concat())
+}
+
+/// Ed25519 AlgorithmIdentifier (no parameters).
+fn ed25519_alg() -> Vec<u8> {
+    seq(&oid(&[0x2b, 0x65, 0x70]))
+}
+
+/// GeneralizedTime `YYYYMMDDHHMMSSZ` for a given calendar time.
+fn gen_time(y: u32, mo: u32, d: u32, h: u32, mi: u32, s: u32) -> Vec<u8> {
+    use alloc::format;
+    let str = format!("{y:04}{mo:02}{d:02}{h:02}{mi:02}{s:02}Z");
+    tlv(0x18, str.as_bytes())
+}
+
+// ─── Certificate builder ───────────────────────────────────────────
+
+/// A SubjectAltName entry to embed.
+pub enum San {
+    Dns(&'static str),
+    Ip(Vec<u8>),
+}
+
+/// Fluent builder for a synthetic Ed25519 certificate.
+pub struct CertBuilder {
+    pub subject: &'static str,
+    pub issuer: &'static str,
+    pub serial: u8,
+    pub not_before: (u32, u32, u32, u32, u32, u32),
+    pub not_after: (u32, u32, u32, u32, u32, u32),
+    pub sans: Vec<San>,
+    pub san_extension: bool,
+    pub ca: bool,
+    pub basic_constraints: bool,
+    pub key_cert_sign: bool,
+    pub digital_signature: bool,
+    pub key_usage: bool,
+    pub server_auth_eku: bool,
+    pub ext_key_usage: bool,
+    /// Override the version field with a raw value (None ⇒ v3).
+    pub version_override: Option<u8>,
+}
+
+impl Default for CertBuilder {
+    fn default() -> Self {
+        Self {
+            subject: "leaf.example.com",
+            issuer: "Test CA",
+            serial: 1,
+            not_before: (2024, 1, 1, 0, 0, 0),
+            not_after: (2099, 1, 1, 0, 0, 0),
+            sans: Vec::new(),
+            san_extension: true,
+            ca: false,
+            basic_constraints: true,
+            key_cert_sign: false,
+            digital_signature: true,
+            key_usage: true,
+            server_auth_eku: true,
+            ext_key_usage: true,
+            version_override: None,
+        }
+    }
+}
+
+impl CertBuilder {
+    /// A typical leaf: SAN, serverAuth EKU, digitalSignature.
+    pub fn leaf(subject: &'static str, dns: &'static str) -> Self {
+        Self {
+            subject,
+            sans: alloc::vec![San::Dns(dns)],
+            ..Self::default()
+        }
+    }
+
+    /// A typical CA: cA=true, keyCertSign, no SAN/EKU.
+    pub fn ca(name: &'static str) -> Self {
+        Self {
+            subject: name,
+            issuer: name,
+            sans: Vec::new(),
+            san_extension: false,
+            ca: true,
+            key_cert_sign: true,
+            digital_signature: false,
+            server_auth_eku: false,
+            ext_key_usage: false,
+            ..Self::default()
+        }
+    }
+
+    fn extensions(&self) -> Vec<u8> {
+        let mut exts = Vec::new();
+
+        if self.san_extension {
+            let mut names = Vec::new();
+            for san in &self.sans {
+                match san {
+                    San::Dns(d) => names.extend_from_slice(&tlv(0x82, d.as_bytes())),
+                    San::Ip(a) => names.extend_from_slice(&tlv(0x87, a)),
+                }
+            }
+            let san_value = octet_string(&seq(&names));
+            exts.extend_from_slice(&seq(&[oid(&[0x55, 0x1d, 0x11]), san_value].concat()));
+        }
+
+        if self.basic_constraints {
+            let ca_bool = if self.ca {
+                tlv(0x01, &[0xff])
+            } else {
+                tlv(0x01, &[0x00])
+            };
+            let bc_value = octet_string(&seq(&ca_bool));
+            let critical = tlv(0x01, &[0xff]);
+            exts.extend_from_slice(&seq(
+                &[oid(&[0x55, 0x1d, 0x13]), critical, bc_value].concat()
+            ));
+        }
+
+        if self.key_usage {
+            let mut b0 = 0u8;
+            if self.digital_signature {
+                b0 |= 0x80;
+            }
+            if self.key_cert_sign {
+                b0 |= 0x04;
+            }
+            let ku_value = octet_string(&bit_string(&[b0]));
+            let critical = tlv(0x01, &[0xff]);
+            exts.extend_from_slice(&seq(
+                &[oid(&[0x55, 0x1d, 0x0f]), critical, ku_value].concat()
+            ));
+        }
+
+        if self.ext_key_usage {
+            let mut ekus = Vec::new();
+            if self.server_auth_eku {
+                ekus.extend_from_slice(&oid(&[0x2b, 0x06, 0x01, 0x05, 0x05, 0x07, 0x03, 0x01]));
+            }
+            let eku_value = octet_string(&seq(&ekus));
+            exts.extend_from_slice(&seq(&[oid(&[0x55, 0x1d, 0x25]), eku_value].concat()));
+        }
+
+        explicit(0xa3, &seq(&exts))
+    }
+
+    fn tbs(&self, subject_pk: &[u8; 32]) -> Vec<u8> {
+        let version = explicit(0xa0, &integer(&[self.version_override.unwrap_or(2)]));
+        let serial = integer(&[self.serial]);
+        let sig_alg = ed25519_alg();
+        let issuer = distinguished_name(self.issuer);
+        let validity = {
+            let (y, mo, d, h, mi, s) = self.not_before;
+            let nb = gen_time(y, mo, d, h, mi, s);
+            let (y, mo, d, h, mi, s) = self.not_after;
+            let na = gen_time(y, mo, d, h, mi, s);
+            seq(&[nb, na].concat())
+        };
+        let subject = distinguished_name(self.subject);
+        let spki = ed25519_spki(subject_pk);
+        let exts = self.extensions();
+        seq(&[
+            version, serial, sig_alg, issuer, validity, subject, spki, exts,
+        ]
+        .concat())
+    }
+
+    /// Build the DER certificate: `subject_kp` provides the SPKI;
+    /// `issuer_kp` signs the TBS.
+    pub fn build(&self, subject_kp: &Ed25519KeyPair, issuer_kp: &Ed25519KeyPair) -> Vec<u8> {
+        let tbs = self.tbs(subject_kp.public_key.as_bytes());
+        let sig = ed25519_sign(&issuer_kp.secret_key, &tbs);
+        let sig_value = bit_string(sig.as_bytes());
+        seq(&[tbs, ed25519_alg(), sig_value].concat())
+    }
+
+    /// Build a self-signed certificate (subject == issuer key).
+    pub fn build_self_signed(&self, kp: &Ed25519KeyPair) -> Vec<u8> {
+        self.build(kp, kp)
+    }
+}
+
+/// Deterministic Ed25519 keypair from a one-byte seed fill.
+pub fn keypair(seed_fill: u8) -> Ed25519KeyPair {
+    ed25519_keygen(&[seed_fill; 32])
+}

--- a/tls-client/src/cert/verify.rs
+++ b/tls-client/src/cert/verify.rs
@@ -1,0 +1,424 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Certificate-chain verification (tasks 5.4, 5.5, 5.6).
+//!
+//! [`TrustStoreVerifier`] is the production [`ServerCertVerifier`]
+//! the handshake driver calls. It:
+//!
+//! 1. parses the leaf, requires a SubjectAltName, binds it to the
+//!    operator hostname (RFC 6125, via [`super::hostname`]), and
+//!    requires the serverAuth EKU;
+//! 2. builds a chain leaf → intermediate(s) → a trust-store anchor,
+//!    requiring `BasicConstraints.cA` + `keyUsage.keyCertSign` on
+//!    every CA link;
+//! 3. verifies the signature on every link;
+//! 4. checks each certificate's validity window against the wall
+//!    clock, with the design.md unsynced-clock sentinel.
+//!
+//! **Signature-algorithm coverage:** Ed25519 links are verified
+//! today. ECDSA-P256 and RSA-PSS/PKCS#1 links are recognised by the
+//! parser but cannot yet be verified — their `security/` primitives
+//! are tracked by `security-ecdsa-p256-v1` / `security-rsa-pss-v1`.
+//! A chain that needs one of them is refused with `ChainUntrusted`
+//! rather than silently accepted.
+
+use super::hostname::match_hostname;
+use super::x509::{Certificate, SignatureAlgorithm, SubjectPublicKey};
+use super::{LeafPublicKey, ServerCertVerifier};
+use crate::trust::TrustStore;
+use crate::{Result, TlsClientError};
+use alloc::vec::Vec;
+use smallaios_security::crypto::ed25519::{ed25519_verify, Ed25519PublicKey, Ed25519Signature};
+
+/// Wall-clock sentinel (design.md): a "now" earlier than
+/// 2026-01-01T00:00:00Z is treated as an unsynchronized clock.
+const SYNCED_CLOCK_THRESHOLD: i64 = 1_767_225_600;
+
+/// Maximum certificates considered while building a chain. Bounds
+/// the search regardless of how many the peer sent.
+const MAX_CHAIN_DEPTH: usize = 8;
+
+/// Production chain verifier over an operator [`TrustStore`].
+pub struct TrustStoreVerifier<'a> {
+    trust: &'a TrustStore,
+    /// Current wall-clock time as Unix seconds (from `kernel::clock`
+    /// in production; injected in tests).
+    now_unix: i64,
+    /// When true, an unsynchronized clock refuses the chain instead
+    /// of bypassing the validity window.
+    require_synced_clock: bool,
+}
+
+impl<'a> TrustStoreVerifier<'a> {
+    /// Construct with an explicit `now` (Unix seconds).
+    ///
+    /// The caller supplies the wall-clock time. In production the
+    /// integration layer reads it from `kernel::clock()` (the
+    /// `tls-client` crate stays decoupled from the kernel allocator);
+    /// tests inject a fixed value.
+    pub fn new(trust: &'a TrustStore, now_unix: i64, require_synced_clock: bool) -> Self {
+        Self {
+            trust,
+            now_unix,
+            require_synced_clock,
+        }
+    }
+
+    /// True when the wall clock looks synchronized (≥ the sentinel).
+    fn clock_synced(&self) -> bool {
+        self.now_unix >= SYNCED_CLOCK_THRESHOLD
+    }
+
+    /// Enforce a certificate's validity window. Bypassed (with the
+    /// design.md caveat) when the clock is unsynced unless
+    /// `require_synced_clock`.
+    fn check_validity(&self, cert: &Certificate<'_>) -> Result<()> {
+        if !self.clock_synced() {
+            // Unsynchronized clock. The audit hook
+            // (`audit_export_unsynced_clock`) is wired in Phase 8;
+            // here we either bypass or refuse per operator policy.
+            if self.require_synced_clock {
+                return Err(TlsClientError::Expired);
+            }
+            return Ok(());
+        }
+        if self.now_unix < cert.not_before || self.now_unix > cert.not_after {
+            return Err(TlsClientError::Expired);
+        }
+        Ok(())
+    }
+}
+
+impl ServerCertVerifier for TrustStoreVerifier<'_> {
+    fn verify_chain(&self, certs: &[Vec<u8>], server_name: Option<&str>) -> Result<LeafPublicKey> {
+        // An empty trust store refuses everything (design.md D5).
+        if self.trust.is_empty() {
+            return Err(TlsClientError::ChainUntrusted);
+        }
+        let leaf_der = certs.first().ok_or(TlsClientError::BadCertificate)?;
+        let leaf = Certificate::parse(leaf_der)?;
+
+        // ── Leaf identity policy ──────────────────────────────────
+        // SAN is mandatory (design.md D4 / RFC 6125 §6.4.4).
+        if !leaf.san_present || leaf.san.is_empty() {
+            return Err(TlsClientError::BadCertificate);
+        }
+        if let Some(name) = server_name {
+            match_hostname(name, &leaf.san)?;
+        }
+        // serverAuth EKU required on the leaf (design.md D4).
+        if !leaf.ext_key_usage_present || !leaf.server_auth_eku {
+            return Err(TlsClientError::BadCertificate);
+        }
+        self.check_validity(&leaf)?;
+
+        // ── Chain construction ────────────────────────────────────
+        // Parse the intermediates the peer offered (leaf excluded).
+        let mut intermediates: Vec<Certificate<'_>> = Vec::new();
+        for der in &certs[1..] {
+            intermediates.push(Certificate::parse(der)?);
+        }
+
+        // Walk issuer links until we hit a trust-store anchor.
+        let mut current = leaf.clone();
+        let mut used = alloc::vec![false; intermediates.len()];
+        for _ in 0..MAX_CHAIN_DEPTH {
+            // Anchored? Find an anchor whose Subject is our issuer.
+            if let Some(anchor) = self
+                .trust
+                .anchors()
+                .iter()
+                .find(|a| a.subject == current.issuer)
+            {
+                verify_signature(&current, &anchor.public_key)?;
+                // Pin check (task 6.3): the anchoring cert must match.
+                if let Some(pin) = self.trust.pin() {
+                    if &anchor.fingerprint != pin {
+                        return Err(TlsClientError::ChainUntrusted);
+                    }
+                }
+                // Whole chain verified — hand back the leaf key.
+                return leaf_public_key(&leaf);
+            }
+
+            // Otherwise extend via an offered intermediate whose
+            // Subject is our issuer and which is a usable CA.
+            let next = intermediates
+                .iter()
+                .enumerate()
+                .find(|(i, c)| !used[*i] && c.subject == current.issuer && is_ca(c));
+            match next {
+                Some((idx, issuer)) => {
+                    verify_signature(&current, &issuer.public_key)?;
+                    self.check_validity(issuer)?;
+                    used[idx] = true;
+                    current = issuer.clone();
+                }
+                None => return Err(TlsClientError::ChainUntrusted),
+            }
+        }
+        Err(TlsClientError::ChainUntrusted)
+    }
+}
+
+/// A certificate is a usable CA link iff `BasicConstraints.cA` is
+/// set and, when a `keyUsage` extension is present, it asserts
+/// `keyCertSign`.
+fn is_ca(cert: &Certificate<'_>) -> bool {
+    if !cert.basic_constraints.ca {
+        return false;
+    }
+    if cert.key_usage.present && !cert.key_usage.key_cert_sign {
+        return false;
+    }
+    true
+}
+
+/// Verify `cert`'s outer signature over its `tbs_der` using the
+/// issuer's public key. Only Ed25519 is supported today; other
+/// algorithms are refused as `ChainUntrusted`.
+fn verify_signature(cert: &Certificate<'_>, issuer_key: &SubjectPublicKey) -> Result<()> {
+    match (cert.signature_algorithm, issuer_key) {
+        (SignatureAlgorithm::Ed25519, SubjectPublicKey::Ed25519(pk)) => {
+            if cert.signature.len() != 64 {
+                return Err(TlsClientError::BadCertificate);
+            }
+            let mut sig = [0u8; 64];
+            sig.copy_from_slice(cert.signature);
+            ed25519_verify(
+                &Ed25519PublicKey::from_bytes(*pk),
+                cert.tbs_der,
+                &Ed25519Signature::from_bytes(sig),
+            )
+            .map_err(|_| TlsClientError::ChainUntrusted)
+        }
+        // Algorithm/key mismatch, or an algorithm whose primitive is
+        // not yet available (ECDSA-P256, RSA-PSS/PKCS#1).
+        _ => Err(TlsClientError::ChainUntrusted),
+    }
+}
+
+/// Map the leaf's SPKI to the [`LeafPublicKey`] the driver uses for
+/// CertificateVerify. Non-Ed25519 leaves cannot be used yet.
+fn leaf_public_key(leaf: &Certificate<'_>) -> Result<LeafPublicKey> {
+    match &leaf.public_key {
+        SubjectPublicKey::Ed25519(pk) => Ok(LeafPublicKey::Ed25519(*pk)),
+        _ => Err(TlsClientError::ChainUntrusted),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cert::test_certs::{keypair, CertBuilder, San};
+
+    /// Build a (trust store, leaf-der, [intermediate-ders]) fixture:
+    /// root CA → leaf signed directly by the root.
+    fn direct_chain(now_ok: bool) -> (TrustStore, Vec<Vec<u8>>) {
+        let root = keypair(10);
+        let leaf = keypair(11);
+        let na = if now_ok {
+            (2099, 1, 1, 0, 0, 0)
+        } else {
+            (2024, 6, 1, 0, 0, 0)
+        };
+        let mut lb = CertBuilder::leaf("leaf.example.com", "leaf.example.com");
+        lb.issuer = "Root CA";
+        lb.not_after = na;
+        let leaf_der = lb.build(&leaf, &root);
+        let root_der = CertBuilder::ca("Root CA").build_self_signed(&root);
+
+        let mut store = TrustStore::new();
+        store.add_anchor_der(&root_der).unwrap();
+        (store, alloc::vec![leaf_der])
+    }
+
+    // 2026-06-01 — a synced "now".
+    const NOW: i64 = 1_780_000_000;
+
+    #[test]
+    fn accepts_direct_chain_and_returns_leaf_key() {
+        let (store, certs) = direct_chain(true);
+        let v = TrustStoreVerifier::new(&store, NOW, false);
+        let key = v.verify_chain(&certs, Some("leaf.example.com")).unwrap();
+        assert!(matches!(key, LeafPublicKey::Ed25519(_)));
+    }
+
+    #[test]
+    fn accepts_two_link_chain() {
+        let root = keypair(20);
+        let inter = keypair(21);
+        let leaf = keypair(22);
+
+        let mut ib = CertBuilder::ca("Intermediate CA");
+        ib.issuer = "Root CA";
+        let inter_der = ib.build(&inter, &root);
+        let root_der = CertBuilder::ca("Root CA").build_self_signed(&root);
+
+        let mut lb = CertBuilder::leaf("svc.example.com", "svc.example.com");
+        lb.issuer = "Intermediate CA";
+        let leaf_der = lb.build(&leaf, &inter);
+
+        let mut store = TrustStore::new();
+        store.add_anchor_der(&root_der).unwrap();
+        let v = TrustStoreVerifier::new(&store, NOW, false);
+        v.verify_chain(&alloc::vec![leaf_der, inter_der], Some("svc.example.com"))
+            .unwrap();
+    }
+
+    #[test]
+    fn empty_trust_store_refuses() {
+        let (_full, certs) = direct_chain(true);
+        let store = TrustStore::new();
+        let v = TrustStoreVerifier::new(&store, NOW, false);
+        assert_eq!(
+            v.verify_chain(&certs, Some("leaf.example.com"))
+                .unwrap_err(),
+            TlsClientError::ChainUntrusted
+        );
+    }
+
+    #[test]
+    fn unknown_anchor_refused() {
+        let (_store, certs) = direct_chain(true);
+        // A trust store holding an unrelated root.
+        let other = keypair(99);
+        let other_der = CertBuilder::ca("Other Root").build_self_signed(&other);
+        let mut store = TrustStore::new();
+        store.add_anchor_der(&other_der).unwrap();
+        let v = TrustStoreVerifier::new(&store, NOW, false);
+        assert_eq!(
+            v.verify_chain(&certs, Some("leaf.example.com"))
+                .unwrap_err(),
+            TlsClientError::ChainUntrusted
+        );
+    }
+
+    #[test]
+    fn tampered_leaf_signature_refused() {
+        let (store, mut certs) = direct_chain(true);
+        // Flip a byte in the leaf's signatureValue region (tail).
+        let last = certs[0].len() - 1;
+        certs[0][last] ^= 0x01;
+        let v = TrustStoreVerifier::new(&store, NOW, false);
+        assert!(v.verify_chain(&certs, Some("leaf.example.com")).is_err());
+    }
+
+    #[test]
+    fn hostname_mismatch_refused() {
+        let (store, certs) = direct_chain(true);
+        let v = TrustStoreVerifier::new(&store, NOW, false);
+        assert_eq!(
+            v.verify_chain(&certs, Some("evil.example.com"))
+                .unwrap_err(),
+            TlsClientError::NameMismatch
+        );
+    }
+
+    #[test]
+    fn expired_leaf_refused_when_clock_synced() {
+        let (store, certs) = direct_chain(false); // notAfter 2024-06
+        let v = TrustStoreVerifier::new(&store, NOW, false);
+        assert_eq!(
+            v.verify_chain(&certs, Some("leaf.example.com"))
+                .unwrap_err(),
+            TlsClientError::Expired
+        );
+    }
+
+    #[test]
+    fn expired_leaf_bypassed_when_clock_unsynced() {
+        let (store, certs) = direct_chain(false);
+        // now < 2026 sentinel ⇒ unsynced ⇒ validity bypassed.
+        let v = TrustStoreVerifier::new(&store, 1_000, false);
+        v.verify_chain(&certs, Some("leaf.example.com")).unwrap();
+    }
+
+    #[test]
+    fn unsynced_clock_refused_when_required() {
+        let (store, certs) = direct_chain(true);
+        let v = TrustStoreVerifier::new(&store, 1_000, true);
+        assert_eq!(
+            v.verify_chain(&certs, Some("leaf.example.com"))
+                .unwrap_err(),
+            TlsClientError::Expired
+        );
+    }
+
+    #[test]
+    fn leaf_without_san_refused() {
+        let root = keypair(30);
+        let leaf = keypair(31);
+        let mut lb = CertBuilder::leaf("leaf.example.com", "leaf.example.com");
+        lb.issuer = "Root CA";
+        lb.san_extension = false;
+        let leaf_der = lb.build(&leaf, &root);
+        let root_der = CertBuilder::ca("Root CA").build_self_signed(&root);
+        let mut store = TrustStore::new();
+        store.add_anchor_der(&root_der).unwrap();
+        let v = TrustStoreVerifier::new(&store, NOW, false);
+        assert_eq!(
+            v.verify_chain(&alloc::vec![leaf_der], Some("leaf.example.com"))
+                .unwrap_err(),
+            TlsClientError::BadCertificate
+        );
+    }
+
+    #[test]
+    fn non_ca_intermediate_refused() {
+        let root = keypair(40);
+        let inter = keypair(41);
+        let leaf = keypair(42);
+        // "Intermediate" lacks cA=true (built as a leaf-shaped cert).
+        let mut ib = CertBuilder::leaf("Intermediate", "intermediate.invalid");
+        ib.issuer = "Root CA";
+        let inter_der = ib.build(&inter, &root);
+        let root_der = CertBuilder::ca("Root CA").build_self_signed(&root);
+        let mut lb = CertBuilder::leaf("svc.example.com", "svc.example.com");
+        lb.issuer = "Intermediate";
+        let leaf_der = lb.build(&leaf, &inter);
+        let mut store = TrustStore::new();
+        store.add_anchor_der(&root_der).unwrap();
+        let v = TrustStoreVerifier::new(&store, NOW, false);
+        assert_eq!(
+            v.verify_chain(&alloc::vec![leaf_der, inter_der], Some("svc.example.com"))
+                .unwrap_err(),
+            TlsClientError::ChainUntrusted
+        );
+    }
+
+    #[test]
+    fn pin_match_accepts_mismatch_refuses() {
+        let (mut store, certs) = direct_chain(true);
+        let good_pin = store.anchors()[0].fingerprint;
+        store.set_pin(good_pin);
+        let v = TrustStoreVerifier::new(&store, NOW, false);
+        v.verify_chain(&certs, Some("leaf.example.com")).unwrap();
+
+        let (mut store2, certs2) = direct_chain(true);
+        store2.set_pin([0xaa; 32]); // wrong pin
+        let v2 = TrustStoreVerifier::new(&store2, NOW, false);
+        assert_eq!(
+            v2.verify_chain(&certs2, Some("leaf.example.com"))
+                .unwrap_err(),
+            TlsClientError::ChainUntrusted
+        );
+    }
+
+    #[test]
+    fn ip_san_leaf_accepts_matching_literal() {
+        let root = keypair(50);
+        let leaf = keypair(51);
+        let mut lb = CertBuilder::leaf("server", "unused");
+        lb.issuer = "Root CA";
+        lb.sans = alloc::vec![San::Ip(alloc::vec![192, 0, 2, 1])];
+        let leaf_der = lb.build(&leaf, &root);
+        let root_der = CertBuilder::ca("Root CA").build_self_signed(&root);
+        let mut store = TrustStore::new();
+        store.add_anchor_der(&root_der).unwrap();
+        let v = TrustStoreVerifier::new(&store, NOW, false);
+        v.verify_chain(&alloc::vec![leaf_der], Some("192.0.2.1"))
+            .unwrap();
+    }
+}

--- a/tls-client/src/cert/x509.rs
+++ b/tls-client/src/cert/x509.rs
@@ -1,0 +1,707 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! "Just-enough" X.509v3 structure parser (task 5.2, design.md D4).
+//!
+//! Decodes only the `tbsCertificate` fields TLS 1.3 path
+//! validation needs, on top of the strict DER decoder in
+//! [`super::der`]. Every additional ASN.1 type is attacker-
+//! controlled surface, so anything not listed below is left
+//! unparsed:
+//!
+//! - `version` — **must** be v3 (`2`); v1/v2 are refused.
+//! - `serialNumber` — captured raw (not validated for uniqueness).
+//! - `signature.algorithm` — mapped to [`SignatureAlgorithm`];
+//!   any SHA-1 algorithm (or anything unrecognised) is refused.
+//! - `validity.{notBefore, notAfter}` — UTCTime / GeneralizedTime
+//!   in the mandatory `Z` (UTC) form, converted to Unix seconds.
+//! - `issuer` / `subject` — kept as raw DN DER for byte-exact
+//!   comparison during chain construction (never pretty-printed).
+//! - `subjectPublicKeyInfo` — algorithm OID + key bytes.
+//! - extensions `subjectAltName`, `basicConstraints`, `keyUsage`,
+//!   `extKeyUsage`.
+//!
+//! Deliberately **not** parsed (design.md D4): NameConstraints,
+//! CertificatePolicies, AuthorityInfoAccess, CRLDistributionPoints,
+//! SignedCertificateTimestamp.
+
+use super::der::{read_uint, tag, Reader};
+use super::hostname::SanEntry;
+use crate::{Result, TlsClientError};
+use alloc::string::String;
+use alloc::vec::Vec;
+
+/// OID content bytes (the value of an OBJECT IDENTIFIER TLV, i.e.
+/// without the `0x06 len` header).
+pub mod oid {
+    /// id-ecPublicKey (1.2.840.10045.2.1).
+    pub const EC_PUBLIC_KEY: &[u8] = &[0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01];
+    /// prime256v1 / P-256 named curve (1.2.840.10045.3.1.7).
+    pub const P256: &[u8] = &[0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07];
+    /// id-Ed25519 (1.3.101.112).
+    pub const ED25519: &[u8] = &[0x2b, 0x65, 0x70];
+    /// rsaEncryption (1.2.840.113549.1.1.1).
+    pub const RSA_ENCRYPTION: &[u8] = &[0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01];
+
+    /// ecdsa-with-SHA256 (1.2.840.10045.4.3.2).
+    pub const ECDSA_SHA256: &[u8] = &[0x2a, 0x86, 0x48, 0xce, 0x3d, 0x04, 0x03, 0x02];
+    /// sha256WithRSAEncryption (1.2.840.113549.1.1.11).
+    pub const RSA_PKCS1_SHA256: &[u8] = &[0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0b];
+    /// id-RSASSA-PSS (1.2.840.113549.1.1.10).
+    pub const RSA_PSS: &[u8] = &[0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0a];
+
+    /// sha1WithRSAEncryption (1.2.840.113549.1.1.5) — refused.
+    pub const RSA_PKCS1_SHA1: &[u8] = &[0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x05];
+    /// ecdsa-with-SHA1 (1.2.840.10045.4.1) — refused.
+    pub const ECDSA_SHA1: &[u8] = &[0x2a, 0x86, 0x48, 0xce, 0x3d, 0x04, 0x01];
+
+    /// id-ce-subjectAltName (2.5.29.17).
+    pub const SUBJECT_ALT_NAME: &[u8] = &[0x55, 0x1d, 0x11];
+    /// id-ce-basicConstraints (2.5.29.19).
+    pub const BASIC_CONSTRAINTS: &[u8] = &[0x55, 0x1d, 0x13];
+    /// id-ce-keyUsage (2.5.29.15).
+    pub const KEY_USAGE: &[u8] = &[0x55, 0x1d, 0x0f];
+    /// id-ce-extKeyUsage (2.5.29.37).
+    pub const EXT_KEY_USAGE: &[u8] = &[0x55, 0x1d, 0x25];
+    /// id-kp-serverAuth (1.3.6.1.5.5.7.3.1).
+    pub const SERVER_AUTH: &[u8] = &[0x2b, 0x06, 0x01, 0x05, 0x05, 0x07, 0x03, 0x01];
+}
+
+/// Certificate signature algorithm, restricted to the set TLS 1.3
+/// path validation accepts (design.md D4). SHA-1 algorithms are
+/// never represented here — they are refused at parse time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignatureAlgorithm {
+    Ed25519,
+    EcdsaP256Sha256,
+    RsaPkcs1Sha256,
+    RsaPssSha256,
+}
+
+/// A subject public key, tagged by algorithm. Only Ed25519 can be
+/// *used* for verification today; ECDSA-P256 and RSA keys are
+/// parsed and carried so chain construction can report a precise
+/// "unsupported algorithm" rather than a generic parse failure,
+/// until their `security/` primitives land (tasks 5.5 note).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SubjectPublicKey {
+    Ed25519([u8; 32]),
+    /// Uncompressed SEC1 point bytes (`0x04 || X || Y`).
+    EcdsaP256(Vec<u8>),
+    /// DER `RSAPublicKey` bytes.
+    Rsa(Vec<u8>),
+}
+
+/// Parsed `BasicConstraints` (RFC 5280 §4.2.1.9). Absent extension
+/// is represented as `ca = false` with no path-length limit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct BasicConstraints {
+    pub ca: bool,
+    pub path_len: Option<u64>,
+}
+
+/// The `keyUsage` bits we care about for path validation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct KeyUsage {
+    /// Whether a `keyUsage` extension was present at all. When
+    /// absent, RFC 5280 places no key-usage restriction.
+    pub present: bool,
+    /// `digitalSignature` (bit 0).
+    pub digital_signature: bool,
+    /// `keyCertSign` (bit 5) — required on CA certs.
+    pub key_cert_sign: bool,
+}
+
+/// A parsed certificate. Borrows from the input DER for the raw
+/// `tbsCertificate`, issuer/subject DN, and signature bytes so the
+/// chain verifier can do byte-exact DN comparison and verify the
+/// outer signature over the exact TBS encoding without copying.
+#[derive(Debug, Clone)]
+pub struct Certificate<'a> {
+    /// Complete `tbsCertificate` DER (header + contents) — the
+    /// octets the outer signature is computed over.
+    pub tbs_der: &'a [u8],
+    /// `serialNumber` content octets (unvalidated, for logging).
+    pub serial: &'a [u8],
+    /// Algorithm from `tbsCertificate.signature`.
+    pub signature_algorithm: SignatureAlgorithm,
+    /// Raw `issuer` Name DER (the SEQUENCE contents).
+    pub issuer: &'a [u8],
+    /// Raw `subject` Name DER (the SEQUENCE contents).
+    pub subject: &'a [u8],
+    /// `validity.notBefore` as Unix seconds.
+    pub not_before: i64,
+    /// `validity.notAfter` as Unix seconds.
+    pub not_after: i64,
+    /// Subject public key.
+    pub public_key: SubjectPublicKey,
+    /// SubjectAltName entries (empty when the extension is absent).
+    pub san: Vec<SanEntry>,
+    /// Whether a SubjectAltName extension was present.
+    pub san_present: bool,
+    /// Parsed BasicConstraints (default when absent).
+    pub basic_constraints: BasicConstraints,
+    /// Parsed KeyUsage (default when absent).
+    pub key_usage: KeyUsage,
+    /// True when `extKeyUsage` is present AND lists id-kp-serverAuth
+    /// (or anyExtendedKeyUsage). When `ext_key_usage_present` is
+    /// false, no EKU restriction applies.
+    pub server_auth_eku: bool,
+    /// Whether an `extKeyUsage` extension was present.
+    pub ext_key_usage_present: bool,
+    /// Outer `signatureAlgorithm` (must equal `signature_algorithm`).
+    pub outer_signature_algorithm: SignatureAlgorithm,
+    /// `signatureValue` payload (BIT STRING contents, unused-bits
+    /// octet stripped).
+    pub signature: &'a [u8],
+}
+
+/// Context-specific constructed `[0]` (EXPLICIT version wrapper).
+const CTX_0_CONSTRUCTED: u8 = 0xa0;
+/// Context-specific constructed `[3]` (EXPLICIT extensions wrapper).
+const CTX_3_CONSTRUCTED: u8 = 0xa3;
+/// X.509 `Version` value for v3 (the only version we accept).
+const VERSION_V3: u64 = 2;
+
+impl<'a> Certificate<'a> {
+    /// Parse a single DER certificate. Enforces the design.md D4
+    /// constraints: v3 only, no SHA-1 signature algorithms, and a
+    /// well-formed structure for every field listed in the module
+    /// docs. Does NOT itself require SAN — that (leaf-only) policy
+    /// is applied by the chain verifier.
+    pub fn parse(der: &'a [u8]) -> Result<Self> {
+        let mut outer = Reader::new(der);
+        let cert_body = outer.expect_tlv(tag::SEQUENCE)?;
+        if !outer.is_empty() {
+            // Trailing bytes after the Certificate SEQUENCE.
+            return Err(TlsClientError::BadCertificate);
+        }
+        let mut cert = Reader::new(cert_body);
+
+        // tbsCertificate — capture its exact DER for signature checks.
+        let (tbs_tlv, tbs_der) = cert.next_tlv_with_raw()?;
+        if !tbs_tlv.is(tag::SEQUENCE) {
+            return Err(TlsClientError::BadCertificate);
+        }
+        let mut tbs = Reader::new(tbs_tlv.value);
+
+        // version [0] EXPLICIT INTEGER — required to be present and v3.
+        let version_tlv = tbs.next_tlv()?;
+        if !version_tlv.is(CTX_0_CONSTRUCTED) {
+            // A v1 certificate omits the version wrapper entirely; we
+            // refuse anything that is not explicit v3.
+            return Err(TlsClientError::BadCertificate);
+        }
+        let mut version_inner = Reader::new(version_tlv.value);
+        let version = read_uint(version_inner.expect_tlv(tag::INTEGER)?)?;
+        if !version_inner.is_empty() || version != VERSION_V3 {
+            return Err(TlsClientError::BadCertificate);
+        }
+
+        // serialNumber INTEGER (kept raw; may be large / 0x00-prefixed).
+        let serial = tbs.expect_tlv(tag::INTEGER)?;
+
+        // signature AlgorithmIdentifier.
+        let signature_algorithm = parse_sig_alg(tbs.expect_tlv(tag::SEQUENCE)?)?;
+
+        // issuer Name (raw DN contents).
+        let issuer = tbs.expect_tlv(tag::SEQUENCE)?;
+
+        // validity SEQUENCE { notBefore Time, notAfter Time }.
+        let mut validity = Reader::new(tbs.expect_tlv(tag::SEQUENCE)?);
+        let not_before = parse_time(validity.next_tlv()?)?;
+        let not_after = parse_time(validity.next_tlv()?)?;
+        if !validity.is_empty() {
+            return Err(TlsClientError::BadCertificate);
+        }
+        if not_after < not_before {
+            return Err(TlsClientError::BadCertificate);
+        }
+
+        // subject Name (raw DN contents).
+        let subject = tbs.expect_tlv(tag::SEQUENCE)?;
+
+        // subjectPublicKeyInfo.
+        let public_key = parse_spki(tbs.expect_tlv(tag::SEQUENCE)?)?;
+
+        // Optional issuerUniqueID [1] / subjectUniqueID [2] are
+        // skipped if present; then extensions [3] EXPLICIT.
+        let mut san = Vec::new();
+        let mut san_present = false;
+        let mut basic_constraints = BasicConstraints::default();
+        let mut key_usage = KeyUsage::default();
+        let mut server_auth_eku = false;
+        let mut ext_key_usage_present = false;
+
+        while !tbs.is_empty() {
+            let field = tbs.next_tlv()?;
+            if field.is(CTX_3_CONSTRUCTED) {
+                parse_extensions(
+                    field.value,
+                    &mut san,
+                    &mut san_present,
+                    &mut basic_constraints,
+                    &mut key_usage,
+                    &mut server_auth_eku,
+                    &mut ext_key_usage_present,
+                )?;
+                // extensions is the final TBS field.
+                if !tbs.is_empty() {
+                    return Err(TlsClientError::BadCertificate);
+                }
+                break;
+            }
+            // [1]/[2] unique IDs (0x81/0x82) — tolerate and ignore.
+            // Anything else here is malformed.
+            if field.tag != 0x81 && field.tag != 0x82 {
+                return Err(TlsClientError::BadCertificate);
+            }
+        }
+
+        // signatureAlgorithm (outer) must match the TBS signature alg.
+        let outer_signature_algorithm = parse_sig_alg(cert.expect_tlv(tag::SEQUENCE)?)?;
+        if outer_signature_algorithm != signature_algorithm {
+            return Err(TlsClientError::BadCertificate);
+        }
+
+        // signatureValue BIT STRING (unused-bits octet must be 0).
+        let signature = parse_bit_string(cert.expect_tlv(tag::BIT_STRING)?)?;
+        if !cert.is_empty() {
+            return Err(TlsClientError::BadCertificate);
+        }
+
+        Ok(Certificate {
+            tbs_der,
+            serial,
+            signature_algorithm,
+            issuer,
+            subject,
+            not_before,
+            not_after,
+            public_key,
+            san,
+            san_present,
+            basic_constraints,
+            key_usage,
+            server_auth_eku,
+            ext_key_usage_present,
+            outer_signature_algorithm,
+            signature,
+        })
+    }
+}
+
+/// Parse an `AlgorithmIdentifier` SEQUENCE contents into a
+/// [`SignatureAlgorithm`], refusing SHA-1 and unknown OIDs.
+fn parse_sig_alg(seq: &[u8]) -> Result<SignatureAlgorithm> {
+    let mut r = Reader::new(seq);
+    let alg_oid = r.expect_tlv(tag::OID)?;
+    // Parameters (NULL for RSA PKCS#1, absent for Ed25519/ECDSA,
+    // a structured AlgorithmIdentifier for PSS) are not inspected
+    // beyond the OID for v1 of this client.
+    match alg_oid {
+        oid::ED25519 => Ok(SignatureAlgorithm::Ed25519),
+        oid::ECDSA_SHA256 => Ok(SignatureAlgorithm::EcdsaP256Sha256),
+        oid::RSA_PKCS1_SHA256 => Ok(SignatureAlgorithm::RsaPkcs1Sha256),
+        oid::RSA_PSS => Ok(SignatureAlgorithm::RsaPssSha256),
+        // Explicitly refuse SHA-1 with a certificate-specific error.
+        oid::RSA_PKCS1_SHA1 | oid::ECDSA_SHA1 => Err(TlsClientError::BadCertificate),
+        _ => Err(TlsClientError::BadCertificate),
+    }
+}
+
+/// Parse a `SubjectPublicKeyInfo` SEQUENCE contents.
+fn parse_spki(seq: &[u8]) -> Result<SubjectPublicKey> {
+    let mut r = Reader::new(seq);
+    let mut alg = Reader::new(r.expect_tlv(tag::SEQUENCE)?);
+    let alg_oid = alg.expect_tlv(tag::OID)?;
+    let key_bits = parse_bit_string(r.expect_tlv(tag::BIT_STRING)?)?;
+    if !r.is_empty() {
+        return Err(TlsClientError::BadCertificate);
+    }
+
+    match alg_oid {
+        oid::ED25519 => {
+            if key_bits.len() != 32 {
+                return Err(TlsClientError::BadCertificate);
+            }
+            let mut k = [0u8; 32];
+            k.copy_from_slice(key_bits);
+            Ok(SubjectPublicKey::Ed25519(k))
+        }
+        oid::EC_PUBLIC_KEY => {
+            // Require the namedCurve parameter to be P-256, and an
+            // uncompressed point (0x04 || 32 || 32).
+            let curve = alg.expect_tlv(tag::OID)?;
+            if curve != oid::P256 {
+                return Err(TlsClientError::BadCertificate);
+            }
+            if key_bits.len() != 65 || key_bits[0] != 0x04 {
+                return Err(TlsClientError::BadCertificate);
+            }
+            Ok(SubjectPublicKey::EcdsaP256(key_bits.to_vec()))
+        }
+        oid::RSA_ENCRYPTION => Ok(SubjectPublicKey::Rsa(key_bits.to_vec())),
+        _ => Err(TlsClientError::BadCertificate),
+    }
+}
+
+/// Strip the leading "unused bits" octet from a BIT STRING's
+/// contents, requiring it to be zero (whole-octet payloads only).
+fn parse_bit_string(value: &[u8]) -> Result<&[u8]> {
+    match value.split_first() {
+        Some((0, rest)) => Ok(rest),
+        _ => Err(TlsClientError::BadCertificate),
+    }
+}
+
+/// Walk `extensions [3]` contents, filling the fields we honour.
+fn parse_extensions(
+    ctx3: &[u8],
+    san: &mut Vec<SanEntry>,
+    san_present: &mut bool,
+    basic_constraints: &mut BasicConstraints,
+    key_usage: &mut KeyUsage,
+    server_auth_eku: &mut bool,
+    ext_key_usage_present: &mut bool,
+) -> Result<()> {
+    let mut outer = Reader::new(ctx3);
+    let mut list = Reader::new(outer.expect_tlv(tag::SEQUENCE)?);
+    if !outer.is_empty() {
+        return Err(TlsClientError::BadCertificate);
+    }
+    while !list.is_empty() {
+        let mut ext = Reader::new(list.expect_tlv(tag::SEQUENCE)?);
+        let ext_oid = ext.expect_tlv(tag::OID)?;
+        // Optional critical BOOLEAN, then the extnValue OCTET STRING.
+        let next = ext.next_tlv()?;
+        let extn_value = if next.is(0x01) {
+            // critical flag present; the value is the following TLV.
+            ext.expect_tlv(tag::OCTET_STRING)?
+        } else if next.is(tag::OCTET_STRING) {
+            next.value
+        } else {
+            return Err(TlsClientError::BadCertificate);
+        };
+        if !ext.is_empty() {
+            return Err(TlsClientError::BadCertificate);
+        }
+
+        match ext_oid {
+            oid::SUBJECT_ALT_NAME => {
+                *san_present = true;
+                parse_san(extn_value, san)?;
+            }
+            oid::BASIC_CONSTRAINTS => {
+                *basic_constraints = parse_basic_constraints(extn_value)?;
+            }
+            oid::KEY_USAGE => {
+                *key_usage = parse_key_usage(extn_value)?;
+            }
+            oid::EXT_KEY_USAGE => {
+                *ext_key_usage_present = true;
+                *server_auth_eku = parse_ext_key_usage(extn_value)?;
+            }
+            // Unhandled extensions are ignored (design.md D4). A
+            // production hardening pass could refuse unknown
+            // *critical* extensions; v1 does not.
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// Parse `SubjectAltName ::= GeneralNames` (the OCTET STRING value).
+fn parse_san(extn_value: &[u8], san: &mut Vec<SanEntry>) -> Result<()> {
+    let mut outer = Reader::new(extn_value);
+    let mut names = Reader::new(outer.expect_tlv(tag::SEQUENCE)?);
+    if !outer.is_empty() {
+        return Err(TlsClientError::BadCertificate);
+    }
+    while !names.is_empty() {
+        let entry = names.next_tlv()?;
+        match entry.tag {
+            // dNSName [2] IMPLICIT IA5String (primitive context [2]).
+            0x82 => {
+                let s = core::str::from_utf8(entry.value)
+                    .map_err(|_| TlsClientError::BadCertificate)?;
+                san.push(SanEntry::Dns(String::from(s)));
+            }
+            // iPAddress [7] IMPLICIT OCTET STRING (4 or 16 octets).
+            0x87 => {
+                if entry.value.len() != 4 && entry.value.len() != 16 {
+                    return Err(TlsClientError::BadCertificate);
+                }
+                san.push(SanEntry::IpAddress(entry.value.to_vec()));
+            }
+            // Other GeneralName forms (rfc822Name, URI, directoryName,
+            // …) are not used for TLS server identity — ignore.
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// Parse `BasicConstraints ::= SEQUENCE { cA BOOLEAN DEFAULT FALSE,
+/// pathLenConstraint INTEGER OPTIONAL }`.
+fn parse_basic_constraints(extn_value: &[u8]) -> Result<BasicConstraints> {
+    let mut outer = Reader::new(extn_value);
+    let mut seq = Reader::new(outer.expect_tlv(tag::SEQUENCE)?);
+    if !outer.is_empty() {
+        return Err(TlsClientError::BadCertificate);
+    }
+    let mut bc = BasicConstraints::default();
+    if seq.is_empty() {
+        return Ok(bc);
+    }
+    let first = seq.next_tlv()?;
+    let after_ca = if first.is(0x01) {
+        // BOOLEAN cA: DER encodes TRUE as a single 0xFF octet.
+        bc.ca = matches!(first.value, [0xff]);
+        if !bc.ca && first.value != [0x00] {
+            return Err(TlsClientError::BadCertificate);
+        }
+        if seq.is_empty() {
+            return Ok(bc);
+        }
+        Some(seq.next_tlv()?)
+    } else {
+        Some(first)
+    };
+    if let Some(tlv) = after_ca {
+        if !tlv.is(tag::INTEGER) {
+            return Err(TlsClientError::BadCertificate);
+        }
+        bc.path_len = Some(read_uint(tlv.value)?);
+    }
+    if !seq.is_empty() {
+        return Err(TlsClientError::BadCertificate);
+    }
+    Ok(bc)
+}
+
+/// Parse `KeyUsage ::= BIT STRING`, extracting the bits we enforce.
+fn parse_key_usage(extn_value: &[u8]) -> Result<KeyUsage> {
+    let mut outer = Reader::new(extn_value);
+    let bits_tlv = outer.next_tlv()?;
+    if !bits_tlv.is(tag::BIT_STRING) || !outer.is_empty() {
+        return Err(TlsClientError::BadCertificate);
+    }
+    // First octet is the unused-bit count; bit 0 (digitalSignature)
+    // is the MSB of the first content octet, bit 5 (keyCertSign) is
+    // mask 0x04 of that octet.
+    let (_, body) = bits_tlv
+        .value
+        .split_first()
+        .ok_or(TlsClientError::BadCertificate)?;
+    let b0 = body.first().copied().unwrap_or(0);
+    Ok(KeyUsage {
+        present: true,
+        digital_signature: b0 & 0x80 != 0,
+        key_cert_sign: b0 & 0x04 != 0,
+    })
+}
+
+/// Parse `ExtKeyUsage ::= SEQUENCE OF OID`; returns true iff
+/// id-kp-serverAuth is present.
+fn parse_ext_key_usage(extn_value: &[u8]) -> Result<bool> {
+    let mut outer = Reader::new(extn_value);
+    let mut seq = Reader::new(outer.expect_tlv(tag::SEQUENCE)?);
+    if !outer.is_empty() {
+        return Err(TlsClientError::BadCertificate);
+    }
+    let mut found = false;
+    while !seq.is_empty() {
+        if seq.expect_tlv(tag::OID)? == oid::SERVER_AUTH {
+            found = true;
+        }
+    }
+    Ok(found)
+}
+
+/// Parse an X.509 `Time` (UTCTime or GeneralizedTime) in the
+/// mandatory `Z` (UTC) form into Unix seconds. Fractional seconds
+/// and explicit offsets are refused.
+fn parse_time(tlv: super::der::Tlv<'_>) -> Result<i64> {
+    let (yyyy_off, body) = match tlv.tag {
+        // UTCTime: YYMMDDHHMMSSZ (13 octets). RFC 5280: YY < 50 ⇒
+        // 20YY, else 19YY.
+        tag::UTC_TIME => {
+            if tlv.value.len() != 13 {
+                return Err(TlsClientError::BadCertificate);
+            }
+            let yy = parse_digits(&tlv.value[0..2])?;
+            let year = if yy < 50 { 2000 + yy } else { 1900 + yy };
+            (year, &tlv.value[2..])
+        }
+        // GeneralizedTime: YYYYMMDDHHMMSSZ (15 octets).
+        tag::GENERALIZED_TIME => {
+            if tlv.value.len() != 15 {
+                return Err(TlsClientError::BadCertificate);
+            }
+            let year = parse_digits(&tlv.value[0..4])?;
+            (year, &tlv.value[4..])
+        }
+        _ => return Err(TlsClientError::BadCertificate),
+    };
+    // body = MMDDHHMMSSZ (11 octets).
+    if body.len() != 11 || body[10] != b'Z' {
+        return Err(TlsClientError::BadCertificate);
+    }
+    let month = parse_digits(&body[0..2])?;
+    let day = parse_digits(&body[2..4])?;
+    let hour = parse_digits(&body[4..6])?;
+    let minute = parse_digits(&body[6..8])?;
+    let second = parse_digits(&body[8..10])?;
+    if !(1..=12).contains(&month)
+        || !(1..=31).contains(&day)
+        || hour > 23
+        || minute > 59
+        || second > 60
+    {
+        return Err(TlsClientError::BadCertificate);
+    }
+    let days = days_from_civil(yyyy_off as i64, month as i64, day as i64);
+    Ok(days * 86_400 + hour as i64 * 3_600 + minute as i64 * 60 + second as i64)
+}
+
+/// Parse a run of ASCII digits into an integer.
+fn parse_digits(bytes: &[u8]) -> Result<u32> {
+    let mut v: u32 = 0;
+    for &b in bytes {
+        if !b.is_ascii_digit() {
+            return Err(TlsClientError::BadCertificate);
+        }
+        v = v * 10 + (b - b'0') as u32;
+    }
+    Ok(v)
+}
+
+/// Days from the Unix epoch (1970-01-01) to `y-m-d` (proleptic
+/// Gregorian). Howard Hinnant's `days_from_civil` algorithm.
+fn days_from_civil(y: i64, m: i64, d: i64) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let doy = (153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5 + d - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146_097 + doe - 719_468
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_certs::{keypair, CertBuilder, San};
+    use super::*;
+
+    #[test]
+    fn parses_typical_leaf() {
+        let kp = keypair(1);
+        let ca = keypair(2);
+        let der = CertBuilder::leaf("leaf.example.com", "leaf.example.com").build(&kp, &ca);
+        let cert = Certificate::parse(&der).unwrap();
+
+        assert_eq!(cert.signature_algorithm, SignatureAlgorithm::Ed25519);
+        assert_eq!(cert.outer_signature_algorithm, SignatureAlgorithm::Ed25519);
+        assert_eq!(
+            cert.public_key,
+            SubjectPublicKey::Ed25519(*kp.public_key.as_bytes())
+        );
+        assert!(cert.san_present);
+        assert_eq!(
+            cert.san,
+            alloc::vec![SanEntry::Dns("leaf.example.com".into())]
+        );
+        assert!(cert.key_usage.present);
+        assert!(cert.key_usage.digital_signature);
+        assert!(!cert.key_usage.key_cert_sign);
+        assert!(cert.ext_key_usage_present);
+        assert!(cert.server_auth_eku);
+        assert!(!cert.basic_constraints.ca);
+        assert_eq!(cert.signature.len(), 64);
+        // 2024-01-01T00:00:00Z .. 2099-01-01T00:00:00Z
+        assert_eq!(cert.not_before, 1_704_067_200);
+        assert!(cert.not_after > cert.not_before);
+    }
+
+    #[test]
+    fn parses_ca_with_basic_constraints() {
+        let ca = keypair(2);
+        let der = CertBuilder::ca("Test Root CA").build_self_signed(&ca);
+        let cert = Certificate::parse(&der).unwrap();
+        assert!(cert.basic_constraints.ca);
+        assert!(cert.key_usage.key_cert_sign);
+        assert!(!cert.san_present);
+        // Issuer == subject for a self-signed root.
+        assert_eq!(cert.issuer, cert.subject);
+    }
+
+    #[test]
+    fn refuses_non_v3_version() {
+        let kp = keypair(1);
+        let ca = keypair(2);
+        let mut b = CertBuilder::leaf("leaf.example.com", "leaf.example.com");
+        b.version_override = Some(0); // v1
+        let der = b.build(&kp, &ca);
+        assert_eq!(
+            Certificate::parse(&der).unwrap_err(),
+            TlsClientError::BadCertificate
+        );
+    }
+
+    #[test]
+    fn ip_san_round_trips() {
+        let kp = keypair(1);
+        let ca = keypair(2);
+        let mut b = CertBuilder::leaf("server", "unused");
+        b.sans = alloc::vec![San::Ip(alloc::vec![192, 0, 2, 1])];
+        let der = b.build(&kp, &ca);
+        let cert = Certificate::parse(&der).unwrap();
+        assert_eq!(
+            cert.san,
+            alloc::vec![SanEntry::IpAddress(alloc::vec![192, 0, 2, 1])]
+        );
+    }
+
+    #[test]
+    fn trailing_garbage_rejected() {
+        let kp = keypair(1);
+        let ca = keypair(2);
+        let mut der = CertBuilder::leaf("a", "a").build(&kp, &ca);
+        der.push(0x00);
+        assert_eq!(
+            Certificate::parse(&der).unwrap_err(),
+            TlsClientError::BadCertificate
+        );
+    }
+
+    #[test]
+    fn truncated_rejected() {
+        let kp = keypair(1);
+        let ca = keypair(2);
+        let der = CertBuilder::leaf("a", "a").build(&kp, &ca);
+        for cut in [3, 10, der.len() / 2, der.len() - 1] {
+            assert!(Certificate::parse(&der[..cut]).is_err());
+        }
+    }
+
+    #[test]
+    fn utctime_two_digit_year() {
+        // Directly exercise the time parser via a hand-built cert is
+        // covered by the builder's GeneralizedTime; here check the
+        // civil-day epoch anchor and the UTCTime pivot.
+        assert_eq!(days_from_civil(1970, 1, 1), 0);
+        assert_eq!(days_from_civil(2000, 1, 1), 10_957);
+        assert_eq!(days_from_civil(2024, 1, 1) * 86_400, 1_704_067_200);
+    }
+
+    #[test]
+    fn no_san_parses_but_flag_clear() {
+        let ca = keypair(2);
+        let mut b = CertBuilder::ca("Root");
+        b.san_extension = false;
+        let der = b.build_self_signed(&ca);
+        let cert = Certificate::parse(&der).unwrap();
+        assert!(!cert.san_present);
+        assert!(cert.san.is_empty());
+    }
+}

--- a/tls-client/src/lib.rs
+++ b/tls-client/src/lib.rs
@@ -42,7 +42,7 @@ extern crate alloc;
 pub mod cert;
 pub mod handshake;
 pub mod record;
-// pub mod trust;      // Phase 6
+pub mod trust;
 // pub mod std_io;     // Phase 7
 
 /// Errors surfaced by the TLS client.

--- a/tls-client/src/trust.rs
+++ b/tls-client/src/trust.rs
@@ -1,0 +1,275 @@
+// Copyright 2026 SmallAIOS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Operator-controlled trust store (Phase 6, design.md D5).
+//!
+//! SmallAIOS ships **no** baked-in CA bundle. The operator points
+//! `tls.trust_store_path` at a PEM bundle of the CA roots they
+//! choose to trust; an empty store refuses every chain. Optional
+//! pinning (`tls.trust_store_pin`) restricts acceptance to a single
+//! anchor by its SHA-256 fingerprint.
+//!
+//! This module owns the in-memory anchor set and the PEM loader.
+//! Chain construction against it lives in [`crate::cert::verify`].
+
+use crate::cert::x509::{Certificate, SubjectPublicKey};
+use alloc::vec::Vec;
+use smallaios_security::sha2::sha256;
+
+/// Errors from loading or validating a trust bundle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrustStoreError {
+    /// The bundle parsed to zero anchors (design.md D5: an empty
+    /// store is a configuration error, not a silent allow-none).
+    Empty,
+    /// An anchor is not a CA certificate (`BasicConstraints.cA`
+    /// absent or false).
+    NotCa,
+    /// Two anchors share the same Subject DN.
+    DuplicateSubject,
+    /// A PEM block or its base64 payload was malformed.
+    Pem,
+    /// An anchor's DER failed X.509 parsing.
+    Parse,
+}
+
+/// A single trusted CA anchor.
+#[derive(Debug, Clone)]
+pub struct TrustAnchor {
+    /// Raw Subject DN (SEQUENCE contents) for issuer matching.
+    pub subject: Vec<u8>,
+    /// The anchor's public key, used to verify the cert it signed.
+    pub public_key: SubjectPublicKey,
+    /// SHA-256 over the full anchor certificate DER (for pinning).
+    pub fingerprint: [u8; 32],
+}
+
+/// An operator trust store: a set of CA anchors plus an optional
+/// pin.
+#[derive(Debug, Clone, Default)]
+pub struct TrustStore {
+    anchors: Vec<TrustAnchor>,
+    pin: Option<[u8; 32]>,
+}
+
+impl TrustStore {
+    /// An empty store. Refuses every chain until anchors are added.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// True when no anchors are loaded (every chain will be refused).
+    pub fn is_empty(&self) -> bool {
+        self.anchors.is_empty()
+    }
+
+    /// Number of loaded anchors.
+    pub fn len(&self) -> usize {
+        self.anchors.len()
+    }
+
+    /// All anchors (for the chain verifier).
+    pub fn anchors(&self) -> &[TrustAnchor] {
+        &self.anchors
+    }
+
+    /// Set the optional pin: a SHA-256 fingerprint over a single
+    /// anchor's DER. When set, only chains anchored at that exact
+    /// certificate are accepted.
+    pub fn set_pin(&mut self, fingerprint: [u8; 32]) {
+        self.pin = Some(fingerprint);
+    }
+
+    /// The configured pin, if any.
+    pub fn pin(&self) -> Option<&[u8; 32]> {
+        self.pin.as_ref()
+    }
+
+    /// Add one anchor from raw certificate DER. Rejects non-CA
+    /// certificates and duplicate Subjects.
+    pub fn add_anchor_der(&mut self, der: &[u8]) -> Result<(), TrustStoreError> {
+        let cert = Certificate::parse(der).map_err(|_| TrustStoreError::Parse)?;
+        if !cert.basic_constraints.ca {
+            return Err(TrustStoreError::NotCa);
+        }
+        if self.anchors.iter().any(|a| a.subject == cert.subject) {
+            return Err(TrustStoreError::DuplicateSubject);
+        }
+        self.anchors.push(TrustAnchor {
+            subject: cert.subject.to_vec(),
+            public_key: cert.public_key.clone(),
+            fingerprint: sha256(der),
+        });
+        Ok(())
+    }
+
+    /// Load a PEM bundle of `BEGIN CERTIFICATE` / `END CERTIFICATE`
+    /// blocks. Returns [`TrustStoreError::Empty`] if no anchors
+    /// result.
+    pub fn from_pem(pem: &str) -> Result<Self, TrustStoreError> {
+        let mut store = TrustStore::new();
+        for block in pem_certificate_blocks(pem)? {
+            store.add_anchor_der(&block)?;
+        }
+        if store.is_empty() {
+            return Err(TrustStoreError::Empty);
+        }
+        Ok(store)
+    }
+}
+
+/// Extract every base64-decoded `CERTIFICATE` block from a PEM text.
+fn pem_certificate_blocks(pem: &str) -> Result<Vec<Vec<u8>>, TrustStoreError> {
+    const BEGIN: &str = "-----BEGIN CERTIFICATE-----";
+    const END: &str = "-----END CERTIFICATE-----";
+    let mut out = Vec::new();
+    let mut rest = pem;
+    while let Some(begin) = rest.find(BEGIN) {
+        let after_begin = &rest[begin + BEGIN.len()..];
+        let end = after_begin.find(END).ok_or(TrustStoreError::Pem)?;
+        let body = &after_begin[..end];
+        out.push(b64_decode(body)?);
+        rest = &after_begin[end + END.len()..];
+    }
+    Ok(out)
+}
+
+/// Decode standard RFC 4648 base64 (with `=` padding), skipping
+/// ASCII whitespace. Rejects any other character.
+fn b64_decode(input: &str) -> Result<Vec<u8>, TrustStoreError> {
+    fn val(c: u8) -> Option<u8> {
+        match c {
+            b'A'..=b'Z' => Some(c - b'A'),
+            b'a'..=b'z' => Some(c - b'a' + 26),
+            b'0'..=b'9' => Some(c - b'0' + 52),
+            b'+' => Some(62),
+            b'/' => Some(63),
+            _ => None,
+        }
+    }
+    let mut out = Vec::new();
+    let mut acc: u32 = 0;
+    let mut bits = 0u32;
+    for &c in input.as_bytes() {
+        if c.is_ascii_whitespace() {
+            continue;
+        }
+        if c == b'=' {
+            break;
+        }
+        let v = val(c).ok_or(TrustStoreError::Pem)? as u32;
+        acc = (acc << 6) | v;
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            out.push((acc >> bits) as u8);
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cert::test_certs::{keypair, CertBuilder};
+    use alloc::string::String;
+
+    /// Re-encode DER as a PEM CERTIFICATE block (test mirror of the
+    /// loader's decoder).
+    fn to_pem(der: &[u8]) -> String {
+        const ALPHA: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        let mut b64 = String::new();
+        for chunk in der.chunks(3) {
+            let b = [
+                chunk[0],
+                *chunk.get(1).unwrap_or(&0),
+                *chunk.get(2).unwrap_or(&0),
+            ];
+            let n = ((b[0] as u32) << 16) | ((b[1] as u32) << 8) | b[2] as u32;
+            b64.push(ALPHA[(n >> 18 & 63) as usize] as char);
+            b64.push(ALPHA[(n >> 12 & 63) as usize] as char);
+            b64.push(if chunk.len() > 1 {
+                ALPHA[(n >> 6 & 63) as usize] as char
+            } else {
+                '='
+            });
+            b64.push(if chunk.len() > 2 {
+                ALPHA[(n & 63) as usize] as char
+            } else {
+                '='
+            });
+        }
+        let mut pem = String::from("-----BEGIN CERTIFICATE-----\n");
+        pem.push_str(&b64);
+        pem.push_str("\n-----END CERTIFICATE-----\n");
+        pem
+    }
+
+    #[test]
+    fn loads_ca_anchor_from_pem() {
+        let ca = keypair(2);
+        let der = CertBuilder::ca("Root CA").build_self_signed(&ca);
+        let store = TrustStore::from_pem(&to_pem(&der)).unwrap();
+        assert_eq!(store.len(), 1);
+        assert!(!store.is_empty());
+    }
+
+    #[test]
+    fn empty_bundle_rejected() {
+        assert_eq!(
+            TrustStore::from_pem("no certs here").unwrap_err(),
+            TrustStoreError::Empty
+        );
+    }
+
+    #[test]
+    fn non_ca_anchor_rejected() {
+        let leaf = keypair(1);
+        let ca = keypair(2);
+        let der = CertBuilder::leaf("leaf.example.com", "leaf.example.com").build(&leaf, &ca);
+        let mut store = TrustStore::new();
+        assert_eq!(
+            store.add_anchor_der(&der).unwrap_err(),
+            TrustStoreError::NotCa
+        );
+    }
+
+    #[test]
+    fn duplicate_subject_rejected() {
+        let ca = keypair(2);
+        let der = CertBuilder::ca("Root CA").build_self_signed(&ca);
+        let mut store = TrustStore::new();
+        store.add_anchor_der(&der).unwrap();
+        assert_eq!(
+            store.add_anchor_der(&der).unwrap_err(),
+            TrustStoreError::DuplicateSubject
+        );
+    }
+
+    #[test]
+    fn two_distinct_anchors_load() {
+        let ca1 = keypair(2);
+        let ca2 = keypair(3);
+        let mut pem = to_pem(&CertBuilder::ca("Root One").build_self_signed(&ca1));
+        pem.push_str(&to_pem(
+            &CertBuilder::ca("Root Two").build_self_signed(&ca2),
+        ));
+        let store = TrustStore::from_pem(&pem).unwrap();
+        assert_eq!(store.len(), 2);
+    }
+
+    #[test]
+    fn malformed_base64_rejected() {
+        let pem = "-----BEGIN CERTIFICATE-----\n!!!not base64!!!\n-----END CERTIFICATE-----";
+        assert_eq!(TrustStore::from_pem(pem).unwrap_err(), TrustStoreError::Pem);
+    }
+
+    #[test]
+    fn fingerprint_matches_sha256_of_der() {
+        let ca = keypair(2);
+        let der = CertBuilder::ca("Root CA").build_self_signed(&ca);
+        let mut store = TrustStore::new();
+        store.add_anchor_der(&der).unwrap();
+        assert_eq!(store.anchors()[0].fingerprint, sha256(&der));
+    }
+}


### PR DESCRIPTION
## Summary

Continues `tls-tcp-client-v1` after #217 landed the handshake core, filling in the **certificate-chain verification** seam the merged driver left open (the `ServerCertVerifier` trait previously had only test doubles). Covers Phase 5 (X.509 parser + chain verifier) and Phase 6 (trust store).

Built on the existing strict DER decoder and RFC 6125 hostname matcher from #217.

## What's in it

**X.509v3 structure parser** (`cert/x509.rs`, task 5.2) — "just-enough" per design.md D4:
- v3-only enforcement; serial; signature algorithm with **SHA-1 refused**; validity (UTCTime/GeneralizedTime in the mandatory `Z` form → Unix seconds); raw issuer/subject DN capture; SPKI; and the SAN / BasicConstraints / KeyUsage / ExtKeyUsage extensions.
- RSA-PSS/PKCS#1 and ECDSA-P256 OIDs are *recognized* (for precise "unsupported" reporting) but their signature verification is deferred to their primitive sub-adds.
- Adds a raw-TLV capture to `der::Reader` so the outer signature is checked over the exact `tbsCertificate` octets.

**Trust store** (`trust.rs`, tasks 6.1/6.2/6.3/6.5) — operator-controlled in-memory CA anchors, PEM bundle loader (RFC 4648 base64), rejecting empty bundles / non-CA certs / duplicate Subjects, with optional per-anchor SHA-256 pinning.

**Chain verifier** (`cert/verify.rs`, tasks 5.4/5.6, 5.5 Ed25519) — `TrustStoreVerifier` is the production `ServerCertVerifier`:
- requires a leaf SAN, binds it to the operator hostname (RFC 6125), requires the serverAuth EKU;
- builds a depth-bounded chain leaf → intermediate(s) → trust-store anchor, checking `BasicConstraints.cA` + `keyCertSign` on each CA link;
- verifies every link's signature; enforces validity windows with the 2026 unsynced-clock sentinel + `require_synced_clock` policy.

## Scope / deferrals (intentional)

- **Ed25519 links verify today.** ECDSA-P256 and RSA-PSS/PKCS#1 are parsed and recognized but **refused with `ChainUntrusted`** — never silently accepted — pending `security-ecdsa-p256-v1` / `security-rsa-pss-v1`. (So this does not yet validate typical public-CA chains; that's gated on those primitives.)
- The verifier takes an **injected** wall-clock time, keeping `tls-client` decoupled from the kernel global allocator. (The first reference to `smallaios_kernel` pulls its `#[global_allocator]` into the host test binary and OOMs the suite — so `kernel::clock()` reading + the `audit_export_unsynced_clock` record land in the Phase 8 container integration instead.)
- Phase 7 (`TcpTlsStream`) and Phase 8 (audit-export wiring) remain follow-on.

## Tests

29 new tests (157 total in `tls-client`, all pass), including a `#[cfg(test)]` synthetic Ed25519 cert generator (task 5.8 harness) and good/bad cross-vectors: direct + two-link chains, tampered signature, unknown anchor, hostname mismatch, expiry (synced/unsynced/required), missing SAN, non-CA intermediate, pinning accept/reject, IP-SAN literal.

`cargo clippy -p smallaios-tls-client --all-targets -- -D warnings` clean; `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8CYR19HgR4QDdEWNmspyZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01V8CYR19HgR4QDdEWNmspyZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * X.509 certificate parsing and validation with multiple signature algorithm support
  * Certificate chain verification against operator-managed trust anchors
  * Trust store implementation for managing trusted CA certificates with optional pin verification
  * Server certificate validation including hostname and validity checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->