### PR TITLE
test(container): raise e2e healthz wait 10s -> 30s

### DIFF
--- a/container/tests/test_full_inference_e2e.rs
+++ b/container/tests/test_full_inference_e2e.rs
@@ -249,8 +249,8 @@ fn test_full_inference_pipeline_relu() {
 
     // 3. Wait for server to become healthy
     assert!(
-        wait_for_healthz(&addr, Duration::from_secs(10)),
-        "container did not become healthy within 10s"
+        wait_for_healthz(&addr, Duration::from_secs(30)),
+        "container did not become healthy within 30s"
     );
 
     // 4. Verify model is listed
@@ -316,7 +316,7 @@ fn test_inference_unknown_model_returns_404() {
     let _guard = ChildGuard(child);
     let addr = format!("127.0.0.1:{}", port);
     assert!(
-        wait_for_healthz(&addr, Duration::from_secs(10)),
+        wait_for_healthz(&addr, Duration::from_secs(30)),
         "container did not become healthy"
     );
 
@@ -335,7 +335,7 @@ fn test_inference_malformed_json_returns_400() {
     let _guard = ChildGuard(child);
     let addr = format!("127.0.0.1:{}", port);
     assert!(
-        wait_for_healthz(&addr, Duration::from_secs(10)),
+        wait_for_healthz(&addr, Duration::from_secs(30)),
         "container did not become healthy"
     );
 
@@ -353,7 +353,7 @@ fn test_inference_invalid_input_shape_returns_400() {
     let _guard = ChildGuard(child);
     let addr = format!("127.0.0.1:{}", port);
     assert!(
-        wait_for_healthz(&addr, Duration::from_secs(10)),
+        wait_for_healthz(&addr, Duration::from_secs(30)),
         "container did not become healthy"
     );
 


### PR DESCRIPTION
One of the seven e2e tests (`test_inference_invalid_input_shape_returns_400`) flaked at exactly 10.00s on a loaded shared runner during #235's formal-gate job while its six identical-pattern siblings passed. The wait is a ceiling, not a delay — locally all seven still finish in 0.36s total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)